### PR TITLE
Add some cards from SHD

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -34,7 +34,7 @@ jobs:
           with:
             path: ./test/json
             # IMPORTANT: if you change the cache key name below, also change it in update-cache.yml
-            key: sor-shd-twi-manual-v08-addtwi
+            key: sor-shd-twi-manual-v09-duplicateaspects
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards
 

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -25,7 +25,7 @@ jobs:
           with:
             path: ./test/json
             # IMPORTANT: if you change the cache key name below, also change it in pullrequest.yml
-            key: sor-shd-twi-manual-v08-addtwi
+            key: sor-shd-twi-manual-v09-duplicateaspects
 
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards

--- a/bin/fetchdata.js
+++ b/bin/fetchdata.js
@@ -68,7 +68,7 @@ function filterValues(card) {
 
     populateMissingData(card.attributes, filteredObj.id);
 
-    filteredObj.aspects = getAttributeNames(card.attributes.aspects);
+    filteredObj.aspects = getAttributeNames(card.attributes.aspects).concat(getAttributeNames(card.attributes.aspectDuplicates));
     filteredObj.traits = getAttributeNames(card.attributes.traits);
     filteredObj.arena = getAttributeNames(card.attributes.arenas)[0];
     filteredObj.keywords = getAttributeNames(card.attributes.keywords);

--- a/server/game/cards/02_SHD/events/ANewAdventure.ts
+++ b/server/game/cards/02_SHD/events/ANewAdventure.ts
@@ -21,7 +21,7 @@ export default class ANewAdventure extends EventCard {
             then: (thenContext) => ({
                 title: `Play ${thenContext.target.title} for free`,
                 optional: true,
-                abilityController: (thenContext.source.controller !== thenContext.target.controller ? RelativePlayer.Opponent : RelativePlayer.Self),
+                abilityController: thenContext.source.controller !== thenContext.target.controller ? RelativePlayer.Opponent : RelativePlayer.Self,
                 immediateEffect: AbilityHelper.immediateEffects.playCardFromHand({
                     target: thenContext.target,
                     adjustCost: {

--- a/server/game/cards/02_SHD/events/ANewAdventure.ts
+++ b/server/game/cards/02_SHD/events/ANewAdventure.ts
@@ -1,0 +1,36 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { EventCard } from '../../../core/card/EventCard';
+import { RelativePlayer } from '../../../core/Constants';
+import { CostAdjustType } from '../../../core/cost/CostAdjuster';
+
+export default class ANewAdventure extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: '4717189843',
+            internalName: 'a-new-adventure',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Return a non-leader unit that costs 6 or less to its owner\'s hand',
+            targetResolver: {
+                cardCondition: (card) => card.isNonLeaderUnit() && card.cost <= 6,
+                immediateEffect: AbilityHelper.immediateEffects.returnToHand()
+            },
+            then: (thenContext) => ({
+                title: `Play ${thenContext.target.title} for free`,
+                optional: true,
+                abilityController: (thenContext.source.controller !== thenContext.target.controller ? RelativePlayer.Opponent : RelativePlayer.Self),
+                immediateEffect: AbilityHelper.immediateEffects.playCardFromHand({
+                    target: thenContext.target,
+                    adjustCost: {
+                        costAdjustType: CostAdjustType.Free
+                    }
+                })
+            })
+        });
+    }
+}
+
+ANewAdventure.implemented = true;

--- a/server/game/cards/02_SHD/events/AlteringTheDeal.ts
+++ b/server/game/cards/02_SHD/events/AlteringTheDeal.ts
@@ -1,0 +1,25 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { EventCard } from '../../../core/card/EventCard';
+import { ZoneName } from '../../../core/Constants';
+
+export default class AlteringTheDeal extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: '6425029011',
+            internalName: 'altering-the-deal',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Discard a captured card guarded by a friendly unit',
+            targetResolver: {
+                zoneFilter: ZoneName.Capture,
+                capturedByFilter: (context) => context.source.controller.getArenaUnits(),
+                immediateEffect: AbilityHelper.immediateEffects.discardSpecificCard()
+            }
+        });
+    }
+}
+
+AlteringTheDeal.implemented = true;

--- a/server/game/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.ts
+++ b/server/game/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.ts
@@ -1,0 +1,51 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
+import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+
+export default class CadBaneHeWhoNeedsNoIntroduction extends LeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '1384530409',
+            internalName: 'cad-bane#he-who-needs-no-introduction',
+        };
+    }
+
+    protected override setupLeaderSideAbilities() {
+        this.addTriggeredAbility({
+            title: 'Exhaust this leader',
+            optional: true,
+            when: {
+                onCardPlayed: (event, context) => event.card.controller === context.source.controller && event.card.hasSomeTrait(Trait.Underworld)
+            },
+            immediateEffect: AbilityHelper.immediateEffects.exhaust(),
+            ifYouDo: {
+                title: 'The opponent chooses a unit they control. Deal 1 damage to it.',
+                targetResolver: {
+                    choosingPlayer: RelativePlayer.Opponent,
+                    controller: RelativePlayer.Opponent,
+                    cardTypeFilter: WildcardCardType.Unit,
+                    immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1 })
+                },
+            }
+        });
+    }
+
+    protected override setupLeaderUnitSideAbilities() {
+        this.addTriggeredAbility({
+            title: 'The opponent chooses a unit they control. Deal 2 damage to it.',
+            optional: true,
+            when: {
+                onCardPlayed: (event, context) => event.card.controller === context.source.controller && event.card.hasSomeTrait(Trait.Underworld)
+            },
+            limit: AbilityHelper.limit.perRound(1),
+            targetResolver: {
+                choosingPlayer: RelativePlayer.Opponent,
+                controller: RelativePlayer.Opponent,
+                cardTypeFilter: WildcardCardType.Unit,
+                immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 })
+            },
+        });
+    }
+}
+
+CadBaneHeWhoNeedsNoIntroduction.implemented = true;

--- a/server/game/cards/02_SHD/units/UnlicensedHeadhunter.ts
+++ b/server/game/cards/02_SHD/units/UnlicensedHeadhunter.ts
@@ -1,0 +1,30 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { KeywordName } from '../../../core/Constants';
+
+export default class UnlicensedHeadhunter extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '2965702252',
+            internalName: 'unlicensed-headhunter',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addConstantAbility({
+            title: 'When this unit is exhausted, it gains \'Bounty - Heal 5 damage from your base\'',
+            condition: (context) => context.source.exhausted,
+            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
+                keyword: KeywordName.Bounty,
+                ability: {
+                    title: 'Heal 5 damage from your base',
+                    immediateEffect: AbilityHelper.immediateEffects.heal(
+                        (context) => ({ target: context.player.base, amount: 5 })
+                    )
+                }
+            })
+        });
+    }
+}
+
+UnlicensedHeadhunter.implemented = true;

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -24,17 +24,28 @@ export type InPlayCardConstructor = new (...args: any[]) => InPlayCard;
  * 3. Uniqueness management
  */
 export class InPlayCard extends PlayableOrDeployableCard {
+    protected _disableOngoingEffectsForDefeat? = null;
     protected _pendingDefeat? = null;
     protected triggeredAbilities: TriggeredAbility[] = [];
 
     private movedFromZone?: ZoneName = null;
 
     /**
+     * If true, then this card's ongoing effects are disabled in preparation for it to be defeated (usually due to unique rule).
+     * Triggered abilities are not disabled until it leaves the field.
+     *
+     * Can only be true if pendingDefeat is also true.
+     */
+    public get disableOngoingEffectsForDefeat() {
+        this.assertPropertyEnabled(this._disableOngoingEffectsForDefeat, 'disableOngoingEffectsForDefeat');
+        return this._disableOngoingEffectsForDefeat;
+    }
+
+    /**
      * If true, then this card is queued to be defeated as a consequence of another effect (damage, unique rule)
      * and will be removed from the field after the current event window has finished the resolution step.
      *
-     * When this is true, most systems cannot target the card and any ongoing effects are disabled.
-     * Triggered abilities are not disabled until it leaves the field.
+     * When this is true, most systems cannot target the card.
      */
     public get pendingDefeat() {
         this.assertPropertyEnabled(this._pendingDefeat, 'pendingDefeat');
@@ -58,6 +69,7 @@ export class InPlayCard extends PlayableOrDeployableCard {
 
     protected setPendingDefeatEnabled(enabledStatus: boolean) {
         this._pendingDefeat = enabledStatus ? false : null;
+        this._disableOngoingEffectsForDefeat = enabledStatus ? false : null;
     }
 
     // ********************************************** ABILITY GETTERS **********************************************
@@ -324,6 +336,7 @@ export class InPlayCard extends PlayableOrDeployableCard {
         Contract.assertTrue(this.getDuplicatesInPlayForController().length === 1);
 
         this._pendingDefeat = true;
+        this._disableOngoingEffectsForDefeat = true;
     }
 
     public checkUnique() {

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -117,7 +117,7 @@ export abstract class OngoingEffect {
         }
 
         // disable ongoing effects if the card is queued up to be defeated (e.g. due to combat or unique rule)
-        if ((this.source.isUnit() || this.source.isUpgrade()) && this.source.isInPlay() && this.source.pendingDefeat) {
+        if ((this.source.isUnit() || this.source.isUpgrade()) && this.source.isInPlay() && this.source.disableOngoingEffectsForDefeat) {
             return false;
         }
 

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -76,7 +76,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -113,7 +113,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -144,7 +144,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -181,7 +181,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -212,7 +212,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -244,7 +244,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -275,7 +275,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -306,7 +306,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(actual)}`;
+                result.message += `\n\n${generatePromptHelpMessage(actual.testContext)}`;
 
                 return result;
             }
@@ -330,7 +330,7 @@ var customMatchers = {
                     result.message = `Expected ${card.name} to be selectable by ${player.name} but it wasn't.`;
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(player)}`;
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -374,7 +374,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(player)}`;
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -418,7 +418,7 @@ var customMatchers = {
                     }
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(player)}`;
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -466,7 +466,7 @@ var customMatchers = {
                     result.message = message;
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(player)}`;
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -491,7 +491,7 @@ var customMatchers = {
                 result.pass = !promptStatesEqual(beforeClick, afterClick);
 
                 if (result.pass) {
-                    result.message = `Expected ${card.name} not to have an action available when clicked by ${player.name} but it has ability prompt:\n${generatePromptHelpMessage(player)}`;
+                    result.message = `Expected ${card.name} not to have an action available when clicked by ${player.name} but it has ability prompt:\n${generatePromptHelpMessage(player.testContext)}`;
                 } else {
                     result.message = `Expected ${card.name} to have an action available when clicked by ${player.name} but it did not.`;
                 }
@@ -513,6 +513,8 @@ var customMatchers = {
                 } else {
                     result.message = `Expected ${player.name} to be the active player but they were not.`;
                 }
+
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -550,7 +552,7 @@ var customMatchers = {
                 if (result.pass) {
                     result.message = `Expected ${player.name} not to have pass prompt '${passPromptText}' but it did.`;
                 } else {
-                    result.message = `Expected ${player.name} to have pass prompt '${passPromptText}' but it has prompt:\n${generatePromptHelpMessage(player)}`;
+                    result.message = `Expected ${player.name} to have pass prompt '${passPromptText}' but it has prompt:\n${generatePromptHelpMessage(player.testContext)}`;
                 }
 
                 return result;
@@ -575,7 +577,7 @@ var customMatchers = {
                 if (result.pass) {
                     result.message = `Expected ${player.name} not to have pass prompt '${passPromptText}' but it did.`;
                 } else {
-                    result.message = `Expected ${player.name} to have pass prompt '${passPromptText}' but it has prompt:\n${generatePromptHelpMessage(player)}`;
+                    result.message = `Expected ${player.name} to have pass prompt '${passPromptText}' but it has prompt:\n${generatePromptHelpMessage(player.testContext)}`;
                 }
 
                 return result;
@@ -774,7 +776,7 @@ var customMatchers = {
                     result.message = `Expected ${player.name} to have this exact set of buttons: '${expectedButtons.join(', ')}'`;
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(player)}`;
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -799,7 +801,7 @@ var customMatchers = {
                     result.message = `Expected ${player.name} to have this exact list of options: '${Util.createStringForOptions(expectedOptions)}'`;
                 }
 
-                result.message += `\n\n${generatePromptHelpMessage(player)}`;
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
 
                 return result;
             }
@@ -807,8 +809,8 @@ var customMatchers = {
     }
 };
 
-function generatePromptHelpMessage(player) {
-    return `Current prompt for ${player.name}:\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}`;
+function generatePromptHelpMessage(testContext) {
+    return `Current prompts for players:\n${Util.formatBothPlayerPrompts(testContext)}`;
 }
 
 function validatePlayerOptions(playerOptions, playerName, startPhase) {

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -4,7 +4,7 @@ const Player = require('../../server/game/core/Player.js');
 const { detectBinary } = require('../../server/Util.js');
 const GameFlowWrapper = require('./GameFlowWrapper.js');
 const TestSetupError = require('./TestSetupError.js');
-const { checkNullCard, formatPrompt, getPlayerPromptState, promptStatesEqual } = require('./Util.js');
+const { checkNullCard, formatPrompt, getPlayerPromptState, promptStatesEqual, formatBothPlayerPrompts } = require('./Util.js');
 
 class PlayerInteractionWrapper {
     /**
@@ -470,7 +470,7 @@ class PlayerInteractionWrapper {
 
         if (!promptButton || promptButton.disabled) {
             throw new TestSetupError(
-                `Couldn't click on '${text}' for ${this.player.name}. Current prompt is:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`
+                `Couldn't click on '${text}' for ${this.player.name}. Current prompt is:\n${formatBothPlayerPrompts(this.testContext)}`
             );
         }
 
@@ -483,7 +483,7 @@ class PlayerInteractionWrapper {
         var currentPrompt = this.player.currentPrompt();
         if (!currentPrompt.dropdownListOptions.includes(text)) {
             throw new TestSetupError(
-                `Couldn't choose list option '${text}' for ${this.player.name}. Current prompt is:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`
+                `Couldn't choose list option '${text}' for ${this.player.name}. Current prompt is:\n${formatBothPlayerPrompts(this.testContext)}`
             );
         }
 
@@ -523,7 +523,7 @@ class PlayerInteractionWrapper {
         if (currentPrompt.buttons.length <= index) {
             throw new TestSetupError(
                 `Couldn't click on Button '${index}' for ${this.player.name
-                }. Current prompt is:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`
+                }. Current prompt is:\n${formatBothPlayerPrompts(this.testContext)}`
             );
         }
 
@@ -532,7 +532,7 @@ class PlayerInteractionWrapper {
         if (!promptButton || promptButton.disabled) {
             throw new TestSetupError(
                 `Couldn't click on Button '${index}' for ${this.player.name
-                }. Current prompt is:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`
+                }. Current prompt is:\n${formatBothPlayerPrompts(this.testContext)}`
             );
         }
 
@@ -551,7 +551,7 @@ class PlayerInteractionWrapper {
         if (!promptControl) {
             throw new TestSetupError(
                 `Couldn't click card '${cardName}' for ${this.player.name
-                } - unable to find control '${controlName}'. Current prompt is:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`
+                } - unable to find control '${controlName}'. Current prompt is:\n${formatBothPlayerPrompts(this.testContext)}`
             );
         }
 
@@ -566,7 +566,7 @@ class PlayerInteractionWrapper {
         let availableCards = this.currentActionTargets;
 
         if (!availableCards || availableCards.length < nCardsToChoose) {
-            throw new TestSetupError(`Insufficient card targets available for control, expected ${nCardsToChoose} found ${availableCards?.length ?? 0} prompt:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`);
+            throw new TestSetupError(`Insufficient card targets available for control, expected ${nCardsToChoose} found ${availableCards?.length ?? 0} prompt:\n${formatBothPlayerPrompts(this.testContext)}`);
         }
 
         for (let i = 0; i < nCardsToChoose; i++) {
@@ -598,7 +598,7 @@ class PlayerInteractionWrapper {
         if (expectChange) {
             const afterClick = getPlayerPromptState(this.player);
             if (promptStatesEqual(beforeClick, afterClick)) {
-                throw new TestSetupError(`Expected player prompt state to change after clicking ${card.internalName} but it did not. Current prompt:\n${formatPrompt(this.currentPrompt(), this.currentActionTargets)}`);
+                throw new TestSetupError(`Nothing happened when ${this.player.name} clicked ${card.internalName} (prompt and board state did not change). Current prompts:\n${formatBothPlayerPrompts(this.testContext)}`);
             }
         }
 

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -105,6 +105,19 @@ function formatPrompt(prompt, currentActionTargets) {
     );
 }
 
+function formatBothPlayerPrompts(testContext) {
+    if (!testContext) {
+        throw new TestSetupError('Null context passed to format method');
+    }
+
+    var result = '';
+    for (const player of [testContext.player1, testContext.player2]) {
+        result += `\n${player.name}:\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}`;
+    }
+
+    return result;
+}
+
 function getPlayerPromptState(player) {
     return {
         selectableCards: copySelectionArray(player.promptState.selectableCards),
@@ -170,5 +183,6 @@ module.exports = {
     getPlayerPromptState,
     promptStatesEqual,
     stringArraysEqual,
-    createStringForOptions
+    createStringForOptions,
+    formatBothPlayerPrompts
 };

--- a/test/server/cards/01_SOR/leaders/BobaFettCollectingTheBounty.spec.ts
+++ b/test/server/cards/01_SOR/leaders/BobaFettCollectingTheBounty.spec.ts
@@ -5,7 +5,7 @@ describe('Boba Fett, Collecting the Bounty', function() {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
-                        hand: ['rivals-fall', 'cantina-bouncer'],
+                        hand: ['rivals-fall', 'waylay'],
                         groundArena: ['death-star-stormtrooper'],
                         leader: 'boba-fett#collecting-the-bounty',
                         base: 'dagobah-swamp',
@@ -37,10 +37,10 @@ describe('Boba Fett, Collecting the Bounty', function() {
                 // Case 2 - when returning an enemy unit to hand
                 reset();
 
-                context.player1.clickCard(context.cantinaBouncer);
+                context.player1.clickCard(context.waylay);
                 context.player1.clickCard(context.wampa);
 
-                expect(context.player1.readyResourceCount).toBe(2);
+                expect(context.player1.readyResourceCount).toBe(4);
                 expect(context.bobaFett.exhausted).toBeTrue();
 
                 // Case 3 - when defeating an enemy leader unit
@@ -66,7 +66,6 @@ describe('Boba Fett, Collecting the Bounty', function() {
                 context.player1.moveCard(context.deathStarStormtrooper, 'groundArena');
 
                 context.player1.clickCard(context.rivalsFall);
-                context.player1.clickCard(context.deathStarStormtrooper);
 
                 expect(context.player1.readyResourceCount).toBe(0);
                 expect(context.bobaFett.exhausted).toBeFalse();

--- a/test/server/cards/01_SOR/units/GeneralKrellHeartlessTactician.spec.ts
+++ b/test/server/cards/01_SOR/units/GeneralKrellHeartlessTactician.spec.ts
@@ -104,7 +104,8 @@ describe('General Krell, Heartless Tactician', function() {
                     phase: 'action',
                     player1: {
                         hand: ['the-emperors-legion'],
-                        groundArena: ['battlefield-marine', 'general-krell#heartless-tactician', 'reputable-hunter']
+                        groundArena: ['battlefield-marine', 'general-krell#heartless-tactician', 'reputable-hunter'],
+                        base: 'echo-base'
                     },
                     player2: {
                         groundArena: ['wampa', 'atst'],

--- a/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
+++ b/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
@@ -6,28 +6,47 @@ describe('A New Adventure', function() {
                     phase: 'action',
                     player1: {
                         hand: ['a-new-adventure'],
-                        groundArena: ['pyke-sentinel'],
-                        spaceArena: ['cartel-spacer']
+                        groundArena: ['salacious-crumb#obnoxious-pet', 'atat-suppressor'],
+                        spaceArena: ['cartel-spacer'],
+                        base: { card: 'echo-base', damage: 2 }
                     },
                     player2: {
                         groundArena: ['wampa'],
-                        spaceArena: ['imperial-interceptor']
+                        spaceArena: ['redemption#medical-frigate', 'patrolling-vwing']
                     }
                 });
             });
 
-            it('can deal damage to a unit', function () {
+            it('should return an enemy unit to hand and then the opponent can play it for free', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.aNewAdventure);
-                expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.cartelSpacer, context.wampa, context.imperialInterceptor]);
+                expect(context.player1).toBeAbleToSelectExactly([context.salaciousCrumb, context.cartelSpacer, context.wampa, context.patrollingVwing]);
 
-                context.player1.clickCard(context.wampa);
-                expect(context.wampa).toBeInZone('hand');
-                expect(context.player2).toHavePassAbilityPrompt('Play Wampa for free');
-                context.player2.clickPrompt('Play Wampa for free');
-                expect(context.wampa).toBeInZone('groundArena');
+                context.player1.clickCard(context.patrollingVwing);
+                expect(context.patrollingVwing).toBeInZone('hand');
+                expect(context.player2).toHavePassAbilityPrompt('Play Patrolling V-Wing for free');
+
+                context.player2.clickPrompt('Play Patrolling V-Wing for free');
+                expect(context.patrollingVwing).toBeInZone('spaceArena');
                 expect(context.player2.exhaustedResourceCount).toBe(0);
+                expect(context.player2.handSize).toBe(1);   // from V-Wing ability
+            });
+
+            it('should return a friendly unit to hand and then the controller can play it for free', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.aNewAdventure);
+                expect(context.player1).toBeAbleToSelectExactly([context.salaciousCrumb, context.cartelSpacer, context.wampa, context.patrollingVwing]);
+
+                context.player1.clickCard(context.salaciousCrumb);
+                expect(context.salaciousCrumb).toBeInZone('hand');
+                expect(context.player1).toHavePassAbilityPrompt('Play Salacious Crumb for free');
+
+                context.player1.clickPrompt('Play Salacious Crumb for free');
+                expect(context.salaciousCrumb).toBeInZone('groundArena');
+                expect(context.player1.exhaustedResourceCount).toBe(6); // just the cost of A New Adventure (with aspect penalties)
+                expect(context.p1Base.damage).toBe(1);   // from Crumb ability
             });
         });
     });

--- a/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
+++ b/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
@@ -1,0 +1,34 @@
+describe('A New Adventure', function() {
+    integration(function(contextRef) {
+        describe('A New Adventure\'s ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['a-new-adventure'],
+                        groundArena: ['pyke-sentinel'],
+                        spaceArena: ['cartel-spacer']
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['imperial-interceptor']
+                    }
+                });
+            });
+
+            it('can deal damage to a unit', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.aNewAdventure);
+                expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.cartelSpacer, context.wampa, context.imperialInterceptor]);
+
+                context.player1.clickCard(context.wampa);
+                expect(context.wampa).toBeInZone('hand');
+                expect(context.player2).toHavePassAbilityPrompt('Play Wampa for free');
+                context.player2.clickPrompt('Play Wampa for free');
+                expect(context.wampa).toBeInZone('groundArena');
+                expect(context.player2.exhaustedResourceCount).toBe(0);
+            });
+        });
+    });
+});

--- a/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
+++ b/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
@@ -49,5 +49,40 @@ describe('A New Adventure', function() {
                 expect(context.p1Base.damage).toBe(1);   // from Crumb ability
             });
         });
+
+        it('A New Adventure\'s ability should return a friendly-owned unit controlled by the opponent to hand and then the onwer can play it for free', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['a-new-adventure'],
+                    groundArena: [{ card: 'salacious-crumb#obnoxious-pet', damage: 1 }, 'atat-suppressor'],
+                    spaceArena: ['cartel-spacer'],
+                    base: { card: 'echo-base', damage: 2 }
+                },
+                player2: {
+                    groundArena: ['wampa'],
+                    spaceArena: ['redemption#medical-frigate', 'patrolling-vwing'],
+                    leader: { card: 'emperor-palpatine#galactic-ruler', exhausted: true },
+                    hasInitiative: true
+                }
+            });
+
+            const { context } = contextRef;
+
+            // P2 takes control of Crumb
+            context.player2.clickCard(context.emperorPalpatine);
+
+            context.player1.clickCard(context.aNewAdventure);
+            expect(context.player1).toBeAbleToSelectExactly([context.salaciousCrumb, context.cartelSpacer, context.wampa, context.patrollingVwing]);
+
+            context.player1.clickCard(context.salaciousCrumb);
+            expect(context.salaciousCrumb).toBeInZone('hand', context.player1);
+            expect(context.player1).toHavePassAbilityPrompt('Play Salacious Crumb for free');
+
+            context.player1.clickPrompt('Play Salacious Crumb for free');
+            expect(context.salaciousCrumb).toBeInZone('groundArena');
+            expect(context.player1.exhaustedResourceCount).toBe(6); // just the cost of A New Adventure (with aspect penalties)
+            expect(context.p1Base.damage).toBe(1);   // from Crumb ability
+        });
     });
 });

--- a/test/server/cards/02_SHD/events/AlteringTheDeal.spec.ts
+++ b/test/server/cards/02_SHD/events/AlteringTheDeal.spec.ts
@@ -10,7 +10,7 @@ describe('Altering the Deal', function() {
                 },
                 player2: {
                     groundArena: ['snowspeeder', 'specforce-soldier'],
-                    spaceArena: ['wing-leader'],
+                    spaceArena: ['ruthless-raider'],
                     hand: ['discerning-veteran', 'take-captive']
                 }
             });
@@ -24,7 +24,7 @@ describe('Altering the Deal', function() {
             // SETUP:
             // - P2 Discerning Veteran captures Wampa + AT-ST
             // - P1 Discerning Veteran captures Snowspeeder + SpecForce Soldier
-            // - P1 TIE/LN captures Wing Leader
+            // - P1 TIE/LN captures Ruthless Raider
             context.player1.clickCard(p1TakeCaptive1);
             context.player1.clickCard(context.tielnFighter);
 
@@ -46,9 +46,10 @@ describe('Altering the Deal', function() {
 
             // TEST: can't select friendly cards (Wampa, AT-ST) guarded by enemy unit
             context.player1.clickCard(context.alteringTheDeal);
-            expect(context.player1).toBeAbleToSelectExactly([context.wingLeader, context.snowspeeder, context.specforceSoldier]);
-            context.player1.clickCard(context.wingLeader);
-            expect(context.wingLeader).toBeInZone('discard');
+            expect(context.player1).toBeAbleToSelectExactly([context.ruthlessRaider, context.snowspeeder, context.specforceSoldier]);
+            context.player1.clickCard(context.ruthlessRaider);
+            expect(context.ruthlessRaider).toBeInZone('discard');
+            expect(context.player2).toBeActivePlayer();
         });
     });
 });

--- a/test/server/cards/02_SHD/events/AlteringTheDeal.spec.ts
+++ b/test/server/cards/02_SHD/events/AlteringTheDeal.spec.ts
@@ -1,0 +1,54 @@
+describe('Altering the Deal', function() {
+    integration(function(contextRef) {
+        it('Altering the Deal\'s event ability should discard a card guarded by a friendly unit', function() {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['take-captive', 'take-captive', 'discerning-veteran', 'altering-the-deal'],
+                    groundArena: ['wampa', 'atst', 'pyke-sentinel'],
+                    spaceArena: ['tieln-fighter']
+                },
+                player2: {
+                    groundArena: ['snowspeeder', 'specforce-soldier'],
+                    spaceArena: ['wing-leader'],
+                    hand: ['discerning-veteran', 'take-captive']
+                }
+            });
+
+            const { context } = contextRef;
+            const [p1TakeCaptive1, p1TakeCaptive2] = context.player1.findCardsByName('take-captive');
+            const p2TakeCaptive = context.player2.findCardByName('take-captive');
+            const p1DiscerningVeteran = context.player1.findCardByName('discerning-veteran');
+            const p2DiscerningVeteran = context.player2.findCardByName('discerning-veteran');
+
+            // SETUP:
+            // - P2 Discerning Veteran captures Wampa + AT-ST
+            // - P1 Discerning Veteran captures Snowspeeder + SpecForce Soldier
+            // - P1 TIE/LN captures Wing Leader
+            context.player1.clickCard(p1TakeCaptive1);
+            context.player1.clickCard(context.tielnFighter);
+
+            context.player2.clickCard(p2DiscerningVeteran);
+            context.player2.clickCard(context.wampa);
+
+            context.player1.clickCard(p1DiscerningVeteran);
+            context.player1.clickCard(context.snowspeeder);
+
+            context.player2.clickCard(p2TakeCaptive);
+            context.player2.clickCard(p2DiscerningVeteran);
+            context.player2.clickCard(context.atst);
+
+            context.player1.clickCard(p1TakeCaptive2);
+            context.player1.clickCard(p1DiscerningVeteran);
+            context.player1.clickCard(context.specforceSoldier);
+
+            context.player2.passAction();
+
+            // TEST: can't select friendly cards (Wampa, AT-ST) guarded by enemy unit
+            context.player1.clickCard(context.alteringTheDeal);
+            expect(context.player1).toBeAbleToSelectExactly([context.wingLeader, context.snowspeeder, context.specforceSoldier]);
+            context.player1.clickCard(context.wingLeader);
+            expect(context.wingLeader).toBeInZone('discard');
+        });
+    });
+});

--- a/test/server/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.spec.ts
+++ b/test/server/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.spec.ts
@@ -1,0 +1,98 @@
+describe('Cad Bane, He Who Needs No Introduction', function () {
+    integration(function (contextRef) {
+        it('Cad Bane\'s leader undeployed ability should cause an opponent to choose a unit and deal 1 damage to it when a friendly Underworld card is played', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['battlefield-marine', 'pyke-sentinel'],
+                    leader: 'cad-bane#he-who-needs-no-introduction',
+                },
+                player2: {
+                    hand: ['cantina-braggart'],
+                    groundArena: ['wampa'],
+                    spaceArena: ['tie-advanced'],
+                    hasInitiative: true
+                },
+            });
+
+            const { context } = contextRef;
+
+            // CASE 1: opponent plays an Underworld card, no trigger
+            context.player2.clickCard(context.cantinaBraggart);
+            expect(context.player1).toBeActivePlayer();
+
+            // CASE 2: controller plays a non-Underworld card, no trigger
+            context.player1.clickCard(context.battlefieldMarine);
+            expect(context.player2).toBeActivePlayer();
+            context.player2.passAction();
+
+            // CASE 3: controller plays an Underworld card, ability triggers
+            context.player1.clickCard(context.pykeSentinel);
+            expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
+            context.player1.clickPrompt('Exhaust this leader');
+
+            expect(context.cadBane.exhausted).toBeTrue();
+            expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.tieAdvanced, context.cantinaBraggart]);
+            expect(context.player2).not.toHavePassAbilityButton();
+            context.player2.clickCard(context.wampa);
+            expect(context.wampa.damage).toBe(1);
+
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('Cad Bane\'s leader deployed ability should cause an opponent to choose a unit and deal 2 damage to it when a friendly Underworld card is played', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['battlefield-marine', 'pyke-sentinel', 'hylobon-enforcer', 'outlaw-corona'],
+                    leader: { card: 'cad-bane#he-who-needs-no-introduction', deployed: true },
+                },
+                player2: {
+                    hand: ['cantina-braggart'],
+                    groundArena: ['wampa'],
+                    spaceArena: ['tie-advanced'],
+                    hasInitiative: true
+                },
+            });
+
+            const { context } = contextRef;
+
+            // CASE 1: opponent plays an Underworld card, no trigger
+            context.player2.clickCard(context.cantinaBraggart);
+            expect(context.player1).toBeActivePlayer();
+
+            // CASE 2: controller plays a non-Underworld card, no trigger
+            context.player1.clickCard(context.battlefieldMarine);
+            expect(context.player2).toBeActivePlayer();
+            context.player2.passAction();
+
+            // CASE 3: controller plays an Underworld card, ability triggers
+            context.player1.clickCard(context.pykeSentinel);
+            expect(context.player1).toHavePassAbilityPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
+            context.player1.clickPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
+
+            expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.tieAdvanced, context.cantinaBraggart]);
+            expect(context.player2).not.toHavePassAbilityButton();
+            context.player2.clickCard(context.wampa);
+            expect(context.wampa.damage).toBe(2);
+
+            // CASE 4: controller plays an Underworld card, ability limit is already reached
+            context.player2.passAction();
+            context.player1.clickCard(context.hylobonEnforcer);
+            expect(context.player2).toBeActivePlayer();
+
+            context.moveToNextActionPhase();
+
+            // CASE 5: next round, ability is usable again
+            context.player2.passAction();
+            context.player1.clickCard(context.outlawCorona);
+            expect(context.player1).toHavePassAbilityPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
+            context.player1.clickPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
+
+            expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.tieAdvanced, context.cantinaBraggart]);
+            expect(context.player2).not.toHavePassAbilityButton();
+            context.player2.clickCard(context.wampa);
+            expect(context.wampa.damage).toBe(4);
+        });
+    });
+});

--- a/test/server/cards/02_SHD/units/UnlicensedHeadhunter.spec.ts
+++ b/test/server/cards/02_SHD/units/UnlicensedHeadhunter.spec.ts
@@ -1,0 +1,69 @@
+describe('Unlicensed Headhunter', function() {
+    integration(function(contextRef) {
+        describe('Unlicensed Headhunter\'s Bounty ability', function() {
+            it('should heal 5 damage from the opponent\'s base if the unit is exhausted', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: [{ card: 'unlicensed-headhunter', exhausted: true }]
+                    },
+                    player2: {
+                        spaceArena: ['survivors-gauntlet'],
+                        base: { card: 'echo-base', damage: 6 },
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.survivorsGauntlet);
+                context.player2.clickCard(context.unlicensedHeadhunter);
+
+                expect(context.player2).toHavePassAbilityPrompt('Bounty: Heal 5 damage from your base');
+                context.player2.clickPrompt('Bounty: Heal 5 damage from your base');
+                expect(context.p2Base.damage).toBe(1);
+            });
+
+            it('should heal 5 damage from the opponent\'s base if the unit is exhausted by its own attack', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: ['unlicensed-headhunter']
+                    },
+                    player2: {
+                        spaceArena: ['survivors-gauntlet'],
+                        base: { card: 'echo-base', damage: 6 }
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.unlicensedHeadhunter);
+                context.player1.clickCard(context.survivorsGauntlet);
+
+                expect(context.player2).toHavePassAbilityPrompt('Bounty: Heal 5 damage from your base');
+                context.player2.clickPrompt('Bounty: Heal 5 damage from your base');
+                expect(context.p2Base.damage).toBe(1);
+            });
+
+            it('should do nothing if the unit is not exhausted', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: ['unlicensed-headhunter']
+                    },
+                    player2: {
+                        spaceArena: ['survivors-gauntlet'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.survivorsGauntlet);
+                context.player2.clickCard(context.unlicensedHeadhunter);
+                expect(context.player1).toBeActivePlayer();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added some open cards from SHD (images below). Also fixed a few bugs and improved some test stuff, the major ones are:

- A data format change in the SWU official site meant that we were incorrectly reading the aspects for double-aspect cards like A New Adventure. Fixed this and corrected some broken tests.
- Improved test failure reporting to show prompts for both players instead of just the active one to make it easier to figure out failure causes faster

![image](https://github.com/user-attachments/assets/fec70ddf-fc1c-4613-87ce-1b30742d4b59)

![image](https://github.com/user-attachments/assets/3f5bb74e-6bff-4170-9a9a-c4b8ca63e68b)

![image](https://github.com/user-attachments/assets/0e097471-3ef7-4643-82e9-e8128dc0d200)

![image](https://github.com/user-attachments/assets/9aa11c01-1b73-47c9-8576-694817b2946e)

![image](https://github.com/user-attachments/assets/e5461d94-378f-4749-93dd-7031716bb978)
