### PR TITLE
Batch of improvements to upgrade setup + tests

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -381,17 +381,14 @@ Static upgrade stat bonuses from the printed upgrade values are automatically in
 
 Since most upgrade abilities target the attached card, we have helper methods available to declare such abilities succintly.
 
-Most upgrades say that the attached unit gains a triggered ability:
+Most upgrades say that the attached unit gains a triggered ability, for which we have the methods `addGainTriggeredAbilityTargetingAttached` and `addGainOnAttackAbilityTargetingAttached`. See Vambrace Grappleshot:
 ```typescript
 // Attached character gains ability 'On Attack: Exhaust the defender'
-this.addGainTriggeredAbilityTargetingAttached({
+this.addGainOnAttackAbilityTargetingAttached({
     title: 'Exhaust the defender on attack',
-    // note here that context.source refers to the attached unit card, not the upgrade itself
-    when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
-    targetResolver: {
-        cardCondition: (card, context) => card === context.event.attack.target,
-        immediateEffect: AbilityHelper.immediateEffects.exhaust()
-    }
+    immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {
+        return { target: context.source.activeAttack?.target };
+    })
 });
 ```
 
@@ -404,16 +401,15 @@ this.addGainKeywordTargetingAttached({
 });
 ```
 
-If an attachment effect has a condition, it can be set using the optional second parameter of the setup method. See the implementation of the Fallen Lightsaber text, "If attached unit is a Force unit, it gains: “On Attack: Deal 1 damage to each ground unit the defending player controls.”
+If an attachment effect has a condition, it can be set using the `gainCondition` property. See the implementation of the Fallen Lightsaber text, "If attached unit is a Force unit, it gains: “On Attack: Deal 1 damage to each ground unit the defending player controls.”
 ```typescript
-this.addGainTriggeredAbilityTargetingAttached({
+this.addGainOnAttackAbilityTargetingAttached({
     title: 'Deal 1 damage to each ground unit the defending player controls',
-    when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
     immediateEffect: AbilityHelper.immediateEffects.damage((context) => {
         return { target: context.source.controller.opponent.getUnitsInPlay(Location.GroundArena), amount: 1 };
-    })
-},
-(context) => context.source.parentCard?.hasSomeTrait(Trait.Force));
+    }),
+    gainCondition: (context) => context.source.parentCard?.hasSomeTrait(Trait.Force)
+});
 ```
 
 In some rare cases an upgrade's ability targets the attached card without giving it any new abilities

--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -377,6 +377,18 @@ Some helper methods are available to make it easier to declare constant abilitie
 
 Static upgrade stat bonuses from the printed upgrade values are automatically included in combat calculations for the attached unit.
 
+#### Attachment requirements
+
+Some cards can only attach to cards that meet certain requirements. These requirements can be set with the `setAttachCondition()` method, which accepts a handler method accepting a potential card to attach to and returns true if the card is a legal attach target for this upgrade. See Vambrace Grappleshot, which can only attach to non-vehicles:
+
+```typescript
+public override setupCardAbilities() {
+    this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
+
+    // ...set abilities here ...
+}
+```
+
 #### Effects targeting attached card
 
 Since most upgrade abilities target the attached card, we have helper methods available to declare such abilities succintly.
@@ -401,7 +413,7 @@ this.addGainKeywordTargetingAttached({
 });
 ```
 
-If an attachment effect has a condition, it can be set using the `gainCondition` property. See the implementation of the Fallen Lightsaber text, "If attached unit is a Force unit, it gains: “On Attack: Deal 1 damage to each ground unit the defending player controls.”
+If an attachment _effect_ has a condition - meaning that the effect is only active if certain conditions are met - it can be set using the `gainCondition` property. See the implementation of the Fallen Lightsaber text, "If attached unit is a Force unit, it gains: “On Attack: Deal 1 damage to each ground unit the defending player controls.”
 ```typescript
 this.addGainOnAttackAbilityTargetingAttached({
     title: 'Deal 1 damage to each ground unit the defending player controls',

--- a/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
@@ -21,9 +21,8 @@ export default class FallenLightsaber extends UpgradeCard {
     }
 
     public override setupCardAbilities() {
-        this.addGainTriggeredAbilityTargetingAttached({
+        this.addGainOnAttackAbilityTargetingAttached({
             title: 'Deal 1 damage to each ground unit the defending player controls',
-            when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             immediateEffect: AbilityHelper.immediateEffects.damage((context) => {
                 return { target: context.source.controller.opponent.getUnitsInPlay(Location.GroundArena), amount: 1 };
             }),

--- a/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
@@ -12,15 +12,9 @@ export default class FallenLightsaber extends UpgradeCard {
         };
     }
 
-    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
-        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
-            return false;
-        }
-
-        return super.canAttach(targetCard, controller);
-    }
-
     public override setupCardAbilities() {
+        this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
+
         this.addGainOnAttackAbilityTargetingAttached({
             title: 'Deal 1 damage to each ground unit the defending player controls',
             immediateEffect: AbilityHelper.immediateEffects.damage((context) => {

--- a/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
@@ -26,9 +26,9 @@ export default class FallenLightsaber extends UpgradeCard {
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             immediateEffect: AbilityHelper.immediateEffects.damage((context) => {
                 return { target: context.source.controller.opponent.getUnitsInPlay(Location.GroundArena), amount: 1 };
-            })
-        },
-        (context) => context.source.parentCard?.hasSomeTrait(Trait.Force));
+            }),
+            gainCondition: (context) => context.source.parentCard?.hasSomeTrait(Trait.Force)
+        });
     }
 }
 

--- a/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
@@ -22,8 +22,10 @@ export default class JediLightsaber extends UpgradeCard {
     }
 
     public override setupCardAbilities() {
-        this.addGainTriggeredAbilityTargetingAttached({ title: 'Give the defender -2/-2 for this phase',
+        this.addGainTriggeredAbilityTargetingAttached({
+            title: 'Give the defender -2/-2 for this phase',
             when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
+            gainCondition: (context) => context.source.parentCard?.hasSomeTrait(Trait.Force),
 
             // need to check if the target is a base - if so, don't apply the stat modifier effect
             immediateEffect: AbilityHelper.immediateEffects.conditional({
@@ -33,8 +35,8 @@ export default class JediLightsaber extends UpgradeCard {
                     effect: AbilityHelper.ongoingEffects.modifyStats({ power: -2, hp: -2 }),
                     target: (context.event.attack as Attack).target
                 }))
-            }) },
-        (context) => context.source.parentCard?.hasSomeTrait(Trait.Force));
+            })
+        });
     }
 }
 

--- a/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
@@ -22,9 +22,8 @@ export default class JediLightsaber extends UpgradeCard {
     }
 
     public override setupCardAbilities() {
-        this.addGainTriggeredAbilityTargetingAttached({
+        this.addGainOnAttackAbilityTargetingAttached({
             title: 'Give the defender -2/-2 for this phase',
-            when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             gainCondition: (context) => context.source.parentCard?.hasSomeTrait(Trait.Force),
 
             // need to check if the target is a base - if so, don't apply the stat modifier effect

--- a/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
@@ -13,15 +13,9 @@ export default class JediLightsaber extends UpgradeCard {
         };
     }
 
-    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
-        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
-            return false;
-        }
-
-        return super.canAttach(targetCard, controller);
-    }
-
     public override setupCardAbilities() {
+        this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
+
         this.addGainOnAttackAbilityTargetingAttached({
             title: 'Give the defender -2/-2 for this phase',
             gainCondition: (context) => context.source.parentCard?.hasSomeTrait(Trait.Force),

--- a/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
@@ -12,15 +12,9 @@ export default class LukesLightsaber extends UpgradeCard {
         };
     }
 
-    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
-        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
-            return false;
-        }
-
-        return super.canAttach(targetCard, controller);
-    }
-
     public override setupCardAbilities() {
+        this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
+
         this.addWhenPlayedAbility({
             title: 'Heal all damage from Luke and give him a shield token',
             immediateEffect: AbilityHelper.immediateEffects.conditional((context) => ({

--- a/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
@@ -12,15 +12,9 @@ export default class VadersLightsaber extends UpgradeCard {
         };
     }
 
-    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
-        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
-            return false;
-        }
-
-        return super.canAttach(targetCard, controller);
-    }
-
     public override setupCardAbilities() {
+        this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
+
         this.addWhenPlayedAbility({
             title: 'Deal 4 damage to a ground unit',
             optional: true,

--- a/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
@@ -13,15 +13,9 @@ export default class VambraceGrappleshot extends UpgradeCard {
         };
     }
 
-    public override canAttach(targetCard: Card, controller: Player = this.controller): boolean {
-        if (targetCard.hasSomeTrait(Trait.Vehicle)) {
-            return false;
-        }
-
-        return super.canAttach(targetCard, controller);
-    }
-
     public override setupCardAbilities() {
+        this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
+
         this.addGainOnAttackAbilityTargetingAttached({
             title: 'Exhaust the defender on attack',
             immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {

--- a/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
@@ -22,9 +22,8 @@ export default class VambraceGrappleshot extends UpgradeCard {
     }
 
     public override setupCardAbilities() {
-        this.addGainTriggeredAbilityTargetingAttached({
+        this.addGainOnAttackAbilityTargetingAttached({
             title: 'Exhaust the defender on attack',
-            when: { onAttackDeclared: (event, context) => event.attack.attacker === context.source },
             immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => {
                 return { target: context.source.activeAttack?.target };
             })

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -29,6 +29,8 @@ const UpgradeCardParent = WithPrintedPower(WithPrintedHp(WithCost(WithStandardAb
 export class UpgradeCard extends UpgradeCardParent {
     protected _parentCard?: UnitCard = null;
 
+    private attachCondition: (card: Card) => boolean;
+
     public constructor(owner: Player, cardData: any) {
         super(owner, cardData);
         Contract.assertTrue([CardType.BasicUpgrade, CardType.TokenUpgrade].includes(this.printedType));
@@ -85,7 +87,7 @@ export class UpgradeCard extends UpgradeCardParent {
      * implementations must override this if they have specific attachment conditions.
      */
     public canAttach(targetCard: Card, controller: Player = this.controller): boolean {
-        if (!targetCard.isUnit()) {
+        if (!targetCard.isUnit() || (this.attachCondition && !this.attachCondition(targetCard))) {
             return false;
         }
 
@@ -156,6 +158,13 @@ export class UpgradeCard extends UpgradeCardParent {
             condition: gainCondition,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(keywordProperties)
         });
+    }
+
+    /** Adds a condition that must return true for the upgrade to be allowed to attach to the passed card. */
+    protected setAttachCondition(attachCondition: (card: Card) => boolean) {
+        Contract.assertIsNullLike(this.attachCondition, 'Attach condition is already set');
+
+        this.attachCondition = attachCondition;
     }
 
     protected override initializeForCurrentLocation(prevLocation: Location): void {

--- a/test/helpers/DeckBuilder.js
+++ b/test/helpers/DeckBuilder.js
@@ -49,7 +49,6 @@ class DeckBuilder {
 
         allCards.push(this.getLeaderCard(playerCards, playerNumber));
         allCards.push(this.getBaseCard(playerCards, playerNumber));
-        // allCards.push(playerCards.base ? playerCards.base : defaultBase[playerNumber]);
 
         // if user didn't provide explicit resource cards, create default ones to be added to deck
         playerCards.resources = this.padCardListIfNeeded(playerCards.resources, defaultResourceCount);
@@ -71,6 +70,7 @@ class DeckBuilder {
 
         inPlayCards = inPlayCards.concat(this.getInPlayCardsForArena(playerCards.groundArena));
         inPlayCards = inPlayCards.concat(this.getInPlayCardsForArena(playerCards.spaceArena));
+        inPlayCards = inPlayCards.concat(this.getUpgradesFromCard(playerCards.leader));
 
         //Collect all the cards together
         allCards = allCards.concat(inPlayCards);
@@ -96,15 +96,21 @@ class DeckBuilder {
             namedCards = namedCards.concat(playerEntry);
         } else if ('card' in playerEntry) {
             namedCards.push(playerEntry.card);
-            if ('upgrades' in playerEntry) {
-                namedCards = namedCards.concat(this.getNamedCardsInPlayerEntry(playerEntry.upgrades));
-            }
+            namedCards = namedCards.concat(this.getUpgradesFromCard(playerEntry));
         } else if (Array.isArray(playerEntry)) {
             playerEntry.forEach((card) => namedCards = namedCards.concat(this.getNamedCardsInPlayerEntry(card)));
         } else {
             throw new TestSetupError(`Unknown test card specifier format: '${playerObject}'`);
         }
         return namedCards;
+    }
+
+    getUpgradesFromCard(playerEntry) {
+        if (playerEntry && typeof playerEntry !== 'string' && 'upgrades' in playerEntry) {
+            return this.getNamedCardsInPlayerEntry(playerEntry.upgrades);
+        }
+
+        return [];
     }
 
     padCardListIfNeeded(cardList, defaultCount) {

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -99,9 +99,27 @@ class PlayerInteractionWrapper {
 
             leaderCard.damage = leaderOptions.damage || 0;
             leaderCard.exhausted = leaderOptions.exhausted || false;
+
+            // Get the upgrades
+            if (leaderOptions.upgrades) {
+                leaderOptions.upgrades.forEach((upgradeName) => {
+                    const isToken = ['shield', 'experience'].includes(upgradeName);
+                    let upgrade;
+                    if (isToken) {
+                        upgrade = this.game.generateToken(this.player, upgradeName);
+                    } else {
+                        upgrade = this.findCardByName(upgradeName);
+                    }
+
+                    upgrade.attachTo(leaderCard);
+                });
+            }
         } else {
             if (leaderOptions.damage) {
                 throw new TestSetupError('Leader should not have damage when not deployed');
+            }
+            if (leaderOptions.upgrades) {
+                throw new TestSetupError('Leader should not have upgrades when not deployed');
             }
 
             leaderCard.exhausted = leaderOptions.exhausted || false;
@@ -201,8 +219,6 @@ class PlayerInteractionWrapper {
                 card.damage = options.damage;
             }
 
-            // Activate persistent effects of the card
-            //card.applyPersistentEffects();
             // Get the upgrades
             if (options.upgrades) {
                 options.upgrades.forEach((upgradeName) => {

--- a/test/server/actions/PlayUpgradeFromHand.spec.js
+++ b/test/server/actions/PlayUpgradeFromHand.spec.js
@@ -22,6 +22,7 @@ describe('Play upgrade from hand', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
                 this.player1.clickCard(this.wampa);
                 expect(this.wampa.upgrades).toContain(this.entrenched);
+                expect(this.wampa.upgrades.length).toBe(1);
                 expect(this.entrenched).toBeInLocation('ground arena');
                 expect(this.wampa.getPower()).toBe(7);
                 expect(this.wampa.getHp()).toBe(8);
@@ -35,6 +36,7 @@ describe('Play upgrade from hand', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
                 this.player1.clickCard(this.tielnFighter);
                 expect(this.tielnFighter.upgrades).toContain(this.academyTraining);
+                expect(this.wampa.upgrades.length).toBe(1);
                 expect(this.academyTraining).toBeInLocation('space arena');
                 expect(this.tielnFighter.getPower()).toBe(4);
                 expect(this.tielnFighter.getHp()).toBe(3);
@@ -48,6 +50,7 @@ describe('Play upgrade from hand', function() {
                 expect(this.player1).toBeAbleToSelectExactly([this.wampa, this.tielnFighter, this.brightHope]);
                 this.player1.clickCard(this.brightHope);
                 expect(this.brightHope.upgrades).toContain(this.resilient);
+                expect(this.wampa.upgrades.length).toBe(1);
                 expect(this.resilient).toBeInLocation('space arena', this.player2);
                 expect(this.brightHope.getPower()).toBe(2);
                 expect(this.brightHope.getHp()).toBe(9);

--- a/test/server/cards/01_SOR/leaders/GrandMoffTarkinOversectorGovernor.spec.js
+++ b/test/server/cards/01_SOR/leaders/GrandMoffTarkinOversectorGovernor.spec.js
@@ -23,8 +23,7 @@ describe('Grand Moff Tarkin, Oversector Governor', function() {
 
                 this.player1.clickCard(this.atst);
                 expect(this.grandMoffTarkin.exhausted).toBe(true);
-                expect(this.atst.upgrades.length).toBe(1);
-                expect(this.atst.upgrades[0].internalName).toBe('experience');
+                expect(this.atst).toHaveExactUpgradeNames(['experience']);
                 expect(this.player1.countExhaustedResources()).toBe(1);
             });
         });

--- a/test/server/cards/01_SOR/tokens/Shield.spec.js
+++ b/test/server/cards/01_SOR/tokens/Shield.spec.js
@@ -63,7 +63,7 @@ describe('Shield', function() {
 
                 expect(this.cartelSpacer.damage).toBe(2);
                 expect(this.tielnFighter.damage).toBe(0);
-                expect(this.tielnFighter.upgrades.length).toBe(1);
+                expect(this.tielnFighter).toHaveExactUpgradeNames(['shield']);
 
                 expect(getShieldLocationsSorted(this.shields)).toEqual(['outside the game', 'space arena']);
 

--- a/test/server/cards/01_SOR/upgrades/FallenLightsaber.spec.js
+++ b/test/server/cards/01_SOR/upgrades/FallenLightsaber.spec.js
@@ -88,7 +88,7 @@ describe('Fallen Lightsaber', function() {
 
             it('should not be playable on vehicles', function () {
                 this.player1.clickCard(this.fallenLightsaber);
-                expect(this.battlefieldMarine.upgrades).toContain(this.fallenLightsaber);
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['fallen-lightsaber']);
             });
         });
     });

--- a/test/server/cards/01_SOR/upgrades/JediLightsaber.spec.js
+++ b/test/server/cards/01_SOR/upgrades/JediLightsaber.spec.js
@@ -107,7 +107,7 @@ describe('Jedi Lightsaber', function() {
 
             it('should not be playable on vehicles', function () {
                 this.player1.clickCard(this.jediLightsaber);
-                expect(this.battlefieldMarine.upgrades).toContain(this.jediLightsaber);
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['jedi-lightsaber']);
             });
         });
     });

--- a/test/server/cards/02_SHD/upgrades/VambraceGrappleshot.spec.js
+++ b/test/server/cards/02_SHD/upgrades/VambraceGrappleshot.spec.js
@@ -50,7 +50,7 @@ describe('Vambrace Grappleshot', function() {
 
             it('should not be playable on vehicles', function () {
                 this.player1.clickCard(this.vambraceGrappleshot);
-                expect(this.battlefieldMarine.upgrades).toContain(this.vambraceGrappleshot);
+                expect(this.battlefieldMarine).toHaveExactUpgradeNames(['vambrace-grappleshot']);
             });
         });
     });

--- a/test/server/core/card/Upgrade.spec.js
+++ b/test/server/core/card/Upgrade.spec.js
@@ -24,6 +24,7 @@ describe('Upgrade cards', function() {
 
                 expect(this.wampa.upgrades).toContain(this.academyTraining);
                 expect(this.wampa.upgrades).toContain(this.foundling);
+                expect(this.wampa.upgrades.length).toBe(2);
                 expect(this.wampa.getPower()).toBe(7);
                 expect(this.wampa.getHp()).toBe(8);
             });

--- a/test/server/core/card/Upgrade.spec.js
+++ b/test/server/core/card/Upgrade.spec.js
@@ -55,6 +55,28 @@ describe('Upgrade cards', function() {
             });
         });
 
+        describe('When an upgrade is attached to a leader', function() {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'boba-fett#daimyo', deployed: true, upgrades: ['academy-training'] }
+                    },
+                    player2: {
+                        groundArena: ['atat-suppressor']
+                    }
+                });
+            });
+
+            it('its stat bonuses should be correctly applied during combat', function () {
+                this.player1.clickCard(this.bobaFett);
+                this.player1.clickCard(this.atatSuppressor);
+                expect(this.bobaFett).toBeInLocation('ground arena');
+                expect(this.bobaFett.damage).toBe(8);
+                expect(this.atatSuppressor.damage).toBe(6);
+            });
+        });
+
         describe('When an upgrade is attached,', function() {
             beforeEach(function () {
                 this.setupTest({


### PR DESCRIPTION
We had accumulated a lot of small TODOs related to implementing and testing upgrade cards. Handled them all in a batch. Specific improvements:

- There is now a dedicated method for setting up attachment conditions
- Made the `gainCondition` option for enabling / disabling gained effects on the attached card a property instead of a method parameter to improve readability
- Added support for declaring deployed leaders to have attached upgrades in test setup
- Updated some older tests to use the most up-to-date test helper methods