### PR TITLE
Coordinate keyword

### DIFF
--- a/server/game/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.ts
+++ b/server/game/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.ts
@@ -11,17 +11,13 @@ export default class AnakinSkywalkerMaverickMentor extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities () {
-        this.addConstantAbility({
-            title: 'Coordinate: This unit gains On Attack: Draw a card',
-            condition: (context) => context.source.controller.getArenaUnits().length >= 3,
-            ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
-                type: AbilityType.Triggered,
-                title: 'Draw a card',
-                when: {
-                    onAttackDeclared: (event, context) => event.attack.attacker === context.source
-                },
-                immediateEffect: AbilityHelper.immediateEffects.draw()
-            })
+        this.addCoordinateAbility({
+            type: AbilityType.Triggered,
+            title: 'Draw a card',
+            when: {
+                onAttackDeclared: (event, context) => event.attack.attacker === context.source
+            },
+            immediateEffect: AbilityHelper.immediateEffects.draw()
         });
     }
 }

--- a/server/game/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.ts
+++ b/server/game/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.ts
@@ -1,0 +1,29 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { AbilityType } from '../../../core/Constants';
+
+export default class AnakinSkywalkerMaverickMentor extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '2282198576',
+            internalName: 'anakin-skywalker#maverick-mentor',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addConstantAbility({
+            title: 'Coordinate: This unit gains On Attack: Draw a card',
+            condition: (context) => context.source.controller.getArenaUnits().length >= 3,
+            ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
+                type: AbilityType.Triggered,
+                title: 'Draw a card',
+                when: {
+                    onAttackDeclared: (event, context) => event.attack.attacker === context.source
+                },
+                immediateEffect: AbilityHelper.immediateEffects.draw()
+            })
+        });
+    }
+}
+
+AnakinSkywalkerMaverickMentor.implemented = true;

--- a/server/game/cards/03_TWI/units/CloneHeavyGunner.ts
+++ b/server/game/cards/03_TWI/units/CloneHeavyGunner.ts
@@ -11,14 +11,10 @@ export default class CloneHeavyGunner extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities () {
-        this.addConstantAbility({
-            title: 'Coordinate: This unit gets +2/+0',
-            condition: (context) => context.source.controller.getArenaUnits().length >= 3,
-            ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
-                type: AbilityType.Constant,
-                title: 'This unit gets +2/+0',
-                ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })
-            })
+        this.addCoordinateAbility({
+            type: AbilityType.Constant,
+            title: 'This unit gets +2/+0',
+            ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })
         });
     }
 }

--- a/server/game/cards/03_TWI/units/CloneHeavyGunner.ts
+++ b/server/game/cards/03_TWI/units/CloneHeavyGunner.ts
@@ -1,0 +1,26 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { AbilityType } from '../../../core/Constants';
+
+export default class CloneHeavyGunner extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '9227411088',
+            internalName: 'clone-heavy-gunner',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addConstantAbility({
+            title: 'Coordinate: This unit gets +2/+0',
+            condition: (context) => context.source.controller.getArenaUnits().length >= 3,
+            ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
+                type: AbilityType.Constant,
+                title: 'This unit gets +2/+0',
+                ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })
+            })
+        });
+    }
+}
+
+CloneHeavyGunner.implemented = true;

--- a/server/game/cards/03_TWI/units/CoruscantGuard.ts
+++ b/server/game/cards/03_TWI/units/CoruscantGuard.ts
@@ -13,7 +13,7 @@ export default class CoruscantGuard extends NonLeaderUnitCard {
     public override setupCardAbilities () {
         this.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Gain Sentinel',
+            title: 'Gain Ambush',
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });
     }

--- a/server/game/cards/03_TWI/units/CoruscantGuard.ts
+++ b/server/game/cards/03_TWI/units/CoruscantGuard.ts
@@ -1,0 +1,22 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { AbilityType, KeywordName } from '../../../core/Constants';
+
+export default class CoruscantGuard extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '7380773849',
+            internalName: 'coruscant-guard',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addCoordinateAbility({
+            type: AbilityType.Constant,
+            title: 'Gain Sentinel',
+            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
+        });
+    }
+}
+
+CoruscantGuard.implemented = true;

--- a/server/game/cards/03_TWI/units/RecklessTorrent.ts
+++ b/server/game/cards/03_TWI/units/RecklessTorrent.ts
@@ -13,7 +13,7 @@ export default class RecklessTorrent extends NonLeaderUnitCard {
     public override setupCardAbilities () {
         this.addCoordinateAbility({
             type: AbilityType.Triggered,
-            title: 'Draw a card',
+            title: 'Deal 2 damage to a friendly unit and 2 damage to an enemy unit in the same arena',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source
             },

--- a/server/game/cards/03_TWI/units/RecklessTorrent.ts
+++ b/server/game/cards/03_TWI/units/RecklessTorrent.ts
@@ -1,0 +1,41 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { AbilityType, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+
+export default class RecklessTorrent extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '2298508689',
+            internalName: 'reckless-torrent',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addCoordinateAbility({
+            type: AbilityType.Triggered,
+            title: 'Draw a card',
+            when: {
+                onCardPlayed: (event, context) => event.card === context.source
+            },
+            targetResolvers: {
+                friendlyUnit: {
+                    cardTypeFilter: WildcardCardType.Unit,
+                    controller: RelativePlayer.Self,
+                    immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 }),
+                },
+                enemyUnit: {
+                    cardTypeFilter: WildcardCardType.Unit,
+                    controller: RelativePlayer.Opponent,
+                    cardCondition: (card, context) => (
+                        context.targets.friendlyUnit
+                            ? card.zoneName === context.targets.friendlyUnit.zoneName
+                            : true
+                    ),
+                    immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 }),
+                }
+            },
+        });
+    }
+}
+
+RecklessTorrent.implemented = true;

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -274,6 +274,7 @@ export enum Aspect {
 export enum KeywordName {
     Ambush = 'ambush',
     Bounty = 'bounty',
+    Coordinate = 'coordinate',
     Grit = 'grit',
     Overwhelm = 'overwhelm',
     Raid = 'raid',

--- a/server/game/core/ability/AbilityTypes.ts
+++ b/server/game/core/ability/AbilityTypes.ts
@@ -1,0 +1,29 @@
+import { AbilityType } from '../Constants';
+import { IConstantAbility } from '../ongoingEffect/IConstantAbility';
+import { ActionAbility } from './ActionAbility';
+import TriggeredAbility from './TriggeredAbility';
+
+interface IAbilityWithTypeBase {
+    type: AbilityType;
+    ability: ActionAbility | IConstantAbility | TriggeredAbility;
+}
+
+export interface IActionAbilityWithType extends IAbilityWithTypeBase {
+    type: AbilityType.Action;
+    ability: ActionAbility;
+}
+
+export interface IConstantAbilityWithType extends IAbilityWithTypeBase {
+    type: AbilityType.Constant;
+    ability: IConstantAbility;
+}
+
+export interface ITriggeredAbilityWithType extends IAbilityWithTypeBase {
+    type: AbilityType.Triggered;
+    ability: TriggeredAbility;
+}
+
+export type IAbilityWithType =
+  | IActionAbilityWithType
+  | IConstantAbilityWithType
+  | ITriggeredAbilityWithType;

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -20,6 +20,7 @@ export function parseKeywords(expectedKeywordsRaw: string[], cardText: string, c
             if (smuggleValuesOrNull != null) {
                 keywords.push(smuggleValuesOrNull);
             }
+            // } else if (keywordName === KeywordName.Bounty || keywordName === KeywordName.Coordinate) {
         } else if (keywordName === KeywordName.Bounty) {
             if (isKeywordEnabled(keywordName, cardText, cardName)) {
                 keywords.push(new KeywordWithAbilityDefinition(keywordName));
@@ -67,6 +68,7 @@ export function createBountyAbilityFromProps(properties: Omit<ITriggeredAbilityP
 export const isNumericType: Record<KeywordName, boolean> = {
     [KeywordName.Ambush]: false,
     [KeywordName.Bounty]: false,
+    [KeywordName.Coordinate]: false,
     [KeywordName.Grit]: false,
     [KeywordName.Overwhelm]: false,
     [KeywordName.Raid]: true,
@@ -165,6 +167,8 @@ function getRegexForKeyword(keyword: KeywordName) {
             return /(?:^|(?:\n))Ambush/g;
         case KeywordName.Bounty:
             return /(?:^|(?:\n))Bounty/g;
+        case KeywordName.Coordinate:
+            return /(?:^|(?:\n))Coordinate/g;
         case KeywordName.Grit:
             return /(?:^|(?:\n))Grit/g;
         case KeywordName.Overwhelm:

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -41,7 +41,9 @@ export function keywordFromProperties(properties: IKeywordProperties) {
     }
 
     if (properties.keyword === KeywordName.Bounty) {
-        return new KeywordWithAbilityDefinition(properties.keyword, createBountyAbilityFromProps(properties.ability));
+        const bountyAbilityProps = createBountyAbilityFromProps(properties.ability);
+
+        return new KeywordWithAbilityDefinition(properties.keyword, { ...bountyAbilityProps, type: AbilityType.Triggered });
     }
 
     // TODO SMUGGLE: add smuggle here for "gain smuggle" abilities

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -20,8 +20,7 @@ export function parseKeywords(expectedKeywordsRaw: string[], cardText: string, c
             if (smuggleValuesOrNull != null) {
                 keywords.push(smuggleValuesOrNull);
             }
-            // } else if (keywordName === KeywordName.Bounty || keywordName === KeywordName.Coordinate) {
-        } else if (keywordName === KeywordName.Bounty) {
+        } else if (keywordName === KeywordName.Bounty || keywordName === KeywordName.Coordinate) {
             if (isKeywordEnabled(keywordName, cardText, cardName)) {
                 keywords.push(new KeywordWithAbilityDefinition(keywordName));
             }

--- a/server/game/core/ability/KeywordInstance.ts
+++ b/server/game/core/ability/KeywordInstance.ts
@@ -26,11 +26,15 @@ export class KeywordInstance {
     }
 
     public hasNumericValue(): this is KeywordWithNumericValue {
-        return this instanceof KeywordWithNumericValue;
+        return false;
     }
 
     public hasCostValue(): this is KeywordWithCostValues {
-        return this instanceof KeywordWithCostValues;
+        return false;
+    }
+
+    public hasAbilityDefinition(): this is KeywordWithAbilityDefinition {
+        return false;
     }
 
     public valueOf() {
@@ -53,6 +57,10 @@ export class KeywordWithNumericValue extends KeywordInstance {
     ) {
         super(name);
     }
+
+    public override hasNumericValue(): this is KeywordWithNumericValue {
+        return true;
+    }
 }
 
 export class KeywordWithCostValues extends KeywordInstance {
@@ -64,10 +72,14 @@ export class KeywordWithCostValues extends KeywordInstance {
     ) {
         super(name);
     }
+
+    public override hasCostValue(): this is KeywordWithCostValues {
+        return true;
+    }
 }
 
 export class KeywordWithAbilityDefinition<TSource extends Card = Card> extends KeywordInstance {
-    private _abilityProps?: ITriggeredAbilityProps<TSource> = null;
+    private _abilityProps?: IAbilityPropsWithType<TSource> = null;
 
     public get abilityProps() {
         if (this._abilityProps == null) {
@@ -77,17 +89,21 @@ export class KeywordWithAbilityDefinition<TSource extends Card = Card> extends K
         return this._abilityProps;
     }
 
+    public override hasAbilityDefinition(): this is KeywordWithAbilityDefinition {
+        return true;
+    }
+
     public override get isFullyImplemented(): boolean {
         return this._abilityProps != null;
     }
 
     /** @param abilityProps Optional, but if not provided must be provided via {@link KeywordWithAbilityDefinition.setAbilityProps} */
-    public constructor(name: KeywordName, abilityProps: ITriggeredAbilityProps<TSource> = null) {
+    public constructor(name: KeywordName, abilityProps: IAbilityPropsWithType<TSource> = null) {
         super(name);
         this._abilityProps = abilityProps;
     }
 
-    public setAbilityProps(abilityProps: ITriggeredAbilityProps<TSource>) {
+    public setAbilityProps(abilityProps: IAbilityPropsWithType<TSource>) {
         Contract.assertNotNullLike(abilityProps, `Attempting to set null ability definition for ${this.name}`);
         Contract.assertIsNullLike(this._abilityProps, `Attempting to set ability definition for ${this.name} but it already has a value`);
 

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -623,29 +623,6 @@ export class Card extends OngoingEffectSource {
     }
 
     // ******************************************* MISC *******************************************
-    /**
-     * Adds a dynamically gained action ability to the unit. Used for "gain ability" effects.
-     *
-     * Duplicates of the same gained action from duplicates of the same source card can be added,
-     * but only one will be presented to the user as an available action.
-     *
-     * @returns The uuid of the created action ability
-     */
-    public addGainedActionAbility(properties: IActionAbilityProps): string {
-        const addedAbility = this.createActionAbility(properties);
-        this.actionAbilities.push(addedAbility);
-
-        return addedAbility.uuid;
-    }
-
-    /** Removes a dynamically gained action ability */
-    public removeGainedActionAbility(removeAbilityUuid: string): void {
-        const updatedAbilityList = this.actionAbilities.filter((ability) => ability.uuid !== removeAbilityUuid);
-        Contract.assertEqual(updatedAbilityList.length, this.actionAbilities.length - 1, `Expected to find one instance of gained action ability to remove but instead found ${this.actionAbilities.length - updatedAbilityList.length}`);
-
-        this.actionAbilities = updatedAbilityList;
-    }
-
     protected assertPropertyEnabled(propertyVal: any, propertyName: string) {
         Contract.assertNotNullLike(propertyVal, this.buildPropertyDisabledStr(propertyName));
     }

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -489,6 +489,10 @@ export class Card extends OngoingEffectSource {
             newZone: this.zoneName
         });
 
+        this.registerMove(movedFromZone);
+    }
+
+    protected registerMove(movedFromZone: ZoneName) {
         this.game.registerMovedCard(this);
     }
 

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -9,6 +9,7 @@ import ReplacementEffectAbility from '../../ability/ReplacementEffectAbility';
 import { Card } from '../Card';
 import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 import { FrameworkDefeatCardSystem } from '../../../gameSystems/FrameworkDefeatCardSystem';
+import { IConstantAbility } from '../../ongoingEffect/IConstantAbility';
 
 // required for mixins to be based on this class
 export type InPlayCardConstructor = new (...args: any[]) => InPlayCard;
@@ -136,7 +137,70 @@ export class InPlayCard extends PlayableOrDeployableCard {
 
     // ******************************************** ABILITY STATE MANAGEMENT ********************************************
     /**
-     * Adds a dynamically gained triggered ability to the unit and immediately registers its triggers. Used for "gain ability" effects.
+     * Adds a dynamically gained action ability to the card. Used for "gain ability" effects.
+     *
+     * Duplicates of the same gained action from duplicates of the same source card can be added,
+     * but only one will be presented to the user as an available action.
+     *
+     * @returns The uuid of the created action ability
+     */
+    public addGainedActionAbility(properties: IActionAbilityProps): string {
+        const addedAbility = this.createActionAbility(properties);
+        this.actionAbilities.push(addedAbility);
+
+        return addedAbility.uuid;
+    }
+
+    /** Removes a dynamically gained action ability */
+    public removeGainedActionAbility(removeAbilityUuid: string): void {
+        const updatedAbilityList = this.actionAbilities.filter((ability) => ability.uuid !== removeAbilityUuid);
+        Contract.assertEqual(updatedAbilityList.length, this.actionAbilities.length - 1, `Expected to find one instance of gained action ability to remove but instead found ${this.actionAbilities.length - updatedAbilityList.length}`);
+
+        this.actionAbilities = updatedAbilityList;
+    }
+
+    /**
+     * Adds a dynamically gained constant ability to the card and immediately registers its triggers. Used for "gain ability" effects.
+     *
+     * @returns The uuid of the created triggered ability
+     */
+    public addGainedConstantAbility(properties: IConstantAbilityProps): string {
+        const addedAbility = this.createConstantAbility(properties);
+        this.constantAbilities.push(addedAbility);
+        addedAbility.registeredEffects = this.addEffectToEngine(addedAbility);
+
+        return addedAbility.uuid;
+    }
+
+    /** Removes a dynamically gained constant ability and unregisters its effects */
+    public removeGainedConstantAbility(removeAbilityUuid: string): void {
+        let abilityToRemove: IConstantAbility = null;
+        const remainingAbilities: IConstantAbility[] = [];
+
+        for (const constantAbility of this.constantAbilities) {
+            if (constantAbility.uuid === removeAbilityUuid) {
+                if (abilityToRemove) {
+                    Contract.fail(`Expected to find one instance of gained ability '${abilityToRemove.abilityIdentifier}' on card ${this.internalName} to remove but instead found multiple`);
+                }
+
+                abilityToRemove = constantAbility;
+            } else {
+                remainingAbilities.push(constantAbility);
+            }
+        }
+
+        if (abilityToRemove == null) {
+            Contract.fail(`Did not find any instance of target gained ability to remove on card ${this.internalName}`);
+        }
+
+        this.constantAbilities = remainingAbilities;
+
+        this.removeEffectFromEngine(abilityToRemove.registeredEffects);
+        abilityToRemove.registeredEffects = [];
+    }
+
+    /**
+     * Adds a dynamically gained triggered ability to the card and immediately registers its triggers. Used for "gain ability" effects.
      *
      * @returns The uuid of the created triggered ability
      */

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -242,14 +242,19 @@ export class InPlayCard extends PlayableOrDeployableCard {
         // where we maybe wouldn't reset events / effects / limits?
         this.updateTriggeredAbilityEvents(this.movedFromZone, this.zoneName);
         this.updateConstantAbilityEffects(this.movedFromZone, this.zoneName);
+        this.updateKeywordAbilityEffects(this.movedFromZone, this.zoneName);
 
         this.movedFromZone = null;
     }
 
+    public override registerMove(movedFromZone: ZoneName): void {
+        super.registerMove(movedFromZone);
+
+        this.movedFromZone = movedFromZone;
+    }
+
     protected override initializeForCurrentZone(prevZone?: ZoneName) {
         super.initializeForCurrentZone(prevZone);
-
-        this.movedFromZone = prevZone;
 
         if (EnumHelpers.isArena(this.zoneName)) {
             this.setPendingDefeatEnabled(true);
@@ -299,6 +304,10 @@ export class InPlayCard extends PlayableOrDeployableCard {
             }
         }
     }
+
+    /** Register / un-register the effects for any abilities from keywords */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    protected updateKeywordAbilityEffects(from: ZoneName, to: ZoneName) { }
 
     protected override resetLimits() {
         super.resetLimits();

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -125,7 +125,7 @@ export class PlayableOrDeployableCard extends Card {
             this.zone.updateController(this);
 
             // register this transition with the engine so it can do uniqueness check if needed
-            this.game.registerMovedCard(this);
+            this.registerMove(this.zone.name);
         } else {
             this.moveTo(moveDestination, false);
         }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -1,5 +1,5 @@
 import { InitiateAttackAction } from '../../../actions/InitiateAttackAction';
-import { Arena, CardType, EffectName, EventName, KeywordName, StatType, ZoneName } from '../../Constants';
+import { AbilityType, Arena, CardType, EffectName, EventName, KeywordName, StatType, ZoneName } from '../../Constants';
 import StatsModifierWrapper from '../../ongoingEffect/effectImpl/StatsModifierWrapper';
 import { IOngoingCardEffect } from '../../ongoingEffect/IOngoingCardEffect';
 import * as Contract from '../../utils/Contract';
@@ -9,7 +9,7 @@ import { WithPrintedPower } from './PrintedPower';
 import * as EnumHelpers from '../../utils/EnumHelpers';
 import { UpgradeCard } from '../UpgradeCard';
 import { Card } from '../Card';
-import { ITriggeredAbilityProps } from '../../../Interfaces';
+import { IConstantAbilityProps, ITriggeredAbilityProps } from '../../../Interfaces';
 import { KeywordWithAbilityDefinition, KeywordWithNumericValue } from '../../ability/KeywordInstance';
 import TriggeredAbility from '../../ability/TriggeredAbility';
 import { IConstantAbility } from '../../ongoingEffect/IConstantAbility';
@@ -24,6 +24,9 @@ import { DefeatSourceType, IDamageSource } from '../../../IDamageOrDefeatSource'
 import { FrameworkDefeatCardSystem } from '../../../gameSystems/FrameworkDefeatCardSystem';
 import * as KeywordHelpers from '../../ability/KeywordHelpers';
 import { CaptureZone } from '../../zone/CaptureZone';
+import { IAbilityWithType } from '../../ability/AbilityTypes';
+import OngoingEffectLibrary from '../../../ongoingEffects/OngoingEffectLibrary';
+
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
 
@@ -83,6 +86,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         private _whenCapturedKeywordAbilities?: TriggeredAbility[] = null;
         private _whenDefeatedKeywordAbilities?: TriggeredAbility[] = null;
         private _whenPlayedKeywordAbilities?: TriggeredAbility[] = null;
+        private _whileInPlayKeywordAbilities?: IConstantAbility[] = null;
 
         public get capturedUnits() {
             this.assertPropertyEnabled(this._captureZone, 'capturedUnits');
@@ -222,7 +226,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
             // TODO: see if there's a better way using discriminating unions to avoid needing a cast when getting keyword instances
             Contract.assertTrue(bountyAbilityToAssign instanceof KeywordWithAbilityDefinition);
-            bountyAbilityToAssign.setAbilityProps(triggeredProperties);
+            bountyAbilityToAssign.setAbilityProps({ ...triggeredProperties, type: AbilityType.Triggered });
         }
 
         public override getTriggeredAbilities(): TriggeredAbility[] {
@@ -257,6 +261,42 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             }
 
             return constantAbilities;
+        }
+
+        /** Register / un-register the effects for any abilities from keywords */
+        protected override updateKeywordAbilityEffects(from: ZoneName, to: ZoneName) {
+            if (!EnumHelpers.isArena(from) && EnumHelpers.isArena(to)) {
+                Contract.assertIsNullLike(
+                    this._whileInPlayKeywordAbilities,
+                    `Failed to unregister when played abilities from previous play: ${this._whileInPlayKeywordAbilities?.map((ability) => ability.title).join(', ')}`
+                );
+
+                this._whileInPlayKeywordAbilities = [];
+
+                for (const keywordInstance of this.getCoordinateAbilities()) {
+                    const gainedAbilityProps = keywordInstance.abilityProps;
+
+                    const coordinateKeywordAbilityProps: IConstantAbilityProps = {
+                        title: `Coordinate: ${gainedAbilityProps.title}`,
+                        condition: (context) => context.source.controller.getArenaUnits().length >= 3 && !keywordInstance.isBlank,
+                        ongoingEffect: OngoingEffectLibrary.gainAbility(gainedAbilityProps)
+                    };
+
+                    const coordinateKeywordAbility = this.createConstantAbility(coordinateKeywordAbilityProps);
+                    coordinateKeywordAbility.registeredEffects = this.addEffectToEngine(coordinateKeywordAbility);
+
+                    this._whileInPlayKeywordAbilities.push(coordinateKeywordAbility);
+                }
+            } else if (EnumHelpers.isArena(from) && !EnumHelpers.isArena(to)) {
+                Contract.assertTrue(Array.isArray(this._whileInPlayKeywordAbilities), 'Keyword ability while in play registration was skipped');
+
+                for (const keywordAbility of this._whileInPlayKeywordAbilities) {
+                    this.removeEffectFromEngine(keywordAbility.registeredEffects);
+                    keywordAbility.registeredEffects = [];
+                }
+
+                this._whileInPlayKeywordAbilities = null;
+            }
         }
 
         // *************************************** KEYWORD HELPERS ***************************************
@@ -383,9 +423,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             for (const bountyKeyword of bountyKeywords) {
                 const abilityProps = bountyKeyword.abilityProps;
 
+                Contract.assertTrue(abilityProps.type === AbilityType.Triggered, `Bounty abilities must be triggered abilities but instead found ${abilityProps.type}`);
+
+                const { type, ...abilityPropsWithoutType } = abilityProps;
+
                 const bountyAbility = this.createTriggeredAbility({
                     ...this.buildGeneralAbilityProps('keyword_bounty'),
-                    ...abilityProps
+                    ...abilityPropsWithoutType,
                 });
 
                 bountyAbility.registerEvents();
@@ -397,6 +441,11 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
         private getBountyAbilities() {
             return this.getKeywords().filter((keyword) => keyword.name === KeywordName.Bounty)
+                .map((keyword) => keyword as KeywordWithAbilityDefinition);
+        }
+
+        private getCoordinateAbilities() {
+            return this.getKeywords().filter((keyword) => keyword.name === KeywordName.Coordinate)
                 .map((keyword) => keyword as KeywordWithAbilityDefinition);
         }
 

--- a/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
+++ b/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
@@ -1,20 +1,20 @@
-import { IActionAbilityPropsWithType, ITriggeredAbilityPropsWithType } from '../../../Interfaces';
+import { IAbilityPropsWithType } from '../../../Interfaces';
 import type { InPlayCard } from '../../card/baseClasses/InPlayCard';
 import type { Card } from '../../card/Card';
 import { AbilityType } from '../../Constants';
 import * as Contract from '../../utils/Contract';
 import { OngoingEffectValueWrapper } from './OngoingEffectValueWrapper';
 
-export class GainAbility extends OngoingEffectValueWrapper<IActionAbilityPropsWithType | ITriggeredAbilityPropsWithType> {
+export class GainAbility extends OngoingEffectValueWrapper<IAbilityPropsWithType> {
     public readonly abilityType: AbilityType;
-    public readonly properties: IActionAbilityPropsWithType | ITriggeredAbilityPropsWithType;
+    public readonly properties: IAbilityPropsWithType;
 
     private abilityIdentifier: string;
     private abilityUuidByTargetCard = new Map<InPlayCard, string>();
     private gainAbilitySource: Card;
     private source: Card;
 
-    public constructor(gainedAbilityProps: IActionAbilityPropsWithType | ITriggeredAbilityPropsWithType) {
+    public constructor(gainedAbilityProps: IAbilityPropsWithType) {
         super(Object.assign(gainedAbilityProps, { printedAbility: false }));
 
         this.abilityType = gainedAbilityProps.type;
@@ -48,6 +48,10 @@ export class GainAbility extends OngoingEffectValueWrapper<IActionAbilityPropsWi
                 this.abilityUuidByTargetCard.set(target, target.addGainedActionAbility(properties));
                 return;
 
+            case AbilityType.Constant:
+                this.abilityUuidByTargetCard.set(target, target.addGainedConstantAbility(properties));
+                return;
+
             case AbilityType.Triggered:
                 this.abilityUuidByTargetCard.set(target, target.addGainedTriggeredAbility(properties));
                 return;
@@ -63,6 +67,12 @@ export class GainAbility extends OngoingEffectValueWrapper<IActionAbilityPropsWi
         switch (this.abilityType) {
             case AbilityType.Action:
                 target.removeGainedActionAbility(this.abilityUuidByTargetCard.get(target));
+                this.abilityUuidByTargetCard.delete(target);
+                return;
+
+            case AbilityType.Constant:
+                target.removeGainedConstantAbility(this.abilityUuidByTargetCard.get(target));
+                this.abilityUuidByTargetCard.delete(target);
                 return;
 
             case AbilityType.Triggered:

--- a/server/game/ongoingEffects/OngoingEffectLibrary.ts
+++ b/server/game/ongoingEffects/OngoingEffectLibrary.ts
@@ -11,7 +11,7 @@ import { modifyCost } from './ModifyCost';
 // const { switchAttachmentSkillModifiers } = require('./Effects/Library/switchAttachmentSkillModifiers');
 import { EffectName, PlayType, KeywordName } from '../core/Constants';
 import { StatsModifier } from '../core/ongoingEffect/effectImpl/StatsModifier';
-import { IActionAbilityPropsWithType, ITriggeredAbilityPropsWithType, KeywordNameOrProperties } from '../Interfaces';
+import { IAbilityPropsWithType, KeywordNameOrProperties } from '../Interfaces';
 import { GainAbility } from '../core/ongoingEffect/effectImpl/GainAbility';
 import * as KeywordHelpers from '../core/ability/KeywordHelpers';
 import { CostAdjustType, IIgnoreAllAspectsCostAdjusterProperties, IIgnoreSpecificAspectsCostAdjusterProperties, IIncreaseOrDecreaseCostAdjusterProperties } from '../core/cost/CostAdjuster';
@@ -92,7 +92,7 @@ export = {
     // fateCostToAttack: (amount = 1) => OngoingEffectBuilder.card.flexible(EffectName.FateCostToAttack, amount),
     // cardCostToAttackMilitary: (amount = 1) => OngoingEffectBuilder.card.flexible(EffectName.CardCostToAttackMilitary, amount),
     // fateCostToTarget: (properties) => OngoingEffectBuilder.card.flexible(EffectName.FateCostToTarget, properties),
-    gainAbility: (properties: IActionAbilityPropsWithType | ITriggeredAbilityPropsWithType) =>
+    gainAbility: (properties: IAbilityPropsWithType) =>
         OngoingEffectBuilder.card.static(EffectName.GainAbility, new GainAbility(properties)),
     gainKeyword: (keywordOrKeywordProperties: KeywordNameOrProperties) =>
         OngoingEffectBuilder.card.static(EffectName.GainKeyword,

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -928,7 +928,6 @@ global.integration = function (definitions) {
                 this.player1.moveAllNonBaseZonesToRemoved();
                 this.player2.moveAllNonBaseZonesToRemoved();
 
-
                 if (options.phase !== 'setup') {
                     // Resources
                     this.player1.setResourceCards(options.player1.resources, ['outsideTheGame']);

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -38,6 +38,8 @@ class PlayerInteractionWrapper {
         this.player.discardZone.cards.forEach((card) => this.moveCard(card, 'outsideTheGame'));
         this.player.handZone.cards.forEach((card) => this.moveCard(card, 'outsideTheGame'));
         this.player.deckZone.cards.forEach((card) => this.moveCard(card, 'outsideTheGame'));
+
+        this.game.resolveGameState(true);
     }
 
     get hand() {

--- a/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
+++ b/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
@@ -6,36 +6,31 @@ describe('Anakin Skywalker, Maverick Mentor', function() {
                 player1: {
                     groundArena: ['anakin-skywalker#maverick-mentor', 'battlefield-marine'],
                     spaceArena: ['wing-leader'],
-                    deck: ['wampa']
+                    deck: ['wampa', 'atst']
+                },
+                player2: {
+                    hand: ['vanquish']
                 }
             });
 
             const { context } = contextRef;
 
+            // CASE 1: Coordinate online
             context.player1.clickCard(context.anakinSkywalker);
 
             expect(context.p2Base.damage).toBe(6);
             expect(context.player1.handSize).toBe(1);
             expect(context.wampa).toBeInZone('hand');
-        });
 
-        // TODO THIS PR: merge these tests
-        it('Anakin\'s on attack Coordinate ability should do nothing if fewer than 3 units', function () {
-            contextRef.setupTest({
-                phase: 'action',
-                player1: {
-                    groundArena: ['anakin-skywalker#maverick-mentor'],
-                    spaceArena: ['wing-leader'],
-                    deck: ['wampa']
-                }
-            });
+            // CASE 2: Coordinate offline
+            context.player2.clickCard(context.vanquish);
+            context.player2.clickCard(context.battlefieldMarine);
 
-            const { context } = contextRef;
-
+            context.anakinSkywalker.exhausted = false;
             context.player1.clickCard(context.anakinSkywalker);
 
-            expect(context.p2Base.damage).toBe(6);
-            expect(context.player1.handSize).toBe(0);
+            expect(context.p2Base.damage).toBe(12);
+            expect(context.player1.handSize).toBe(1);
         });
     });
 });

--- a/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
+++ b/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
@@ -1,0 +1,41 @@
+describe('Anakin Skywalker, Maverick Mentor', function() {
+    integration(function(contextRef) {
+        it('Anakin\'s on attack Coordinate ability should draw a card', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['anakin-skywalker#maverick-mentor', 'battlefield-marine'],
+                    spaceArena: ['wing-leader'],
+                    deck: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.anakinSkywalker);
+
+            expect(context.p2Base.damage).toBe(6);
+            expect(context.player1.handSize).toBe(1);
+            expect(context.wampa).toBeInZone('hand');
+        });
+
+        // TODO THIS PR: merge these tests
+        it('Anakin\'s on attack Coordinate ability should do nothing if fewer than 3 units', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['anakin-skywalker#maverick-mentor'],
+                    spaceArena: ['wing-leader'],
+                    deck: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.anakinSkywalker);
+
+            expect(context.p2Base.damage).toBe(6);
+            expect(context.player1.handSize).toBe(0);
+        });
+    });
+});

--- a/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
+++ b/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
@@ -15,14 +15,14 @@ describe('Anakin Skywalker, Maverick Mentor', function() {
 
             const { context } = contextRef;
 
-            // CASE 1: Coordinate online
+            // Coordinate online
             context.player1.clickCard(context.anakinSkywalker);
 
             expect(context.p2Base.damage).toBe(6);
             expect(context.player1.handSize).toBe(1);
             expect(context.wampa).toBeInZone('hand');
 
-            // CASE 2: Coordinate offline
+            // Coordinate offline
             context.player2.clickCard(context.vanquish);
             context.player2.clickCard(context.battlefieldMarine);
 

--- a/test/server/cards/03_TWI/units/CloneHeavyGunner.spec.ts
+++ b/test/server/cards/03_TWI/units/CloneHeavyGunner.spec.ts
@@ -1,0 +1,32 @@
+describe('Clone Heavy Gunner', function() {
+    integration(function(contextRef) {
+        it('Clone Heavy Gunner\'s constant Coordinate ability should give +2/+0', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['clone-heavy-gunner', 'battlefield-marine'],
+                    spaceArena: ['wing-leader']
+                }
+            });
+
+            const { context } = contextRef;
+
+            expect(context.cloneHeavyGunner.getPower()).toBe(3);
+        });
+
+        // TODO THIS PR: merge these tests
+        it('Clone Heavy Gunner\'s constant Coordinate ability should do nothing if fewer than 3 units', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['clone-heavy-gunner'],
+                    spaceArena: ['wing-leader'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            expect(context.cloneHeavyGunner.getPower()).toBe(1);
+        });
+    });
+});

--- a/test/server/cards/03_TWI/units/CloneHeavyGunner.spec.ts
+++ b/test/server/cards/03_TWI/units/CloneHeavyGunner.spec.ts
@@ -5,28 +5,19 @@ describe('Clone Heavy Gunner', function() {
                 phase: 'action',
                 player1: {
                     groundArena: ['clone-heavy-gunner', 'battlefield-marine'],
-                    spaceArena: ['wing-leader']
+                    hand: ['wing-leader']
                 }
             });
 
             const { context } = contextRef;
 
-            expect(context.cloneHeavyGunner.getPower()).toBe(3);
-        });
-
-        // TODO THIS PR: merge these tests
-        it('Clone Heavy Gunner\'s constant Coordinate ability should do nothing if fewer than 3 units', function () {
-            contextRef.setupTest({
-                phase: 'action',
-                player1: {
-                    groundArena: ['clone-heavy-gunner'],
-                    spaceArena: ['wing-leader'],
-                }
-            });
-
-            const { context } = contextRef;
-
+            // Coordinate offline
             expect(context.cloneHeavyGunner.getPower()).toBe(1);
+
+            context.player1.clickCard(context.wingLeader);
+
+            // Coordinate online
+            expect(context.cloneHeavyGunner.getPower()).toBe(3);
         });
     });
 });

--- a/test/server/cards/03_TWI/units/CoruscantGuard.spec.ts
+++ b/test/server/cards/03_TWI/units/CoruscantGuard.spec.ts
@@ -1,0 +1,43 @@
+describe('Coruscant Guard', function() {
+    integration(function(contextRef) {
+        it('Coruscant Guard\'s constant Coordinate ability should grant Ambush', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['battlefield-marine'],
+                    spaceArena: ['wing-leader'],
+                    hand: ['coruscant-guard']
+                },
+                player2: {
+                    groundArena: ['hylobon-enforcer']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.coruscantGuard);
+            expect(context.player1).toHavePassAbilityPrompt('Ambush');
+            context.player1.clickPrompt('Ambush');
+            expect(context.coruscantGuard.damage).toBe(1);
+            expect(context.hylobonEnforcer.damage).toBe(3);
+        });
+
+        it('Coruscant Guard\'s constant Coordinate ability should do nothing if the Coordinate condition is not met', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['wing-leader'],
+                    hand: ['coruscant-guard']
+                },
+                player2: {
+                    groundArena: ['hylobon-enforcer']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.coruscantGuard);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/cards/03_TWI/units/RecklessTorrent.spec.ts
+++ b/test/server/cards/03_TWI/units/RecklessTorrent.spec.ts
@@ -1,0 +1,66 @@
+describe('Reckless Torrent', function() {
+    integration(function(contextRef) {
+        describe('Reckless Torrent\'s when played Coordinate ability', function() {
+            beforeEach(function() {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['wing-leader'],
+                        hand: ['reckless-torrent']
+                    },
+                    player2: {
+                        groundArena: ['wampa', 'atst'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+            });
+
+            it('should deal 2 damage to a friendly unit and 2 damage to an enemy unit in the same arena (ground)', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.recklessTorrent);
+                expect(context.player1).toBeAbleToSelectExactly([context.recklessTorrent, context.battlefieldMarine, context.wingLeader]);
+
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.atst]);
+                context.player1.clickCard(context.atst);
+
+                expect(context.battlefieldMarine.damage).toBe(2);
+                expect(context.atst.damage).toBe(2);
+            });
+
+            it('should deal 2 damage to a friendly unit and 2 damage to an enemy unit in the same arena (space)', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.recklessTorrent);
+                expect(context.player1).toBeAbleToSelectExactly([context.recklessTorrent, context.battlefieldMarine, context.wingLeader]);
+
+                context.player1.clickCard(context.recklessTorrent);
+                // Cartel Spacer is automatically selected
+
+                expect(context.recklessTorrent).toBeInZone('discard');
+                expect(context.cartelSpacer.damage).toBe(2);
+            });
+        });
+
+        it('should do nothing if the Coordinate condition is not met', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['battlefield-marine'],
+                    hand: ['reckless-torrent']
+                },
+                player2: {
+                    groundArena: ['wampa', 'atst'],
+                    spaceArena: ['cartel-spacer']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.recklessTorrent);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/core/abilities/keyword/Coordinate.spec.ts
+++ b/test/server/core/abilities/keyword/Coordinate.spec.ts
@@ -1,0 +1,149 @@
+describe('Coordinate keyword', function() {
+    integration(function(contextRef) {
+        describe('When a unit with the Coordinate keyword', function() {
+            it('is in play with at least 2 other friendly units, its Coordinate ability is online', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['anakin-skywalker#maverick-mentor', 'clone-heavy-gunner'],
+                        spaceArena: ['wing-leader'],
+                        deck: ['wampa']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // constant Coordinate ability
+                expect(context.cloneHeavyGunner.getPower()).toBe(3);
+
+                // triggered Coordinate ability
+                context.player1.clickCard(context.anakinSkywalker);
+
+                expect(context.p2Base.damage).toBe(6);
+                expect(context.player1.handSize).toBe(1);
+                expect(context.wampa).toBeInZone('hand');
+            });
+
+            it('is in play with at fewer than 2 other friendly units, its Coordinate ability is offline', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['anakin-skywalker#maverick-mentor', 'clone-heavy-gunner'],
+                        deck: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['atst'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // constant Coordinate ability
+                expect(context.cloneHeavyGunner.getPower()).toBe(1);
+
+                // triggered Coordinate ability
+                context.player1.clickCard(context.anakinSkywalker);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.p2Base.damage).toBe(6);
+                expect(context.player1.handSize).toBe(0);
+                expect(context.wampa).toBeInZone('deck');
+            });
+
+            it('is in play with a variable number of other friendly units, its Coordinate ability will correct go online / offline', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['anakin-skywalker#maverick-mentor', 'clone-heavy-gunner'],
+                        hand: ['wing-leader'],
+                        deck: ['wampa', 'atst']
+                    },
+                    player2: {
+                        hand: ['waylay']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Coordinate starts offline
+                expect(context.cloneHeavyGunner.getPower()).toBe(1);
+                context.player1.clickCard(context.anakinSkywalker);
+                expect(context.p2Base.damage).toBe(6);
+                expect(context.player1.handSize).toBe(1);
+                expect(context.wampa).toBeInZone('deck');
+
+                // turn Coordinate online
+                context.player2.passAction();
+                context.player1.clickCard(context.wingLeader);
+                context.player2.passAction();
+                context.anakinSkywalker.exhausted = false;
+
+                expect(context.cloneHeavyGunner.getPower()).toBe(3);
+                context.player1.clickCard(context.anakinSkywalker);
+                expect(context.p2Base.damage).toBe(12);
+                expect(context.player1.handSize).toBe(1);
+                expect(context.wampa).toBeInZone('hand');
+
+                // turn Coordinate offline again
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.wingLeader);
+                context.anakinSkywalker.exhausted = false;
+
+                expect(context.cloneHeavyGunner.getPower()).toBe(1);
+                context.player1.clickCard(context.anakinSkywalker);
+                expect(context.p2Base.damage).toBe(18);
+                expect(context.player1.handSize).toBe(2);
+                expect(context.atst).toBeInZone('deck');
+            });
+
+            it('is returned to hand and played again, its Coordinate ability doesn\'t trigger twice', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['anakin-skywalker#maverick-mentor', 'clone-heavy-gunner'],
+                        spaceArena: ['wing-leader'],
+                        deck: ['wampa', 'atst'],
+                        hand: ['waylay']
+                    },
+                    player2: {
+                        hand: ['cantina-bouncer']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // confirm Coordinate online
+                expect(context.cloneHeavyGunner.getPower()).toBe(3);
+                context.player1.clickCard(context.anakinSkywalker);
+                expect(context.p2Base.damage).toBe(6);
+                expect(context.player1.handSize).toBe(2);
+                expect(context.wampa).toBeInZone('hand');
+
+                // return Coordinate units to hand
+                context.player2.clickCard(context.cantinaBouncer);
+                context.player2.clickCard(context.anakinSkywalker);
+                context.player1.clickCard(context.waylay);
+                context.player1.clickCard(context.cloneHeavyGunner);
+
+                // play Coordinate units back out
+                context.player2.passAction();
+                context.player1.clickCard(context.anakinSkywalker);
+                context.player2.passAction();
+                context.player1.clickCard(context.cloneHeavyGunner);
+                context.player2.passAction();
+
+                // confirm Coordinate online and working normally
+                expect(context.cloneHeavyGunner.getPower()).toBe(3);
+                context.anakinSkywalker.exhausted = false;
+                context.player1.clickCard(context.anakinSkywalker);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.p2Base.damage).toBe(12);
+                expect(context.player1.handSize).toBe(2);
+                expect(context.wampa).toBeInZone('hand');
+                expect(context.atst).toBeInZone('hand');
+            });
+        });
+    });
+});

--- a/test/server/core/abilities/keyword/Raid.spec.ts
+++ b/test/server/core/abilities/keyword/Raid.spec.ts
@@ -80,7 +80,5 @@ describe('Raid keyword', function() {
                 expect(context.p2Base.damage).toBe(4);
             });
         });
-
-        // TODO test that a card that attacked and then is bounced back to hand (i.e. Waylay) doesn't receive a second Raid buff
     });
 });

--- a/test/server/core/abilities/keyword/Restore.spec.ts
+++ b/test/server/core/abilities/keyword/Restore.spec.ts
@@ -78,7 +78,5 @@ describe('Restore keyword', function() {
                 expect(context.regionalSympathizers.exhausted).toBe(true);
             });
         });
-
-        // TODO test that a card that attacked and then is bounced back to hand (i.e. Waylay) doesn't receive a second Restore instance
     });
 });

--- a/test/server/core/abilities/keyword/Shielded.spec.ts
+++ b/test/server/core/abilities/keyword/Shielded.spec.ts
@@ -53,6 +53,4 @@ describe('Shielded keyword', function() {
             });
         });
     });
-
-    // TODO test that a card that is bounced back to hand (i.e. Waylay) doesn't receive a second Shield when replayed
 });


### PR DESCRIPTION
Added support for the Coordinate keyword, using similar mechanisms to the Bounty keyword. Added several test units to confirm that the timing works and that triggered and constant abilities work.

Two special cases are not covered in this PR and will require additional work:
- Coordinate on leaders (Ahsoka, Padme)
- "Gain coordinate" (For the Republic)