### PR TITLE
General improvements

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,6 +5,7 @@ on:
       - main
 jobs:
   lint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -16,6 +17,7 @@ jobs:
 
         - run: npx eslint --quiet
   test:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   lint:
-    if: !github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
 
         - run: npx eslint --quiet
   test:
-    if: !github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,6 @@ on:
       - main
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -17,7 +16,6 @@ jobs:
 
         - run: npx eslint --quiet
   test:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,10 +1,12 @@
 name: Pull Request Checks
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
 jobs:
   lint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -16,6 +18,7 @@ jobs:
 
         - run: npx eslint --quiet
   test:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
+    if: !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
 
         - run: npx eslint --quiet
   test:
-    if: github.event.pull_request.draft == false
+    if: !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v4

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -32,7 +32,7 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbility {
 
                     let target: Shield[];
                     const attack: Attack = context.event.attack;
-                    if (attack.target.isUnit() && EnumHelpers.isArena(attack.target.location)) {
+                    if (attack.target.isUnit() && attack.target.isInPlay()) {
                         target = attack.target.upgrades?.filter((card) => card.isShield());
                     } else {
                         target = [];

--- a/server/game/cards/01_SOR/units/FirstLegionSnowtrooper.ts
+++ b/server/game/cards/01_SOR/units/FirstLegionSnowtrooper.ts
@@ -15,7 +15,7 @@ export default class FirstLegionSnowtrooper extends NonLeaderUnitCard {
             title: 'While attacking a damaged unit, this unit gets +2/+0 and gains Overwhelm.',
             condition: (context) => context.source.isAttacking() &&
                 context.source.activeAttack?.target.isUnit() &&
-                (EnumHelpers.isArena(context.source.activeAttack?.target.location) && context.source.activeAttack?.target.damage > 0),
+                (context.source.activeAttack?.target.isInPlay() && context.source.activeAttack?.target.damage > 0),
             ongoingEffect: [AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm), AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })],
         });
     }

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -35,11 +35,11 @@ export class Attack extends GameObject {
     }
 
     public isAttackerInPlay(): boolean {
-        return EnumHelpers.isArena(this.attacker.location);
+        return this.attacker.isInPlay();
     }
 
-    public isDefenderInPlay(): boolean {
-        return this.target.isBase() || EnumHelpers.isArena(this.target.location);
+    public isAttackTargetInPlay(): boolean {
+        return this.target.isBase() || this.target.isInPlay();
     }
 
     public isInvolved(card: Card): boolean {
@@ -54,7 +54,7 @@ export class Attack extends GameObject {
     }
 
     private getUnitPower(involvedUnit: UnitCard): StatisticTotal {
-        Contract.assertTrue(EnumHelpers.isArena(involvedUnit.location), `Unit ${involvedUnit.name} location is ${involvedUnit.location}, cannot participate in combat`);
+        Contract.assertTrue(involvedUnit.isInPlay(), `Unit ${involvedUnit.name} location is ${involvedUnit.location}, cannot participate in combat`);
 
         return involvedUnit.getPower();
     }

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -38,7 +38,7 @@ export class Attack extends GameObject {
         return this.attacker.isInPlay();
     }
 
-    public isAttackTargetInPlay(): boolean {
+    public isAttackTargetLegal(): boolean {
         return this.target.isBase() || this.target.isInPlay();
     }
 

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -49,7 +49,7 @@ export class AttackFlow extends BaseStepWithPipeline {
         }
 
         let overwhelmDamageOnly = false;
-        if (!this.attack.isDefenderInPlay()) {
+        if (!this.attack.isAttackTargetInPlay()) {
             if (!this.attack.hasOverwhelm()) {
                 this.context.game.addMessage('The attack does not resolve because the defender is no longer in play');
                 return;
@@ -110,7 +110,7 @@ export class AttackFlow extends BaseStepWithPipeline {
             attack: this.attack,
             handler: () => {
                 // only unregister if the attacker hasn't been moved out of the play area (e.g. defeated)
-                if (EnumHelpers.isArena(this.attack.attacker.location)) {
+                if (this.attack.isAttackerInPlay()) {
                     this.attack.attacker.unregisterAttackKeywords();
                 }
             }

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -49,7 +49,7 @@ export class AttackFlow extends BaseStepWithPipeline {
         }
 
         let overwhelmDamageOnly = false;
-        if (!this.attack.isAttackTargetInPlay()) {
+        if (!this.attack.isAttackTargetLegal()) {
             if (!this.attack.hasOverwhelm()) {
                 this.context.game.addMessage('The attack does not resolve because the defender is no longer in play');
                 return;

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -302,7 +302,7 @@ export class Card extends OngoingEffectSource {
     }
 
     /**
-     * Returns true if the card is a type that can legally have triggered abilities
+     * Returns true if the card is a type that can legally have triggered abilities.
      * The returned type set is equivalent to {@link CardWithTriggeredAbilities}.
      */
     public canRegisterTriggeredAbilities(): this is InPlayCard {
@@ -310,10 +310,18 @@ export class Card extends OngoingEffectSource {
     }
 
     /**
-     * Returns true if the card is a type that can legally have constant abilities
+     * Returns true if the card is a type that can legally have constant abilities.
      * The returned type set is equivalent to {@link CardWithConstantAbilities}.
      */
     public canRegisterConstantAbilities(): this is InPlayCard {
+        return false;
+    }
+
+    /**
+     * Returns true if the card is a type that can be put into play and considered "in play."
+     * The returned type set is equivalent to {@link InPlayCard}.
+     */
+    public canBeInPlay(): this is InPlayCard {
         return false;
     }
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -46,7 +46,7 @@ export class UpgradeCard extends UpgradeCardParent {
     /** The card that this card is underneath */
     public get parentCard(): UnitCard {
         Contract.assertNotNullLike(this._parentCard);
-        Contract.assertTrue(EnumHelpers.isArena(this.location));
+        Contract.assertTrue(this.isInPlay());
 
         return this._parentCard;
     }
@@ -60,7 +60,7 @@ export class UpgradeCard extends UpgradeCardParent {
 
     public attachTo(newParentCard: UnitCard) {
         Contract.assertTrue(newParentCard.isUnit());
-        Contract.assertTrue(EnumHelpers.isArena(newParentCard.location));
+        Contract.assertTrue(newParentCard.isInPlay());
 
         if (this._parentCard) {
             this.unattach();

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -25,7 +25,6 @@ export class InPlayCard extends PlayableOrDeployableCard {
     protected constantAbilities: IConstantAbility[] = [];
     protected triggeredAbilities: TriggeredAbility[] = [];
 
-    // ********************************************** CONSTRUCTOR **********************************************
     public constructor(owner: Player, cardData: any) {
         super(owner, cardData);
 
@@ -33,8 +32,15 @@ export class InPlayCard extends PlayableOrDeployableCard {
         Contract.assertFalse(this.printedType === CardType.Event);
     }
 
+    public isInPlay(): boolean {
+        return EnumHelpers.isArena(this.location);
+    }
 
-    // **************************************** ABILITY GETTERS ****************************************
+    public override canBeInPlay(): this is InPlayCard {
+        return true;
+    }
+
+    // ********************************************** ABILITY GETTERS **********************************************
     /**
      * `SWU 7.3.1`: A constant ability is always in effect while the card it is on is in play. Constant abilities
      * don’t have any special styling

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -145,7 +145,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         // *************************************** KEYWORD HELPERS ***************************************
         protected override cleanupBeforeMove(nextLocation: Location) {
-            if (EnumHelpers.isArena(this.location) && this.isAttacking()) {
+            if (this.isInPlay() && this.isAttacking()) {
                 this.unregisterAttackKeywords();
             }
         }

--- a/server/game/core/gameSteps/prompts/ResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/ResourcePrompt.ts
@@ -25,7 +25,7 @@ export class ResourcePrompt extends AllPlayerPrompt {
         if (!this.isComplete()) {
             this.highlightSelectableCards();
         } else {
-            this.game.getPlayers().forEach((player) => this.resourceSelectedCards(player));
+            this.complete();
         }
 
         return super.continue();
@@ -96,5 +96,16 @@ export class ResourcePrompt extends AllPlayerPrompt {
         } else {
             this.game.addMessage('{0} has not resourced any cards', player);
         }
+    }
+
+    public override complete() {
+        this.game.getPlayers().forEach((player) => this.resourceSelectedCards(player));
+
+        for (const player of this.game.getPlayers()) {
+            player.clearSelectedCards();
+            player.clearSelectableCards();
+        }
+
+        return super.complete();
     }
 }

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -148,7 +148,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
             // add events to defeat any upgrades attached to this card. the events will be added as "contingent events"
             // in the event window, so they'll resolve in the same window but after the primary event
             for (const upgrade of (event.card.upgrades ?? []) as UpgradeCard[]) {
-                if (EnumHelpers.isArena(upgrade.location)) {
+                if (upgrade.isInPlay()) {
                     const attachmentEvent = context.game.actions
                         .defeat()
                         .generateEvent(upgrade, context.game.getFrameworkContext());

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -60,12 +60,9 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         const target = event.target;
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        if (
-            !EnumHelpers.isArena(properties.attacker.location) || !EnumHelpers.isAttackableLocation(target.location)
-        ) {
-            context.game.addMessage(
-                'The attack cannot proceed as the attacker or defender is no longer in play'
-            );
+        Contract.assertTrue(properties.attacker.isUnit());
+        if (!properties.attacker.isInPlay() || !EnumHelpers.isAttackableLocation(target.location)) {
+            context.game.addMessage('The attack cannot proceed as the attacker or defender is no longer in play');
             return;
         }
 
@@ -101,7 +98,7 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         Contract.assertNotNullLike(properties.attacker);
         Contract.assertTrue(properties.attacker.isUnit());
 
-        if (!EnumHelpers.isArena(properties.attacker.location)) {
+        if (!properties.attacker.isInPlay()) {
             return false;
         }
         if (!super.canAffect(targetCard, context)) {

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -39,7 +39,7 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext> 
     }
 
     public override canAffect(card: Card, context: TContext): boolean {
-        if (!EnumHelpers.isArena(card.location)) {
+        if (!card.canBeInPlay() || !card.isInPlay()) {
             return false;
         }
         return super.canAffect(card, context);

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -21,7 +21,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         const properties = this.generatePropertiesFromContext(event.context);
 
         Contract.assertTrue(cardReceivingTokenUpgrade.isUnit());
-        Contract.assertTrue(EnumHelpers.isArena(cardReceivingTokenUpgrade.location));
+        Contract.assertTrue(cardReceivingTokenUpgrade.isInPlay());
 
         for (let i = 0; i < properties.amount; i++) {
             const tokenUpgrade = event.context.game.generateToken(event.context.source.controller, properties.tokenType);
@@ -47,7 +47,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
 
         if (
             !card.isUnit() ||
-            !EnumHelpers.isArena(card.location) ||
+            !card.isInPlay() ||
             properties.amount === 0
         ) {
             return false;

--- a/server/game/gameSystems/PutIntoPlaySystem.ts
+++ b/server/game/gameSystems/PutIntoPlaySystem.ts
@@ -55,10 +55,10 @@ export class PutIntoPlaySystem<TContext extends AbilityContext = AbilityContext>
         const contextCopy = context.copy({ source: card });
         const player = this.getPutIntoPlayPlayer(contextCopy);
 
-        if (!context || !super.canAffect(card, context)) {
+        if (!super.canAffect(card, context)) {
             return false;
         // TODO SMUGGLE: impl here
-        } else if (EnumHelpers.isArena(card.location) || card.facedown) {
+        } else if (!card.canBeInPlay() || card.isInPlay() || card.facedown) {
             return false;
         } else if (card.hasRestriction(AbilityRestriction.EnterPlay, context)) {
             return false;

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -466,11 +466,6 @@ class PlayerInteractionWrapper {
         // this.checkUnserializableGameState();
     }
 
-    passAction() {
-        this.clickPrompt('Pass');
-    }
-
-
     clickPromptButtonIndex(index) {
         var currentPrompt = this.player.currentPrompt();
 
@@ -608,7 +603,7 @@ class PlayerInteractionWrapper {
     /**
      * Player's action of passing priority
      */
-    pass() {
+    passAction() {
         if (!this.canAct) {
             throw new TestSetupError(`${this.name} can't pass, because they don't have priority`);
         }

--- a/test/server/cards/01_SOR/events/KeepFighting.spec.js
+++ b/test/server/cards/01_SOR/events/KeepFighting.spec.js
@@ -26,7 +26,7 @@ describe('Keep Fighting', function () {
                 this.player1.clickCard(this.pykeSentinel);
                 expect(this.pykeSentinel.exhausted).toBeFalse();
                 expect(this.keepFighting.location).toBe('discard');
-                this.player2.pass();
+                this.player2.passAction();
 
                 // attack again with pyke sentinel
                 this.player1.clickCard(this.pykeSentinel);
@@ -43,7 +43,7 @@ describe('Keep Fighting', function () {
                 this.player1.clickCard(this.pykeSentinel);
                 expect(this.pykeSentinel.exhausted).toBeFalse();
                 expect(this.keepFighting.location).toBe('discard');
-                this.player2.pass();
+                this.player2.passAction();
 
                 // attack again with pyke sentinel
                 this.player1.clickCard(this.pykeSentinel);

--- a/test/server/cards/01_SOR/leaders/DarthVaderDarkLordOfTheSith.spec.js
+++ b/test/server/cards/01_SOR/leaders/DarthVaderDarkLordOfTheSith.spec.js
@@ -32,9 +32,9 @@ describe('Darth Vader, Dark Lord of the Sith', function() {
 
                 // play a villainy card
                 this.darthVader.exhausted = false;
-                this.player2.pass();
+                this.player2.passAction();
                 this.player1.clickCard(this.tielnFighter);
-                this.player2.pass();
+                this.player2.passAction();
 
                 // use ability with effect
                 exhaustedResourcesBeforeAbilityUsed = this.player1.countExhaustedResources();

--- a/test/server/cards/01_SOR/units/GamorreanGuards.spec.js
+++ b/test/server/cards/01_SOR/units/GamorreanGuards.spec.js
@@ -15,7 +15,7 @@ describe('Gamorrean Guards', function() {
             });
 
             it('should give it sentinel while he has a Cunning ally', function () {
-                this.player1.pass();
+                this.player1.passAction();
                 this.player2.clickCard(this.wampa);
                 this.player2.clickCard(this.p1Base);
                 expect(this.p1Base.damage).toBe(4);

--- a/test/server/cards/01_SOR/units/GladiatorStarDestroyer.spec.js
+++ b/test/server/cards/01_SOR/units/GladiatorStarDestroyer.spec.js
@@ -29,7 +29,7 @@ describe('Gladiator Star Destroyer', function() {
                 this.moveToNextActionPhase();
 
                 // should no longer have sentinel
-                this.player1.pass();
+                this.player1.passAction();
                 this.player2.clickCard(this.wampa);
                 expect(this.player2).toBeAbleToSelectExactly([this.directorKrennic, this.p1Base]);
             });

--- a/test/server/cards/01_SOR/units/GuerillaAttackPod.spec.js
+++ b/test/server/cards/01_SOR/units/GuerillaAttackPod.spec.js
@@ -26,14 +26,14 @@ describe('Guerilla Attack Pod', function () {
                 this.player1.clickCard(this.battlefieldMarine);
                 this.player1.clickCard(this.p2Base);
                 expect(this.p2Base.damage).toBe(17);
-                this.player2.pass();
+                this.player2.passAction();
                 this.player1.clickCard(this.guerillaAttackPod);
                 expect(this.guerillaAttackPod.exhausted).toBeFalse();
             });
 
             it('should be ready if p1 base have more than 15 damage', function () {
                 // attack with rugged survivors to trigger guerilla attack pod
-                this.player1.pass();
+                this.player1.passAction();
                 this.player2.clickCard(this.ruggedSurvivors);
                 this.player2.clickCard(this.p1Base);
                 expect(this.p1Base.damage).toBe(17);

--- a/test/server/cards/01_SOR/units/HomesteadMilitia.spec.js
+++ b/test/server/cards/01_SOR/units/HomesteadMilitia.spec.js
@@ -16,7 +16,7 @@ describe('Homestead Militia', function () {
             });
 
             it('should not gain Sentinel with 6 or more resources', function () {
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.cargoJuggernaut);
                 // no sentinel, I can attack base
@@ -25,7 +25,7 @@ describe('Homestead Militia', function () {
                 expect(this.p1Base.damage).toBe(4);
 
                 this.player1.moveCard(this.wampa, 'resource');
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.ruggedSurvivors);
                 // homestead militia automatically selected because of Sentinel
@@ -34,7 +34,7 @@ describe('Homestead Militia', function () {
 
                 // remove resource and check if homestead militia lost sentinel
                 this.player1.moveCard(this.wampa, 'hand', 'resource');
-                this.player1.pass();
+                this.player1.passAction();
                 this.player2.clickCard(this.atst);
                 expect(this.player2).toBeAbleToSelectExactly([this.p1Base, this.homesteadMilitia]);
                 this.player2.clickCard(this.p1Base);

--- a/test/server/cards/01_SOR/units/PartisanInsurgent.spec.js
+++ b/test/server/cards/01_SOR/units/PartisanInsurgent.spec.js
@@ -29,7 +29,7 @@ describe('Partisan Insurgent', function () {
                 // attack again with partisan insurgent, damage should be 1 because a-wing is dead
                 this.player1.clickCard(this.keepFighting);
                 this.player1.clickCard(this.partisanInsurgent);
-                this.player2.pass();
+                this.player2.passAction();
                 this.player1.clickCard(this.partisanInsurgent);
                 expect(this.p2Base.damage).toBe(4);
             });

--- a/test/server/cards/01_SOR/units/RedThreeUnstoppable.spec.js
+++ b/test/server/cards/01_SOR/units/RedThreeUnstoppable.spec.js
@@ -21,7 +21,7 @@ describe('Red Three', function () {
                 expect(this.p2Base.damage).toBe(4);
 
                 // should not give Raid 1 to non-heroism unit
-                this.player2.pass();
+                this.player2.passAction();
                 this.p2Base.damage = 0;
                 this.player1.clickCard(this.deathTrooper);
                 expect(this.player1).toBeAbleToSelectExactly([this.p2Base, this.ruggedSurvivors, this.cargoJuggernaut]);
@@ -29,7 +29,7 @@ describe('Red Three', function () {
                 expect(this.p2Base.damage).toBe(3);
 
                 // should give Raid 1 cumulative with other Raid values
-                this.player2.pass();
+                this.player2.passAction();
                 this.p2Base.damage = 0;
                 this.player1.clickCard(this.greenSquadronAwing);
                 expect(this.p2Base.damage).toBe(4);

--- a/test/server/cards/01_SOR/units/RelentlessKonstantinesFolly.spec.js
+++ b/test/server/cards/01_SOR/units/RelentlessKonstantinesFolly.spec.js
@@ -24,7 +24,7 @@ describe('Relentless, Konstantine\'s Folly', function() {
                 expect(this.relentless).toBeInLocation('space arena');
                 expect(this.vanquish).toBeInLocation('discard');
 
-                this.player1.pass();
+                this.player1.passAction();
 
                 // play a second event, with effect
                 exhaustedResourcesBeforeCardPlay = this.player2.countExhaustedResources();
@@ -35,7 +35,7 @@ describe('Relentless, Konstantine\'s Folly', function() {
 
                 // next round, it should nullify the first event played again
                 this.moveToNextActionPhase();
-                this.player1.pass();
+                this.player1.passAction();
                 exhaustedResourcesBeforeCardPlay = this.player2.countExhaustedResources();
                 this.player2.clickCard(this.momentOfPeace);
                 expect(this.player2.countExhaustedResources()).toBe(exhaustedResourcesBeforeCardPlay + 1);
@@ -43,7 +43,7 @@ describe('Relentless, Konstantine\'s Folly', function() {
             });
 
             it('should not nullify a second or later event even if Relentless was played after the first event', function () {
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.repair);
                 this.player2.clickCard(this.p2Base);
@@ -59,7 +59,7 @@ describe('Relentless, Konstantine\'s Folly', function() {
             it('should not nullify an event played by its controller', function () {
                 this.player1.clickCard(this.relentless);
 
-                this.player2.pass();
+                this.player2.passAction();
 
                 this.player1.clickCard(this.daringRaid);
                 expect(this.player1).toBeAbleToSelectExactly([this.p1Base, this.p2Base, this.relentless]);

--- a/test/server/cards/01_SOR/units/SeasonedShoretrooper.spec.js
+++ b/test/server/cards/01_SOR/units/SeasonedShoretrooper.spec.js
@@ -42,7 +42,7 @@ describe('Seasoned Shoretrooper', function () {
                 this.p2Base.damage = 0;
                 this.seasonedShoretrooper.exhausted = false;
                 this.player1.moveCard(this.battlefieldMarine, 'resource');
-                this.player2.pass();
+                this.player2.passAction();
                 expect(this.player1.resources.length).toBe(7);
                 expect(this.seasonedShoretrooper.getPower()).toBe(4);
                 expect(this.seasonedShoretrooper.getHp()).toBe(3);
@@ -57,7 +57,7 @@ describe('Seasoned Shoretrooper', function () {
                 // remove 2 resources : seasoned shoretrooper lost its buff
                 this.player1.moveCard(this.battlefieldMarine, 'hand', 'resource');
                 this.player1.moveCard(this.wampa, 'hand', 'resource');
-                this.player2.pass();
+                this.player2.passAction();
                 expect(this.player1.resources.length).toBe(5);
                 expect(this.seasonedShoretrooper.getPower()).toBe(2);
                 expect(this.seasonedShoretrooper.getHp()).toBe(3);

--- a/test/server/cards/01_SOR/units/SteadfastBattalion.spec.js
+++ b/test/server/cards/01_SOR/units/SteadfastBattalion.spec.js
@@ -17,7 +17,7 @@ describe('Steadfast Battalion', function () {
                 this.player1.clickCard(this.battlefieldMarine);
                 expect(this.battlefieldMarine.getPower()).toBe(5);
 
-                this.player2.pass();
+                this.player2.passAction();
                 this.player1.clickCard(this.battlefieldMarine);
                 // steadfast battalion: 5 + battlefieldMarine: 3+2 = 10
                 expect(this.p2Base.damage).toBe(10);
@@ -39,7 +39,7 @@ describe('Steadfast Battalion', function () {
                 this.player1.clickCard(this.steadfastBattalion);
                 expect(this.battlefieldMarine.getPower()).toBe(3);
 
-                this.player2.pass();
+                this.player2.passAction();
                 this.player1.clickCard(this.battlefieldMarine);
                 // steadfast battalion: 5 + battlefieldMarine: 3 = 8
                 expect(this.p2Base.damage).toBe(8);

--- a/test/server/cards/01_SOR/units/VigilantHonorGuards.spec.js
+++ b/test/server/cards/01_SOR/units/VigilantHonorGuards.spec.js
@@ -21,7 +21,7 @@ describe('Vigilant Honor Guards', function() {
                 expect(this.vigilantHonorGuards.damage).toBe(3);
                 expect(this.consularSecurityForce.damage).toBe(4);
 
-                this.player2.pass();
+                this.player2.passAction();
                 this.consularSecurityForce.exhausted = false;
 
                 this.player1.clickCard(this.consularSecurityForce);

--- a/test/server/cards/02_SHD/events/FellTheDragon.spec.js
+++ b/test/server/cards/02_SHD/events/FellTheDragon.spec.js
@@ -16,7 +16,7 @@ describe('Fell the Dragon', function() {
                 });
             });
 
-            it('should defeat a enemy', function () {
+            it('should defeat an enemy', function () {
                 this.player1.clickCard(this.fellTheDragon);
                 expect(this.player1).toBeAbleToSelectExactly([this.avenger, this.atst, this.scoutBikePursuer]);
 

--- a/test/server/cards/02_SHD/units/ProtectorOfTheThrone.spec.js
+++ b/test/server/cards/02_SHD/units/ProtectorOfTheThrone.spec.js
@@ -14,7 +14,7 @@ describe('Protector of the Throne', function() {
             });
 
             it('should give it sentinel only as long as it is upgraded', function () {
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.wampa);
                 // Protector of the Throne automatically selected due to sentinel
@@ -25,7 +25,7 @@ describe('Protector of the Throne', function() {
                 expect(this.protectorOfTheThrone.isUpgraded()).toBe(false);
                 expect(this.wampa.damage).toBe(2);
 
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.jedhaAgitator);
 

--- a/test/server/cards/02_SHD/units/SupercommandoSquad.spec.js
+++ b/test/server/cards/02_SHD/units/SupercommandoSquad.spec.js
@@ -14,7 +14,7 @@ describe('Supercommando Squad', function() {
             });
 
             it('should give it sentinel only as long as it is upgraded', function () {
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.wampa);
                 // Supercommando Squad automatically selected due to sentinel
@@ -25,7 +25,7 @@ describe('Supercommando Squad', function() {
                 expect(this.supercommandoSquad.isUpgraded()).toBe(false);
                 expect(this.wampa.damage).toBe(4);
 
-                this.player1.pass();
+                this.player1.passAction();
 
                 this.player2.clickCard(this.jedhaAgitator);
 

--- a/test/server/cards/02_SHD/upgrades/Foundling.spec.js
+++ b/test/server/cards/02_SHD/upgrades/Foundling.spec.js
@@ -29,7 +29,7 @@ describe('Foundling\'s', function () {
                 expect(this.battlefieldMarine.hasSomeTrait(Trait.Mandalorian)).toBeTrue();
                 expect(this.pykeSentinel.hasSomeTrait(Trait.Mandalorian)).toBeFalse();
 
-                this.player2.pass();
+                this.player2.passAction();
                 // mandalorian warrior should be able to add experience to battlefield marine
                 this.player1.clickCard(this.mandalorianWarrior);
                 expect(this.player1).toBeAbleToSelectExactly([this.battlefieldMarine, this.protectorOfTheThrone]);


### PR DESCRIPTION
Some bug fixes and improvements to make writing cards easier:

- We had both `pass()` and `passAction()` available for tests, standardized on the name of the latter with the behavior of the former
- Added the helper methods `canBeInPlay()` and `isInPlay()` to make testing for cards being in play much simpler
- Fixed the bug where "Underworld Thug" would appear in the selection prompt sometimes for a player who was waiting on the other player
- Added a guard so that github actions will not fire on draft PRs