### PR TITLE
#Added Additional on-play tests

### DIFF
--- a/test/scenarios/ability/MultiplePlay.spec.ts
+++ b/test/scenarios/ability/MultiplePlay.spec.ts
@@ -20,7 +20,7 @@ describe('Abilities', function() {
                 context.secondWaylay = context.player2.hand[1];
             });
 
-            it('should only trigger once after the unit was removed from play and played again', function () {
+            it('on attack ability should trigger only once after the unit was removed from play and played again', function () {
                 const { context } = contextRef;
 
                 // CASE 1: we test the on attack ability
@@ -38,14 +38,18 @@ describe('Abilities', function() {
 
                 // check board state
                 expect(context.player1.hand.length).toBe(1);
+            });
 
-                // CASE 2: on play should trigger only once
+            it('on play ability should trigger only once after the unit was removed from play and played again', function() {
+                const { context } = contextRef;
+                context.player1.passAction();
+
                 context.player2.clickCard(context.secondWaylay);
                 context.player2.clickCard(context.patrollingVwing);
                 context.player1.clickCard(context.patrollingVwing);
 
                 // check board state
-                expect(context.player1.hand.length).toBe(2);
+                expect(context.player1.hand.length).toBe(1);
             });
         });
 
@@ -67,41 +71,48 @@ describe('Abilities', function() {
                 context.secondWaylay = context.player2.hand[0];
             });
 
-            it('should only trigger once after the unit was removed from play and played again', function () {
-                const { context } = contextRef;
+            it('negative constant effects should only trigger once after the unit was removed from play and played again',
+                function () {
+                    const { context } = contextRef;
 
-                // check pre-board state to see if both effects work
-                context.player1.passAction();
-                expect(context.battlefieldMarine.getPower()).toBe(2);
-                expect(context.battlefieldMarine.getHp()).toBe(2);
+                    // check pre-board state to see if both effects work
+                    context.player1.passAction();
+                    expect(context.battlefieldMarine.getPower()).toBe(2);
+                    expect(context.battlefieldMarine.getHp()).toBe(2);
 
-                // CASE 1: we test the negative constant abilities
-                context.player2.clickCard(context.secondWaylay);
-                context.player2.clickCard(context.supremeLeaderSnoke);
+                    context.player2.clickCard(context.secondWaylay);
+                    context.player2.clickCard(context.supremeLeaderSnoke);
 
-                // check board state
-                expect(context.battlefieldMarine.getPower()).toBe(4);
-                expect(context.battlefieldMarine.getHp()).toBe(4);
+                    // check board state
+                    expect(context.battlefieldMarine.getPower()).toBe(4);
+                    expect(context.battlefieldMarine.getHp()).toBe(4);
 
-                // play snoke and check board state
-                context.player1.clickCard(context.supremeLeaderSnoke);
-                expect(context.battlefieldMarine.getPower()).toBe(2);
-                expect(context.battlefieldMarine.getHp()).toBe(2);
+                    // play snoke and check board state
+                    context.player1.clickCard(context.supremeLeaderSnoke);
+                    expect(context.battlefieldMarine.getPower()).toBe(2);
+                    expect(context.battlefieldMarine.getHp()).toBe(2);
+                });
 
-                // CASE 2: we test the positive constant abilities
-                context.player2.passAction();
-                context.player1.clickCard(context.firstWaylay);
-                context.player1.clickCard(context.generalDodonna);
+            it('positive constant effects should only trigger once after the unit was removed from play and played again',
+                function () {
+                    const { context } = contextRef;
 
-                // check board state
-                expect(context.battlefieldMarine.getPower()).toBe(1);
-                expect(context.battlefieldMarine.getHp()).toBe(1);
+                    // check pre-board state to see if both effects work
+                    expect(context.battlefieldMarine.getPower()).toBe(2);
+                    expect(context.battlefieldMarine.getHp()).toBe(2);
 
-                // play general dodonna and check board state
-                context.player2.clickCard(context.generalDodonna);
-                expect(context.battlefieldMarine.getPower()).toBe(2);
-                expect(context.battlefieldMarine.getHp()).toBe(2);
-            });
+                    context.player1.clickCard(context.firstWaylay);
+                    context.player1.clickCard(context.generalDodonna);
+
+                    // check board state
+                    expect(context.battlefieldMarine.getPower()).toBe(1);
+                    expect(context.battlefieldMarine.getHp()).toBe(1);
+
+                    // play general dodonna and check board state
+                    context.player2.clickCard(context.generalDodonna);
+                    expect(context.battlefieldMarine.getPower()).toBe(2);
+                    expect(context.battlefieldMarine.getHp()).toBe(2);
+                });
         });
         describe('cost reduction', function () {
             beforeEach(function () {

--- a/test/scenarios/ability/MultiplePlay.spec.ts
+++ b/test/scenarios/ability/MultiplePlay.spec.ts
@@ -1,0 +1,181 @@
+describe('Abilities', function() {
+    integration(function (contextRef) {
+        describe('When played ability, on attack ability', function () {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        deck: ['foundling', 'pyke-sentinel', 'atst', 'cartel-spacer', 'wampa'],
+                        groundArena: ['rugged-survivors'],
+                        leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true },
+                        spaceArena: ['patrolling-vwing']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine'],
+                        hand: ['waylay', 'waylay']
+                    }
+                });
+                const { context } = contextRef;
+                context.firstWaylay = context.player2.hand[0];
+                context.secondWaylay = context.player2.hand[1];
+            });
+
+            it('should only trigger once after the unit was removed from play and played again', function () {
+                const { context } = contextRef;
+
+                // CASE 1: we test the on attack ability
+                context.player1.passAction();
+                context.player2.clickCard(context.firstWaylay);
+                context.player2.clickCard(context.ruggedSurvivors);
+
+                context.player1.clickCard(context.ruggedSurvivors);
+                context.ruggedSurvivors.exhausted = false;
+                context.player2.passAction();
+
+                context.player1.clickCard(context.ruggedSurvivors);
+                context.player1.clickCard(context.p2Base);
+                context.player1.clickPrompt('Draw a card if you control a leader unit');
+
+                // check board state
+                expect(context.player1.hand.length).toBe(1);
+
+                // CASE 2: on play should trigger only once
+                context.player2.clickCard(context.secondWaylay);
+                context.player2.clickCard(context.patrollingVwing);
+                context.player1.clickCard(context.patrollingVwing);
+
+                // check board state
+                expect(context.player1.hand.length).toBe(2);
+            });
+        });
+
+        describe('Constant abilities', function () {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['waylay'],
+                        groundArena: ['rugged-survivors', 'supreme-leader-snoke#shadow-ruler'],
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine', 'general-dodonna#massassi-group-commander'],
+                        hand: ['waylay']
+                    }
+                });
+                const { context } = contextRef;
+                context.firstWaylay = context.player1.hand[0];
+                context.secondWaylay = context.player2.hand[0];
+            });
+
+            it('should only trigger once after the unit was removed from play and played again', function () {
+                const { context } = contextRef;
+
+                // check pre-board state to see if both effects work
+                context.player1.passAction();
+                expect(context.battlefieldMarine.getPower()).toBe(2);
+                expect(context.battlefieldMarine.getHp()).toBe(2);
+
+                // CASE 1: we test the negative constant abilities
+                context.player2.clickCard(context.secondWaylay);
+                context.player2.clickCard(context.supremeLeaderSnoke);
+
+                // check board state
+                expect(context.battlefieldMarine.getPower()).toBe(4);
+                expect(context.battlefieldMarine.getHp()).toBe(4);
+
+                // play snoke and check board state
+                context.player1.clickCard(context.supremeLeaderSnoke);
+                expect(context.battlefieldMarine.getPower()).toBe(2);
+                expect(context.battlefieldMarine.getHp()).toBe(2);
+
+                // CASE 2: we test the positive constant abilities
+                context.player2.passAction();
+                context.player1.clickCard(context.firstWaylay);
+                context.player1.clickCard(context.generalDodonna);
+
+                // check board state
+                expect(context.battlefieldMarine.getPower()).toBe(1);
+                expect(context.battlefieldMarine.getHp()).toBe(1);
+
+                // play general dodonna and check board state
+                context.player2.clickCard(context.generalDodonna);
+                expect(context.battlefieldMarine.getPower()).toBe(2);
+                expect(context.battlefieldMarine.getHp()).toBe(2);
+            });
+        });
+        describe('cost reduction', function () {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['reputable-hunter'],
+                        base: 'energy-conversion-lab',
+                    },
+                    player2: {
+                        groundArena: [{ card: 'battlefield-marine', upgrades: ['top-target'] }],
+                        hand: ['waylay']
+                    }
+                });
+            });
+
+            it('should only trigger once after the unit was removed from play and played again', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.reputableHunter);
+                expect(context.player1.exhaustedResourceCount).toBe(2);
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.reputableHunter);
+
+                // Player 1 plays reputable hunter again
+                context.player1.clickCard(context.reputableHunter);
+
+                // we check board state
+                expect(context.player1.exhaustedResourceCount).toEqual(4);
+            });
+        });
+        describe('when defeated', function () {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['the-emperors-legion'],
+                        spaceArena: ['rhokai-gunship']
+                    },
+                    player2: {
+                        spaceArena: ['desperado-freighter']
+                    }
+                });
+            });
+
+            it('should only trigger once after the unit was defeated, returned and played again', function () {
+                const { context } = contextRef;
+                context.player1.clickCard(context.rhokaiGunship);
+                context.player1.clickCard(context.desperadoFreighter);
+                context.player1.clickCard(context.p2Base);
+
+                // check board state
+                expect(context.p2Base.damage).toBe(1);
+                expect(context.player2).toBeActivePlayer();
+                context.player2.passAction();
+
+                // return the unit and play it again
+                context.player1.clickCard(context.theEmperorsLegion);
+                context.player2.passAction();
+                context.player1.clickCard(context.rhokaiGunship);
+
+                context.rhokaiGunship.exhausted = false;
+                context.player2.passAction();
+
+                context.player1.clickCard(context.rhokaiGunship);
+                context.player1.clickCard(context.desperadoFreighter);
+
+                context.player1.clickCard(context.p2Base);
+
+                // check board state
+                expect(context.p2Base.damage).toBe(2);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/units/GeneralKrellHeartlessTactician.spec.ts
+++ b/test/server/cards/01_SOR/units/GeneralKrellHeartlessTactician.spec.ts
@@ -98,7 +98,60 @@ describe('General Krell, Heartless Tactician', function() {
                 expect(context.player1.handSize).toBe(startingHandSize + 1);
             });
         });
+        describe('Krell\'s ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['the-emperors-legion'],
+                        groundArena: ['battlefield-marine', 'general-krell#heartless-tactician', 'reputable-hunter']
+                    },
+                    player2: {
+                        groundArena: ['wampa', 'atst'],
+                        hand: ['waylay']
+                    }
+                });
+            });
 
-        // TODO WAYLAY: once we have a card implemented that can return cards from discard to hand, add a test confirming that the ability is regained correctly
+            it('should draw only 1 card when returned to hand and played again.', function() {
+                const { context } = contextRef;
+                const startingHandSize = context.player1.handSize;
+
+                // CASE 1: We defeat krell, return him to hand, play him again and defeat a friendly unit so we draw 1 card
+                context.player1.clickCard(context.generalKrell);
+                context.player1.clickCard(context.atst);
+
+                context.player2.passAction();
+                context.player1.clickCard(context.theEmperorsLegion);
+                context.player2.passAction();
+
+                context.player1.clickCard(context.generalKrell);
+                context.player2.passAction();
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.wampa);
+
+                expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
+                context.player1.clickPrompt('Draw a card');
+                expect(context.player2).toBeActivePlayer();
+
+                // its the same as the starting hand since we play 1 card
+                expect(context.player1.handSize).toBe(startingHandSize);
+
+                // CASE 2: we Waylay krell and return him to hand and play him again
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.generalKrell);
+
+                context.player1.clickCard(context.generalKrell);
+                context.player2.passAction();
+                context.player1.clickCard(context.reputableHunter);
+                context.player1.clickCard(context.atst);
+
+                expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
+                context.player1.clickPrompt('Draw a card');
+
+                expect(context.player1.handSize).toBe(startingHandSize + 1);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
     });
 });

--- a/test/server/core/abilities/keyword/Ambush.spec.ts
+++ b/test/server/core/abilities/keyword/Ambush.spec.ts
@@ -31,23 +31,6 @@ describe('Ambush keyword', function() {
                 expect(context.syndicateLackeys.damage).toBe(3);
                 expect(context.consularSecurityForce.damage).toBe(5);
                 expect(context.player2).toBeActivePlayer();
-
-                // CASE 2 waylay the card and play it again. It should not trigger twice
-                context.player2.clickCard(context.waylay);
-                context.player2.clickCard(context.syndicateLackeys);
-
-                context.player1.clickCard(context.syndicateLackeys);
-                expect(context.player1).toHavePassAbilityPrompt('Ambush');
-                context.player1.clickPrompt('Ambush');
-
-                expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce, context.snowspeeder]);
-
-                context.player1.clickCard(context.snowspeeder);
-                expect(context.syndicateLackeys.exhausted).toBe(true);
-                expect(context.p2Base.damage).toBe(0);
-                expect(context.syndicateLackeys.damage).toBe(3);
-                expect(context.snowspeeder.damage).toBe(5);
-                expect(context.player2).toBeActivePlayer();
             });
         });
 
@@ -100,6 +83,42 @@ describe('Ambush keyword', function() {
 
                 context.player1.clickCard(context.syndicateLackeys);
                 expect(context.syndicateLackeys.exhausted).toBe(true);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+        describe('When a unit with the Ambush keyword', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['wampa', 'syndicate-lackeys']
+                    },
+                    player2: {
+                        groundArena: ['consular-security-force', 'snowspeeder'],
+                        spaceArena: ['cartel-spacer'],
+                        hand: ['waylay']
+                    }
+                });
+            });
+
+            it('enters play after being returned to hand should ready and attack an enemy unit once', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.syndicateLackeys);
+
+                context.player1.clickCard(context.syndicateLackeys);
+                expect(context.player1).toHavePassAbilityPrompt('Ambush');
+                context.player1.clickPrompt('Ambush');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce, context.snowspeeder]);
+
+                context.player1.clickCard(context.snowspeeder);
+                expect(context.syndicateLackeys.exhausted).toBe(true);
+                expect(context.p2Base.damage).toBe(0);
+                expect(context.syndicateLackeys.damage).toBe(3);
+                expect(context.snowspeeder.damage).toBe(5);
                 expect(context.player2).toBeActivePlayer();
             });
         });

--- a/test/server/core/abilities/keyword/Ambush.spec.ts
+++ b/test/server/core/abilities/keyword/Ambush.spec.ts
@@ -10,7 +10,8 @@ describe('Ambush keyword', function() {
                     },
                     player2: {
                         groundArena: ['consular-security-force', 'snowspeeder'],
-                        spaceArena: ['cartel-spacer']
+                        spaceArena: ['cartel-spacer'],
+                        hand: ['waylay']
                     }
                 });
             });
@@ -29,6 +30,23 @@ describe('Ambush keyword', function() {
                 expect(context.p2Base.damage).toBe(0);
                 expect(context.syndicateLackeys.damage).toBe(3);
                 expect(context.consularSecurityForce.damage).toBe(5);
+                expect(context.player2).toBeActivePlayer();
+
+                // CASE 2 waylay the card and play it again. It should not trigger twice
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.syndicateLackeys);
+
+                context.player1.clickCard(context.syndicateLackeys);
+                expect(context.player1).toHavePassAbilityPrompt('Ambush');
+                context.player1.clickPrompt('Ambush');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce, context.snowspeeder]);
+
+                context.player1.clickCard(context.snowspeeder);
+                expect(context.syndicateLackeys.exhausted).toBe(true);
+                expect(context.p2Base.damage).toBe(0);
+                expect(context.syndicateLackeys.damage).toBe(3);
+                expect(context.snowspeeder.damage).toBe(5);
                 expect(context.player2).toBeActivePlayer();
             });
         });

--- a/test/server/core/abilities/keyword/Bounty.spec.ts
+++ b/test/server/core/abilities/keyword/Bounty.spec.ts
@@ -101,7 +101,7 @@ describe('Bounty', function() {
                 context.covetousRivals.exhausted = false;
             });
 
-            it('should not trigger twice when removed from play and played again.', function () {
+            it('leaves play it should not trigger the bounty twice', function () {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
@@ -110,7 +110,6 @@ describe('Bounty', function() {
                     },
                     player2: {
                         groundArena: ['hylobon-enforcer'],
-                        spaceArena: ['cartel-turncoat'],
                         hand: ['waylay'],
                     }
                 });
@@ -119,24 +118,34 @@ describe('Bounty', function() {
                 context.firstWaylay = context.player1.hand[0];
                 context.secondWaylay = context.player2.hand[0];
 
-                // CASE 1: check that the bounty isn't triggered when removed from play
+                // check that the bounty isn't triggered when removed from play
                 context.player1.clickCard(context.firstWaylay);
                 context.player1.clickCard(context.hylobonEnforcer);
 
                 // return atst to hand without collecting bounty
                 expect(context.player2).toBeActivePlayer();
                 context.player2.clickCard(context.secondWaylay);
-                context.player2.clickCard(context.atst);
-
                 expect(context.player1).toBeActivePlayer();
-                context.player1.passAction();
+            });
 
-                // CASE 2: We now defeat it to check it doesn't trigger twice.
+            it('should not trigger twice when removed from play', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['waylay'],
+                        groundArena: ['atst']
+                    },
+                    player2: {
+                        groundArena: ['hylobon-enforcer'],
+                    }
+                });
+
+                // We now defeat it to check it doesn't trigger twice.
+                const { context } = contextRef;
+                context.player1.clickCard(context.waylay);
+                context.player1.clickCard(context.hylobonEnforcer);
+
                 context.player2.clickCard(context.hylobonEnforcer);
-                context.player1.clickCard(context.atst);
-                context.player2.passAction();
-                context.atst.exhausted = false;
-
                 context.player1.clickCard(context.atst);
                 context.player1.clickCard(context.hylobonEnforcer);
 

--- a/test/server/core/abilities/keyword/Bounty.spec.ts
+++ b/test/server/core/abilities/keyword/Bounty.spec.ts
@@ -78,7 +78,7 @@ describe('Bounty', function() {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['covetous-rivals'],
+                        hand: ['covetous-rivals', 'waylay'],
                         groundArena: ['fugitive-wookiee', 'battlefield-marine', { card: 'atst', upgrades: ['wanted'] }]
                     },
                     player2: {
@@ -99,6 +99,53 @@ describe('Bounty', function() {
 
                 context.player2.passAction();
                 context.covetousRivals.exhausted = false;
+            });
+
+            it('should not trigger twice when removed from play and played again.', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['waylay'],
+                        groundArena: [{ card: 'atst', upgrades: ['top-target'] }]
+                    },
+                    player2: {
+                        groundArena: ['hylobon-enforcer'],
+                        spaceArena: ['cartel-turncoat'],
+                        hand: ['waylay'],
+                    }
+                });
+
+                const { context } = contextRef;
+                context.firstWaylay = context.player1.hand[0];
+                context.secondWaylay = context.player2.hand[0];
+
+                // CASE 1: check that the bounty isn't triggered when removed from play
+                context.player1.clickCard(context.firstWaylay);
+                context.player1.clickCard(context.hylobonEnforcer);
+
+                // return atst to hand without collecting bounty
+                expect(context.player2).toBeActivePlayer();
+                context.player2.clickCard(context.secondWaylay);
+                context.player2.clickCard(context.atst);
+
+                expect(context.player1).toBeActivePlayer();
+                context.player1.passAction();
+
+                // CASE 2: We now defeat it to check it doesn't trigger twice.
+                context.player2.clickCard(context.hylobonEnforcer);
+                context.player1.clickCard(context.atst);
+                context.player2.passAction();
+                context.atst.exhausted = false;
+
+                context.player1.clickCard(context.atst);
+                context.player1.clickCard(context.hylobonEnforcer);
+
+                expect(context.player1).toHavePassAbilityPrompt('Bounty: Draw a card');
+                context.player1.clickPrompt('Bounty: Draw a card');
+
+                expect(context.player1.handSize).toBe(1);
+                expect(context.player2.handSize).toBe(0);
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/core/abilities/keyword/Grit.spec.ts
+++ b/test/server/core/abilities/keyword/Grit.spec.ts
@@ -9,6 +9,7 @@ describe('Grit keyword', function() {
                     },
                     player2: {
                         groundArena: ['regional-governor'],
+                        hand: ['waylay']
                     }
                 });
             });
@@ -30,6 +31,22 @@ describe('Grit keyword', function() {
 
                 context.setDamage(context.scoutBikePursuer, 0);
                 expect(context.scoutBikePursuer.getPower()).toBe(1);
+            });
+
+            it('is removed from play it shouldn\'t have the keyword twice.', function() {
+                const { context } = contextRef;
+                context.player1.passAction();
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.scoutBikePursuer);
+
+                context.player1.clickCard(context.scoutBikePursuer);
+                context.player2.clickCard(context.regionalGovernor);
+                context.player2.clickCard(context.scoutBikePursuer);
+
+                // check board state
+                expect(context.scoutBikePursuer.damage).toBe(1);
+                expect(context.scoutBikePursuer.getPower()).toBe(2);
+                expect(context.regionalGovernor.damage).toBe(1);
             });
         });
 

--- a/test/server/core/abilities/keyword/Overwhelm.spec.ts
+++ b/test/server/core/abilities/keyword/Overwhelm.spec.ts
@@ -12,7 +12,8 @@ describe('Overwhelm keyword', function() {
                             'partisan-insurgent',
                             'specforce-soldier',
                             { card: 'battlefield-marine', upgrades: ['shield'] }
-                        ]
+                        ],
+                        hand: ['waylay']
                     }
                 });
             });
@@ -67,6 +68,23 @@ describe('Overwhelm keyword', function() {
                 context.player1.clickCard(context.wampa);
                 context.player1.clickCard(context.partisanInsurgent);
                 expect(context.p2Base.damage).toBe(0);
+            });
+
+            it('after it was removed from play and played again it should only deal excess damage once', function() {
+                const { context } = contextRef;
+                context.player1.passAction();
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.wampa);
+
+                context.player1.clickCard(context.wampa);
+                context.wampa.exhausted = false;
+                context.player2.passAction();
+
+                context.player1.clickCard(context.wampa);
+                context.player1.clickCard(context.specforceSoldier);
+                expect(context.p2Base.damage).toBe(2);
+                expect(context.wampa.damage).toBe(2);
+                expect(context.wampa.exhausted).toBe(true);
             });
         });
 

--- a/test/server/core/abilities/keyword/Raid.spec.ts
+++ b/test/server/core/abilities/keyword/Raid.spec.ts
@@ -9,6 +9,7 @@ describe('Raid keyword', function() {
                     },
                     player2: {
                         groundArena: ['battlefield-marine'],
+                        hand: ['waylay']
                     }
                 });
             });
@@ -40,6 +41,23 @@ describe('Raid keyword', function() {
 
                 expect(context.battlefieldMarine.damage).toBe(0);
                 expect(context.cantinaBraggart).toBeInZone('discard');
+            });
+
+            it('is removed from play and played again it shouldn\'t have an additional raid.', function () {
+                const { context } = contextRef;
+                context.player1.passAction();
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.cantinaBraggart);
+
+                context.player1.clickCard(context.cantinaBraggart);
+                context.cantinaBraggart.exhausted = false;
+                context.player2.passAction();
+
+                context.player1.clickCard(context.cantinaBraggart);
+                context.player1.clickCard(context.p2Base);
+                expect(context.cantinaBraggart.exhausted).toBe(true);
+                expect(context.cantinaBraggart.getPower()).toBe(0);
+                expect(context.p2Base.damage).toBe(2);
             });
         });
 

--- a/test/server/core/abilities/keyword/Restore.spec.ts
+++ b/test/server/core/abilities/keyword/Restore.spec.ts
@@ -8,6 +8,7 @@ describe('Restore keyword', function() {
                         groundArena: ['regional-sympathizers'],
                     },
                     player2: {
+                        hand: ['waylay']
                     }
                 });
             });
@@ -20,6 +21,23 @@ describe('Restore keyword', function() {
                 // attack resolves automatically since there's only one target (p2Base)
                 context.player1.clickCard(context.regionalSympathizers);
 
+                expect(context.p1Base.damage).toBe(3);
+                expect(context.p2Base.damage).toBe(3);
+                expect(context.regionalSympathizers.exhausted).toBe(true);
+            });
+
+            it('is removed from play and played again it should not gain an additional restore keyword', function() {
+                const { context } = contextRef;
+                context.setDamage(context.p1Base, 5);
+
+                context.player1.passAction();
+                context.player2.clickCard(context.waylay);
+
+                context.player1.clickCard(context.regionalSympathizers);
+                context.regionalSympathizers.exhausted = false;
+                context.player2.passAction();
+
+                context.player1.clickCard(context.regionalSympathizers);
                 expect(context.p1Base.damage).toBe(3);
                 expect(context.p2Base.damage).toBe(3);
                 expect(context.regionalSympathizers.exhausted).toBe(true);

--- a/test/server/core/abilities/keyword/Saboteur.spec.ts
+++ b/test/server/core/abilities/keyword/Saboteur.spec.ts
@@ -11,7 +11,8 @@ describe('Saboteur keyword', function() {
                         groundArena: ['echo-base-defender',
                             { card: 'wampa', upgrades: ['shield', 'shield', 'resilient'] }
                         ],
-                        spaceArena: ['system-patrol-craft']
+                        spaceArena: ['system-patrol-craft'],
+                        hand: ['waylay']
                     }
                 });
             });
@@ -26,6 +27,25 @@ describe('Saboteur keyword', function() {
                 expect(context.resourcefulPursuers.damage).toBe(0);
                 expect(context.echoBaseDefender).toBeInZone('groundArena');
                 expect(context.wampa.zoneName).toBe('groundArena');
+            });
+
+            it('after it was removed from play and played again it shouldn\'t cause an error', function() {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.resourcefulPursuers);
+                context.player1.clickCard(context.resourcefulPursuers);
+
+
+                context.resourcefulPursuers.exhausted = false;
+                context.player2.passAction();
+
+                // see if everything goes normally
+                context.player1.clickCard(context.resourcefulPursuers);
+                context.player1.clickCard(context.p2Base);
+                expect(context.p2Base.damage).toBe(5);
+                expect(context.resourcefulPursuers.damage).toBe(0);
             });
 
             it('a unit with shields, the shields are defeated before the attack', function () {

--- a/test/server/core/abilities/keyword/Sentinel.spec.ts
+++ b/test/server/core/abilities/keyword/Sentinel.spec.ts
@@ -5,11 +5,12 @@ describe('Sentinel keyword', function() {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
+                        hand: ['waylay'],
                         groundArena: ['liberated-slaves'],
                     },
                     player2: {
                         groundArena: ['echo-base-defender', 'battlefield-marine', 'wookiee-warrior'],
-                        spaceArena: ['system-patrol-craft', 'seventh-fleet-defender', 'imperial-interceptor']
+                        spaceArena: ['system-patrol-craft', 'seventh-fleet-defender', 'imperial-interceptor'],
                     }
                 });
             });
@@ -18,6 +19,22 @@ describe('Sentinel keyword', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.liberatedSlaves);
+                expect(context.liberatedSlaves.exhausted).toBe(true);
+                expect(context.p2Base.damage).toBe(0);
+                expect(context.liberatedSlaves.damage).toBe(4);
+                expect(context.echoBaseDefender).toBeInZone('discard');
+            });
+
+            it('is removed from play and played again it should retain its 1 keyword', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.waylay);
+                context.player1.clickCard(context.echoBaseDefender);
+
+                context.player2.clickCard(context.echoBaseDefender);
+                context.player1.clickCard(context.liberatedSlaves);
+
+                // check board state
                 expect(context.liberatedSlaves.exhausted).toBe(true);
                 expect(context.p2Base.damage).toBe(0);
                 expect(context.liberatedSlaves.damage).toBe(4);

--- a/test/server/core/abilities/keyword/Shielded.spec.ts
+++ b/test/server/core/abilities/keyword/Shielded.spec.ts
@@ -6,6 +6,9 @@ describe('Shielded keyword', function() {
                     phase: 'action',
                     player1: {
                         hand: ['crafty-smuggler']
+                    },
+                    player2: {
+                        hand: ['waylay']
                     }
                 });
             });
@@ -14,6 +17,17 @@ describe('Shielded keyword', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.craftySmuggler);
+                expect(context.craftySmuggler).toHaveExactUpgradeNames(['shield']);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('enters play, is removed from play and enters play again it should receive only 1 shield', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.craftySmuggler);
+                context.player2.clickCard(context.waylay);
+                context.player1.clickCard(context.craftySmuggler);
+
                 expect(context.craftySmuggler).toHaveExactUpgradeNames(['shield']);
                 expect(context.player2).toBeActivePlayer();
             });


### PR DESCRIPTION
- All keywords except Smuggle (under test/core/abilities/keyword)
- two when-played ability, one on-attack ability (ideally something simple like draw a card)
- One constant ability like Snoke or Dodonna Something like Reputable Hunter that gives itself a play discount effect

- a generic "when defeated" ability test where we defeat, recall with Emperor's Legion, play, then defeat again
- a test for General Krell, there's already a comment note there. basically we want to start him in play, defeat, recall to hand, play again, and then confirm that friendly units draw exactly 1 card when they die (the concern is that they might gain two instances of his ability)