### PR TITLE
Add support for system array factories for aggregate systems

### DIFF
--- a/server/game/core/gameSystem/AggregateSystem.ts
+++ b/server/game/core/gameSystem/AggregateSystem.ts
@@ -1,6 +1,9 @@
 import { AbilityContext } from '../ability/AbilityContext';
 import { GameSystem, IGameSystemProperties } from './GameSystem';
 
+// helper type useful for some extensions of this class
+export type ISystemArrayOrFactory<TContext extends AbilityContext> = (GameSystem<TContext>)[] | ((context: TContext) => (GameSystem<TContext>)[]);
+
 /**
  * Meta-system used for executing a set of other systems together.
  *

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -72,6 +72,7 @@ import { ILookMoveDeckCardsTopOrBottomProperties, LookMoveDeckCardsTopOrBottomSy
 import { DiscardFromDeckSystem, IDiscardFromDeckProperties } from './DiscardFromDeckSystem';
 import { DiscardCardsFromHand, IDiscardCardsFromHandProperties } from './DiscardCardsFromHand';
 import { DiscardEntireHandSystem, IDiscardEntireHandSystemProperties } from './DiscardEntireHandSystem';
+import { ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
 // import { TakeControlAction, TakeControlProperties } from './TakeControlAction';
 // import { TriggerAbilityAction, TriggerAbilityProperties } from './TriggerAbilityAction';
 // import { TurnCardFacedownAction, TurnCardFacedownProperties } from './TurnCardFacedownAction';
@@ -405,13 +406,10 @@ export function selectCard<TContext extends AbilityContext = AbilityContext>(pro
 // export function selectToken(propertyFactory: PropsFactory<SelectTokenProperties>): GameSystem {
 //     return new SelectTokenAction(propertyFactory);
 // }
-export function sequential<TContext extends AbilityContext = AbilityContext>(gameSystems: GameSystem<TContext>[]): GameSystem<TContext> {
+export function sequential<TContext extends AbilityContext = AbilityContext>(gameSystems: ISystemArrayOrFactory<TContext>): GameSystem<TContext> {
     return new SequentialSystem<TContext>(gameSystems);
 } // takes an array of gameActions, not a propertyFactory
-// export function sequentialContext(propertyFactory: PropsFactory<SequentialContextProperties>): GameSystem {
-//     return new SequentialContextAction(propertyFactory);
-// }
-export function simultaneous<TContext extends AbilityContext = AbilityContext>(gameSystems: (GameSystem<TContext>)[], ignoreTargetingRequirements = null): GameSystem<TContext> {
+export function simultaneous<TContext extends AbilityContext = AbilityContext>(gameSystems: ISystemArrayOrFactory<TContext>, ignoreTargetingRequirements = null): GameSystem<TContext> {
     return new SimultaneousGameSystem<TContext>(gameSystems, ignoreTargetingRequirements);
 }
 

--- a/server/game/gameSystems/SequentialSystem.ts
+++ b/server/game/gameSystems/SequentialSystem.ts
@@ -3,7 +3,7 @@ import { MetaEventName } from '../core/Constants';
 import { GameEvent } from '../core/event/GameEvent';
 import { GameObject } from '../core/GameObject';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
-import { AggregateSystem } from '../core/gameSystem/AggregateSystem';
+import { AggregateSystem, ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
 
 
 export interface ISequentialSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
@@ -20,8 +20,12 @@ export interface ISequentialSystemProperties<TContext extends AbilityContext = A
  */
 export class SequentialSystem<TContext extends AbilityContext = AbilityContext> extends AggregateSystem<TContext, ISequentialSystemProperties<TContext>> {
     protected override readonly eventName: MetaEventName.Sequential;
-    public constructor(gameSystems: (GameSystem<TContext>)[]) {
-        super({ gameSystems });
+    public constructor(gameSystems: ISystemArrayOrFactory<TContext>) {
+        if (typeof gameSystems === 'function') {
+            super((context: TContext) => ({ gameSystems: gameSystems(context) }));
+        } else {
+            super({ gameSystems });
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/server/game/gameSystems/SimultaneousSystem.ts
+++ b/server/game/gameSystems/SimultaneousSystem.ts
@@ -2,7 +2,7 @@ import { AbilityContext } from '../core/ability/AbilityContext';
 import { GameStateChangeRequired, MetaEventName } from '../core/Constants';
 import { GameObject } from '../core/GameObject';
 import { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
-import { AggregateSystem } from '../core/gameSystem/AggregateSystem';
+import { AggregateSystem, ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
 
 export interface ISimultaneousSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
     gameSystems: GameSystem<TContext>[];
@@ -16,13 +16,13 @@ export interface ISimultaneousSystemProperties<TContext extends AbilityContext =
 
 export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityContext> extends AggregateSystem<TContext, ISimultaneousSystemProperties<TContext>> {
     protected override readonly eventName: MetaEventName.Simultaneous;
-    protected override readonly defaultProperties: ISimultaneousSystemProperties<TContext> = {
-        gameSystems: null,
-        ignoreTargetingRequirements: false
-    };
 
-    public constructor(gameSystems: (GameSystem<TContext>)[], ignoreTargetingRequirements = null) {
-        super({ gameSystems, ignoreTargetingRequirements });
+    public constructor(gameSystems: ISystemArrayOrFactory<TContext>, ignoreTargetingRequirements = false) {
+        if (typeof gameSystems === 'function') {
+            super((context: TContext) => ({ gameSystems: gameSystems(context), ignoreTargetingRequirements }));
+        } else {
+            super({ gameSystems, ignoreTargetingRequirements });
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
We ran into a scenario where we needed to generate a list of systems from context for an aggregate system. Added support for doing that in both sequential and simultaneous. Tested in another branch.