### PR TITLE
Add unique rules

### DIFF
--- a/server/game/IDamageOrDefeatSource.ts
+++ b/server/game/IDamageOrDefeatSource.ts
@@ -2,38 +2,47 @@ import type { Attack } from './core/attack/Attack';
 import type { Card } from './core/card/Card';
 import type { UnitCard } from './core/card/CardTypes';
 import type Player from './core/Player';
-import type CardAbilityStep from './core/ability/CardAbilityStep';
+import PlayerOrCardAbility from './core/ability/PlayerOrCardAbility';
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file
 /* eslint @stylistic/lines-around-comment: off */
 
 // ********************************************** EXPORTED TYPES **********************************************
-export type IDamageOrDefeatSource = IDamagedOrDefeatedByAttack | IDamagedOrDefeatedByAbility;
+export type IDamageSource = IDamagedOrDefeatedByAttack | IDamagedOrDefeatedByAbility;
+export type IDefeatSource = IDamagedOrDefeatedByAttack | IDamagedOrDefeatedByAbility | IDefeatedByUniqueRule;
 
-/** Damage or defeat source that is not caused by a framework effect - e.g., Snoke hp effect */
-export type INonFrameworkDamageOrDefeatSource = IDamagedOrDefeatedByAttack | IDamagedOrDefeatedByAbility;
-
-export enum DamageOrDefeatSourceType {
+export enum DamageSourceType {
     Ability = 'ability',
     Attack = 'attack'
 }
 
+export enum DefeatSourceType {
+    Ability = 'ability',
+    Attack = 'attack',
+    FrameworkEffect = 'frameworkEffect', // TODO: this is a workaround until we get the comp 3.0 rules
+    UniqueRule = 'uniqueRule'
+}
+
 export interface IDamagedOrDefeatedByAttack extends IDamageOrDefeatSourceBase {
-    type: DamageOrDefeatSourceType.Attack;
+    type: DamageSourceType.Attack | DefeatSourceType.Attack;
     attack: Attack;
     damageDealtBy: UnitCard;
     isOverwhelmDamage: boolean;
 }
 
 export interface IDamagedOrDefeatedByAbility extends IDamageOrDefeatSourceBase {
-    type: DamageOrDefeatSourceType.Ability;
-    ability: CardAbilityStep;
+    type: DamageSourceType.Ability | DefeatSourceType.Ability;
+    ability: PlayerOrCardAbility;
     card: Card;
+}
+
+export interface IDefeatedByUniqueRule extends IDamageOrDefeatSourceBase {
+    type: DefeatSourceType.UniqueRule;
 }
 
 // ********************************************** INTERNAL TYPES **********************************************
 interface IDamageOrDefeatSourceBase {
     /** The player that owns the effect causing the defeat / damage to this unit */
     player: Player;
-    type: DamageOrDefeatSourceType;
+    type: DamageSourceType | DefeatSourceType;
 }

--- a/server/game/cards/01_SOR/units/AgentKallusSeekingTheRebels.ts
+++ b/server/game/cards/01_SOR/units/AgentKallusSeekingTheRebels.ts
@@ -1,0 +1,29 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Aspect } from '../../../core/Constants';
+
+export default class AgentKallusSeekingTheRebels extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '2649829005',
+            internalName: 'agent-kallus#seeking-the-rebels',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addTriggeredAbility({
+            title: 'Draw a card',
+            optional: true,
+            when: {
+                onCardDefeated: (event, context) =>
+                    event.card.isUnit() &&
+                    event.card.unique &&
+                    event.card !== context.source
+            },
+            immediateEffect: AbilityHelper.immediateEffects.draw(),
+            limit: AbilityHelper.limit.perRound(1)
+        });
+    }
+}
+
+AgentKallusSeekingTheRebels.implemented = true;

--- a/server/game/cards/01_SOR/units/ColonelYularenIsbDirector.ts
+++ b/server/game/cards/01_SOR/units/ColonelYularenIsbDirector.ts
@@ -1,0 +1,30 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Aspect, CardType, Location, RelativePlayer } from '../../../core/Constants';
+
+export default class ColonelYularenIsbDirector extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '0961039929',
+            internalName: 'colonel-yularen#isb-director',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addTriggeredAbility({
+            title: 'Heal 1 damage from your base',
+            when: {
+                onCardPlayed: (event, context) =>
+                    event.card.isUnit() &&
+                    event.card.controller === context.source.controller &&
+                    event.card.hasSomeAspect(Aspect.Command)
+            },
+            immediateEffect: AbilityHelper.immediateEffects.heal((context) => ({
+                amount: 1,
+                target: context.source.controller.base
+            }))
+        });
+    }
+}
+
+ColonelYularenIsbDirector.implemented = true;

--- a/server/game/cards/02_SHD/units/SalaciousCrumbObnoxiousPet.ts
+++ b/server/game/cards/02_SHD/units/SalaciousCrumbObnoxiousPet.ts
@@ -12,12 +12,11 @@ export default class SalaciousCrumbObnoxiousPet extends NonLeaderUnitCard {
 
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
-            title: 'Heal 1 damage from friendly base',
-            targetResolver: {
-                cardTypeFilter: CardType.Base,
-                controller: RelativePlayer.Self,
-                immediateEffect: AbilityHelper.immediateEffects.heal({ amount: 1 })
-            }
+            title: 'Heal 1 damage from your base',
+            immediateEffect: AbilityHelper.immediateEffects.heal((context) => ({
+                amount: 1,
+                target: context.source.controller.base
+            }))
         });
 
         this.addActionAbility({

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -28,6 +28,7 @@ const { LeaderCard } = require('./card/LeaderCard');
 const { LeaderUnitCard } = require('./card/LeaderUnitCard');
 const { Card } = require('./card/Card');
 const { PlayableOrDeployableCard } = require('./card/baseClasses/PlayableOrDeployableCard');
+const { InPlayCard } = require('./card/baseClasses/InPlayCard');
 
 class Player extends GameObject {
     constructor(id, user, owner, game, clockDetails) {
@@ -384,19 +385,14 @@ class Player extends GameObject {
         return undefined;
     }
 
-    // /**
-    //  * Returns a character in play under this player's control which matches (for uniqueness) the passed card.
-    //  * @param card DrawCard
-    //  */
-    // getDuplicateInPlay(card) {
-    //     if (!card.isUnique()) {
-    //         return undefined;
-    //     }
-
-    //     return this.findCard(this.cardsInPlay, (playCard) => {
-    //         return playCard !== card && (playCard.id === card.id || playCard.name === card.name);
-    //     });
-    // }
+    /**
+     * Returns a card in play under this player's control which matches (for uniqueness) the passed card
+     * @param {InPlayCard} card
+     * @returns {InPlayCard[]} Duplicates of passed card (does not check unique status)
+     */
+    getDuplicatesInPlay(card) {
+        return this.getArenaCards().filter((otherCard) => otherCard.id === card.id && otherCard !== card);
+    }
 
     /**
      * Returns ths top card of the player's deck

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -391,7 +391,11 @@ class Player extends GameObject {
      * @returns {InPlayCard[]} Duplicates of passed card (does not check unique status)
      */
     getDuplicatesInPlay(card) {
-        return this.getArenaCards().filter((otherCard) => otherCard.id === card.id && otherCard !== card);
+        return this.getArenaCards().filter((otherCard) =>
+            otherCard.title === card.title &&
+            otherCard.subtitle === card.subtitle &&
+            otherCard !== card
+        );
     }
 
     /**

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -40,6 +40,7 @@ export class Card extends OngoingEffectSource {
     public static implemented = false;
 
     public readonly aspects: Aspect[] = [];
+    public override readonly id: string;
     public readonly internalName: string;
     public readonly subtitle?: string;
     public readonly title: string;
@@ -47,7 +48,6 @@ export class Card extends OngoingEffectSource {
 
     public controller: Player;
 
-    protected override readonly id: string;
     protected readonly printedKeywords: KeywordInstance[];
     protected readonly printedTraits: Set<Trait>;
     protected readonly printedType: CardType;

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -40,7 +40,6 @@ export class Card extends OngoingEffectSource {
     public static implemented = false;
 
     public readonly aspects: Aspect[] = [];
-    public override readonly id: string;
     public readonly internalName: string;
     public readonly subtitle?: string;
     public readonly title: string;
@@ -48,6 +47,7 @@ export class Card extends OngoingEffectSource {
 
     public controller: Player;
 
+    protected override readonly id: string;
     protected readonly printedKeywords: KeywordInstance[];
     protected readonly printedTraits: Set<Trait>;
     protected readonly printedType: CardType;

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -4,7 +4,7 @@ import PlayerOrCardAbility from '../ability/PlayerOrCardAbility';
 import OngoingEffectSource from '../ongoingEffect/OngoingEffectSource';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
-import { AbilityRestriction, AbilityType, Arena, Aspect, CardType, Duration, EffectName, EventName, KeywordName, Location, Trait, WildcardLocation } from '../Constants';
+import { AbilityRestriction, AbilityType, Arena, Aspect, CardType, Duration, EffectName, EventName, KeywordName, Location, LocationFilter, Trait, WildcardLocation } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import AbilityHelper from '../../AbilityHelper';
 import * as Helpers from '../utils/Helpers';

--- a/server/game/core/card/CardTypes.ts
+++ b/server/game/core/card/CardTypes.ts
@@ -1,4 +1,5 @@
 import { BaseCard } from './BaseCard';
+import { InPlayCard } from './baseClasses/InPlayCard';
 import { EventCard } from './EventCard';
 import { LeaderCard } from './LeaderCard';
 import { LeaderUnitCard } from './LeaderUnitCard';

--- a/server/game/core/card/CardTypes.ts
+++ b/server/game/core/card/CardTypes.ts
@@ -59,5 +59,3 @@ export type PlayableCard =
 
 // Base is the only type of card that isn't in the PlayableOrDeployable subclass
 type PlayableOrDeployableCardTypes = Exclude<AnyCard, BaseCard>;
-
-export type InPlayCard = Exclude<AnyCard, BaseCard | EventCard>;

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -79,8 +79,8 @@ export class UpgradeCard extends UpgradeCardParent {
             this.controller.removeCardFromPile(this);
         }
 
-        this.moveTo(newParentCard.location);
         newParentCard.controller.putUpgradeInArena(this, newParentCard.location);
+        this.moveTo(newParentCard.location);
         newParentCard.attachUpgrade(this);
         this._parentCard = newParentCard;
     }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -267,9 +267,11 @@ export class InPlayCard extends PlayableOrDeployableCard {
             `Found that ${this.controller.name} has ${uniqueDuplicatesInPlay.length} duplicates of ${this.internalName} in play`
         );
 
+        const unitDisplayName = this.title + (this.subtitle ? ', ' + this.subtitle : '');
+
         const chooseDuplicateToDefeatPromptProperties = {
-            activePromptTitle: `Choose which copy of ${this.title}, ${this.subtitle} to defeat`,
-            waitingPromptTitle: `Waiting for opponent to choose which copy of ${this.title}, ${this.subtitle} to defeat`,
+            activePromptTitle: `Choose which copy of ${unitDisplayName} to defeat`,
+            waitingPromptTitle: `Waiting for opponent to choose which copy of ${unitDisplayName} to defeat`,
             locationFilter: WildcardLocation.AnyArena,
             controller: RelativePlayer.Self,
             cardCondition: (card: InPlayCard) =>

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -150,6 +150,29 @@ export class InPlayCard extends PlayableOrDeployableCard {
         // where we maybe wouldn't reset events / effects / limits?
         this.updateTriggeredAbilityEvents(prevLocation, this.location);
         this.updateConstantAbilityEffects(prevLocation, this.location);
+
+        if (this.unique) {
+            this.checkUnique();
+        }
+    }
+
+    private checkUnique() {
+        Contract.assertTrue(this.unique);
+
+        // need to filter for other cards that have unique = true since Clone will create non-unique duplicates
+        const uniqueDuplicatesInPlay = this.controller.getDuplicatesInPlay(this)
+            .filter((duplicateCard) => duplicateCard.unique);
+
+        if (uniqueDuplicatesInPlay.length === 0) {
+            return;
+        }
+
+        Contract.assertTrue(
+            uniqueDuplicatesInPlay.length < 2,
+            `Found that ${this.controller.name} has ${uniqueDuplicatesInPlay.length} duplicates of ${this.internalName} in play`
+        );
+
+        const duplicateToRemove = uniqueDuplicatesInPlay[0];
     }
 
     /** Register / un-register the event triggers for any triggered abilities */

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -9,6 +9,7 @@ import ReplacementEffectAbility from '../../ability/ReplacementEffectAbility';
 import { Card } from '../Card';
 import { DefeatCardSystem } from '../../../gameSystems/DefeatCardSystem';
 import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
+import { FrameworkDefeatCardSystem } from '../../../gameSystems/FrameworkDefeatCardSystem';
 
 // required for mixins to be based on this class
 export type InPlayCardConstructor = new (...args: any[]) => InPlayCard;
@@ -27,7 +28,11 @@ export class InPlayCard extends PlayableOrDeployableCard {
     protected _pendingDefeat? = null;
 
     /**
-     * If true, then this card is queued to be defeated due to an indirect effect (damage, unique rule) but has not yet been removed from the field
+     * If true, then this card is queued to be defeated as a consequence of another effect (damage, unique rule)
+     * and will be removed from the field after the current event window has finished the resolution step.
+     *
+     * When this is true, most systems cannot target the card and any ongoing effects are disabled.
+     * Triggered abilities are not disabled until it leaves the field.
      */
     public get pendingDefeat() {
         this.assertPropertyEnabled(this._pendingDefeat, 'pendingDefeat');
@@ -263,8 +268,7 @@ export class InPlayCard extends PlayableOrDeployableCard {
 
         const duplicateToRemove = uniqueDuplicatesInPlay[0];
 
-        // TODO THIS PR: shouldn't need to specify target here for this to work
-        const duplicateDefeatSystem = new DefeatCardSystem({ defeatSource: DefeatSourceType.UniqueRule, target: duplicateToRemove });
+        const duplicateDefeatSystem = new FrameworkDefeatCardSystem({ defeatSource: DefeatSourceType.UniqueRule, target: duplicateToRemove });
         this.game.addSubwindowEvents(duplicateDefeatSystem.generateEvent(duplicateToRemove, this.game.getFrameworkContext()));
 
         duplicateToRemove.registerPendingUniqueDefeat();

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -3,7 +3,7 @@ import * as Contract from '../../utils/Contract';
 import { Card, CardConstructor } from '../Card';
 import type { CardWithDamageProperty } from '../CardTypes';
 import { WithPrintedHp } from './PrintedHp';
-import { INonFrameworkDamageOrDefeatSource } from '../../../IDamageOrDefeatSource';
+import { IDamageSource } from '../../../IDamageOrDefeatSource';
 
 /**
  * Mixin function that adds the `damage` property and corresponding methods to a base class.
@@ -59,7 +59,7 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         }
 
         /** @param source Metadata about the source of the damage (attack or ability) */
-        public addDamage(amount: number, source: INonFrameworkDamageOrDefeatSource) {
+        public addDamage(amount: number, source: IDamageSource) {
             Contract.assertNonNegative(amount);
 
             // damage source is only needed for tracking cause of defeat on units but we should enforce that it's provided consistently

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -64,14 +64,6 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         private _attackKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
         private _whenPlayedKeywordAbilities?: (TriggeredAbility | IConstantAbility)[] = null;
 
-        /** If true, then this unit has taken sufficient damage to be defeated but not yet been removed from the field */
-        private _pendingDefeat? = null;
-
-        public get pendingDefeat() {
-            this.assertPropertyEnabled(this._pendingDefeat, 'pendingDefeat');
-            return this._pendingDefeat;
-        }
-
         public get upgrades(): UpgradeCard[] {
             this.assertPropertyEnabled(this._upgrades, 'upgrades');
             return this._upgrades;
@@ -131,7 +123,6 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         protected override setDamageEnabled(enabledStatus: boolean): void {
             super.setDamageEnabled(enabledStatus);
-            this._pendingDefeat = enabledStatus ? false : null;
         }
 
         // ***************************************** ATTACK HELPERS *****************************************

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -22,6 +22,7 @@ import type Game from '../../Game';
 import { GameEvent } from '../../event/GameEvent';
 import { DefeatSourceType, IDamageSource } from '../../../IDamageOrDefeatSource';
 import { DefeatCardSystem } from '../../../gameSystems/DefeatCardSystem';
+import { FrameworkDefeatCardSystem } from '../../../gameSystems/FrameworkDefeatCardSystem';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
 
@@ -310,7 +311,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         private checkDefeated(source: IDamageSource | DefeatSourceType.FrameworkEffect) {
             if (this.damage >= this.getHp() && !this._pendingDefeat) {
                 // add defeat event to window
-                this.game.addSubwindowEvents(new DefeatCardSystem({ target: this, defeatSource: source }).generateEvent(this, this.game.getFrameworkContext()));
+                this.game.addSubwindowEvents(
+                    new FrameworkDefeatCardSystem({ target: this, defeatSource: source })
+                        .generateEvent(this, this.game.getFrameworkContext())
+                );
 
                 // mark that this unit has a defeat pending so that other effects targeting it will not resolve
                 this._pendingDefeat = true;

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -20,7 +20,7 @@ import { SaboteurDefeatShieldsAbility } from '../../../abilities/keyword/Saboteu
 import { AmbushAbility } from '../../../abilities/keyword/AmbushAbility';
 import type Game from '../../Game';
 import { GameEvent } from '../../event/GameEvent';
-import { IDamageOrDefeatSource, INonFrameworkDamageOrDefeatSource } from '../../../IDamageOrDefeatSource';
+import { DefeatSourceType, IDamageSource } from '../../../IDamageOrDefeatSource';
 import { DefeatCardSystem } from '../../../gameSystems/DefeatCardSystem';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
@@ -301,7 +301,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         }
 
         // ***************************************** STAT HELPERS *****************************************
-        public override addDamage(amount: number, source: INonFrameworkDamageOrDefeatSource): void {
+        public override addDamage(amount: number, source: IDamageSource): void {
             super.addDamage(amount, source);
 
             this.checkDefeated(source);
@@ -313,13 +313,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         /** Checks if the unit has been defeated due to an ongoing effect such as hp reduction */
         public checkDefeatedByOngoingEffect() {
-            this.checkDefeated(null);
+            this.checkDefeated(DefeatSourceType.FrameworkEffect);
         }
 
-        private checkDefeated(source?: IDamageOrDefeatSource) {
+        private checkDefeated(source: IDamageSource | DefeatSourceType.FrameworkEffect) {
             if (this.damage >= this.getHp() && !this._pendingDefeat) {
                 // add defeat event to window
-                this.game.addSubwindowEvents(new DefeatCardSystem({ target: this, damageSource: source }).generateEvent(this, this.game.getFrameworkContext()));
+                this.game.addSubwindowEvents(new DefeatCardSystem({ target: this, defeatSource: source }).generateEvent(this, this.game.getFrameworkContext()));
 
                 // mark that this unit has a defeat pending so that other effects targeting it will not resolve
                 this._pendingDefeat = true;

--- a/server/game/core/event/EventWindow.js
+++ b/server/game/core/event/EventWindow.js
@@ -46,7 +46,7 @@ class EventWindow extends BaseStepWithPipeline {
             new SimpleStep(this.game, () => this.generateContingentEvents(), 'generateContingentEvents'),
             new SimpleStep(this.game, () => this.preResolutionEffects(), 'preResolutionEffects'),
             new SimpleStep(this.game, () => this.executeHandlersEmitEvents(), 'executeHandlersEmitEvents'),
-            new SimpleStep(this.game, () => this.resolveGameStateEmitEvents(), 'resolveGameStateEmitEvents'),
+            new SimpleStep(this.game, () => this.resolveGameStateAndEmitEvents(), 'resolveGameStateEmitEvents'),
             new SimpleStep(this.game, () => this.resolveSubwindowEvents(), 'checkSubwindowEvents'),
             new SimpleStep(this.game, () => this.resolveThenAbilityStep(), 'checkThenAbilitySteps'),
             new SimpleStep(this.game, () => this.resolveTriggersIfNecessary(), 'resolveTriggersIfNecessary'),
@@ -146,7 +146,7 @@ class EventWindow extends BaseStepWithPipeline {
 
     // resolve game state and emit triggers again
     // this is to catch triggers on cards that entered play or gained abilities during event resolution
-    resolveGameStateEmitEvents() {
+    resolveGameStateAndEmitEvents() {
         // TODO: understand if resolveGameState really needs the emittedEvents array or not
         this.game.resolveGameState(this.emittedEvents.some((event) => event.handler), this.emittedEvents);
 

--- a/server/game/core/gameSteps/prompts/SelectCardPrompt.js
+++ b/server/game/core/gameSteps/prompts/SelectCardPrompt.js
@@ -75,7 +75,9 @@ class SelectCardPrompt extends UiPrompt {
                 cardCondition(card, context) && this.properties.immediateEffect.canAffect(card, context);
         }
         this.hideIfNoLegalTargets = properties.hideIfNoLegalTargets;
+
         this.selector = properties.selector || CardSelectorFactory.create(this.properties);
+
         this.selectedCards = [];
         if (properties.mustSelect) {
             if (this.selector.hasEnoughSelected(properties.mustSelect, properties.context) && this.selector.numCards > 0 && properties.mustSelect.length >= this.selector.numCards) {

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -127,7 +127,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
     public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         // if a unit is pending defeat (damage >= hp but defeat not yet resolved), always return canAffect() = false unless
         // we're the system that is enacting the defeat
-        if (card.isUnit() && card.isInPlay() && card.pendingDefeat && !this.isPendingDefeatFor(card, context)) {
+        if (card.isUnit() && card.isInPlay() && card.pendingDefeat) {
             return false;
         }
 

--- a/server/game/core/gameSystem/GameSystem.ts
+++ b/server/game/core/gameSystem/GameSystem.ts
@@ -103,7 +103,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @param additionalProperties Any additional properties on top of the default ones
      * @returns An object of the `GameSystemProperties` template type
      */
-    public generatePropertiesFromContext(context: TContext, additionalProperties = {}): TProperties {
+    public generatePropertiesFromContext(context: TContext, additionalProperties: any = {}): TProperties {
         const properties = Object.assign(
             { target: this.getDefaultTargets(context) },
             this.defaultProperties,
@@ -121,7 +121,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
         return [this.costDescription, []];
     }
 
-    public getEffectMessage(context: TContext, additionalProperties = {}): [string, any[]] {
+    public getEffectMessage(context: TContext, additionalProperties: any = {}): [string, any[]] {
         const { target } = this.generatePropertiesFromContext(context, additionalProperties);
         return [this.effectDescription, [target]];
     }
@@ -135,7 +135,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @returns True if the target is legal for the system, false otherwise
      */
     // IMPORTANT: this method is referred to in the debugging guide. if we change the signature, we should upgrade the guide.
-    public canAffect(target: any, context: TContext, additionalProperties = {}): boolean {
+    public canAffect(target: any, context: TContext, additionalProperties: any = {}): boolean {
         const { cannotBeCancelled } = this.generatePropertiesFromContext(context, additionalProperties);
 
         return (
@@ -152,7 +152,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @param additionalProperties Any additional properties to extend the default ones with
      * @returns True if any of the candidate targets are legal, false otherwise
      */
-    public hasLegalTarget(context: TContext, additionalProperties = {}): boolean {
+    public hasLegalTarget(context: TContext, additionalProperties: any = {}): boolean {
         for (const candidateTarget of this.targets(context, additionalProperties)) {
             if (this.canAffect(candidateTarget, context, additionalProperties)) {
                 return true;
@@ -169,7 +169,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @param additionalProperties Any additional properties to extend the default ones with
      * @returns True if all of the candidate targets are legal, false otherwise
      */
-    public allTargetsLegal(context: TContext, additionalProperties = {}): boolean {
+    public allTargetsLegal(context: TContext, additionalProperties: any = {}): boolean {
         for (const candidateTarget of this.targets(context, additionalProperties)) {
             if (!this.canAffect(candidateTarget, context, additionalProperties)) {
                 return false;
@@ -190,7 +190,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @param context Context of ability being executed
      * @param additionalProperties Any additional properties to extend the default ones with
      */
-    public queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
+    public queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: any = {}): void {
         for (const target of this.targets(context, additionalProperties)) {
             if (this.canAffect(target, context, additionalProperties)) {
                 events.push(this.generateEvent(target, context, additionalProperties));
@@ -206,7 +206,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @param context Context of ability being executed
      * @param additionalProperties Any additional properties to extend the default ones with
      */
-    public generateEvent(target: any, context: TContext, additionalProperties = {}): GameEvent {
+    public generateEvent(target: any, context: TContext, additionalProperties: any = {}): GameEvent {
         const event = this.createEvent(target, context, additionalProperties);
         this.updateEvent(event, target, context, additionalProperties);
         return event;
@@ -237,23 +237,23 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
         context.game.queueSimpleStep(() => context.game.openEventWindow(events), `openEventWindow for '${this}'`);
     }
 
-    public checkEventCondition(event: GameEvent, additionalProperties = {}): boolean {
+    public checkEventCondition(event: GameEvent, additionalProperties: any = {}): boolean {
         return true;
     }
 
-    public isEventFullyResolved(event: GameEvent, target: any, context: TContext, additionalProperties = {}): boolean {
+    public isEventFullyResolved(event: GameEvent, target: any, context: TContext, additionalProperties: any = {}): boolean {
         return !event.cancelled && event.name === this.eventName;
     }
 
-    public isOptional(context: TContext, additionalProperties = {}): boolean {
+    public isOptional(context: TContext, additionalProperties: any = {}): boolean {
         return this.generatePropertiesFromContext(context, additionalProperties).optional ?? false;
     }
 
-    public hasTargetsChosenByInitiatingPlayer(context: TContext, additionalProperties = {}): boolean {
+    public hasTargetsChosenByInitiatingPlayer(context: TContext, additionalProperties: any = {}): boolean {
         return false;
     }
 
-    protected addPropertiesToEvent(event: any, target: any, context: TContext, additionalProperties = {}): void {
+    protected addPropertiesToEvent(event: any, target: any, context: TContext, additionalProperties: any = {}): void {
         event.context = context;
     }
 
@@ -272,7 +272,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * Writes the important properties of this system onto the passed event object. Only used internally by
      * systems during event generation.
      */
-    protected updateEvent(event: GameEvent, target: any, context: TContext, additionalProperties = {}): void {
+    protected updateEvent(event: GameEvent, target: any, context: TContext, additionalProperties: any = {}): void {
         event.name = this.eventName;
         this.addPropertiesToEvent(event, target, context, additionalProperties);
         event.replaceHandler((event) => this.eventHandler(event, additionalProperties));
@@ -297,7 +297,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      * @param additionalProperties Any additional properties to extend the default ones with
      * @returns The default target(s) of this {@link GameSystem}
      */
-    private targets(context: TContext, additionalProperties = {}) {
+    private targets(context: TContext, additionalProperties: any = {}) {
         return Helpers.asArray(this.generatePropertiesFromContext(context, additionalProperties).target);
     }
 

--- a/server/game/core/ongoingEffect/OngoingEffect.js
+++ b/server/game/core/ongoingEffect/OngoingEffect.js
@@ -93,8 +93,17 @@ class OngoingEffect {
         if (this.duration !== Duration.Persistent) {
             return true;
         }
-        let effectOnSource = this.source.getConstantAbilities().some((effect) => effect.registeredEffects && effect.registeredEffects.includes(this));
-        return !this.source.facedown && effectOnSource;
+
+        // disable ongoing effects if the card is queued up to be defeated (e.g. due to combat or unique rule)
+        if (this.source.isUnit() && this.source.pendingDefeat) {
+            return false;
+        }
+
+        if (!this.source.getConstantAbilities().some((effect) => effect.registeredEffects && effect.registeredEffects.includes(this))) {
+            return false;
+        }
+
+        return !this.source.facedown;
     }
 
     resolveEffectTargets(stateChanged) {

--- a/server/game/core/ongoingEffect/OngoingEffect.js
+++ b/server/game/core/ongoingEffect/OngoingEffect.js
@@ -95,7 +95,7 @@ class OngoingEffect {
         }
 
         // disable ongoing effects if the card is queued up to be defeated (e.g. due to combat or unique rule)
-        if (this.source.isUnit() && this.source.pendingDefeat) {
+        if ((this.source.isUnit() || this.source.isUpgrade()) && this.source.pendingDefeat) {
             return false;
         }
 

--- a/server/game/gameSystems/DamageSystem.ts
+++ b/server/game/gameSystems/DamageSystem.ts
@@ -5,7 +5,7 @@ import * as EnumHelpers from '../core/utils/EnumHelpers';
 import { type ICardTargetSystemProperties, CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import * as Contract from '../core/utils/Contract';
 import { Attack } from '../core/attack/Attack';
-import { DamageOrDefeatSourceType, IDamageOrDefeatSource } from '../IDamageOrDefeatSource';
+import { DamageSourceType, IDamageSource } from '../IDamageOrDefeatSource';
 import { UnitCard } from '../core/card/CardTypes';
 import CardAbilityStep from '../core/ability/CardAbilityStep';
 
@@ -76,7 +76,7 @@ export class DamageSystem<TContext extends AbilityContext = AbilityContext> exte
     }
 
     /** Generates metadata indicating the source of the damage is an attack for relevant effects such as Rukh's ability */
-    private generateAttackSourceMetadata(event: any, card: Card, context: TContext, properties: IDamageProperties): IDamageOrDefeatSource {
+    private generateAttackSourceMetadata(event: any, card: Card, context: TContext, properties: IDamageProperties): IDamageSource {
         Contract.assertTrue(context.source.isUnit());
 
         let damageDealtBy: UnitCard;
@@ -98,7 +98,7 @@ export class DamageSystem<TContext extends AbilityContext = AbilityContext> exte
         }
 
         return {
-            type: DamageOrDefeatSourceType.Attack,
+            type: DamageSourceType.Attack,
             attack: properties.sourceAttack,
             player: context.source.controller,
             damageDealtBy,
@@ -108,11 +108,11 @@ export class DamageSystem<TContext extends AbilityContext = AbilityContext> exte
 
     // TODO: confirm that this works when the player controlling the ability is different than the player controlling the card (e.g., bounty)
     /** Generates metadata indicating the source of the damage is an ability */
-    private generateAbilitySourceMetadata(card: Card, context: TContext): IDamageOrDefeatSource {
+    private generateAbilitySourceMetadata(card: Card, context: TContext): IDamageSource {
         Contract.assertTrue(context.ability instanceof CardAbilityStep, `Damage was created by non-card ability ${context.ability.title} targeting ${card.internalName}`);
 
         return {
-            type: DamageOrDefeatSourceType.Ability,
+            type: DamageSourceType.Ability,
             player: context.player,
             ability: context.ability,
             card: context.source

--- a/server/game/gameSystems/FrameworkDefeatCardSystem.ts
+++ b/server/game/gameSystems/FrameworkDefeatCardSystem.ts
@@ -1,0 +1,67 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import type { Card } from '../core/card/Card';
+import { EventName, WildcardCardType } from '../core/Constants';
+import { type ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
+import * as Contract from '../core/utils/Contract';
+import { DefeatSourceType, IDamageSource, IDefeatSource } from '../IDamageOrDefeatSource';
+import { DefeatCardSystem } from './DefeatCardSystem';
+
+export interface IFrameworkDefeatCardProperties extends ICardTargetSystemProperties {
+    defeatSource: IDamageSource | DefeatSourceType.UniqueRule | DefeatSourceType.FrameworkEffect;
+    target: Card | Card[];
+}
+
+/**
+ * Extension of {@link DefeatCardSystem} that handles special cases where a card is defeated indirectly by a framework effect
+ * such as damage or the unique rule. Card implementations **should not** use this system.
+ */
+export class FrameworkDefeatCardSystem<TContext extends AbilityContext = AbilityContext> extends DefeatCardSystem<TContext, IFrameworkDefeatCardProperties> {
+    public override readonly name = 'defeat';
+    public override readonly eventName = EventName.OnCardDefeated;
+    protected override readonly targetTypeFilter = [WildcardCardType.Unit, WildcardCardType.Upgrade];
+
+    public override getEffectMessage(context: TContext): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context);
+
+        let causeStr: string;
+        switch (properties.defeatSource) {
+            case DefeatSourceType.UniqueRule:
+                causeStr = 'unique rule';
+                break;
+            case DefeatSourceType.FrameworkEffect:
+                causeStr = 'damage';
+                break;
+            default:
+                Contract.fail(`Unexpected framework defeat reason: '${properties.defeatSource}'`);
+        }
+
+        return ['defeat {0} due to {1}', [properties.target, causeStr]];
+    }
+
+    // fully override the base canAffect method since nothing can interrupt defeat due to framework effect
+    public override canAffect(card: Card, context: TContext): boolean {
+        const { target } = this.generatePropertiesFromContext(context);
+
+        let nonArrayTarget: Card;
+        if (Array.isArray(target)) {
+            Contract.assertArraySize(target, 1);
+            nonArrayTarget = target[0];
+        } else {
+            nonArrayTarget = card;
+        }
+
+        return nonArrayTarget === card;
+    }
+
+    protected override buildDefeatSourceForType(defeatSourceType: DefeatSourceType, card: Card, context: TContext): IDefeatSource | null {
+        switch (defeatSourceType) {
+            case DefeatSourceType.UniqueRule:
+                return { type: DefeatSourceType.UniqueRule, player: card.controller };
+            case DefeatSourceType.FrameworkEffect:
+                // TODO: this is a workaround until we get comp rules 3.0
+                return null;
+            default:
+                Contract.fail(`Unexpected value for defeat source: ${defeatSourceType}`);
+        }
+    }
+}

--- a/server/game/gameSystems/FrameworkDefeatCardSystem.ts
+++ b/server/game/gameSystems/FrameworkDefeatCardSystem.ts
@@ -8,7 +8,7 @@ import { DefeatCardSystem } from './DefeatCardSystem';
 
 export interface IFrameworkDefeatCardProperties extends ICardTargetSystemProperties {
     defeatSource: IDamageSource | DefeatSourceType.UniqueRule | DefeatSourceType.FrameworkEffect;
-    target: Card | Card[];
+    target?: Card | Card[];
 }
 
 /**
@@ -39,18 +39,8 @@ export class FrameworkDefeatCardSystem<TContext extends AbilityContext = Ability
     }
 
     // fully override the base canAffect method since nothing can interrupt defeat due to framework effect
-    public override canAffect(card: Card, context: TContext): boolean {
-        const { target } = this.generatePropertiesFromContext(context);
-
-        let nonArrayTarget: Card;
-        if (Array.isArray(target)) {
-            Contract.assertArraySize(target, 1);
-            nonArrayTarget = target[0];
-        } else {
-            nonArrayTarget = card;
-        }
-
-        return nonArrayTarget === card;
+    public override canAffect(card: Card): boolean {
+        return card.canBeInPlay() && card.isInPlay();
     }
 
     protected override buildDefeatSourceForType(defeatSourceType: DefeatSourceType, card: Card, context: TContext): IDefeatSource | null {

--- a/server/game/gameSystems/FrameworkDefeatCardSystem.ts
+++ b/server/game/gameSystems/FrameworkDefeatCardSystem.ts
@@ -61,7 +61,7 @@ export class FrameworkDefeatCardSystem<TContext extends AbilityContext = Ability
                 // TODO: this is a workaround until we get comp rules 3.0
                 return null;
             default:
-                Contract.fail(`Unexpected value for defeat source: ${defeatSourceType}`);
+                Contract.fail(`Unexpected value for framework defeat source: ${defeatSourceType}`);
         }
     }
 }

--- a/server/game/stateWatchers/CardsEnteredPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsEnteredPlayThisPhaseWatcher.ts
@@ -2,8 +2,8 @@ import { StateWatcher } from '../core/stateWatcher/StateWatcher';
 import { StateWatcherName } from '../core/Constants';
 import { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
 import Player from '../core/Player';
-import { InPlayCard } from '../core/card/CardTypes';
 import { Card } from '../core/card/Card';
+import { InPlayCard } from '../core/card/baseClasses/InPlayCard';
 
 export interface EnteredCardEntry {
     card: InPlayCard;

--- a/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
@@ -1,5 +1,5 @@
+import { InPlayCard } from '../core/card/baseClasses/InPlayCard';
 import { Card } from '../core/card/Card';
-import { InPlayCard } from '../core/card/CardTypes';
 import { StateWatcherName } from '../core/Constants';
 import Player from '../core/Player';
 import { StateWatcher } from '../core/stateWatcher/StateWatcher';

--- a/test/server/cards/01_SOR/units/AgentKallusSeekingTheRebels.spec.ts
+++ b/test/server/cards/01_SOR/units/AgentKallusSeekingTheRebels.spec.ts
@@ -1,0 +1,93 @@
+describe('Agent Kallus, Seeking the Rebels', function() {
+    integration(function(contextRef) {
+        describe('Kallus\'s triggered ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'agent-kallus#seeking-the-rebels',
+                            'battlefield-marine',
+                            'dengar#the-demolisher',
+                            'leia-organa#defiant-princess',
+                            'general-tagge#concerned-commander'
+                        ]
+                    },
+                    player2: {
+                        groundArena: ['wampa', 'admiral-ozzel#overconfident']
+                    }
+                });
+            });
+
+            it('should once per turn allow the controller to draw a card when another unique unit is defeated', function () {
+                const { context } = contextRef;
+
+                const reset = (passAction = true) => {
+                    context.setDamage(context.wampa, 0);
+                    if (passAction) {
+                        context.player2.passAction();
+                    }
+                };
+
+                const round1HandSize = context.player1.handSize;
+
+                // CASE 1: option to draw card when friendly unique unit is defeated (do not take)
+                context.player1.clickCard(context.dengar);
+                context.player1.clickCard(context.wampa);
+                expect(context.dengar).toBeInLocation('discard');
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Pass');
+                expect(context.player1.handSize).toBe(round1HandSize);
+
+                reset();
+
+                // CASE 2: non-unique is defeated, no trigger
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.wampa);
+                expect(context.battlefieldMarine).toBeInLocation('discard');
+                expect(context.player1.handSize).toBe(round1HandSize);
+
+                reset(false);
+
+                // CASE 3: option to draw card when enemy unique unit is defeated (do take)
+                context.player2.clickCard(context.admiralOzzel);
+                context.player2.clickCard(context.agentKallus);
+                expect(context.admiralOzzel).toBeInLocation('discard');
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');
+                expect(context.player1.handSize).toBe(round1HandSize + 1);
+
+                reset(false);
+
+                // CASE 4: unique is defeated but ability already used, no trigger
+                context.player1.clickCard(context.leiaOrgana);
+                context.player1.clickCard(context.wampa);
+                expect(context.leiaOrgana).toBeInLocation('discard');
+                expect(context.player1.handSize).toBe(round1HandSize + 1);
+
+                reset();
+                context.moveToNextActionPhase();
+                const round2HandSize = context.player1.handSize;
+
+                // CASE 5: unique is defeated next round, ability can trigger
+                context.player1.clickCard(context.generalTagge);
+                context.player1.clickCard(context.wampa);
+                expect(context.generalTagge).toBeInLocation('discard');
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');
+                expect(context.player1.handSize).toBe(round2HandSize + 1);
+
+                reset();
+                context.moveToNextActionPhase();
+                const round3HandSize = context.player1.handSize;
+
+                // CASE 6: Kallus is defeated, no trigger
+                context.player1.clickCard(context.agentKallus);
+                context.player1.clickCard(context.wampa);
+                expect(context.agentKallus).toBeInLocation('discard');
+                expect(context.player1.handSize).toBe(round3HandSize);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/units/AgentKallusSeekingTheRebels.spec.ts
+++ b/test/server/cards/01_SOR/units/AgentKallusSeekingTheRebels.spec.ts
@@ -14,7 +14,7 @@ describe('Agent Kallus, Seeking the Rebels', function() {
                         ]
                     },
                     player2: {
-                        groundArena: ['wampa', 'admiral-ozzel#overconfident']
+                        groundArena: ['wampa', 'general-veers#blizzard-force-commander']
                     }
                 });
             });
@@ -50,9 +50,9 @@ describe('Agent Kallus, Seeking the Rebels', function() {
                 reset(false);
 
                 // CASE 3: option to draw card when enemy unique unit is defeated (do take)
-                context.player2.clickCard(context.admiralOzzel);
+                context.player2.clickCard(context.generalVeers);
                 context.player2.clickCard(context.agentKallus);
-                expect(context.admiralOzzel).toBeInLocation('discard');
+                expect(context.generalVeers).toBeInLocation('discard');
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
                 context.player1.clickPrompt('Draw a card');
                 expect(context.player1.handSize).toBe(round1HandSize + 1);

--- a/test/server/cards/01_SOR/units/ColonelYularenIsbDirector.spec.ts
+++ b/test/server/cards/01_SOR/units/ColonelYularenIsbDirector.spec.ts
@@ -1,0 +1,34 @@
+describe('Colonel Yularen, ISB Director', function() {
+    integration(function(contextRef) {
+        describe('Yularen\'s triggered ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['colonel-yularen#isb-director', 'battlefield-marine'],
+                        base: { card: 'nevarro-city', damage: 3 }
+                    },
+                    player2: {
+                        hand: ['vanguard-infantry']
+                    }
+                });
+            });
+
+            it('should heal 1 from friendly base when a friendly Command unit is played', function () {
+                const { context } = contextRef;
+
+                // CASE 1: Yularen heals when he himself is played
+                context.player1.clickCard(context.colonelYularen);
+                expect(context.p1Base.damage).toBe(2);
+
+                // CASE 2: no heal when opponent plays a Command unit
+                context.player2.clickCard(context.vanguardInfantry);
+                expect(context.p1Base.damage).toBe(2);
+
+                // CASE 3: heal happens when another friendly Command unit is played
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.p1Base.damage).toBe(1);
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/units/ColonelYularenIsbDirector.spec.ts
+++ b/test/server/cards/01_SOR/units/ColonelYularenIsbDirector.spec.ts
@@ -28,6 +28,8 @@ describe('Colonel Yularen, ISB Director', function() {
                 // CASE 3: heal happens when another friendly Command unit is played
                 context.player1.clickCard(context.battlefieldMarine);
                 expect(context.p1Base.damage).toBe(1);
+
+                // double Yularen case is covered in UniqueRule.spec.ts
             });
         });
     });

--- a/test/server/cards/01_SOR/units/MaceWinduPartyCrasher.spec.ts
+++ b/test/server/cards/01_SOR/units/MaceWinduPartyCrasher.spec.ts
@@ -18,7 +18,7 @@ describe('Mace Windu, Party Crasher', function() {
                 const { context } = contextRef;
 
                 const reset = (passAction = true) => {
-                    context.maceWindu.damage = 0;
+                    context.setDamage(context.maceWindu, 0);
                     if (passAction) {
                         context.player2.passAction();
                     }

--- a/test/server/cards/02_SHD/units/SalaciousCrumbObnoxiousPet.spec.ts
+++ b/test/server/cards/02_SHD/units/SalaciousCrumbObnoxiousPet.spec.ts
@@ -23,7 +23,6 @@ describe('Salacious Crumb, Obnoxious Pet', function() {
             it('should heal 0 from base if base has no damage', function () {
                 const { context } = contextRef;
 
-                context.setDamage(context.p1Base, 0);
                 context.player1.clickCard(context.salaciousCrumb);
                 expect(context.salaciousCrumb).toBeInLocation('ground arena');
 

--- a/test/server/cards/02_SHD/units/SupremeLeaderSnokeShadowRuler.spec.ts
+++ b/test/server/cards/02_SHD/units/SupremeLeaderSnokeShadowRuler.spec.ts
@@ -39,6 +39,8 @@ describe('Supreme Leader Snoke, Shadow Ruler', function() {
                 context.player2.clickCard(context.deathStarStormtrooper);
                 expect(context.deathStarStormtrooper).toBeInLocation('discard');
             });
+
+            // double Snoke case is covered in UniqueRule.spec.ts
         });
     });
 });

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -83,7 +83,7 @@ describe('Uniqueness rule', function() {
             });
         });
 
-        describe('When a duplicate of a unique card is played that triggers for itself on play,', function() {
+        describe('When a duplicate of a unique card is played that triggers its own ability on play,', function() {
             beforeEach(function () {
                 contextRef.setupTest({
                     phase: 'action',
@@ -112,6 +112,37 @@ describe('Uniqueness rule', function() {
                 expect(context.p1Base.damage).toBe(1);
                 expect(context.yularenInHand).toBeInLocation('ground arena');
                 expect(context.yularenInPlay).toBeInLocation('discard');
+            });
+        });
+
+        describe('When a duplicate of a unique card with an ongoing effect is played,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['supreme-leader-snoke#shadow-ruler'],
+                        groundArena: ['supreme-leader-snoke#shadow-ruler']
+                    },
+                    player2: {
+                        groundArena: ['cell-block-guard']
+                    }
+                });
+
+                const { context } = contextRef;
+                const p1Snokes = context.player1.findCardsByName('supreme-leader-snoke#shadow-ruler');
+                context.snokeInHand = p1Snokes.find((snoke) => snoke.location === 'hand');
+                context.snokeInPlay = p1Snokes.find((snoke) => snoke.location === 'ground arena');
+            });
+
+            it('the ongoing effects should never be active at the same time', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.snokeInHand);
+
+                // Cell block guard should still be alive since the -2/-2 effects never stacked
+                expect(context.cellBlockGuard).toBeInLocation('ground arena');
+                expect(context.snokeInHand).toBeInLocation('ground arena');
+                expect(context.snokeInPlay).toBeInLocation('discard');
             });
         });
     });

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -82,5 +82,37 @@ describe('Uniqueness rule', function() {
                 expect(context.lukeSkywalkerFaithfulFriend).toBeInLocation('ground arena');
             });
         });
+
+        describe('When a duplicate of a unique card is played that triggers for itself on play,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['colonel-yularen#isb-director'],
+                        groundArena: ['colonel-yularen#isb-director'],
+                        base: { card: 'nevarro-city', damage: 3 }
+                    },
+                    player2: {
+                    }
+                });
+
+                const { context } = contextRef;
+                const p1Yularens = context.player1.findCardsByName('colonel-yularen#isb-director');
+                context.yularenInHand = p1Yularens.find((yularen) => yularen.location === 'hand');
+                context.yularenInPlay = p1Yularens.find((yularen) => yularen.location === 'ground arena');
+            });
+
+            it('the trigger should happen twice', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.yularenInHand);
+                expect(context.player1).toHaveExactPromptButtons(['Heal 1 damage from your base', 'Heal 1 damage from your base']);
+                context.player1.clickPrompt('Heal 1 damage from your base');
+
+                expect(context.p1Base.damage).toBe(1);
+                expect(context.yularenInHand).toBeInLocation('ground arena');
+                expect(context.yularenInPlay).toBeInLocation('discard');
+            });
+        });
     });
 });

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -168,7 +168,7 @@ describe('Uniqueness rule', function() {
             });
         });
 
-        describe('When a duplicate of a unique card is played which triggers it\'s copy\'s ability on defeat,', function() {
+        describe('When a duplicate of a unique card is played which triggers its copy\'s ability on defeat,', function() {
             beforeEach(function () {
                 contextRef.setupTest({
                     phase: 'action',
@@ -204,7 +204,34 @@ describe('Uniqueness rule', function() {
                 expect(context.kallusInHand).toBeInLocation('ground arena');
                 expect(context.kallusInPlay).toBeInLocation('discard');
 
-                // triggered abilities from the remaining Kallus, including Ambush (which fizzles due to no target)
+                // triggered abilities from the remaining Kallus, including Ambush (which fizzles due to no attack target)
+                expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Ambush']);
+                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');     // this click is for the 'Pass' prompt
+                expect(context.player1.handSize).toBe(handSize + 1);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('and the copy from hand is chosen for defeat, the ability should trigger', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.kallusInHand);
+
+                const handSize = context.player1.handSize;
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Agent Kallus, Seeking the Rebels to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.kallusInHand, context.kallusInPlay]);
+                expect(context.kallusInHand).toBeInLocation('ground arena');
+                expect(context.kallusInPlay).toBeInLocation('ground arena');
+
+                // defeat resolves
+                context.player1.clickCard(context.kallusInHand);
+                expect(context.kallusInPlay).toBeInLocation('ground arena');
+                expect(context.kallusInHand).toBeInLocation('discard');
+
+                // triggered abilities from the remaining Kallus, including Ambush (which fizzles due to attacker being defeated)
                 expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Ambush']);
                 context.player1.clickPrompt('Draw a card');
                 context.player1.clickPrompt('Draw a card');     // this click is for the 'Pass' prompt

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -1,0 +1,30 @@
+describe('Uniqueness rule', function() {
+    integration(function(contextRef) {
+        describe('When another copy of a unique card in play enters play', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['chopper#metal-menace'],
+                        groundArena: ['chopper#metal-menace'],
+                    },
+                    player2: {
+                    }
+                });
+
+                const { context } = contextRef;
+                const choppers = context.player1.findCardsByName('chopper#metal-menace');
+                context.chopperInHand = choppers.find((chopper) => chopper.location === 'hand');
+                context.chopperInPlay = choppers.find((chopper) => chopper.location === 'ground arena');
+            });
+
+            it('the copy already in play should be defeated', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chopperInHand);
+                expect(context.chopperInHand).toBeInLocation('ground arena');
+                expect(context.chopperInPlay).toBeInLocation('discard');
+            });
+        });
+    });
+});

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -20,130 +20,159 @@ describe('Uniqueness rule', function() {
                 context.p2Chopper = context.player2.findCardByName('chopper#metal-menace');
             });
 
-            it('the copy already in play should be defeated', function () {
+            it('the player should be prompted to choose a copy to defeat', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.chopperInHand);
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Chopper, Metal Menace to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.chopperInHand, context.chopperInPlay]);
+                expect(context.chopperInHand).toBeInLocation('ground arena');
+                expect(context.chopperInPlay).toBeInLocation('ground arena');
+
+                // defeat resolves
+                context.player1.clickCard(context.chopperInPlay);
                 expect(context.chopperInHand).toBeInLocation('ground arena');
                 expect(context.chopperInPlay).toBeInLocation('discard');
                 expect(context.p2Chopper).toBeInLocation('ground arena');
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('the player should be able to defeat either copy', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chopperInHand);
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Chopper, Metal Menace to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.chopperInHand, context.chopperInPlay]);
+                expect(context.chopperInHand).toBeInLocation('ground arena');
+                expect(context.chopperInPlay).toBeInLocation('ground arena');
+
+                // choose other copy this time, defeat resolves
+                context.player1.clickCard(context.chopperInHand);
+                expect(context.chopperInPlay).toBeInLocation('ground arena');
+                expect(context.chopperInHand).toBeInLocation('discard');
+                expect(context.p2Chopper).toBeInLocation('ground arena');
+                expect(context.player2).toBeActivePlayer();
             });
         });
 
-        describe('When another copy of a unique upgrade in play enters play for the same controller,', function() {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        hand: ['lukes-lightsaber'],
-                        groundArena: [{ card: 'wampa', upgrades: ['lukes-lightsaber'] }, 'battlefield-marine'],
-                    },
-                    player2: {
-                        groundArena: [{ card: 'wild-rancor', upgrades: ['lukes-lightsaber'] }]
-                    }
-                });
+        // describe('When another copy of a unique upgrade in play enters play for the same controller,', function() {
+        //     beforeEach(function () {
+        //         contextRef.setupTest({
+        //             phase: 'action',
+        //             player1: {
+        //                 hand: ['lukes-lightsaber'],
+        //                 groundArena: [{ card: 'wampa', upgrades: ['lukes-lightsaber'] }, 'battlefield-marine'],
+        //             },
+        //             player2: {
+        //                 groundArena: [{ card: 'wild-rancor', upgrades: ['lukes-lightsaber'] }]
+        //             }
+        //         });
 
-                const { context } = contextRef;
-                const p1Lightsabers = context.player1.findCardsByName('lukes-lightsaber');
-                context.lightsaberInHand = p1Lightsabers.find((lightsaber) => lightsaber.location === 'hand');
-                context.lightsaberInPlay = p1Lightsabers.find((lightsaber) => lightsaber.location === 'ground arena');
-                context.p2Lightsaber = context.player2.findCardByName('lukes-lightsaber');
-            });
+        //         const { context } = contextRef;
+        //         const p1Lightsabers = context.player1.findCardsByName('lukes-lightsaber');
+        //         context.lightsaberInHand = p1Lightsabers.find((lightsaber) => lightsaber.location === 'hand');
+        //         context.lightsaberInPlay = p1Lightsabers.find((lightsaber) => lightsaber.location === 'ground arena');
+        //         context.p2Lightsaber = context.player2.findCardByName('lukes-lightsaber');
+        //     });
 
-            it('the copy already in play should be defeated', function () {
-                const { context } = contextRef;
+        //     it('the copy already in play should be defeated', function () {
+        //         const { context } = contextRef;
 
-                context.player1.clickCard(context.lightsaberInHand);
-                context.player1.clickCard(context.battlefieldMarine);
-                expect(context.lightsaberInHand).toBeInLocation('ground arena');
-                expect(context.lightsaberInPlay).toBeInLocation('discard');
-                expect(context.p2Lightsaber).toBeInLocation('ground arena');
-            });
-        });
+        //         context.player1.clickCard(context.lightsaberInHand);
+        //         context.player1.clickCard(context.battlefieldMarine);
+        //         expect(context.lightsaberInHand).toBeInLocation('ground arena');
+        //         expect(context.lightsaberInPlay).toBeInLocation('discard');
+        //         expect(context.p2Lightsaber).toBeInLocation('ground arena');
+        //     });
+        // });
 
-        describe('When a card is played that matches only the title of another card in play for the same controller,', function() {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        hand: ['luke-skywalker#jedi-knight'],
-                        leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
-                    },
-                    player2: {
-                    }
-                });
-            });
+        // describe('When a card is played that matches only the title of another card in play for the same controller,', function() {
+        //     beforeEach(function () {
+        //         contextRef.setupTest({
+        //             phase: 'action',
+        //             player1: {
+        //                 hand: ['luke-skywalker#jedi-knight'],
+        //                 leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
+        //             },
+        //             player2: {
+        //             }
+        //         });
+        //     });
 
-            it('both should stay on the field', function () {
-                const { context } = contextRef;
+        //     it('both should stay on the field', function () {
+        //         const { context } = contextRef;
 
-                context.player1.clickCard(context.lukeSkywalkerJediKnight);
-                expect(context.lukeSkywalkerJediKnight).toBeInLocation('ground arena');
-                expect(context.lukeSkywalkerFaithfulFriend).toBeInLocation('ground arena');
-            });
-        });
+        //         context.player1.clickCard(context.lukeSkywalkerJediKnight);
+        //         expect(context.lukeSkywalkerJediKnight).toBeInLocation('ground arena');
+        //         expect(context.lukeSkywalkerFaithfulFriend).toBeInLocation('ground arena');
+        //     });
+        // });
 
-        describe('When a duplicate of a unique card is played that triggers its own ability on play,', function() {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        hand: ['colonel-yularen#isb-director'],
-                        groundArena: ['colonel-yularen#isb-director'],
-                        base: { card: 'nevarro-city', damage: 3 }
-                    },
-                    player2: {
-                    }
-                });
+        // describe('When a duplicate of a unique card is played that triggers its own ability on play,', function() {
+        //     beforeEach(function () {
+        //         contextRef.setupTest({
+        //             phase: 'action',
+        //             player1: {
+        //                 hand: ['colonel-yularen#isb-director'],
+        //                 groundArena: ['colonel-yularen#isb-director'],
+        //                 base: { card: 'nevarro-city', damage: 3 }
+        //             },
+        //             player2: {
+        //             }
+        //         });
 
-                const { context } = contextRef;
-                const p1Yularens = context.player1.findCardsByName('colonel-yularen#isb-director');
-                context.yularenInHand = p1Yularens.find((yularen) => yularen.location === 'hand');
-                context.yularenInPlay = p1Yularens.find((yularen) => yularen.location === 'ground arena');
-            });
+        //         const { context } = contextRef;
+        //         const p1Yularens = context.player1.findCardsByName('colonel-yularen#isb-director');
+        //         context.yularenInHand = p1Yularens.find((yularen) => yularen.location === 'hand');
+        //         context.yularenInPlay = p1Yularens.find((yularen) => yularen.location === 'ground arena');
+        //     });
 
-            it('the trigger should happen twice', function () {
-                const { context } = contextRef;
+        //     it('the trigger should happen twice', function () {
+        //         const { context } = contextRef;
 
-                context.player1.clickCard(context.yularenInHand);
-                expect(context.player1).toHaveExactPromptButtons(['Heal 1 damage from your base', 'Heal 1 damage from your base']);
-                context.player1.clickPrompt('Heal 1 damage from your base');
+        //         context.player1.clickCard(context.yularenInHand);
+        //         expect(context.player1).toHaveExactPromptButtons(['Heal 1 damage from your base', 'Heal 1 damage from your base']);
+        //         context.player1.clickPrompt('Heal 1 damage from your base');
 
-                expect(context.p1Base.damage).toBe(1);
-                expect(context.yularenInHand).toBeInLocation('ground arena');
-                expect(context.yularenInPlay).toBeInLocation('discard');
-            });
-        });
+        //         expect(context.p1Base.damage).toBe(1);
+        //         expect(context.yularenInHand).toBeInLocation('ground arena');
+        //         expect(context.yularenInPlay).toBeInLocation('discard');
+        //     });
+        // });
 
-        describe('When a duplicate of a unique card with an ongoing effect is played,', function() {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        hand: ['supreme-leader-snoke#shadow-ruler'],
-                        groundArena: ['supreme-leader-snoke#shadow-ruler']
-                    },
-                    player2: {
-                        groundArena: ['cell-block-guard']
-                    }
-                });
+        // describe('When a duplicate of a unique card with an ongoing effect is played,', function() {
+        //     beforeEach(function () {
+        //         contextRef.setupTest({
+        //             phase: 'action',
+        //             player1: {
+        //                 hand: ['supreme-leader-snoke#shadow-ruler'],
+        //                 groundArena: ['supreme-leader-snoke#shadow-ruler']
+        //             },
+        //             player2: {
+        //                 groundArena: ['cell-block-guard']
+        //             }
+        //         });
 
-                const { context } = contextRef;
-                const p1Snokes = context.player1.findCardsByName('supreme-leader-snoke#shadow-ruler');
-                context.snokeInHand = p1Snokes.find((snoke) => snoke.location === 'hand');
-                context.snokeInPlay = p1Snokes.find((snoke) => snoke.location === 'ground arena');
-            });
+        //         const { context } = contextRef;
+        //         const p1Snokes = context.player1.findCardsByName('supreme-leader-snoke#shadow-ruler');
+        //         context.snokeInHand = p1Snokes.find((snoke) => snoke.location === 'hand');
+        //         context.snokeInPlay = p1Snokes.find((snoke) => snoke.location === 'ground arena');
+        //     });
 
-            it('the ongoing effects should never be active at the same time', function () {
-                const { context } = contextRef;
+        //     it('the ongoing effects should never be active at the same time', function () {
+        //         const { context } = contextRef;
 
-                context.player1.clickCard(context.snokeInHand);
+        //         context.player1.clickCard(context.snokeInHand);
 
-                // Cell block guard should still be alive since the -2/-2 effects never stacked
-                expect(context.cellBlockGuard).toBeInLocation('ground arena');
-                expect(context.snokeInHand).toBeInLocation('ground arena');
-                expect(context.snokeInPlay).toBeInLocation('discard');
-            });
-        });
+        //         // Cell block guard should still be alive since the -2/-2 effects never stacked
+        //         expect(context.cellBlockGuard).toBeInLocation('ground arena');
+        //         expect(context.snokeInHand).toBeInLocation('ground arena');
+        //         expect(context.snokeInPlay).toBeInLocation('discard');
+        //     });
+        // });
     });
 });

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -168,6 +168,74 @@ describe('Uniqueness rule', function() {
             });
         });
 
+        describe('When a duplicate of a unique card is played,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['admiral-motti#brazen-and-scornful'],
+                        groundArena: [{ card: 'admiral-motti#brazen-and-scornful', exhausted: true }],
+                        base: { card: 'nevarro-city', damage: 3 }
+                    },
+                    player2: {
+                    }
+                });
+
+                const { context } = contextRef;
+                const p1Mottis = context.player1.findCardsByName('admiral-motti#brazen-and-scornful');
+                context.mottiInHand = p1Mottis.find((motti) => motti.location === 'hand');
+                context.mottiInPlay = p1Mottis.find((motti) => motti.location === 'ground arena');
+            });
+
+            it('and the in play copy is chosen for defeat, it should be able to target the copy from hand with a when defeated ability', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.mottiInHand);
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Admiral Motti, Brazen and Scornful to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.mottiInHand, context.mottiInPlay]);
+                expect(context.mottiInHand).toBeInLocation('ground arena');
+                expect(context.mottiInPlay).toBeInLocation('ground arena');
+
+                // defeat resolves
+                context.player1.clickCard(context.mottiInPlay);
+                expect(context.mottiInHand).toBeInLocation('ground arena');
+                expect(context.mottiInPlay).toBeInLocation('discard');
+
+                // triggered ability from defeated Motti
+                expect(context.player1).toHavePassAbilityPrompt('Ready a Villainy unit');
+                context.player1.clickPrompt('Ready a Villainy unit');
+                expect(context.mottiInHand.exhausted).toBe(false);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('and the copy from hand is chosen for defeat, it should be able to target the copy in play with a when defeated ability', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.mottiInHand);
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Admiral Motti, Brazen and Scornful to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.mottiInHand, context.mottiInPlay]);
+                expect(context.mottiInHand).toBeInLocation('ground arena');
+                expect(context.mottiInPlay).toBeInLocation('ground arena');
+
+                // defeat resolves
+                context.player1.clickCard(context.mottiInHand);
+                expect(context.mottiInPlay).toBeInLocation('ground arena');
+                expect(context.mottiInHand).toBeInLocation('discard');
+
+                // triggered ability from defeated Motti
+                expect(context.player1).toHavePassAbilityPrompt('Ready a Villainy unit');
+                context.player1.clickPrompt('Ready a Villainy unit');
+                expect(context.mottiInPlay.exhausted).toBe(false);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
         describe('When a duplicate of a unique card with an ongoing effect is played,', function() {
             beforeEach(function () {
                 contextRef.setupTest({

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -59,120 +59,173 @@ describe('Uniqueness rule', function() {
             });
         });
 
-        // describe('When another copy of a unique upgrade in play enters play for the same controller,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 hand: ['lukes-lightsaber'],
-        //                 groundArena: [{ card: 'wampa', upgrades: ['lukes-lightsaber'] }, 'battlefield-marine'],
-        //             },
-        //             player2: {
-        //                 groundArena: [{ card: 'wild-rancor', upgrades: ['lukes-lightsaber'] }]
-        //             }
-        //         });
+        describe('When another copy of a unique upgrade in play enters play for the same controller,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['lukes-lightsaber'],
+                        groundArena: [{ card: 'wampa', upgrades: ['lukes-lightsaber'] }, 'battlefield-marine'],
+                    },
+                    player2: {
+                        groundArena: [{ card: 'wild-rancor', upgrades: ['lukes-lightsaber'] }]
+                    }
+                });
 
-        //         const { context } = contextRef;
-        //         const p1Lightsabers = context.player1.findCardsByName('lukes-lightsaber');
-        //         context.lightsaberInHand = p1Lightsabers.find((lightsaber) => lightsaber.location === 'hand');
-        //         context.lightsaberInPlay = p1Lightsabers.find((lightsaber) => lightsaber.location === 'ground arena');
-        //         context.p2Lightsaber = context.player2.findCardByName('lukes-lightsaber');
-        //     });
+                const { context } = contextRef;
+                const p1Lightsabers = context.player1.findCardsByName('lukes-lightsaber');
+                context.lightsaberInHand = p1Lightsabers.find((lightsaber) => lightsaber.location === 'hand');
+                context.lightsaberInPlay = p1Lightsabers.find((lightsaber) => lightsaber.location === 'ground arena');
+                context.p2Lightsaber = context.player2.findCardByName('lukes-lightsaber');
+            });
 
-        //     it('the copy already in play should be defeated', function () {
-        //         const { context } = contextRef;
+            it('the player should be prompted to choose a copy to defeat', function () {
+                const { context } = contextRef;
 
-        //         context.player1.clickCard(context.lightsaberInHand);
-        //         context.player1.clickCard(context.battlefieldMarine);
-        //         expect(context.lightsaberInHand).toBeInLocation('ground arena');
-        //         expect(context.lightsaberInPlay).toBeInLocation('discard');
-        //         expect(context.p2Lightsaber).toBeInLocation('ground arena');
-        //     });
-        // });
+                context.player1.clickCard(context.lightsaberInHand);
+                context.player1.clickCard(context.battlefieldMarine);
 
-        // describe('When a card is played that matches only the title of another card in play for the same controller,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 hand: ['luke-skywalker#jedi-knight'],
-        //                 leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
-        //             },
-        //             player2: {
-        //             }
-        //         });
-        //     });
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Luke\'s Lightsaber to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.lightsaberInHand, context.lightsaberInPlay]);
+                expect(context.lightsaberInHand).toBeInLocation('ground arena');
+                expect(context.lightsaberInPlay).toBeInLocation('ground arena');
 
-        //     it('both should stay on the field', function () {
-        //         const { context } = contextRef;
+                // defeat resolves
+                context.player1.clickCard(context.lightsaberInPlay);
+                expect(context.lightsaberInHand).toBeInLocation('ground arena');
+                expect(context.lightsaberInPlay).toBeInLocation('discard');
+                expect(context.p2Lightsaber).toBeInLocation('ground arena');
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
 
-        //         context.player1.clickCard(context.lukeSkywalkerJediKnight);
-        //         expect(context.lukeSkywalkerJediKnight).toBeInLocation('ground arena');
-        //         expect(context.lukeSkywalkerFaithfulFriend).toBeInLocation('ground arena');
-        //     });
-        // });
+        describe('When a card is played that matches the title but not the subtitle of another card in play for the same controller,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['luke-skywalker#jedi-knight'],
+                        leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
+                    },
+                    player2: {
+                    }
+                });
+            });
 
-        // describe('When a duplicate of a unique card is played that triggers its own ability on play,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 hand: ['colonel-yularen#isb-director'],
-        //                 groundArena: ['colonel-yularen#isb-director'],
-        //                 base: { card: 'nevarro-city', damage: 3 }
-        //             },
-        //             player2: {
-        //             }
-        //         });
+            it('both should stay on the field', function () {
+                const { context } = contextRef;
 
-        //         const { context } = contextRef;
-        //         const p1Yularens = context.player1.findCardsByName('colonel-yularen#isb-director');
-        //         context.yularenInHand = p1Yularens.find((yularen) => yularen.location === 'hand');
-        //         context.yularenInPlay = p1Yularens.find((yularen) => yularen.location === 'ground arena');
-        //     });
+                context.player1.clickCard(context.lukeSkywalkerJediKnight);
+                expect(context.lukeSkywalkerJediKnight).toBeInLocation('ground arena');
+                expect(context.lukeSkywalkerFaithfulFriend).toBeInLocation('ground arena');
 
-        //     it('the trigger should happen twice', function () {
-        //         const { context } = contextRef;
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
 
-        //         context.player1.clickCard(context.yularenInHand);
-        //         expect(context.player1).toHaveExactPromptButtons(['Heal 1 damage from your base', 'Heal 1 damage from your base']);
-        //         context.player1.clickPrompt('Heal 1 damage from your base');
+        describe('When a duplicate of a unique card is played that triggers its own ability on play,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['colonel-yularen#isb-director'],
+                        groundArena: ['colonel-yularen#isb-director'],
+                        base: { card: 'nevarro-city', damage: 3 }
+                    },
+                    player2: {
+                    }
+                });
 
-        //         expect(context.p1Base.damage).toBe(1);
-        //         expect(context.yularenInHand).toBeInLocation('ground arena');
-        //         expect(context.yularenInPlay).toBeInLocation('discard');
-        //     });
-        // });
+                const { context } = contextRef;
+                const p1Yularens = context.player1.findCardsByName('colonel-yularen#isb-director');
+                context.yularenInHand = p1Yularens.find((yularen) => yularen.location === 'hand');
+                context.yularenInPlay = p1Yularens.find((yularen) => yularen.location === 'ground arena');
+            });
 
-        // describe('When a duplicate of a unique card with an ongoing effect is played,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 hand: ['supreme-leader-snoke#shadow-ruler'],
-        //                 groundArena: ['supreme-leader-snoke#shadow-ruler']
-        //             },
-        //             player2: {
-        //                 groundArena: ['cell-block-guard']
-        //             }
-        //         });
+            it('the trigger should happen twice', function () {
+                const { context } = contextRef;
 
-        //         const { context } = contextRef;
-        //         const p1Snokes = context.player1.findCardsByName('supreme-leader-snoke#shadow-ruler');
-        //         context.snokeInHand = p1Snokes.find((snoke) => snoke.location === 'hand');
-        //         context.snokeInPlay = p1Snokes.find((snoke) => snoke.location === 'ground arena');
-        //     });
+                context.player1.clickCard(context.yularenInHand);
 
-        //     it('the ongoing effects should never be active at the same time', function () {
-        //         const { context } = contextRef;
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Colonel Yularen, ISB Director to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.yularenInHand, context.yularenInPlay]);
+                expect(context.yularenInHand).toBeInLocation('ground arena');
+                expect(context.yularenInPlay).toBeInLocation('ground arena');
 
-        //         context.player1.clickCard(context.snokeInHand);
+                // defeat resolves
+                context.player1.clickCard(context.yularenInPlay);
+                expect(context.yularenInHand).toBeInLocation('ground arena');
+                expect(context.yularenInPlay).toBeInLocation('discard');
 
-        //         // Cell block guard should still be alive since the -2/-2 effects never stacked
-        //         expect(context.cellBlockGuard).toBeInLocation('ground arena');
-        //         expect(context.snokeInHand).toBeInLocation('ground arena');
-        //         expect(context.snokeInPlay).toBeInLocation('discard');
-        //     });
-        // });
+                // triggered ability from both copies of Yularen
+                expect(context.player1).toHaveExactPromptButtons(['Heal 1 damage from your base', 'Heal 1 damage from your base']);
+                context.player1.clickPrompt('Heal 1 damage from your base');
+                expect(context.p1Base.damage).toBe(1);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
+        describe('When a duplicate of a unique card with an ongoing effect is played,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['supreme-leader-snoke#shadow-ruler'],
+                        groundArena: ['supreme-leader-snoke#shadow-ruler']
+                    },
+                    player2: {
+                        groundArena: ['cell-block-guard']
+                    }
+                });
+
+                const { context } = contextRef;
+                const p1Snokes = context.player1.findCardsByName('supreme-leader-snoke#shadow-ruler');
+                context.snokeInHand = p1Snokes.find((snoke) => snoke.location === 'hand');
+                context.snokeInPlay = p1Snokes.find((snoke) => snoke.location === 'ground arena');
+            });
+
+            it('the ongoing effects should never be active at the same time if the copy in play is defeated', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.snokeInHand);
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Supreme Leader Snoke, Shadow Ruler to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.snokeInHand, context.snokeInPlay]);
+                expect(context.snokeInHand).toBeInLocation('ground arena');
+                expect(context.snokeInPlay).toBeInLocation('ground arena');
+
+                // defeat resolves
+                context.player1.clickCard(context.snokeInPlay);
+                expect(context.snokeInHand).toBeInLocation('ground arena');
+                expect(context.snokeInPlay).toBeInLocation('discard');
+
+                // Cell block guard should still be alive since the -2/-2 effects never stacked
+                expect(context.cellBlockGuard).toBeInLocation('ground arena');
+            });
+
+            it('the ongoing effects should never be active at the same time if the copy from hand is defeated', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.snokeInHand);
+
+                // prompt for defeat step
+                expect(context.player1).toHavePrompt('Choose which copy of Supreme Leader Snoke, Shadow Ruler to defeat');
+                expect(context.player1).toBeAbleToSelectExactly([context.snokeInHand, context.snokeInPlay]);
+                expect(context.snokeInHand).toBeInLocation('ground arena');
+                expect(context.snokeInPlay).toBeInLocation('ground arena');
+
+                // defeat resolves
+                context.player1.clickCard(context.snokeInHand);
+                expect(context.snokeInPlay).toBeInLocation('ground arena');
+                expect(context.snokeInHand).toBeInLocation('discard');
+
+                // Cell block guard should still be alive since the -2/-2 effects never stacked
+                expect(context.cellBlockGuard).toBeInLocation('ground arena');
+            });
+        });
     });
 });

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -1,6 +1,6 @@
 describe('Uniqueness rule', function() {
     integration(function(contextRef) {
-        describe('When another copy of a unique card in play enters play', function() {
+        describe('When another copy of a unique unit in play enters play for the same controller,', function() {
             beforeEach(function () {
                 contextRef.setupTest({
                     phase: 'action',
@@ -9,13 +9,15 @@ describe('Uniqueness rule', function() {
                         groundArena: ['chopper#metal-menace'],
                     },
                     player2: {
+                        groundArena: ['chopper#metal-menace']
                     }
                 });
 
                 const { context } = contextRef;
-                const choppers = context.player1.findCardsByName('chopper#metal-menace');
-                context.chopperInHand = choppers.find((chopper) => chopper.location === 'hand');
-                context.chopperInPlay = choppers.find((chopper) => chopper.location === 'ground arena');
+                const p1Choppers = context.player1.findCardsByName('chopper#metal-menace');
+                context.chopperInHand = p1Choppers.find((chopper) => chopper.location === 'hand');
+                context.chopperInPlay = p1Choppers.find((chopper) => chopper.location === 'ground arena');
+                context.p2Chopper = context.player2.findCardByName('chopper#metal-menace');
             });
 
             it('the copy already in play should be defeated', function () {
@@ -24,6 +26,60 @@ describe('Uniqueness rule', function() {
                 context.player1.clickCard(context.chopperInHand);
                 expect(context.chopperInHand).toBeInLocation('ground arena');
                 expect(context.chopperInPlay).toBeInLocation('discard');
+                expect(context.p2Chopper).toBeInLocation('ground arena');
+            });
+        });
+
+        describe('When another copy of a unique upgrade in play enters play for the same controller,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['lukes-lightsaber'],
+                        groundArena: [{ card: 'wampa', upgrades: ['lukes-lightsaber'] }, 'battlefield-marine'],
+                    },
+                    player2: {
+                        groundArena: [{ card: 'wild-rancor', upgrades: ['lukes-lightsaber'] }]
+                    }
+                });
+
+                const { context } = contextRef;
+                const p1Lightsabers = context.player1.findCardsByName('lukes-lightsaber');
+                context.lightsaberInHand = p1Lightsabers.find((lightsaber) => lightsaber.location === 'hand');
+                context.lightsaberInPlay = p1Lightsabers.find((lightsaber) => lightsaber.location === 'ground arena');
+                context.p2Lightsaber = context.player2.findCardByName('lukes-lightsaber');
+            });
+
+            it('the copy already in play should be defeated', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.lightsaberInHand);
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.lightsaberInHand).toBeInLocation('ground arena');
+                expect(context.lightsaberInPlay).toBeInLocation('discard');
+                expect(context.p2Lightsaber).toBeInLocation('ground arena');
+            });
+        });
+
+        describe('When a card is played that matches only the title of another card in play for the same controller,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['luke-skywalker#jedi-knight'],
+                        leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
+                    },
+                    player2: {
+                    }
+                });
+            });
+
+            it('both should stay on the field', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.lukeSkywalkerJediKnight);
+                expect(context.lukeSkywalkerJediKnight).toBeInLocation('ground arena');
+                expect(context.lukeSkywalkerFaithfulFriend).toBeInLocation('ground arena');
             });
         });
     });


### PR DESCRIPTION
Implemented the rules for enforcing unique cards in play. Added tests for the edge cases of Yularen and Snoke to confirm that they work correctly.

Yularen worked out of the box. Snoke required adding some additional logic to disable ongoing effects when a card has a pending defeat. Also, refactored the "pending defeat" code to be clearer and operate more consistently.