### PR TITLE
New multiSelectCardCondition, TWI #153 Bold Resistance Card and sameDiscardPile cleanup

### DIFF
--- a/server/game/TargetInterfaces.ts
+++ b/server/game/TargetInterfaces.ts
@@ -96,7 +96,6 @@ interface ICardExactlyUpToTargetResolver<TContext extends AbilityContext> extend
     mode: TargetMode.Exactly | TargetMode.UpTo;
     canChooseNoCards?: boolean;
     numCards: number;
-    sameDiscardPile?: boolean;
     multiSelectCardCondition?: (card: Card, selectedCards: Card[], context?: TContext) => boolean;
 }
 

--- a/server/game/TargetInterfaces.ts
+++ b/server/game/TargetInterfaces.ts
@@ -97,12 +97,14 @@ interface ICardExactlyUpToTargetResolver<TContext extends AbilityContext> extend
     canChooseNoCards?: boolean;
     numCards: number;
     sameDiscardPile?: boolean;
+    multiSelectCardCondition?: (card: Card, selectedCards: Card[], context?: TContext) => boolean;
 }
 
 interface ICardExactlyUpToVariableTargetResolver<TContext extends AbilityContext> extends ICardTargetResolverBase<TContext> {
     mode: TargetMode.ExactlyVariable | TargetMode.UpToVariable;
     numCardsFunc: (context: TContext) => number;
     canChooseNoCards?: boolean;
+    multiSelectCardCondition?: (card: Card, selectedCards: Card[], context?: TContext) => boolean;
 }
 
 interface ICardMaxStatTargetResolver<TContext extends AbilityContext> extends ICardTargetResolverBase<TContext> {

--- a/server/game/cards/01_SOR/events/Restock.ts
+++ b/server/game/cards/01_SOR/events/Restock.ts
@@ -1,4 +1,5 @@
 import AbilityHelper from '../../../AbilityHelper';
+import { Card } from '../../../core/card/Card';
 import { EventCard } from '../../../core/card/EventCard';
 import { TargetMode, WildcardRelativePlayer, ZoneName } from '../../../core/Constants';
 
@@ -18,10 +19,19 @@ export default class Restock extends EventCard {
                 numCards: 4,
                 zoneFilter: ZoneName.Discard,
                 controller: WildcardRelativePlayer.Any,
-                sameDiscardPile: true,
+                multiSelectCardCondition: (card, selectedCards) => this.isSameZone(card, selectedCards),
                 immediateEffect: AbilityHelper.immediateEffects.moveToBottomOfDeck({ shuffleMovedCards: true })
             }
         });
+    }
+
+    // Bundled with the zoneFilter:Discard to ensure cards are in same discard pile
+    private isSameZone(card: Card, selectedCards: Card[]) {
+        if (selectedCards.length > 0) {
+            // Short-cut using the first card only -- as we can't add more selected cards without passing this test
+            return card.zoneName === selectedCards[0].zoneName && card.owner === selectedCards[0].owner;
+        }
+        return true;
     }
 }
 

--- a/server/game/cards/03_TWI/events/BoldResistance.ts
+++ b/server/game/cards/03_TWI/events/BoldResistance.ts
@@ -5,15 +5,12 @@ import { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedT
 import { Card } from '../../../core/card/Card';
 
 export default class BoldResistance extends EventCard {
-    private cardsPlayedThisPhaseWatcher: CardsPlayedThisPhaseWatcher;
-
     protected override getImplementationId() {
         return {
             id: '8022262805',
             internalName: 'bold-resistance'
         };
     }
-
 
     public override setupCardAbilities() {
         this.setEventAbility({

--- a/server/game/cards/03_TWI/events/BoldResistance.ts
+++ b/server/game/cards/03_TWI/events/BoldResistance.ts
@@ -1,7 +1,6 @@
 import { EventCard } from '../../../core/card/EventCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { TargetMode, WildcardCardType } from '../../../core/Constants';
-import { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
 import { Card } from '../../../core/card/Card';
 
 export default class BoldResistance extends EventCard {

--- a/server/game/cards/03_TWI/events/BoldResistance.ts
+++ b/server/game/cards/03_TWI/events/BoldResistance.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { TargetMode, WildcardCardType } from '../../../core/Constants';
 import { Card } from '../../../core/card/Card';
+import * as Helpers from '../../../core/utils/Helpers';
 
 export default class BoldResistance extends EventCard {
     protected override getImplementationId() {
@@ -28,7 +29,7 @@ export default class BoldResistance extends EventCard {
 
     private cardHasCommonTraitWithPreviouslySelected(card: Card, selectedCards: Card[]) {
         // Collect all the traits of the card in question first
-        const intersectingTraits = new BoldResistance.IntersectingSet(card.traits);
+        const intersectingTraits = new Helpers.IntersectingSet(card.traits);
 
         // Now intersect those traits with each previously selected card
         for (const selectedCard of selectedCards) {
@@ -40,17 +41,6 @@ export default class BoldResistance extends EventCard {
         }
         return true;
     }
-
-    // eslint-disable-next-line @stylistic/keyword-spacing
-    private static IntersectingSet = class<T> extends Set<T> {
-        public intersect(inputSet: Set<T>): void {
-            for (const item of this) {
-                if (!inputSet.has(item)) {
-                    this.delete(item);
-                }
-            }
-        }
-    };
 }
 
 BoldResistance.implemented = true;

--- a/server/game/core/cardSelector/BaseCardSelector.js
+++ b/server/game/core/cardSelector/BaseCardSelector.js
@@ -14,7 +14,6 @@ class BaseCardSelector {
         this.capturedByFilter = properties.capturedByFilter;
         this.controller = properties.controller || WildcardRelativePlayer.Any;
         this.checkTarget = !!properties.checkTarget;
-        this.sameDiscardPile = !!properties.sameDiscardPile;
 
         if (!Array.isArray(properties.cardTypeFilter)) {
             this.cardTypeFilter = [properties.cardTypeFilter];
@@ -124,10 +123,6 @@ class BaseCardSelector {
             return false;
         }
 
-        if (this.sameDiscardPile && selectedCards.length > 0) {
-            return card.zoneName === selectedCards[0].zoneName && card.owner === selectedCards[0].owner;
-        }
-
         if (this.checkTarget && !card.canBeTargeted(context, selectedCards)) {
             return false;
         }
@@ -147,8 +142,8 @@ class BaseCardSelector {
     }
 
     cardConditionsAreSatisfied(card, selectedCards, context) {
-        const cardConditionPassed = (this.cardCondition) ? this.cardCondition(card, context) : true;
-        const multiSelectConditionPassed = (this.multiSelectCardCondition) ? this.multiSelectCardCondition(card, selectedCards, context) : true;
+        const cardConditionPassed = !this.cardCondition || this.cardCondition(card, context);
+        const multiSelectConditionPassed = !this.multiSelectCardCondition || this.multiSelectCardCondition(card, selectedCards, context);
         return cardConditionPassed && multiSelectConditionPassed;
     }
 

--- a/server/game/core/cardSelector/BaseCardSelector.js
+++ b/server/game/core/cardSelector/BaseCardSelector.js
@@ -7,6 +7,7 @@ const Helpers = require('../utils/Helpers');
 class BaseCardSelector {
     constructor(properties) {
         this.cardCondition = properties.cardCondition;
+        this.multiSelectCardCondition = properties.multiSelectCardCondition;
         this.cardTypeFilter = properties.cardTypeFilter;
         this.optional = properties.optional;
         this.zoneFilter = this.buildZoneFilter(properties.zoneFilter);
@@ -21,7 +22,7 @@ class BaseCardSelector {
     }
 
     get hasAnyCardFilter() {
-        return this.cardTypeFilter || this.cardCondition;
+        return this.cardTypeFilter || this.cardCondition || this.multiSelectCardCondition;
     }
 
     buildZoneFilter(property) {
@@ -142,7 +143,13 @@ class BaseCardSelector {
         if (card.zoneName === ZoneName.Hand && card.controller !== choosingPlayer) {
             return false;
         }
-        return EnumHelpers.cardTypeMatches(card.type, this.cardTypeFilter) && this.cardCondition(card, context);
+        return EnumHelpers.cardTypeMatches(card.type, this.cardTypeFilter) && this.cardConditionsAreSatisfied(card, selectedCards, context);
+    }
+
+    cardConditionsAreSatisfied(card, selectedCards, context) {
+        const cardConditionPassed = (this.cardCondition) ? this.cardCondition(card, context) : true;
+        const multiSelectConditionPassed = (this.multiSelectCardCondition) ? this.multiSelectCardCondition(card, selectedCards, context) : true;
+        return cardConditionPassed && multiSelectConditionPassed;
     }
 
     getAllLegalTargets(context, choosingPlayer) {

--- a/server/game/core/cardSelector/CardSelectorFactory.js
+++ b/server/game/core/cardSelector/CardSelectorFactory.js
@@ -13,7 +13,6 @@ const defaultProperties = {
     numCardsFunc: () => 1,
     cardTypeFilter: [WildcardCardType.Any],
     multiSelect: false,
-    sameDiscardPile: false
 };
 
 const ModeToSelector = {

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -108,3 +108,13 @@ export function getRandomArrayElements(array: any[], nValues: number) {
 
     return chosenItems;
 }
+
+export class IntersectingSet<T> extends Set<T> {
+    public intersect(inputSet: Set<T>): void {
+        for (const item of this) {
+            if (!inputSet.has(item)) {
+                this.delete(item);
+            }
+        }
+    }
+}

--- a/test/server/cards/03_TWI/events/BoldResistance.spec.ts
+++ b/test/server/cards/03_TWI/events/BoldResistance.spec.ts
@@ -1,0 +1,82 @@
+describe('Bold Resistance', function() {
+    integration(function(contextRef) {
+        describe('Bold Resistance\'s ability', function() {
+            it('should apply +2/+0 for up to 3 units that share the same Trait this phase', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['bold-resistance', 'snowspeeder'],
+                        discard: ['star-wing-scout'], // for confirming the zone selection is clean
+                        spaceArena: ['green-squadron-awing', 'wing-leader', 'vanguard-ace'],
+                        groundArena: ['specforce-soldier', 'wampa'],
+                    },
+                    player2: {
+                        groundArena: ['atst'],
+                    }
+                });
+                const { context } = contextRef;
+
+                // Everything is selectable -- except the discard piles / hands
+                context.player1.clickCard(context.boldResistance);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.specforceSoldier, context.wingLeader, context.wampa, context.atst, context.vanguardAce]);
+
+                // Wampa is out, ATST is still in because its a vehicle
+                context.player1.clickCard(context.greenSquadronAwing);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.specforceSoldier, context.wingLeader, context.atst, context.vanguardAce]);
+
+                // Now the only trait should be 'rebel' - no ATST nor vanguard ace
+                context.player1.clickCard(context.specforceSoldier);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.specforceSoldier, context.wingLeader]);
+
+                // test unselect
+                context.player1.clickCard(context.specforceSoldier);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.specforceSoldier, context.wingLeader, context.atst, context.vanguardAce]);
+
+                // Now the common trait should be 'vehicle'
+                context.player1.clickCard(context.vanguardAce);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.wingLeader, context.atst, context.vanguardAce]);
+
+                // Select the 3rd unit
+                context.player1.clickCard(context.wingLeader);
+                context.player1.clickPrompt('Done');
+                expect(context.greenSquadronAwing.getPower()).toBe(3);
+                expect(context.vanguardAce.getPower()).toBe(3);
+                expect(context.wingLeader.getPower()).toBe(4);
+
+                // Reset
+                context.player2.passAction();
+                context.player1.moveCard(context.boldResistance, 'hand');
+
+                // Making sure the reset worked
+                context.player1.clickCard(context.boldResistance);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.specforceSoldier, context.wingLeader, context.wampa, context.atst, context.vanguardAce]);
+
+                // Wampa has no overlap with other card traits - only wampa is still selectable
+                context.player1.clickCard(context.wampa);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+
+                // test unselect
+                context.player1.clickCard(context.wampa);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.specforceSoldier, context.wingLeader, context.wampa, context.atst, context.vanguardAce]);
+
+                // test opponent card select -- and this is matching vehicle trait and should still boost its attack after clicking Done
+                context.player1.clickCard(context.atst);
+                expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.wingLeader, context.atst, context.vanguardAce]);
+                context.player1.clickPrompt('Done');
+                expect(context.atst.getPower()).toBe(8);
+
+                // Reset
+                context.player2.passAction();
+                context.player1.moveCard(context.boldResistance, 'hand');
+
+                context.moveToNextActionPhase();
+
+                // All the +2/0 should have faded now that its a new action phase
+                expect(context.greenSquadronAwing.getPower()).toBe(1);
+                expect(context.vanguardAce.getPower()).toBe(1);
+                expect(context.wingLeader.getPower()).toBe(2);
+                expect(context.atst.getPower()).toBe(6);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Three things in here:

- Created a new multiSelectCardCondition property for handling groups of selected cards
- Implemented the Bold Resistance Card  (TWI # 153)
- Removed the sameDiscardPile property and adjusted Restock to use the new code

![image](https://github.com/user-attachments/assets/e565f60a-2204-4d9d-a788-b3326361eaf3)
