### PR TITLE
 Bug fix for gained ability from lasting effect

### DIFF
--- a/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
+++ b/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
@@ -22,11 +22,17 @@ export class GainAbility extends OngoingEffectValueWrapper<IActionAbilityPropsWi
 
     public override setContext(context) {
         Contract.assertNotNullLike(context.source);
-        Contract.assertNotNullLike(context.ability?.uuid);
+
+        if (context.ability?.abilityIdentifier) {
+            this.abilityIdentifier = `gained_from_${context.ability.abilityIdentifier}`;
+        } else if (context.ability?.isLastingEffect) {
+            this.abilityIdentifier = 'gained_from_lasting_effect';
+        } else if (!this.abilityIdentifier) {
+            Contract.fail('GainAbility.setContext() called without a valid context');
+        }
 
         super.setContext(context);
 
-        this.abilityIdentifier = `gained_from_${context.ability.abilityIdentifier}`;
         this.source = this.context.source;
         this.gainAbilitySource = this.source;
     }

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -29,9 +29,9 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         }
 
         const lastingEffectRestrictions = event.card.getOngoingEffectValues(EffectName.CannotApplyLastingEffects);
-        const { effect: effect, ...otherProperties } = properties;
+        const { effect, ...otherProperties } = properties;
         const effectProperties = Object.assign({ matchTarget: event.card, zoneFilter: WildcardZoneName.Any }, otherProperties);
-        let effects = properties.effect.map((factory) =>
+        let effects = effect.map((factory) =>
             factory(event.context.game, event.context.source, effectProperties)
         );
         effects = effects.filter(
@@ -49,12 +49,14 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         if (!Array.isArray(properties.effect)) {
             properties.effect = [properties.effect];
         }
+
         return properties;
     }
 
     public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        properties.effect = properties.effect.map((factory) => factory(context.game, context.source, properties));
+        properties.effect = properties.effect.map((factory) => factory(context.game, context.source, { ...properties, isLastingEffect: true }));
+
         const lastingEffectRestrictions = card.getOngoingEffectValues(EffectName.CannotApplyLastingEffects);
         return (
             super.canAffect(card, context) &&


### PR DESCRIPTION
In another branch we hit an issue where a gained ability couldn't correctly generate a name for itself when created from an attack lasting effect due to the lack of a name on the effect (or on the originating ability). Added a way to declare when the ability is coming from a lasting effect. Tests pass in the feature branch.