### PR TITLE
Fix windows so that "gain ambush" and "gain shielded" work correctly

### DIFF
--- a/scripts/build-test.js
+++ b/scripts/build-test.js
@@ -27,5 +27,5 @@ if (!buildAll) {
     // Backup if concurrently breaks anything.
     runCommand('tsc -p tsconfig.testserver.json && tsc -p tsconfig.test.json && cpy ./test/json/ ./build/');
     */
-    runCommand('concurrently "tsc -p ./test/tsconfig.json" "cpy ./test/json/ ./build/"');
+    runCommand('concurrently "tsc" "tsc -p ./test/tsconfig.json" "cpy ./test/json/ ./build/"');
 }

--- a/server/game/abilities/keyword/AmbushAbility.ts
+++ b/server/game/abilities/keyword/AmbushAbility.ts
@@ -4,7 +4,7 @@ import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { TriggeredAbilityContext } from '../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../core/card/Card';
 import { UnitCard } from '../../core/card/CardTypes';
-import { EventName, KeywordName } from '../../core/Constants';
+import { KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
 import * as Contract from '../../core/utils/Contract';
 import { ITriggeredAbilityProps } from '../../Interfaces';

--- a/server/game/abilities/keyword/AmbushAbility.ts
+++ b/server/game/abilities/keyword/AmbushAbility.ts
@@ -4,7 +4,7 @@ import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import { TriggeredAbilityContext } from '../../core/ability/TriggeredAbilityContext';
 import { Card } from '../../core/card/Card';
 import { UnitCard } from '../../core/card/CardTypes';
-import { KeywordName } from '../../core/Constants';
+import { EventName, KeywordName } from '../../core/Constants';
 import Game from '../../core/Game';
 import * as Contract from '../../core/utils/Contract';
 import { ITriggeredAbilityProps } from '../../Interfaces';

--- a/server/game/actions/PlayUnitAction.ts
+++ b/server/game/actions/PlayUnitAction.ts
@@ -31,7 +31,6 @@ export class PlayUnitAction extends PlayCardAction {
         );
         const effect = context.source.getOngoingEffectValues(EffectName.EntersPlayForOpponent);
         const player = effect.length > 0 ? RelativePlayer.Opponent : RelativePlayer.Self;
-        context.source.registerWhenPlayedKeywords();
 
         const events = [
             putIntoPlay({ controller: player }).generateEvent(context.source, context),

--- a/server/game/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.ts
+++ b/server/game/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.ts
@@ -1,0 +1,23 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Aspect, KeywordName, RelativePlayer, WildcardCardType, WildcardLocation } from '../../../core/Constants';
+
+export default class AdmiralPiettCaptainOfTheExecutor extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '4566580942',
+            internalName: 'admiral-piett#captain-of-the-executor',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addConstantAbility({
+            title: 'Each friendly non-leader unit that costs 6 or more gains Ambush',
+            targetController: RelativePlayer.Self,
+            matchTarget: (card) => card.isNonLeaderUnit() && card.cost >= 6,
+            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
+        });
+    }
+}
+
+AdmiralPiettCaptainOfTheExecutor.implemented = true;

--- a/server/game/cards/02_SHD/units/PrivateerScyk.ts
+++ b/server/game/cards/02_SHD/units/PrivateerScyk.ts
@@ -1,0 +1,23 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Aspect, KeywordName, WildcardLocation } from '../../../core/Constants';
+
+export default class PrivateerScyk extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '0088477218',
+            internalName: 'privateer-scyk',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addConstantAbility({
+            title: 'While you control another Cunning unit, this unit gains Shielded',
+            condition: (context) => context.source.controller.getOtherUnitsInPlayWithAspect(context.source, Aspect.Cunning).length > 0,
+            matchTarget: (card, context) => card === context.source,
+            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Shielded)
+        });
+    }
+}
+
+PrivateerScyk.implemented = true;

--- a/server/game/cards/02_SHD/units/PrivateerScyk.ts
+++ b/server/game/cards/02_SHD/units/PrivateerScyk.ts
@@ -13,7 +13,7 @@ export default class PrivateerScyk extends NonLeaderUnitCard {
     public override setupCardAbilities () {
         this.addConstantAbility({
             title: 'While you control another Cunning unit, this unit gains Shielded',
-            condition: (context) => context.source.controller.getOtherUnitsInPlayWithAspect(context.source, Aspect.Cunning).length > 0,
+            condition: (context) => context.source.controller.isAspectInPlay(Aspect.Cunning, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Shielded)
         });

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -209,7 +209,7 @@ class Game extends EventEmitter {
     }
 
     registerGlobalRulesListeners() {
-        UnitPropertiesCard.registerRuleListener(this);
+        UnitPropertiesCard.registerRulesListeners(this);
     }
 
     /**

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -35,7 +35,6 @@ const { default: Shield } = require('../cards/01_SOR/tokens/Shield.js');
 const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
 const { DistributeAmongTargetsPrompt } = require('./gameSteps/prompts/DistributeAmongTargetsPrompt.js');
 const HandlerMenuMultipleSelectionPrompt = require('./gameSteps/prompts/HandlerMenuMultipleSelectionPrompt.js');
-const { AmbushAbility } = require('../abilities/keyword/AmbushAbility.js');
 const { UnitPropertiesCard } = require('./card/propertyMixins/UnitProperties.js');
 
 class Game extends EventEmitter {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -35,6 +35,8 @@ const { default: Shield } = require('../cards/01_SOR/tokens/Shield.js');
 const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
 const { DistributeAmongTargetsPrompt } = require('./gameSteps/prompts/DistributeAmongTargetsPrompt.js');
 const HandlerMenuMultipleSelectionPrompt = require('./gameSteps/prompts/HandlerMenuMultipleSelectionPrompt.js');
+const { AmbushAbility } = require('../abilities/keyword/AmbushAbility.js');
+const { UnitPropertiesCard } = require('./card/propertyMixins/UnitProperties.js');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -70,6 +72,8 @@ class Game extends EventEmitter {
         this.actionPhaseActivePlayer = null;
         this.tokenFactories = null;
         this.stateWatcherRegistrar = new StateWatcherRegistrar(this);
+
+        this.registerGlobalRulesListeners();
 
         this.shortCardData = options.shortCardData || [];
 
@@ -202,6 +206,10 @@ class Game extends EventEmitter {
         });
 
         return otherPlayer;
+    }
+
+    registerGlobalRulesListeners() {
+        UnitPropertiesCard.registerRuleListener(this);
     }
 
     /**

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -32,7 +32,6 @@ export class AttackFlow extends BaseStepWithPipeline {
     }
 
     private declareAttack() {
-        this.attack.attacker.registerAttackKeywords();
         this.attack.attacker.setActiveAttack(this.attack);
         this.attack.target.setActiveAttack(this.attack);
 
@@ -121,12 +120,6 @@ export class AttackFlow extends BaseStepWithPipeline {
     private completeAttack() {
         this.game.createEventAndOpenWindow(EventName.OnAttackCompleted, {
             attack: this.attack,
-            handler: () => {
-                // only unregister if the attacker hasn't been moved out of the play area (e.g. defeated)
-                if (this.attack.isAttackerInPlay()) {
-                    this.attack.attacker.unregisterAttackKeywords();
-                }
-            }
         }, true);
     }
 

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -190,7 +190,7 @@ class EventWindow extends BaseStepWithPipeline {
 
     cleanup() {
         for (const event of this.emittedEvents) {
-            this.game.emit(event.name + ':cleanup', event);
+            event.cleanup();
         }
 
         if (this.previousEventWindow) {

--- a/server/game/core/event/GameEvent.ts
+++ b/server/game/core/event/GameEvent.ts
@@ -16,6 +16,7 @@ export class GameEvent {
     public preResolutionEffect = () => true;
 
     private contingentEventsGenerator?: () => any[] = null;
+    private cleanupHandlers: (() => void)[] = [];
 
     public constructor(
         public name: string,
@@ -83,5 +84,15 @@ export class GameEvent {
 
     public generateContingentEvents(): any[] {
         return this.contingentEventsGenerator ? this.contingentEventsGenerator() : [];
+    }
+
+    public addCleanupHandler(handler) {
+        this.cleanupHandlers.push(handler);
+    }
+
+    public cleanup() {
+        for (const handler of this.cleanupHandlers) {
+            handler();
+        }
     }
 }

--- a/server/game/core/gameSteps/abilityWindow/InitiateAbilityEventWindow.js
+++ b/server/game/core/gameSteps/abilityWindow/InitiateAbilityEventWindow.js
@@ -61,7 +61,7 @@ class InitiateAbilityEventWindow extends EventWindow {
     // }
 
     /** @override */
-    executeHandler() {
+    executeHandlersEmitEvents() {
         this.eventsToExecute = this.events.sort((event) => event.order);
 
         // we emit triggered abilities here to ensure that they get triggered in case e.g. a card is defeated during event resolution

--- a/server/game/core/gameSteps/abilityWindow/TriggeredAbilityWindow.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggeredAbilityWindow.ts
@@ -23,7 +23,7 @@ export class TriggeredAbilityWindow extends BaseStep {
     private resolvePlayerOrder?: Player[] = null;
 
     /** The events that were triggered as part of this window */
-    private triggeringEvents: GameEvent[];
+    private triggeringEvents: GameEvent[] = [];
 
     private choosePlayerResolutionOrderComplete = false;
     private readonly toStringName: string;
@@ -47,12 +47,21 @@ export class TriggeredAbilityWindow extends BaseStep {
         this.triggeringEvents = [...this.eventWindow.events];
     }
 
-    public emitEvents(newEvents: GameEvent[] = []) {
-        this.triggeringEvents.push(...newEvents);
+    public addTriggeringEvents(newEvents: GameEvent[] = []) {
+        for (const event of newEvents) {
+            if (!this.triggeringEvents.includes(event)) {
+                this.triggeringEvents.push(event);
+            }
+        }
+    }
+
+    public emitEvents() {
         const events = this.triggeringEvents.filter((event) => !this.eventsToExclude.includes(event) && !event.cancelled);
-        events.forEach((event) => {
+
+        for (const event of events) {
             this.game.emit(event.name + ':' + this.triggerAbilityType, event, this);
-        });
+        }
+
         this.game.emit('aggregateEvent:' + this.triggerAbilityType, events, this);
     }
 

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -220,6 +220,11 @@ class PlayerInteractionWrapper {
                 throw new TestSetupError('You must provide a card name');
             }
             var card = this.findCardByName(options.card, prevLocations);
+
+            if (card.isUnit() && card.defaultArena !== arenaName) {
+                throw new TestSetupError(`Attempting to place ${card.internalName} in invalid arena '${arenaName}'`);
+            }
+
             // Move card to play
             this.moveCard(card, arenaName);
             // Set exhausted state (false by default)

--- a/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
+++ b/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
@@ -5,20 +5,53 @@ describe('Admiral Piett, Captain of the Executor\'s Folly', function() {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['relentless#konstantines-folly'],
-                        groundArena: ['admiral-piett#captain-of-the-executor']
+                        hand: ['relentless#konstantines-folly', 'battlefield-marine', 'clan-saxon-gauntlet'],
+                        groundArena: ['admiral-piett#captain-of-the-executor'],
+                        leader: 'hera-syndulla#spectre-two',
+                        resources: 30
                     },
                     player2: {
-                        spaceArena: ['redemption#medical-frigate']
+                        groundArena: ['wampa'],
+                        spaceArena: ['redemption#medical-frigate'],
+                        hand: ['atst']
                     }
                 });
             });
 
-            it('should nullify the effects of the first event the opponent plays each round', function () {
+            it('should give Ambush to friendly non-leader units with cost 6 or greater', function () {
                 const { context } = contextRef;
 
+                // CASE 1: friendly non-leader unit cost >= 6, gains Ambush
                 context.player1.clickCard(context.relentless);
                 expect(context.player1).toHaveExactPromptButtons(['Ambush', 'Pass']);
+                context.player1.clickPrompt('Ambush');
+                expect(context.relentless.exhausted).toBeTrue();
+                expect(context.relentless.damage).toBe(6);
+                expect(context.redemption.damage).toBe(8);
+
+                // CASE 2: enemy non-leader unit cost >= 6, does not gain Ambush
+                context.player2.clickCard(context.atst);
+                expect(context.player1).toBeActivePlayer();
+                expect(context.atst).toBeInLocation('ground arena');
+
+                // CASE 3: friendly non-leader unit cost < 6, does not gain Ambush
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.player2).toBeActivePlayer();
+                expect(context.battlefieldMarine).toBeInLocation('ground arena');
+
+                context.player2.passAction();
+
+                // CASE 4: friendly leader unit cost >= 6, does not gain Ambush
+                context.player1.clickCard(context.heraSyndulla);
+                expect(context.player2).toBeActivePlayer();
+                expect(context.heraSyndulla).toBeInLocation('ground arena');
+
+                // CASE 5: Piett is defeated, effect goes away
+                context.player2.clickCard(context.wampa);
+                context.player2.clickCard(context.admiralPiett);
+                context.player1.clickCard(context.clanSaxonGauntlet);
+                expect(context.player2).toBeActivePlayer();
+                expect(context.clanSaxonGauntlet.damage).toBe(0);
             });
         });
     });

--- a/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
+++ b/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
@@ -1,0 +1,25 @@
+describe('Admiral Piett, Captain of the Executor\'s Folly', function() {
+    integration(function(contextRef) {
+        describe('Admiral Piett\'s ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['relentless#konstantines-folly'],
+                        groundArena: ['admiral-piett#captain-of-the-executor']
+                    },
+                    player2: {
+                        spaceArena: ['redemption#medical-frigate']
+                    }
+                });
+            });
+
+            it('should nullify the effects of the first event the opponent plays each round', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.relentless);
+                expect(context.player1).toHaveExactPromptButtons(['Ambush', 'Pass']);
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/units/DelMeekoProvidingOverwatch.spec.ts
+++ b/test/server/cards/01_SOR/units/DelMeekoProvidingOverwatch.spec.ts
@@ -11,7 +11,6 @@ describe('Del Meeko, Providing Overwatch', function() {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                        spaceArena: ['grogu#irresistible'],
                         hand: ['daring-raid', 'repair'],
                         leader: 'director-krennic#aspiring-to-authority',
                         base: 'kestro-city'

--- a/test/server/cards/01_SOR/units/TieAdvanced.spec.ts
+++ b/test/server/cards/01_SOR/units/TieAdvanced.spec.ts
@@ -6,7 +6,8 @@ describe('Tie Avanced', function() {
                     phase: 'action',
                     player1: {
                         hand: ['tie-advanced'],
-                        groundArena: ['wampa', 'atst', { card: 'tieln-fighter', upgrades: ['experience'] }],
+                        groundArena: ['wampa', 'atst'],
+                        spaceArena: [{ card: 'tieln-fighter', upgrades: ['experience'] }]
                     },
                     player2: {
                         spaceArena: ['cartel-spacer']

--- a/test/server/cards/02_SHD/events/FellTheDragon.spec.ts
+++ b/test/server/cards/02_SHD/events/FellTheDragon.spec.ts
@@ -6,7 +6,8 @@ describe('Fell the Dragon', function() {
                     phase: 'action',
                     player1: {
                         hand: ['fell-the-dragon'],
-                        groundArena: ['pyke-sentinel', { card: 'scout-bike-pursuer', upgrades: ['academy-training'], damage: 4 }, 'avenger#hunting-star-destroyer'],
+                        groundArena: ['pyke-sentinel', { card: 'scout-bike-pursuer', upgrades: ['academy-training'], damage: 4 }],
+                        spaceArena: ['avenger#hunting-star-destroyer']
                     },
                     player2: {
                         groundArena: ['atst', 'isb-agent'],

--- a/test/server/cards/02_SHD/units/PrivateerScyk.spec.ts
+++ b/test/server/cards/02_SHD/units/PrivateerScyk.spec.ts
@@ -1,0 +1,45 @@
+describe('Privateer Scyk', function() {
+    integration(function(contextRef) {
+        describe('Privateer Scyk\'s ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['privateer-scyk'],
+                        groundArena: ['gamorrean-guards'],
+                    },
+                    player2: {
+                    }
+                });
+            });
+
+            it('should give it shielded while there is a friendly Cunning unit', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.privateerScyk);
+                expect(context.privateerScyk).toHaveExactUpgradeNames(['shield']);
+            });
+        });
+
+        describe('Privateer Scyk\'s ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['privateer-scyk'],
+                    },
+                    player2: {
+                        groundArena: ['gamorrean-guards'],
+                    }
+                });
+            });
+
+            it('should not give it shielded while there is not a friendly Cunning unit', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.privateerScyk);
+                expect(context.privateerScyk.isUpgraded()).toBeFalse();
+            });
+        });
+    });
+});

--- a/test/server/core/ongoingEffects/CostAdjusters.spec.ts
+++ b/test/server/core/ongoingEffects/CostAdjusters.spec.ts
@@ -10,9 +10,6 @@ describe('Cost adjusters', function() {
                         leader: 'director-krennic#aspiring-to-authority'
                     },
                     player2: {
-                        groundArena: ['wampa'],
-                        spaceArena: ['grogu#irresistible'],
-                        hand: ['daring-raid', 'repair'],
                         leader: 'luke-skywalker#faithful-friend',
                         base: { card: 'kestro-city', damage: 5 },
                         resources: ['smugglers-aid', 'atst', 'atst', 'atst']


### PR DESCRIPTION
We had a bug where "gain ambush" and "gain shielded" would not work because units register those abilities when they move into the arena, but the effects that give them abilities resolve after they get to the arena.

Made a few changes to address this. The first is refactoring the event window so that we emit events again after a `resolveGameState` call so that any abilities gained during the event window resolution can successfully trigger.

The other change is refactoring how we handle triggered abilities for keywords. We previously would register keywords at a time point before the event actually resolves (e.g., registering when-played abilities when the unit enters the arena). However, it is possible that gain or lose ability effects can happen in between those two time points, so we need to evaluate whether the unit has the keyword exactly at resolution time.

To facilitate this, refactored how the triggering for keyword abilities happens - instead of pre-registering the abilities at an earlier point, we now check every unit that is played or declares an attack to determine if it has any relevant keywords when the attack / play is resolved, once it is past the point that any effects could add / remove keywords. This guarantees that we will always correctly determine the relevant set of keywords for the card.