### PR TITLE
Add shortcut in ability resolver for no effective targets

### DIFF
--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -94,8 +94,11 @@ export class CardTargetResolver extends TargetResolver<ICardTargetResolver<Abili
                 GameStateChangeRequired.MustFullyOrPartiallyResolve
             ))
         ) {
+            targetResults.hasEffectiveTargets = targetResults.hasEffectiveTargets || false;
             return;
         }
+
+        targetResults.hasEffectiveTargets = true;
 
         // if there's only one target available, automatically select it without prompting
         if (context.player.autoSingleTarget && legalTargets.length === 1) {

--- a/server/game/core/gameSteps/AbilityResolver.js
+++ b/server/game/core/gameSteps/AbilityResolver.js
@@ -133,7 +133,7 @@ class AbilityResolver extends BaseStepWithPipeline {
             return;
         }
 
-        this.cancelled = this.targetResults.cancelled;
+        this.checkTargetResultCancelState();
     }
 
     checkForCancelOrPass() {
@@ -141,12 +141,25 @@ class AbilityResolver extends BaseStepWithPipeline {
             return;
         }
 
-        if (this.passAbilityHandler && !this.passAbilityHandler.hasBeenShown) {
+        this.checkTargetResultCancelState();
+
+        if (!this.cancelled && this.passAbilityHandler && !this.passAbilityHandler.hasBeenShown) {
             this.game.queueSimpleStep(() => this.checkForPass(), 'checkForPass');
             return;
         }
+    }
 
+    checkTargetResultCancelState() {
         this.cancelled = this.targetResults.cancelled;
+
+        if (
+            !this.cancelled &&
+            this.targetResults.hasEffectiveTargets === false &&
+            (!this.context.ability.cost || this.context.ability.cost?.length === 0)
+        ) {
+            this.cancelled = true;
+            this.resolutionComplete = true;
+        }
     }
 
     // TODO: add passHandler support here


### PR DESCRIPTION
We found that in some cases, marking a triggered ability optional would case a prompt to be displayed for activating the ability even if there were no "effective" targets (e.g., an exhaust ability trying to activate when all units are exhausted). Added a shortcut for this, tested in a different branch.