### PR TITLE
Move card target condition check before system check

### DIFF
--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -38,8 +38,8 @@ export class CardTargetResolver extends TargetResolver<ICardTargetResolver<Abili
                 return false;
             }
             return (!this.dependentTarget || this.dependentTarget.hasLegalTarget(contextCopy)) &&
-              (properties.immediateEffect == null || properties.immediateEffect.hasLegalTarget(contextCopy, this.properties.mustChangeGameState) &&
-                (!properties.cardCondition || properties.cardCondition(card, contextCopy)));
+              (!properties.cardCondition || properties.cardCondition(card, contextCopy)) &&
+              (properties.immediateEffect == null || properties.immediateEffect.hasLegalTarget(contextCopy, this.properties.mustChangeGameState));
         };
         return CardSelectorFactory.create(Object.assign({}, properties, { cardCondition: cardCondition, targets: true }));
     }


### PR DESCRIPTION
Rearranged things in CardTargetResolver so that that the condition filter is checked before the system's hasLegalTarget is invoked. This is because the condition filter might be able to prevent the system from trying to properties are cards that are in an invalid state (e.g., attempting to read the damage off of a card in hand).