### PR TITLE
Bug fix for allowing exhausted attackers

### DIFF
--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -48,7 +48,7 @@ export class PlayUpgradeAction extends PlayCardAction {
         ) {
             return 'restriction';
         }
-        return super.meetsRequirements(context);
+        return super.meetsRequirements(context, ignoredRequirements);
     }
 
     public override displayMessage(context: AbilityContext) {

--- a/server/game/core/cost/GameSystemCost.ts
+++ b/server/game/core/cost/GameSystemCost.ts
@@ -7,7 +7,15 @@ import type { GameEvent } from '../event/GameEvent';
  * Class that wraps a {@link GameSystem} so it can be represented as an action cost
  */
 export class GameSystemCost<TContext extends AbilityContext = AbilityContext> implements ICost<TContext> {
-    public constructor(public gameSystem: GameSystem<TContext>) {}
+    public readonly gameSystem: GameSystem<TContext>;
+
+    private readonly ifPossible: boolean;
+
+    /** @param ifPossible Indicates that the cost should be paid if possible, but don't fail the action if not */
+    public constructor(gameSystem: GameSystem<TContext>, ifPossible: boolean = false) {
+        this.gameSystem = gameSystem;
+        this.ifPossible = ifPossible;
+    }
 
     public getActionName(context: TContext): string {
         return this.gameSystem.name;
@@ -20,10 +28,15 @@ export class GameSystemCost<TContext extends AbilityContext = AbilityContext> im
      * @returns True if this cost can be paid, false otherwise
      */
     public canPay(context: TContext): boolean {
-        return this.gameSystem.hasLegalTarget(context);
+        return this.ifPossible || this.gameSystem.hasLegalTarget(context);
     }
 
     public queueGenerateEventGameSteps(events: GameEvent[], context: TContext, result: Result): void {
+        // if the game system has no target but payment is optional, just return
+        if (!this.gameSystem.hasLegalTarget(context) && this.ifPossible) {
+            return;
+        }
+
         context.costs[this.gameSystem.name] = this.gameSystem.generatePropertiesFromContext(context).target;
         this.gameSystem.queueGenerateEventGameSteps(events, context);
     }

--- a/server/game/gameSystems/InitiateAttackSystem.ts
+++ b/server/game/gameSystems/InitiateAttackSystem.ts
@@ -13,6 +13,7 @@ export interface IInitiateAttackProperties<TContext extends AbilityContext = Abi
     ignoredRequirements?: string[];
     attackerCondition?: (card: Card, context: TContext) => boolean;
     isAmbush?: boolean;
+    allowExhaustedAttacker?: boolean;
 
     /** By default, the system will inherit the `optional` property from the activating ability. Use this to override the behavior. */
     optional?: boolean;
@@ -29,7 +30,8 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
     protected override readonly defaultProperties: IInitiateAttackProperties = {
         ignoredRequirements: [],
         attackerCondition: () => true,
-        isAmbush: false
+        isAmbush: false,
+        allowExhaustedAttacker: false
     };
 
     public eventHandler(event, additionalProperties): void {


### PR DESCRIPTION
There was an issue where specifying `ignoredRequirements: ['cost']` for an attack didn't work and was causing a bug for a card impl. Figured out a fix, tested and working in that branch.