### PR TITLE
Add check for open prompt at end of test cases

### DIFF
--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -25,6 +25,8 @@ interface SwuTestContext {
     p2Base: BaseCard;
     p2Leader: LeaderCard;
 
+    allowTestToEndWithOpenPrompt: boolean;
+
     advancePhases(endphase);
     allPlayersInInitiativeOrder(): PlayerInteractionWrapper[];
     getPlayableCardTitles();

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -981,6 +981,30 @@ global.integration = function (definitions) {
             };
         });
 
+        afterEach(function() {
+            const { context } = contextRef;
+
+            if (context.game.currentPhase !== 'action' || context.allowTestToEndWithOpenPrompt) {
+                return;
+            }
+
+            const actionWindowMenuTitles = [
+                'Waiting for opponent to take an action or pass',
+                'Choose an action'
+            ];
+
+            const playersWithUnresolvedPrompts = [context.player1, context.player2]
+                .filter((player) => player.currentPrompt().menuTitle !== 'Choose an action' && !player.currentPrompt().menuTitle.startsWith('Waiting for opponent'));
+
+            if (playersWithUnresolvedPrompts.length > 0) {
+                let activePromptsText = playersWithUnresolvedPrompts.map((player) =>
+                    `\n******* ${player.name.toUpperCase()} PROMPT *******\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}\n`
+                ).join('');
+
+                throw new TestSetupError(`The test ended with an unresolved prompt for one or both players. Unresolved prompts:\n${activePromptsText}`);
+            }
+        });
+
         definitions(contextRef);
     });
 };

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -112,7 +112,7 @@ function formatBothPlayerPrompts(testContext) {
 
     var result = '';
     for (const player of [testContext.player1, testContext.player2]) {
-        result += `\n${player.name}:\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}`;
+        result += `\n******* ${player.name.toUpperCase()} PROMPT *******\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}\n`;
     }
 
     return result;

--- a/test/scenarios/constantEffectInteractions/LosingAndGainingKeywords.spec.ts
+++ b/test/scenarios/constantEffectInteractions/LosingAndGainingKeywords.spec.ts
@@ -41,6 +41,7 @@ describe('Losing and gaining keywords', function() {
 
                 context.player1.clickCard(context.consularSecurityForce);
                 expect(context.player1).toBeAbleToSelectExactly([context.vigilantHonorGuards, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
             });
 
             it('it should be able to gain the keyword again from a different source, lose it again(from a different ability instance), then gain it again from yet another source', function() {

--- a/test/server/actions/UnitAttack.spec.ts
+++ b/test/server/actions/UnitAttack.spec.ts
@@ -26,6 +26,7 @@ describe('Basic attack', function() {
 
                 // can target opponent's ground units and base but not space units
                 expect(context.player1).toBeAbleToSelectExactly([context.frontierAtrt, context.enfysNest, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
             });
 
             it('from space arena to another unit in the space arena, attack should resolve correctly', function () {
@@ -98,6 +99,8 @@ describe('Basic attack', function() {
                 expect(context.player1).toHavePrompt('player1 has won the game!');
                 expect(context.player2).toHavePrompt('player1 has won the game!');
                 expect(context.player1).toBeActivePlayer();
+
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
     });

--- a/test/server/cards/01_SOR/events/OverwhelmingBarrage.spec.ts
+++ b/test/server/cards/01_SOR/events/OverwhelmingBarrage.spec.ts
@@ -113,6 +113,7 @@ describe('Overwhelming Barrage', function() {
 
                 context.player1.clickCard(context.overwhelmingBarrage);
                 expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce]);
+                context.player1.clickPrompt('Choose no targets');
             });
         });
     });

--- a/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
+++ b/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
@@ -6,10 +6,10 @@ describe('Tactical Advantage', function () {
                     phase: 'action',
                     player1: {
                         hand: ['tactical-advantage'],
-                        groundArena: [{ card: 'pyke-sentinel' }],
+                        groundArena: ['pyke-sentinel']
                     },
                     player2: {
-                        groundArena: ['wampa'],
+                        groundArena: ['wampa']
                     }
                 });
             });

--- a/test/server/cards/01_SOR/events/Takedown.spec.ts
+++ b/test/server/cards/01_SOR/events/Takedown.spec.ts
@@ -6,7 +6,7 @@ describe('Takedown', function() {
                     phase: 'action',
                     player1: {
                         hand: ['takedown', 'supreme-leader-snoke#shadow-ruler'],
-                        groundArena: ['pyke-sentinel', { card: 'gideon-hask#ruthless-loyalist', upgrades: ['entrenched'] }],
+                        groundArena: ['pyke-sentinel', { card: 'academy-defense-walker', upgrades: ['entrenched'] }],
                         leader: { card: 'boba-fett#daimyo', deployed: true, damage: 4 }
                     },
                     player2: {

--- a/test/server/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.spec.ts
+++ b/test/server/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.spec.ts
@@ -38,6 +38,7 @@ describe('Chewbacca, Walking Carpet', function() {
                 context.player1.passAction();
                 context.player2.clickCard(context.wampa);
                 expect(context.player2).toBeAbleToSelectExactly([context.p1Base, context.liberatedSlaves]);
+                context.player2.clickCard(context.p1Base);
             });
 
             it('should not affect the cost of playing a unit', function () {

--- a/test/server/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.spec.ts
+++ b/test/server/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.spec.ts
@@ -110,6 +110,7 @@ describe('Leia Organa, Alliance General', function() {
                 expect(context.sabineWren.damage).toBe(1);
                 expect(context.sundariPeacekeeper.damage).toBe(2);
                 expect(context.player1).toBeAbleToSelectExactly([context.sundariPeacekeeper, context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
             });
         });
 

--- a/test/server/cards/01_SOR/leaders/SabineWrenGalvanizedRevolutionary.spec.ts
+++ b/test/server/cards/01_SOR/leaders/SabineWrenGalvanizedRevolutionary.spec.ts
@@ -56,6 +56,8 @@ describe('Sabine Wren, Galvanized Revolutionary', function() {
                 expect(context.p1Base.damage).toBe(0);
                 expect(context.rebelPathfinder.damage).toBe(0);
                 expect(context.player1).toBeActivePlayer();
+
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
     });

--- a/test/server/cards/01_SOR/units/DeathTrooper.spec.ts
+++ b/test/server/cards/01_SOR/units/DeathTrooper.spec.ts
@@ -16,15 +16,6 @@ describe('Death Trooper', function() {
                 });
             });
 
-            it('cannot be passed', function () {
-                const { context } = contextRef;
-
-                // Play Death Trooper
-                context.player1.clickCard(context.deathTrooper);
-                expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.deathTrooper]);
-                expect(context.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
-            });
-
             it('can only target ground units & can damage itself', function () {
                 const { context } = contextRef;
 

--- a/test/server/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.spec.ts
+++ b/test/server/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.spec.ts
@@ -76,6 +76,9 @@ describe('Emperor Palpatine, Master of the Dark Side', function() {
                 ]));
 
                 expect(context.player2).toHaveExactPromptButtons(['Draw a card', 'Draw a card']);
+
+                // so we don't have to resolve the rest of the trigger flow
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
 

--- a/test/server/cards/01_SOR/units/GladiatorStarDestroyer.spec.ts
+++ b/test/server/cards/01_SOR/units/GladiatorStarDestroyer.spec.ts
@@ -34,6 +34,7 @@ describe('Gladiator Star Destroyer', function() {
                 context.player1.passAction();
                 context.player2.clickCard(context.wampa);
                 expect(context.player2).toBeAbleToSelectExactly([context.directorKrennic, context.p1Base]);
+                context.player2.clickCard(context.p1Base);
             });
         });
     });

--- a/test/server/cards/01_SOR/units/SabineWrenExplosivesArtist.spec.ts
+++ b/test/server/cards/01_SOR/units/SabineWrenExplosivesArtist.spec.ts
@@ -22,6 +22,7 @@ describe('Sabine Wren, Explosives Artist', function() {
                 context.player2.clickCard(context.wampa);
 
                 expect(context.player2).toBeAbleToSelectExactly([context.battlefieldMarine, context.p1Base]);
+                context.player2.clickCard(context.p1Base);
             });
 
             it('should be targetable when less than 3 friendly aspects are in play', function () {
@@ -32,6 +33,7 @@ describe('Sabine Wren, Explosives Artist', function() {
                 context.player2.clickCard(context.wampa);
 
                 expect(context.player2).toBeAbleToSelectExactly([context.battlefieldMarine, context.p1Base, context.sabineWren]);
+                context.player2.clickCard(context.p1Base);
             });
 
             it('should be targetable if she has sentinel, even with 3 friendly aspects in play', function () {

--- a/test/server/cards/02_SHD/events/MidnightRepairs.spec.ts
+++ b/test/server/cards/02_SHD/events/MidnightRepairs.spec.ts
@@ -89,6 +89,8 @@ describe('Midnight Repairs', function () {
 
                 context.player1.clickCard(context.midnightRepairs);
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
+
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
     });

--- a/test/server/cards/02_SHD/units/OmegaPartOfTheSquad.spec.ts
+++ b/test/server/cards/02_SHD/units/OmegaPartOfTheSquad.spec.ts
@@ -42,6 +42,9 @@ describe('Omega, Part of the Squad', function() {
                 expect(context.player1.exhaustedResourceCount).toBe(0);
                 context.player1.clickCard(context.secondOmega);
                 expect(context.player1.exhaustedResourceCount).toBe(2);
+
+                // so we don't need to go all the way through the Omega ability again
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
 

--- a/test/server/cards/02_SHD/units/ProtectorOfTheThrone.spec.ts
+++ b/test/server/cards/02_SHD/units/ProtectorOfTheThrone.spec.ts
@@ -33,6 +33,7 @@ describe('Protector of the Throne', function() {
 
                 // player 2 should be able to select base and unit because Protector of the Throne is not sentinel anymore
                 expect(context.player2).toBeAbleToSelectExactly([context.protectorOfTheThrone, context.p1Base]);
+                context.player2.clickCard(context.p1Base);
             });
         });
     });

--- a/test/server/cards/02_SHD/units/SupercommandoSquad.spec.ts
+++ b/test/server/cards/02_SHD/units/SupercommandoSquad.spec.ts
@@ -33,6 +33,7 @@ describe('Supercommando Squad', function() {
 
                 // player 2 should be able to select base and unit because supercommando squad is not sentinel anymore
                 expect(context.player2).toBeAbleToSelectExactly([context.supercommandoSquad, context.p1Base]);
+                context.player2.clickCard(context.p1Base);
             });
         });
     });

--- a/test/server/core/Game.spec.ts
+++ b/test/server/core/Game.spec.ts
@@ -21,6 +21,8 @@ describe('Overall game mechanics', function() {
                 context.player1.clickPrompt('Deal 1 damage to each base');
                 expect(context.player1).toHavePrompt('The game ended in a draw!');
                 expect(context.player2).toHavePrompt('The game ended in a draw!');
+
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
 
@@ -44,6 +46,8 @@ describe('Overall game mechanics', function() {
                 expect(context.player1).toHavePrompt('player1 has won the game!');
                 expect(context.player2).toHavePrompt('player1 has won the game!');
                 expect(context.player1).toBeActivePlayer();
+
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
     });

--- a/test/server/core/card/Leader.spec.ts
+++ b/test/server/core/card/Leader.spec.ts
@@ -95,6 +95,7 @@ describe('Leader cards', function() {
                 context.moveToNextActionPhase();
                 context.player1.clickCard(context.grandMoffTarkin);
                 expect(context.player1).not.toHaveEnabledPromptButton('Deploy Grand Moff Tarkin');
+                context.player1.clickCard(context.atst);
             });
         });
 

--- a/test/server/gameSystems/DrawSystem.spec.ts
+++ b/test/server/gameSystems/DrawSystem.spec.ts
@@ -1,4 +1,4 @@
-describe('Drawing cards', function() {
+describe('Draw system', function() {
     integration(function (contextRef) {
         describe('When a player draws cards', function() {
             beforeEach(function () {
@@ -64,6 +64,8 @@ describe('Drawing cards', function() {
                 expect(context.player2).toHavePrompt('player1 has won the game!');
                 expect(context.player2.hand.length).toBe(1);
                 expect(context.player1).toBeActivePlayer();
+
+                context.allowTestToEndWithOpenPrompt = true;
             });
         });
     });


### PR DESCRIPTION
A common hangup in testing, especially for new folks, is not realizing that a prompt is open and waiting for a click. To help people catch this, added a check at the end of every test case which will throw an error if either player has an open prompt (so long as they end in the action phase).

This functionality can be disabled by setting `context.allowOpenPromptAtEndOfTest = true`. Updated all affected existing test cases to either not end with an open prompt or to use the above setting to disable the check.