### PR TITLE
Better logic for defeat and simultaneous effects

### DIFF
--- a/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
@@ -16,9 +16,9 @@ export default class FallenLightsaber extends UpgradeCard {
 
         this.addGainOnAttackAbilityTargetingAttached({
             title: 'Deal 1 damage to each ground unit the defending player controls',
-            immediateEffect: AbilityHelper.immediateEffects.damage((context) => {
-                return { target: context.source.controller.opponent.getUnitsInPlay(Location.GroundArena), amount: 1 };
-            }),
+            immediateEffect: AbilityHelper.immediateEffects.damage((context) =>
+                ({ target: context.source.controller.opponent.getUnitsInPlay(Location.GroundArena), amount: 1 })
+            ),
             gainCondition: (context) => context.source.parentCard?.hasSomeTrait(Trait.Force)
         });
     }

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -909,7 +909,7 @@ class Player extends GameObject {
             return;
         }
 
-        this.game.addSubwindowEvents(GameSystems.defeat().generateEvent(card, this.game.getFrameworkContext()));
+        this.game.addSubwindowEvents(GameSystems.defeat({ target: card }).generateEvent(card, this.game.getFrameworkContext()));
     }
 
     /**

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -58,7 +58,6 @@ export class PlayableOrDeployableCard extends Card {
         return true;
     }
 
-
     protected setExhaustEnabled(enabledStatus: boolean) {
         this._exhausted = enabledStatus ? true : null;
     }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -41,7 +41,14 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         private _attackKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
         private _whenPlayedKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
-        private defeatEventEmitted = false;
+
+        /** If true, then this unit has taken sufficient damage to be defeated but not yet been removed from the field */
+        private _pendingDefeat? = null;
+
+        public get pendingDefeat() {
+            this.assertPropertyEnabled(this._pendingDefeat, 'pendingDefeat');
+            return this._pendingDefeat;
+        }
 
         public get upgrades(): UpgradeCard[] {
             this.assertPropertyEnabled(this._upgrades, 'upgrades');
@@ -94,6 +101,15 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         public override isUnit(): this is UnitCard {
             return true;
+        }
+
+        protected setUpgradesEnabled(enabledStatus: boolean) {
+            this._upgrades = enabledStatus ? [] : null;
+        }
+
+        protected override setDamageEnabled(enabledStatus: boolean): void {
+            super.setDamageEnabled(enabledStatus);
+            this._pendingDefeat = enabledStatus ? false : null;
         }
 
         // ***************************************** ATTACK HELPERS *****************************************
@@ -265,9 +281,9 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         // ***************************************** STAT HELPERS *****************************************
         public checkDefeated() {
-            if (this.damage >= this.getHp() && !this.defeatEventEmitted) {
+            if (this.damage >= this.getHp() && !this._pendingDefeat) {
                 this.owner.defeatCard(this);
-                this.defeatEventEmitted = true;
+                this._pendingDefeat = true;
             }
         }
 
@@ -361,10 +377,6 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             // }
 
             super.leavesPlay();
-        }
-
-        protected setUpgradesEnabled(enabledStatus: boolean) {
-            this._upgrades = enabledStatus ? [] : null;
         }
     };
 }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -280,6 +280,12 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         }
 
         // ***************************************** STAT HELPERS *****************************************
+        public override addDamage(amount: number): void {
+            super.addDamage(amount);
+
+            this.checkDefeated();
+        }
+
         public checkDefeated() {
             if (this.damage >= this.getHp() && !this._pendingDefeat) {
                 this.owner.defeatCard(this);

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -124,6 +124,16 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
         return this.canAffect(event.card, event.context, additionalProperties);
     }
 
+    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+        // if a unit is pending defeat (damage >= hp but defeat not yet resolved), always return canAffect() = false unless
+        // we're the system that is enacting the defeat
+        if (card.isUnit() && card.isInPlay() && card.pendingDefeat && !this.isPendingDefeatFor(card, context)) {
+            return false;
+        }
+
+        return super.canAffect(card, context, additionalProperties);
+    }
+
     protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties = {}): void {
         super.addPropertiesToEvent(event, card, context, additionalProperties);
         event.card = card;
@@ -176,6 +186,11 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
         //         );
         //     }
         // };
+    }
+
+    /** Returns true if this system is enacting the pending defeat (i.e., delayed defeat from damage) for the specified card */
+    protected isPendingDefeatFor(card: Card, context: TContext) {
+        return false;
     }
 
     /**

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -39,10 +39,27 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext> 
     }
 
     public override canAffect(card: Card, context: TContext): boolean {
-        if (!card.canBeInPlay() || !card.isInPlay()) {
+        if (
+            card.location !== Location.Resource &&
+            (!card.canBeInPlay() || !card.isInPlay())
+        ) {
             return false;
         }
         return super.canAffect(card, context);
+    }
+
+    /** Returns true if this system is enacting the pending defeat (i.e., delayed defeat from damage) for the specified card */
+    protected override isPendingDefeatFor(card: Card, context: TContext) {
+        const { target } = this.generatePropertiesFromContext(context);
+
+        if (Array.isArray(target)) {
+            if (target.length === 1) {
+                return target[0] === card;
+            }
+            return false;
+        }
+
+        return target === card;
     }
 
     protected override updateEvent(event, card: Card, context: TContext, additionalProperties): void {

--- a/test/server/cards/01_SOR/units/GeneralVeersBlizzardForceCommander.spec.js
+++ b/test/server/cards/01_SOR/units/GeneralVeersBlizzardForceCommander.spec.js
@@ -50,7 +50,7 @@ describe('General Veers, Blizzard Force Commander', function() {
                 // Correctly apply buffs to attacks
                 this.player1.clickCard(this.tieAdvanced);
                 this.player1.clickCard(this.relentless);
-                expect(this.tieAdvanced.defeatEventEmitted).toBe(true);
+                expect(this.tieAdvanced).toBeInLocation('discard');
                 expect(this.relentless.damage).toBe(4);
             });
         });


### PR DESCRIPTION
We had a potential issue with timing where if a unit was targeted with multiple simultaneous effects, the first of which was a damage effect that defeated the unit, the other effects would still successfully activate even though the unit is supposed to have technically entered a defeated state.

Not sure yet if there is a specific case where this impacts game behavior, but wanted to get the change in now to catch potential edge cases when they do come up.