### PR TITLE
Implementing criminal muscle

### DIFF
--- a/server/game/cards/02_SHD/units/CriminalMuscle.ts
+++ b/server/game/cards/02_SHD/units/CriminalMuscle.ts
@@ -1,0 +1,24 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+
+export default class CriminalMuscle extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '6475868209',
+            internalName: 'criminal-muscle'
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addWhenPlayedAbility({
+            title: 'Return a non-unique upgrade to its owner\'s hand.',
+            optional: true,
+            targetResolver: {
+                cardCondition: (card) => card.isUpgrade() && !card.unique,
+                immediateEffect: AbilityHelper.immediateEffects.returnToHand()
+            }
+        });
+    }
+}
+
+CriminalMuscle.implemented = true;

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -87,6 +87,10 @@ export class UpgradeCard extends UpgradeCardParent {
         this._parentCard = newParentCard;
     }
 
+    public isAttached(): boolean {
+        return !!this._parentCard;
+    }
+
     public unattach() {
         Contract.assertNotNullLike(this._parentCard, 'Attempting to unattach upgrade when already unattached');
 

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -251,6 +251,11 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
      * @param defaultMoveAction A handler that will move the card to its destination if none of the special cases apply
      */
     protected leavesPlayEventHandler(card: UnitCard, destination: ZoneName, context: TContext, defaultMoveAction: () => void): void {
+        // Attached upgrades should be unattached before moved
+        if (card.isUpgrade() && card.isAttached()) {
+            card.unattach();
+        }
+
         // tokens and leaders are defeated if they move out of an arena zone
         if (
             (card.isToken() || card.isLeader()) &&

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -251,11 +251,6 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
      * @param defaultMoveAction A handler that will move the card to its destination if none of the special cases apply
      */
     protected leavesPlayEventHandler(card: UnitCard, destination: ZoneName, context: TContext, defaultMoveAction: () => void): void {
-        // Attached upgrades should be unattached before moved
-        if (card.isUpgrade() && card.isAttached()) {
-            card.unattach();
-        }
-
         // tokens and leaders are defeated if they move out of an arena zone
         if (
             (card.isToken() || card.isLeader()) &&
@@ -264,6 +259,11 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
             // TODO TOKEN UNITS: the timing for this is wrong, and it needs to not emit a second 'onLeavesPlay' event
             context.game.actions.defeat({ target: card }).resolve(null, context);
         } else {
+            // Attached upgrades should be unattached before moved
+            if (card.isUpgrade() && card.isAttached()) {
+                card.unattach();
+            }
+
             defaultMoveAction();
         }
     }

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -105,18 +105,21 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
     public override canAffect(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const { destination } = this.generatePropertiesFromContext(context, additionalProperties) as IMoveCardProperties;
 
+        // Token cards can be attempted to be moved anywhere
+        if (!card.isToken()) {
         // Ensure that we have a valid destination and that the card can be moved there
-        Contract.assertTrue(
-            destination && context.player.isLegalZoneForCardType(card.type, destination),
-            `${destination} is not a valid zone for ${card.type}`
-        );
-
-        // Ensure that if the card is returning to the hand, it must be in the discard pile or in play or be a resource
-        if (destination === ZoneName.Hand) {
             Contract.assertTrue(
-                [ZoneName.Discard, ZoneName.Resource].includes(card.zoneName) || EnumHelpers.isArena(card.zoneName),
-                `Cannot use MoveCardSystem to return a card to hand from ${card.zoneName}`
+                destination && context.player.isLegalZoneForCardType(card.type, destination),
+                `${destination} is not a valid zone for ${card.type}`
             );
+
+            // Ensure that if the card is returning to the hand, it must be in the discard pile or in play or be a resource
+            if (destination === ZoneName.Hand) {
+                Contract.assertTrue(
+                    [ZoneName.Discard, ZoneName.Resource].includes(card.zoneName) || EnumHelpers.isArena(card.zoneName),
+                    `Cannot use MoveCardSystem to return a card to hand from ${card.zoneName}`
+                );
+            }
         }
 
         // Call the super implementation

--- a/test/server/cards/02_SHD/units/CriminalMuscle.spec.ts
+++ b/test/server/cards/02_SHD/units/CriminalMuscle.spec.ts
@@ -1,0 +1,63 @@
+describe('Criminal Muscle', function () {
+    integration(function (contextRef) {
+        describe('Criminal Muscle\'s ability', function() {
+            it('should return an non-unique upgrade to owner\'s hand', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['frozen-in-carbonite'],
+                        groundArena: [{ card: 'luke-skywalker#jedi-knight', upgrades: ['lukes-lightsaber', 'jedi-lightsaber'] }],
+                        discard: ['entrenched']
+                    },
+                    player2: {
+                        hand: ['criminal-muscle'],
+                        groundArena: ['pyke-sentinel'],
+                        discard: ['hotshot-dl44-blaster']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.frozenInCarbonite);
+                context.player1.clickCard(context.pykeSentinel);
+                expect(context.pykeSentinel.isUpgraded()).toBe(true);
+                expect(context.player2).toBeActivePlayer();
+
+                context.player2.clickCard(context.criminalMuscle);
+                expect(context.player2).toBeAbleToSelectExactly([context.frozenInCarbonite, context.jediLightsaber]);
+                expect(context.player2).toHavePassAbilityButton();
+
+                context.player2.clickCard(context.frozenInCarbonite);
+                expect(context.pykeSentinel.isUpgraded()).toBe(false);
+                expect(context.player1.hand.length).toBe(1);
+                expect(context.frozenInCarbonite).toBeInZone('hand', context.player1);
+            });
+
+            it('should return an token upgrade to out of play arena', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['criminal-muscle'],
+                        groundArena: [{ card: 'pyke-sentinel', upgrades: ['entrenched'] }],
+                        discard: ['hotshot-dl44-blaster']
+                    },
+                    player2: {
+                        hand: ['frozen-in-carbonite'],
+                        groundArena: [{ card: 'luke-skywalker#jedi-knight', upgrades: ['lukes-lightsaber', 'experience'] }],
+                        discard: ['jedi-lightsaber']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.criminalMuscle);
+                expect(context.player1).toBeAbleToSelectExactly([context.entrenched, context.experience]);
+                expect(context.player1).toHavePassAbilityButton();
+
+                context.player1.clickCard(context.experience);
+                expect(context.lukeSkywalkerJediKnight.upgrades.length).toBe(1);
+                expect(context.experience).toBeInZone('out-of-play', context.player2);
+            });
+        });
+    });
+});

--- a/test/server/cards/02_SHD/units/CriminalMuscle.spec.ts
+++ b/test/server/cards/02_SHD/units/CriminalMuscle.spec.ts
@@ -56,7 +56,7 @@ describe('Criminal Muscle', function () {
 
                 context.player1.clickCard(context.experience);
                 expect(context.lukeSkywalkerJediKnight.upgrades.length).toBe(1);
-                expect(context.experience).toBeInZone('out-of-play', context.player2);
+                expect(context.experience).toBeInZone('outsideTheGame', context.player2);
             });
         });
     });


### PR DESCRIPTION
Needed up makes some checks to the move system to take into account unattaching upgrades or handling tokens. This needs to be checked for the proper way to update the move game system.

![image](https://github.com/user-attachments/assets/0921ceb4-9150-47c9-900d-145093bf53a6)
