### PR TITLE
Add ISB Agent implementation

### DIFF
--- a/server/game/cards/01_SOR/units/ISBAgent.ts
+++ b/server/game/cards/01_SOR/units/ISBAgent.ts
@@ -1,0 +1,33 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Location, RelativePlayer, CardType, WildcardCardType } from '../../../core/Constants';
+
+export default class ISBAgent extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '5154172446',
+            internalName: 'isb-agent'
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addWhenPlayedAbility({
+            title: 'Reveal an event from your hand',
+            targetResolver: {
+                cardTypeFilter: CardType.Event,
+                controller: RelativePlayer.Self,
+                locationFilter: Location.Hand,
+                immediateEffect: AbilityHelper.immediateEffects.reveal()
+            },
+            ifYouDo: {
+                title: 'Deal 1 damage to a unit',
+                targetResolver: {
+                    cardTypeFilter: WildcardCardType.Unit,
+                    immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1 })
+                }
+            }
+        });
+    }
+}
+
+ISBAgent.implemented = true;

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -122,7 +122,12 @@ export class CardTargetResolver extends TargetResolver<ICardTargetResolver<Abili
                 passPrompt.hasBeenShown = true;
             }
             if (this.selector.optional) {
-                buttons.push({ text: 'Choose no target', arg: 'noTarget' });
+                // If the selector is for a single card and it will automatically fire on selection,
+                // uses the 'done' arg so that the prompt doesn't show both 'Choose no target' and 'Done' buttons.
+                buttons.push({
+                    text: 'Choose no target',
+                    arg: this.selector.numCards === 1 && this.selector.automaticFireOnSelect(context) ? 'done' : 'noTarget'
+                });
             }
         }
         const mustSelect = legalTargets.filter((card) =>

--- a/test/server/cards/01_SOR/units/ISBAgent.spec.ts
+++ b/test/server/cards/01_SOR/units/ISBAgent.spec.ts
@@ -1,0 +1,75 @@
+describe('ISB Agent', function() {
+    integration(function(contextRef) {
+        describe('ISB Agent\' ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['confiscate', 'waylay', 'isb-agent'],
+                        groundArena: ['atst'],
+                        spaceArena: ['cartel-spacer']
+                    },
+                    player2: {
+                        hand: ['disarm'],
+                        groundArena: ['wampa'],
+                        spaceArena: ['alliance-xwing']
+                    }
+                });
+            });
+
+            describe('when event is revealed', function() {
+                it('should deal 1 damage to a unit', function () {
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.isbAgent);
+
+                    expect(context.player1).toBeAbleToSelectExactly([context.confiscate, context.waylay]);
+                    expect(context.player1).toHaveExactPromptButtons(['Choose no target']);
+                    context.player1.clickCard(context.confiscate);
+
+                    expect(context.getChatLogs(3)).toEqual([
+                        'player1 plays ISB Agent',
+                        'player1 uses ISB Agent to reveal a card',
+                        'player1 reveals Confiscate due to ISB Agent',
+                    ]);
+
+                    expect(context.player1).toBeAbleToSelectExactly([context.isbAgent, context.atst, context.cartelSpacer, context.wampa, context.allianceXwing]);
+                    context.player1.clickCard(context.wampa);
+
+                    expect(context.isbAgent).toBeInLocation('ground arena');
+                    expect(context.isbAgent.damage).toBe(0);
+                    expect(context.atst.damage).toBe(0);
+                    expect(context.cartelSpacer.damage).toBe(0);
+                    expect(context.wampa.damage).toBe(1);
+                    expect(context.allianceXwing.damage).toBe(0);
+                });
+            });
+
+            describe('when event is not revealed', function() {
+                it('should do nothing', function () {
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.isbAgent);
+
+                    expect(context.player1).toBeAbleToSelectExactly([context.confiscate, context.waylay]);
+                    expect(context.player1).toHaveExactPromptButtons(['Choose no target']);
+                    context.player1.clickPrompt('Choose no target');
+
+                    expect(context.getChatLogs(2)).toEqual([
+                        'player1 plays ISB Agent',
+                        'player1 uses ISB Agent',
+                    ]);
+
+                    expect(context.isbAgent).toBeInLocation('ground arena');
+                    expect(context.isbAgent.damage).toBe(0);
+                    expect(context.atst.damage).toBe(0);
+                    expect(context.cartelSpacer.damage).toBe(0);
+                    expect(context.wampa.damage).toBe(0);
+                    expect(context.allianceXwing.damage).toBe(0);
+
+                    expect(context.player2).toBeActivePlayer();
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/units/ISBAgent.spec.ts
+++ b/test/server/cards/01_SOR/units/ISBAgent.spec.ts
@@ -24,7 +24,8 @@ describe('ISB Agent', function() {
                     context.player1.clickCard(context.isbAgent);
 
                     expect(context.player1).toBeAbleToSelectExactly([context.confiscate, context.waylay]);
-                    expect(context.player1).toHaveExactPromptButtons(['Choose no target']);
+                    expect(context.player1).toHaveChooseNoTargetButton();
+                    expect(context.player1).not.toHavePassAbilityButton();
                     context.player1.clickCard(context.confiscate);
 
                     expect(context.getChatLogs(3)).toEqual([
@@ -46,7 +47,8 @@ describe('ISB Agent', function() {
                     context.player1.clickCard(context.isbAgent);
 
                     expect(context.player1).toBeAbleToSelectExactly([context.confiscate, context.waylay]);
-                    expect(context.player1).toHaveExactPromptButtons(['Choose no target']);
+                    expect(context.player1).toHaveChooseNoTargetButton();
+                    expect(context.player1).not.toHavePassAbilityButton();
                     context.player1.clickPrompt('Choose no target');
 
                     expect(context.getChatLogs(2)).toEqual([

--- a/test/server/cards/01_SOR/units/ISBAgent.spec.ts
+++ b/test/server/cards/01_SOR/units/ISBAgent.spec.ts
@@ -1,24 +1,24 @@
 describe('ISB Agent', function() {
     integration(function(contextRef) {
-        describe('ISB Agent\' ability', function() {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        hand: ['confiscate', 'waylay', 'isb-agent'],
-                        groundArena: ['atst'],
-                        spaceArena: ['cartel-spacer']
-                    },
-                    player2: {
-                        hand: ['disarm'],
-                        groundArena: ['wampa'],
-                        spaceArena: ['alliance-xwing']
-                    }
+        describe('ISB Agent\'s When Played ability', function() {
+            describe('when hand contains some events', function() {
+                beforeEach(function () {
+                    contextRef.setupTest({
+                        phase: 'action',
+                        player1: {
+                            hand: ['confiscate', 'waylay', 'isb-agent'],
+                            groundArena: ['atst'],
+                            spaceArena: ['cartel-spacer']
+                        },
+                        player2: {
+                            hand: ['disarm'],
+                            groundArena: ['wampa'],
+                            spaceArena: ['alliance-xwing']
+                        }
+                    });
                 });
-            });
 
-            describe('when event is revealed', function() {
-                it('should deal 1 damage to a unit', function () {
+                it('should deal 1 damage to a unit when an event is revealed', function () {
                     const { context } = contextRef;
 
                     context.player1.clickCard(context.isbAgent);
@@ -37,16 +37,10 @@ describe('ISB Agent', function() {
                     context.player1.clickCard(context.wampa);
 
                     expect(context.isbAgent).toBeInLocation('ground arena');
-                    expect(context.isbAgent.damage).toBe(0);
-                    expect(context.atst.damage).toBe(0);
-                    expect(context.cartelSpacer.damage).toBe(0);
                     expect(context.wampa.damage).toBe(1);
-                    expect(context.allianceXwing.damage).toBe(0);
                 });
-            });
 
-            describe('when event is not revealed', function() {
-                it('should do nothing', function () {
+                it('should do nothing when an event is not revealed', function () {
                     const { context } = contextRef;
 
                     context.player1.clickCard(context.isbAgent);
@@ -66,6 +60,35 @@ describe('ISB Agent', function() {
                     expect(context.cartelSpacer.damage).toBe(0);
                     expect(context.wampa.damage).toBe(0);
                     expect(context.allianceXwing.damage).toBe(0);
+
+                    expect(context.player2).toBeActivePlayer();
+                });
+            });
+
+            describe('when hand contains no events', function() {
+                beforeEach(function () {
+                    contextRef.setupTest({
+                        phase: 'action',
+                        player1: {
+                            hand: ['isb-agent']
+                        },
+                        player2: {
+                            hand: ['disarm']
+                        }
+                    });
+                });
+
+                it('should do nothing', function () {
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.isbAgent);
+
+                    expect(context.getChatLogs(1)).toEqual([
+                        'player1 plays ISB Agent',
+                    ]);
+
+                    expect(context.isbAgent).toBeInLocation('ground arena');
+                    expect(context.isbAgent.damage).toBe(0);
 
                     expect(context.player2).toBeActivePlayer();
                 });


### PR DESCRIPTION
Adds the implementation for ISB Agent and slightly changes the logic for the "Choose no target" button to avoid showing it alongside the "Done" button when only one card needs to be selected.

![image](https://github.com/user-attachments/assets/d5113509-a1d2-4a70-90d0-83b63146a833)
