### PR TITLE
Ongoing Effects TS Conversion

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -37,7 +37,6 @@ export type IActionAbilityProps<TSource extends Card = Card> = Exclude<IAbilityP
 };
 
 export interface IOngoingEffectProps {
-    targetController?: RelativePlayer;
     targetCardTypeFilter?: any;
     sourceLocationFilter?: LocationFilter;
     matchTarget?: () => boolean;
@@ -51,6 +50,14 @@ export interface IOngoingEffectProps {
     target?: (Player | Card) | (Player | Card)[];
     cannotBeCancelled?: boolean;
     optional?: boolean;
+}
+
+export interface IOngoingPlayerEffectProps extends IOngoingEffectProps {
+    targetController?: Player | RelativePlayer;    
+}
+
+export interface IOngoingCardEffectProps extends IOngoingEffectProps {
+    targetController?: RelativePlayer;
 }
 
 // TODO: since many of the files that use this are JS, it's hard to know if it's fully correct.

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -39,9 +39,9 @@ export type IActionAbilityProps<TSource extends Card = Card> = Exclude<IAbilityP
 export interface IOngoingEffectProps {
     targetController?: RelativePlayer;
     targetCardTypeFilter?: any;
-    sourceLocationFilter?: WildcardLocation;
+    sourceLocationFilter?: LocationFilter;
     matchTarget?: () => boolean;
-    targetLocationFilter?: WildcardLocation;
+    targetLocationFilter?: LocationFilter;
     canChangeZoneOnce?: boolean;
     canChangeZoneNTimes?: number;
     duration?: Duration;

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -53,7 +53,7 @@ export interface IOngoingEffectProps {
 }
 
 export interface IOngoingPlayerEffectProps extends IOngoingEffectProps {
-    targetController?: Player | RelativePlayer;    
+    targetController?: Player | RelativePlayer;
 }
 
 export interface IOngoingCardEffectProps extends IOngoingEffectProps {

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -11,8 +11,8 @@ import { ICost } from './core/cost/ICost';
 import Game from './core/Game';
 import PlayerOrCardAbility from './core/ability/PlayerOrCardAbility';
 import Player from './core/Player';
-import OngoingCardEffect from './core/ongoingEffect/OngoingCardEffect';
-import OngoingPlayerEffect from './core/ongoingEffect/OngoingPlayerEffect';
+import { OngoingCardEffect } from './core/ongoingEffect/OngoingCardEffect';
+import { OngoingPlayerEffect } from './core/ongoingEffect/OngoingPlayerEffect';
 import { UnitCard } from './core/card/CardTypes';
 
 // allow block comments without spaces so we can have compact jsdoc descriptions in this file

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from './core/ability/AbilityContext';
 import type { TriggeredAbilityContext } from './core/ability/TriggeredAbilityContext';
 import type { GameSystem } from './core/gameSystem/GameSystem';
 import type { Card } from './core/card/Card';
-import { type RelativePlayer, type CardType, type Location, type EventName, type PhaseName, type LocationFilter, type KeywordName, type AbilityType, type CardTypeFilter, Duration } from './core/Constants';
+import { type RelativePlayer, type CardType, type Location, type EventName, type PhaseName, type LocationFilter, type KeywordName, type AbilityType, type CardTypeFilter, Duration, WildcardLocation } from './core/Constants';
 import type { GameEvent } from './core/event/GameEvent';
 import type { IActionTargetResolver, IActionTargetsResolver, ITriggeredAbilityTargetResolver, ITriggeredAbilityTargetsResolver } from './TargetInterfaces';
 import { IReplacementEffectSystemProperties } from './gameSystems/ReplacementEffectSystem';
@@ -37,7 +37,11 @@ export type IActionAbilityProps<TSource extends Card = Card> = Exclude<IAbilityP
 };
 
 export interface IOngoingEffectProps {
-    targetLocationFilter?: Location | Location[];
+    targetController?: RelativePlayer;
+    targetCardTypeFilter?: any;
+    sourceLocationFilter?: WildcardLocation;
+    matchTarget?: () => boolean;
+    targetLocationFilter?: WildcardLocation;
     canChangeZoneOnce?: boolean;
     canChangeZoneNTimes?: number;
     duration?: Duration;

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -106,7 +106,7 @@ export enum RelativePlayer {
 }
 
 /** RelativePlayer values as an array, primarily for checking if a value is a RelativePlayer at all. */
-export const RelativePlayerValues = Object.freeze(Object.values(RelativePlayer));
+export const relativePlayerValues = Object.freeze(Object.values(RelativePlayer));
 
 export enum TargetMode {
     AutoSingle = 'autoSingle',

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -105,6 +105,9 @@ export enum RelativePlayer {
     Any = 'any'
 }
 
+/** RelativePlayer values as an array, primarily for checking if a value is a RelativePlayer at all. */
+export const RelativePlayerValues = Object.freeze(Object.values(RelativePlayer));
+
 export enum TargetMode {
     AutoSingle = 'autoSingle',
     DropdownList = 'dropdownList',

--- a/server/game/core/ability/AbilityContext.ts
+++ b/server/game/core/ability/AbilityContext.ts
@@ -1,6 +1,6 @@
 import PlayerOrCardAbility from './PlayerOrCardAbility';
 import { Aspect, PlayType, Stage } from '../Constants';
-import OngoingEffectSource from '../ongoingEffect/OngoingEffectSource';
+import { OngoingEffectSource } from '../ongoingEffect/OngoingEffectSource';
 import type Game from '../Game';
 import type { GameSystem } from '../gameSystem/GameSystem';
 import type Player from '../Player';

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -1,7 +1,7 @@
 import { IActionAbilityProps, IConstantAbilityProps } from '../../Interfaces';
 import { ActionAbility } from '../ability/ActionAbility';
 import PlayerOrCardAbility from '../ability/PlayerOrCardAbility';
-import OngoingEffectSource from '../ongoingEffect/OngoingEffectSource';
+import { OngoingEffectSource } from '../ongoingEffect/OngoingEffectSource';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
 import { AbilityRestriction, Aspect, CardType, Duration, EffectName, EventName, KeywordName, Location, RelativePlayer, Trait, WildcardLocation } from '../Constants';

--- a/server/game/core/gameSteps/SimultaneousEffectWindow.ts
+++ b/server/game/core/gameSteps/SimultaneousEffectWindow.ts
@@ -1,4 +1,4 @@
-import OngoingEffect from '../ongoingEffect/OngoingEffect';
+import { OngoingEffect } from '../ongoingEffect/OngoingEffect';
 import { TriggeredAbilityWindow } from './abilityWindow/TriggeredAbilityWindow';
 
 // TODO: do we even need this?

--- a/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
+++ b/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
@@ -1,5 +1,5 @@
 const { AbilityContext } = require('../../ability/AbilityContext.js');
-const OngoingEffectSource = require('../../ongoingEffect/OngoingEffectSource.js');
+const { OngoingEffectSource } = require('../../ongoingEffect/OngoingEffectSource.js');
 const { UiPrompt } = require('./UiPrompt.js');
 
 /**
@@ -128,6 +128,7 @@ class HandlerMenuPrompt extends UiPrompt {
     }
 
     /** @override */
+    // @ts-ignore
     menuCommand(player, arg) {
         if (typeof arg === 'string') {
             if (arg === 'cancel') {

--- a/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
+++ b/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
@@ -128,7 +128,6 @@ class HandlerMenuPrompt extends UiPrompt {
     }
 
     /** @override */
-    // @ts-ignore
     menuCommand(player, arg) {
         if (typeof arg === 'string') {
             if (arg === 'cancel') {

--- a/server/game/core/gameSteps/prompts/SelectCardPrompt.js
+++ b/server/game/core/gameSteps/prompts/SelectCardPrompt.js
@@ -1,6 +1,6 @@
 const { AbilityContext } = require('../../ability/AbilityContext.js');
 const CardSelectorFactory = require('../../cardSelector/CardSelectorFactory.js');
-const OngoingEffectSource = require('../../ongoingEffect/OngoingEffectSource.js');
+const { OngoingEffectSource } = require('../../ongoingEffect/OngoingEffectSource');
 const Contract = require('../../utils/Contract.js');
 const { UiPrompt } = require('./UiPrompt.js');
 

--- a/server/game/core/ongoingEffect/IConstantAbility.ts
+++ b/server/game/core/ongoingEffect/IConstantAbility.ts
@@ -1,6 +1,6 @@
 import type { Duration } from '../Constants';
 import type { IConstantAbilityProps } from '../../Interfaces';
-import OngoingEffect from './OngoingEffect';
+import { OngoingEffect } from './OngoingEffect';
 
 export interface IConstantAbility extends IConstantAbilityProps {
     duration: Duration;

--- a/server/game/core/ongoingEffect/OngoingCardEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingCardEffect.ts
@@ -29,7 +29,7 @@ export class OngoingCardEffect extends OngoingEffect {
 
         this.targetsSourceOnly = false;
         this.targetController = properties.targetController || RelativePlayer.Self;
-        Contract.assertArrayIncludes(relativePlayerValues, this.targetController, "target controller must be a RelativePlayer enum.");
+        Contract.assertArrayIncludes(relativePlayerValues, this.targetController, 'target controller must be a RelativePlayer enum.');
 
         if (!properties.targetLocationFilter) {
             this.targetLocationFilter = properties.sourceLocationFilter === WildcardLocation.Any

--- a/server/game/core/ongoingEffect/OngoingCardEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingCardEffect.ts
@@ -1,19 +1,22 @@
 import { OngoingEffect } from './OngoingEffect';
-import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, LocationFilter } from '../Constants';
+import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, LocationFilter, RelativePlayerValues } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import * as Contract from '../utils/Contract';
 import * as Helpers from '../utils/Helpers';
 import Game from '../Game';
 import { Card } from '../card/Card';
-import { IOngoingEffectProps } from '../../Interfaces';
+import { IOngoingCardEffectProps } from '../../Interfaces';
 import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
+import { AbilityContext } from '../ability/AbilityContext';
 
 export class OngoingCardEffect extends OngoingEffect {
     public readonly targetsSourceOnly: boolean;
     public readonly targetLocationFilter: LocationFilter;
     public readonly targetCardTypeFilter: CardTypeFilter[];
+    public readonly targetController: RelativePlayer;
+    public override matchTarget: Card | ((target: Card, context: AbilityContext) => boolean);
 
-    public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effect: OngoingEffectImpl<any>) {
+    public constructor(game: Game, source: Card, properties: IOngoingCardEffectProps, effect: OngoingEffectImpl<any>) {
         super(game, source, properties, effect);
 
         if (!properties.matchTarget) {
@@ -25,6 +28,8 @@ export class OngoingCardEffect extends OngoingEffect {
         }
 
         this.targetsSourceOnly = false;
+        this.targetController = properties.targetController || RelativePlayer.Self;
+        Contract.assertArrayIncludes(RelativePlayerValues, this.targetController, "target controller must be a RelativePlayer enum.");
 
         if (!properties.targetLocationFilter) {
             this.targetLocationFilter = properties.sourceLocationFilter === WildcardLocation.Any
@@ -41,7 +46,7 @@ export class OngoingCardEffect extends OngoingEffect {
     }
 
     /** @override */
-    public override isValidTarget(target) {
+    public override isValidTarget(target: Card) {
         if (this.targetsSourceOnly) {
             return target === this.context.source;
         }

--- a/server/game/core/ongoingEffect/OngoingCardEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingCardEffect.ts
@@ -1,5 +1,5 @@
 import OngoingEffect from './OngoingEffect';
-import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, Location } from '../Constants';
+import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, LocationFilter } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import * as Contract from '../utils/Contract';
 import * as Helpers from '../utils/Helpers';
@@ -10,7 +10,7 @@ import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
 
 class OngoingCardEffect extends OngoingEffect {
     public targetsSourceOnly: boolean;
-    public targetLocationFilter: WildcardLocation;
+    public targetLocationFilter: LocationFilter;
     public targetCardTypeFilter: CardTypeFilter[];
 
     public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effect: OngoingEffectImpl<any>) {

--- a/server/game/core/ongoingEffect/OngoingCardEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingCardEffect.ts
@@ -1,4 +1,4 @@
-import OngoingEffect from './OngoingEffect';
+import { OngoingEffect } from './OngoingEffect';
 import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, LocationFilter } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import * as Contract from '../utils/Contract';
@@ -8,10 +8,10 @@ import { Card } from '../card/Card';
 import { IOngoingEffectProps } from '../../Interfaces';
 import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
 
-class OngoingCardEffect extends OngoingEffect {
-    public targetsSourceOnly: boolean;
-    public targetLocationFilter: LocationFilter;
-    public targetCardTypeFilter: CardTypeFilter[];
+export class OngoingCardEffect extends OngoingEffect {
+    public readonly targetsSourceOnly: boolean;
+    public readonly targetLocationFilter: LocationFilter;
+    public readonly targetCardTypeFilter: CardTypeFilter[];
 
     public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effect: OngoingEffectImpl<any>) {
         super(game, source, properties, effect);
@@ -76,5 +76,3 @@ class OngoingCardEffect extends OngoingEffect {
         return this.game.allCards;
     }
 }
-
-export default OngoingCardEffect;

--- a/server/game/core/ongoingEffect/OngoingCardEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingCardEffect.ts
@@ -1,5 +1,5 @@
 import { OngoingEffect } from './OngoingEffect';
-import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, LocationFilter, RelativePlayerValues } from '../Constants';
+import { RelativePlayer, WildcardLocation, WildcardCardType, CardTypeFilter, LocationFilter, relativePlayerValues } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import * as Contract from '../utils/Contract';
 import * as Helpers from '../utils/Helpers';
@@ -29,7 +29,7 @@ export class OngoingCardEffect extends OngoingEffect {
 
         this.targetsSourceOnly = false;
         this.targetController = properties.targetController || RelativePlayer.Self;
-        Contract.assertArrayIncludes(RelativePlayerValues, this.targetController, "target controller must be a RelativePlayer enum.");
+        Contract.assertArrayIncludes(relativePlayerValues, this.targetController, "target controller must be a RelativePlayer enum.");
 
         if (!properties.targetLocationFilter) {
             this.targetLocationFilter = properties.sourceLocationFilter === WildcardLocation.Any

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -131,7 +131,7 @@ class OngoingEffect {
     }
 
     public resolveEffectTargets(stateChanged) {
-        if (!this.condition(this.context) || !this.isEffectActive()) {
+        if (!this.isEffectActive() || !this.condition(this.context)) {
             stateChanged = this.targets.length > 0 || stateChanged;
             this.cancel();
             return stateChanged;

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -70,7 +70,7 @@ export abstract class OngoingEffect {
     public refreshContext() {
         this.context = this.game.getFrameworkContext(this.source.controller);
         this.context.source = this.source;
-        // The process of creating the OngoingEffect tacks on additional properties that are ability related, 
+        // The process of creating the OngoingEffect tacks on additional properties that are ability related,
         //  so this is *probably* fine, but definitely a sign it needs a refactor at some point.
         this.context.ability = this.ability as PlayerOrCardAbility;
         this.impl.setContext(this.context);

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -1,7 +1,7 @@
 import { IOngoingEffectProps, WhenType } from '../../Interfaces';
 import { AbilityContext } from '../ability/AbilityContext';
 import { Card } from '../card/Card';
-import { Duration, RelativePlayer, WildcardLocation } from '../Constants';
+import { Duration, LocationFilter, RelativePlayer, WildcardLocation } from '../Constants';
 import Game from '../Game';
 import { GameObject } from '../GameObject';
 import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
@@ -41,7 +41,7 @@ class OngoingEffect {
     public duration?: Duration;
     public until: WhenType;
     public condition: (context?: AbilityContext) => boolean;
-    public sourceLocationFilter: WildcardLocation;
+    public sourceLocationFilter: LocationFilter;
     public canChangeZoneOnce: boolean;
     public canChangeZoneNTimes: number;
     public impl: OngoingEffectImpl<any>;

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -4,6 +4,7 @@ import { Card } from '../card/Card';
 import { Duration, LocationFilter, RelativePlayer, WildcardLocation } from '../Constants';
 import Game from '../Game';
 import { GameObject } from '../GameObject';
+import Player from '../Player';
 import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
 
 /**
@@ -33,23 +34,23 @@ import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
  * impl                 - object with details of effect to be applied. Includes duration
  *                        and the numerical value of the effect, if any.
  */
-class OngoingEffect {
+export class OngoingEffect {
     public game: Game;
     public source: Card;
     // TODO: Can we make GameObject more specific? Can we add generics to the class for AbilityContext?
-    public matchTarget: GameObject | ((target: GameObject, context: AbilityContext) => boolean);
+    public matchTarget: (Player | Card) | ((target: Player | Card, context: AbilityContext) => boolean);
     public duration?: Duration;
     public until: WhenType;
     public condition: (context?: AbilityContext) => boolean;
     public sourceLocationFilter: LocationFilter;
-    public canChangeZoneOnce: boolean;
-    public canChangeZoneNTimes: number;
     public impl: OngoingEffectImpl<any>;
     // ISSUE: refreshContext sets ability to IOngoingEffectProps, but the listed type for context is PlayerOrCardAbility. Why is there a mismatch? Are we just overriding it in the context of OngoingEffects and everywhere else it acts as PlayerOrCardAbility?
     public ability: any;
-    public targets: GameObject[];
+    public targets: (Player | Card)[];
     public context: AbilityContext;
     public targetController: RelativePlayer;
+    public canChangeZoneOnce: boolean;
+    public canChangeZoneNTimes: number;
 
     public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effectImpl: OngoingEffectImpl<any>) {
         this.game = game;
@@ -59,8 +60,6 @@ class OngoingEffect {
         this.until = properties.until || {};
         this.condition = properties.condition || (() => true);
         this.sourceLocationFilter = properties.sourceLocationFilter || WildcardLocation.AnyArena;
-        this.canChangeZoneOnce = !!properties.canChangeZoneOnce;
-        this.canChangeZoneNTimes = properties.canChangeZoneNTimes || 0;
         this.impl = effectImpl;
         this.ability = properties;
         this.targets = [];
@@ -173,5 +172,3 @@ class OngoingEffect {
         };
     }
 }
-
-export default OngoingEffect;

--- a/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
@@ -7,11 +7,11 @@ import type { GameSystem, IGameSystemProperties } from '../gameSystem/GameSystem
 import type { IOngoingEffectProps, WhenType } from '../../Interfaces';
 import type Player from '../Player';
 // import type { StatusToken } from '../StatusToken';
-import OngoingCardEffect from './OngoingCardEffect';
+import { OngoingCardEffect } from './OngoingCardEffect';
 // import ConflictEffect from './ConflictEffect';
 import DetachedOngoingEffectImpl from './effectImpl/DetachedOngoingEffectImpl';
 import DynamicOngoingEffectImpl from './effectImpl/DynamicOngoingEffectImpl';
-import OngoingPlayerEffect from './OngoingPlayerEffect';
+import { OngoingPlayerEffect } from './OngoingPlayerEffect';
 import StaticOngoingEffectImpl from './effectImpl/StaticOngoingEffectImpl';
 
 /* Types of effect

--- a/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
@@ -4,7 +4,7 @@ import type { Card } from '../card/Card';
 import type { Duration, EffectName, Location } from '../Constants';
 import type Game from '../Game';
 import type { GameSystem, IGameSystemProperties } from '../gameSystem/GameSystem';
-import type { IOngoingEffectProps, WhenType } from '../../Interfaces';
+import type { IOngoingCardEffectProps, IOngoingEffectProps, IOngoingPlayerEffectProps, WhenType } from '../../Interfaces';
 import type Player from '../Player';
 // import type { StatusToken } from '../StatusToken';
 import { OngoingCardEffect } from './OngoingCardEffect';
@@ -22,11 +22,11 @@ import StaticOngoingEffectImpl from './effectImpl/StaticOngoingEffectImpl';
 
 export const OngoingEffectBuilder = {
     card: {
-        static: (type: EffectName, value?) => (game: Game, source: Card, props: IOngoingEffectProps) =>
+        static: (type: EffectName, value?) => (game: Game, source: Card, props: IOngoingCardEffectProps) =>
             new OngoingCardEffect(game, source, props, new StaticOngoingEffectImpl(type, value)),
-        dynamic: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingEffectProps) =>
+        dynamic: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingCardEffectProps) =>
             new OngoingCardEffect(game, source, props, new DynamicOngoingEffectImpl(type, value)),
-        detached: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingEffectProps) =>
+        detached: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingCardEffectProps) =>
             new OngoingCardEffect(game, source, props, new DetachedOngoingEffectImpl(type, value.apply, value.unapply)),
         flexible: (type: EffectName, value?: unknown) =>
             (typeof value === 'function'
@@ -34,11 +34,11 @@ export const OngoingEffectBuilder = {
                 : OngoingEffectBuilder.card.static(type, value))
     },
     player: {
-        static: (type: EffectName, value?) => (game: Game, source: Card, props: IOngoingEffectProps) =>
+        static: (type: EffectName, value?) => (game: Game, source: Card, props: IOngoingPlayerEffectProps) =>
             new OngoingPlayerEffect(game, source, props, new StaticOngoingEffectImpl(type, value)),
-        dynamic: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingEffectProps) =>
+        dynamic: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingPlayerEffectProps) =>
             new OngoingPlayerEffect(game, source, props, new DynamicOngoingEffectImpl(type, value)),
-        detached: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingEffectProps) =>
+        detached: (type: EffectName, value) => (game: Game, source: Card, props: IOngoingPlayerEffectProps) =>
             new OngoingPlayerEffect(game, source, props, new DetachedOngoingEffectImpl(type, value.apply, value.unapply)),
         flexible: (type: EffectName, value?) =>
             (typeof value === 'function'

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -1,7 +1,7 @@
 import { Duration, EffectName, EventName } from '../Constants';
 import { GameEvent } from '../event/GameEvent';
 import type OngoingEffect from './OngoingEffect';
-import type OngoingEffectSource from './OngoingEffectSource';
+import type { OngoingEffectSource } from './OngoingEffectSource';
 import { EventRegistrar } from '../event/EventRegistrar';
 import type Game from '../Game';
 

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -92,18 +92,8 @@ export class OngoingEffectEngine {
         this.unapplyAndRemove(
             (effect) =>
                 effect.matchTarget === card &&
-                effect.duration !== Duration.Persistent &&
-                !effect.canChangeZoneOnce &&
-                (!effect.canChangeZoneNTimes || effect.canChangeZoneNTimes === 0)
+                effect.duration !== Duration.Persistent
         );
-        for (const effect of this.effects) {
-            if (effect.matchTarget === card && effect.canChangeZoneOnce) {
-                effect.canChangeZoneOnce = false;
-            }
-            if (effect.matchTarget === card && effect.canChangeZoneNTimes > 0) {
-                effect.canChangeZoneNTimes--;
-            }
-        }
     }
 
     public resolveEffects(prevStateChanged = false, loops = 0) {

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -1,6 +1,6 @@
 import { Duration, EffectName, EventName } from '../Constants';
 import { GameEvent } from '../event/GameEvent';
-import type OngoingEffect from './OngoingEffect';
+import type { OngoingEffect } from './OngoingEffect';
 import type { OngoingEffectSource } from './OngoingEffectSource';
 import { EventRegistrar } from '../event/EventRegistrar';
 import type Game from '../Game';

--- a/server/game/core/ongoingEffect/OngoingEffectSource.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectSource.ts
@@ -1,54 +1,47 @@
-const AbilityHelper = require('../../AbilityHelper');
-const { GameObject } = require('../GameObject.js');
+import AbilityHelper from '../../AbilityHelper';
+import { GameObject } from '../GameObject.js';
 
-const { Duration, WildcardLocation } = require('../Constants.js');
-const OngoingEffect = require('./OngoingEffect.js');
-const Contract = require('../utils/Contract.js');
+import { Duration, WildcardLocation } from '../Constants.js';
+import OngoingEffect from './OngoingEffect';
 
 // This class is inherited by Card and also represents Framework effects
 
-class OngoingEffectSource extends GameObject {
-    constructor(game, name = 'Framework effect') {
+export class OngoingEffectSource extends GameObject {
+    public constructor(game, name = 'Framework effect') {
         super(game, name);
     }
 
     /**
      * Applies an effect which lasts until the end of the phase.
      */
-    untilEndOfPhase(propertyFactory) {
-        var properties = propertyFactory(AbilityHelper);
+    public untilEndOfPhase(propertyFactory) {
+        const properties = propertyFactory(AbilityHelper);
         this.addEffectToEngine(Object.assign({ duration: Duration.UntilEndOfPhase, locationFilter: WildcardLocation.Any }, properties));
     }
 
     /**
      * Applies an effect which lasts until the end of the round.
      */
-    untilEndOfRound(propertyFactory) {
-        var properties = propertyFactory(AbilityHelper);
+    public untilEndOfRound(propertyFactory) {
+        const properties = propertyFactory(AbilityHelper);
         this.addEffectToEngine(Object.assign({ duration: Duration.UntilEndOfRound, locationFilter: WildcardLocation.Any }, properties));
     }
 
     /**
      * Applies a 'lasting effect' (SWU 7.7.3) which lasts until an event contained in the `until` property for the effect has occurred.
      */
-    lastingEffect(propertyFactory) {
-        let properties = propertyFactory(AbilityHelper);
+    public lastingEffect(propertyFactory) {
+        const properties = propertyFactory(AbilityHelper);
         this.addEffectToEngine(Object.assign({ duration: Duration.Custom, locationFilter: WildcardLocation.Any }, properties));
     }
 
     /**
      * Adds persistent/lasting/delayed effect(s) to the effect engine
      * @param {Object} properties properties for the effect(s), see {@link OngoingEffect}
-     * @returns {OngoingEffect[]} the effect(s) that were added to the engine
+     * @returns the effect(s) that were added to the engine
      */
-    addEffectToEngine(properties) {
-        let ongoingEffect = properties.ongoingEffect;
-
-        let propertiesWithoutEffect;
-        {
-            let { ongoingEffect, ...remainingProperties } = properties;
-            propertiesWithoutEffect = remainingProperties;
-        }
+    public addEffectToEngine(properties): OngoingEffect[] {
+        const { ongoingEffect, ...propertiesWithoutEffect } = properties;
 
         if (Array.isArray(ongoingEffect)) {
             return ongoingEffect.map((factory) => this.game.ongoingEffectEngine.add(factory(this.game, this, propertiesWithoutEffect)));
@@ -56,13 +49,11 @@ class OngoingEffectSource extends GameObject {
         return [this.game.ongoingEffectEngine.add(ongoingEffect(this.game, this, propertiesWithoutEffect))];
     }
 
-    removeEffectFromEngine(effectArray) {
+    public removeEffectFromEngine(effectArray) {
         this.game.ongoingEffectEngine.unapplyAndRemove((effect) => effectArray.includes(effect));
     }
 
-    removeLastingEffects() {
+    public removeLastingEffects() {
         this.game.ongoingEffectEngine.removeLastingEffects(this);
     }
 }
-
-module.exports = OngoingEffectSource;

--- a/server/game/core/ongoingEffect/OngoingEffectSource.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectSource.ts
@@ -2,7 +2,7 @@ import AbilityHelper from '../../AbilityHelper';
 import { GameObject } from '../GameObject.js';
 
 import { Duration, WildcardLocation } from '../Constants.js';
-import OngoingEffect from './OngoingEffect';
+import { OngoingEffect } from './OngoingEffect';
 
 // This class is inherited by Card and also represents Framework effects
 

--- a/server/game/core/ongoingEffect/OngoingPlayerEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingPlayerEffect.ts
@@ -3,21 +3,24 @@ import { RelativePlayer } from '../Constants';
 import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
 import Game from '../Game';
 import { Card } from '../card/Card';
-import { IOngoingEffectProps } from '../../Interfaces';
+import { IOngoingPlayerEffectProps } from '../../Interfaces';
 import Player from '../Player';
 
 export class OngoingPlayerEffect extends OngoingEffect {
     public override matchTarget: (target: Player) => boolean;
+    public targetController: Player | RelativePlayer;
 
-    public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effect: OngoingEffectImpl<any>) {
+    public constructor(game: Game, source: Card, properties: IOngoingPlayerEffectProps, effect: OngoingEffectImpl<any>) {
         super(game, source, properties, effect);
         if (typeof this.matchTarget !== 'function') {
             this.matchTarget = (_player) => true;
         }
+
+        this.targetController = properties.targetController || RelativePlayer.Self;
     }
 
     /** @override */
-    public override isValidTarget(target) {
+    public override isValidTarget(target: Player) {
         if (this.targetController !== RelativePlayer.Any && this.targetController !== RelativePlayer.Self && this.targetController !== RelativePlayer.Opponent && this.targetController !== target) {
             return false;
         }

--- a/server/game/core/ongoingEffect/OngoingPlayerEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingPlayerEffect.ts
@@ -1,4 +1,4 @@
-import OngoingEffect from './OngoingEffect';
+import { OngoingEffect } from './OngoingEffect';
 import { RelativePlayer } from '../Constants';
 import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
 import Game from '../Game';
@@ -6,7 +6,7 @@ import { Card } from '../card/Card';
 import { IOngoingEffectProps } from '../../Interfaces';
 import Player from '../Player';
 
-class OngoingPlayerEffect extends OngoingEffect {
+export class OngoingPlayerEffect extends OngoingEffect {
     public override matchTarget: (target: Player) => boolean;
 
     public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effect: OngoingEffectImpl<any>) {
@@ -35,5 +35,3 @@ class OngoingPlayerEffect extends OngoingEffect {
         return this.game.getPlayers().filter((player) => this.matchTarget(player));
     }
 }
-
-export default OngoingPlayerEffect;

--- a/server/game/core/ongoingEffect/OngoingPlayerEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingPlayerEffect.ts
@@ -1,17 +1,23 @@
-const OngoingEffect = require('./OngoingEffect.js');
-const { RelativePlayer } = require('../Constants.js');
+import OngoingEffect from './OngoingEffect';
+import { RelativePlayer } from '../Constants';
+import { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
+import Game from '../Game';
+import { Card } from '../card/Card';
+import { IOngoingEffectProps } from '../../Interfaces';
+import Player from '../Player';
 
 class OngoingPlayerEffect extends OngoingEffect {
-    constructor(game, source, properties, effect) {
+    public override matchTarget: (target: Player) => boolean;
+
+    public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effect: OngoingEffectImpl<any>) {
         super(game, source, properties, effect);
-        this.targetController = properties.targetController || RelativePlayer.Self;
         if (typeof this.matchTarget !== 'function') {
-            this.matchTarget = (player) => true;
+            this.matchTarget = (_player) => true;
         }
     }
 
     /** @override */
-    isValidTarget(target) {
+    public override isValidTarget(target) {
         if (this.targetController !== RelativePlayer.Any && this.targetController !== RelativePlayer.Self && this.targetController !== RelativePlayer.Opponent && this.targetController !== target) {
             return false;
         }
@@ -25,9 +31,9 @@ class OngoingPlayerEffect extends OngoingEffect {
     }
 
     /** @override */
-    getTargets() {
+    public override getTargets() {
         return this.game.getPlayers().filter((player) => this.matchTarget(player));
     }
 }
 
-module.exports = OngoingPlayerEffect;
+export default OngoingPlayerEffect;

--- a/server/game/core/ongoingEffect/effectImpl/OngoingEffectImpl.ts
+++ b/server/game/core/ongoingEffect/effectImpl/OngoingEffectImpl.ts
@@ -3,13 +3,14 @@ import { Duration, EffectName } from '../../Constants';
 
 export abstract class OngoingEffectImpl<TValue> {
     public duration?: Duration = null;
+    public isConditional = false;
     protected context?: AbilityContext = null;
 
     public constructor(public readonly type: EffectName) {
     }
 
     // TODO: add type union in constants.ts for ability targets (player or card, anything else?)
-    public abstract getValue(target): TValue;
+    public abstract getValue(target?): TValue;
     public abstract apply(target): void;
     public abstract unapply(target): void;
     public abstract recalculate(target): boolean;

--- a/server/game/core/ongoingEffect/effectImpl/StatsModifierWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/StatsModifierWrapper.ts
@@ -1,7 +1,7 @@
 import { Card } from '../../card/Card';
 import { CardWithPrintedHp, CardWithPrintedPower, UnitCard } from '../../card/CardTypes';
 import type { CardType } from '../../Constants';
-import OngoingEffect from '../OngoingEffect';
+import { OngoingEffect } from '../OngoingEffect';
 import { IOngoingCardEffect } from '../IOngoingCardEffect';
 import { StatsModifier } from './StatsModifier';
 import { LeaderUnitCard } from '../../card/LeaderUnitCard';

--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -75,21 +75,21 @@ export function assertHasProperty<T extends object, PropertyName extends string>
     }
 }
 
-export function assertArraySize<T>(ara: ReadonlyArray<T>, expectedSize: number, message?: string): asserts ara is NonNullable<T[]> {
+export function assertArraySize<T>(ara: readonly T[], expectedSize: number, message?: string): asserts ara is NonNullable<T[]> {
     assertNotNullLike(ara);
     if (ara.length !== expectedSize) {
         contractCheckImpl.fail(message ?? `Array size ${ara.length} does not match expected size ${expectedSize}`);
     }
 }
 
-export function assertArrayIncludes<T>(ara: ReadonlyArray<T>, element: T, message?: string): asserts ara is NonNullable<T[]> {
+export function assertArrayIncludes<T>(ara: readonly T[], element: T, message?: string): asserts ara is NonNullable<T[]> {
     assertNotNullLike(ara);
     if (!ara.includes(element)) {
         contractCheckImpl.fail(message ?? `Array does not contain element ${element}`);
     }
 }
 
-export function assertNonEmpty<T>(ara: ReadonlyArray<T>, message?: string): asserts ara is NonNullable<T[]> {
+export function assertNonEmpty<T>(ara: readonly T[], message?: string): asserts ara is NonNullable<T[]> {
     assertNotNullLike(ara);
     if (ara.length === 0) {
         contractCheckImpl.fail(message ?? 'Array is empty');

--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -75,21 +75,21 @@ export function assertHasProperty<T extends object, PropertyName extends string>
     }
 }
 
-export function assertArraySize<T>(ara: T[], expectedSize: number, message?: string): asserts ara is NonNullable<T[]> {
+export function assertArraySize<T>(ara: ReadonlyArray<T>, expectedSize: number, message?: string): asserts ara is NonNullable<T[]> {
     assertNotNullLike(ara);
     if (ara.length !== expectedSize) {
         contractCheckImpl.fail(message ?? `Array size ${ara.length} does not match expected size ${expectedSize}`);
     }
 }
 
-export function assertArrayIncludes<T>(ara: T[], element: T, message?: string): asserts ara is NonNullable<T[]> {
+export function assertArrayIncludes<T>(ara: ReadonlyArray<T>, element: T, message?: string): asserts ara is NonNullable<T[]> {
     assertNotNullLike(ara);
     if (!ara.includes(element)) {
         contractCheckImpl.fail(message ?? `Array does not contain element ${element}`);
     }
 }
 
-export function assertNonEmpty<T>(ara: T[], message?: string): asserts ara is NonNullable<T[]> {
+export function assertNonEmpty<T>(ara: ReadonlyArray<T>, message?: string): asserts ara is NonNullable<T[]> {
     assertNotNullLike(ara);
     if (ara.length === 0) {
         contractCheckImpl.fail(message ?? 'Array is empty');

--- a/server/game/gameSystems/PlayerLastingEffectSystem.ts
+++ b/server/game/gameSystems/PlayerLastingEffectSystem.ts
@@ -3,7 +3,7 @@ import { EventName, RelativePlayer } from '../core/Constants';
 import { GameEvent } from '../core/event/GameEvent';
 import { GameSystem } from '../core/gameSystem/GameSystem';
 import { ILastingEffectPropertiesBase } from '../core/gameSystem/LastingEffectPropertiesBase';
-import OngoingEffect from '../core/ongoingEffect/OngoingEffect';
+import { OngoingEffect } from '../core/ongoingEffect/OngoingEffect';
 import Player from '../core/Player';
 
 export interface IPlayerLastingEffectProperties extends ILastingEffectPropertiesBase {


### PR DESCRIPTION
Started to dig into card vs player effects but turned into just converting the OnGoingEffects classes into TS, so I made a PR for the conversion alone.

NOTES:
- Some of the JS files didn't like importing OngoingEffectSource as a default export and I'm not sure why, so for now I've removed the default export.
- Moved targetController assignment logic to the base OngoingEffect class, as both derived classes did the exact same thing.
- Removed unused property.matchTarget assignment in OngoingCardEffect, it's assigning to the properties object, but the base class already does this logic and does it before this line.
- Still has some "any" types, OngoingEffect's "ability" field is seemingly assigned to two completely different types, as noted. A few things I set as "GameObject" because I was unsure, but they could maybe just be Card.
- Re-ordered OngoingCardEffect.isValidTarget checks and made the non-function matchTarget check always return, as it's expected to be a function by the end.