### PR TITLE
Disable autoSingleTarget by default in tests

### DIFF
--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -825,12 +825,13 @@ function validatePlayerOptions(playerOptions, playerName, startPhase) {
         'leader',
         'base',
         'deck',
-        'resource',
+        'resource'
     ];
     // list of approved property names for setup phase
     const setupPhase = [
         'leader',
-        'deck'
+        'deck',
+        'base'
     ];
 
     // Check for unknown properties
@@ -847,7 +848,8 @@ function validateTopLevelOptions(options) {
     const allowedPropertyNames = [
         'player1',
         'player2',
-        'phase'
+        'phase',
+        'autoSingleTarget'
     ];
 
     // Check for unknown properties
@@ -916,6 +918,10 @@ global.integration = function (definitions) {
                 } else if (options.player2.hasInitiative) {
                     this.game.initiativePlayer = this.player2Object;
                 }
+
+                const autoSingleTarget = options.autoSingleTarget ?? true;
+                this.player1Object.autoSingleTarget = autoSingleTarget;
+                this.player2Object.autoSingleTarget = autoSingleTarget;
 
                 // pass decklists to players. they are initialized into real card objects in the startGame() call
                 const [deck1, namedCards1] = deckBuilder.customDeck(1, options.player1, options.phase);

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -843,6 +843,21 @@ function validatePlayerOptions(playerOptions, playerName, startPhase) {
     }
 }
 
+function validateTopLevelOptions(options) {
+    const allowedPropertyNames = [
+        'player1',
+        'player2',
+        'phase'
+    ];
+
+    // Check for unknown properties
+    for (const prop of Object.keys(options)) {
+        if (!allowedPropertyNames.includes(prop)) {
+            throw new Error(`test setup options has an unknown property '${prop}'`);
+        }
+    }
+}
+
 beforeEach(function () {
     jasmine.addMatchers(customMatchers);
 });
@@ -892,6 +907,7 @@ global.integration = function (definitions) {
                 // validate supplied parameters
                 validatePlayerOptions(options.player1, 'player1', options.phase);
                 validatePlayerOptions(options.player2, 'player2', options.phase);
+                validateTopLevelOptions(options, ['player1', 'player2', 'phase']);
 
                 this.game.gameMode = GameMode.Premier;
 

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -919,7 +919,7 @@ global.integration = function (definitions) {
                     this.game.initiativePlayer = this.player2Object;
                 }
 
-                const autoSingleTarget = options.autoSingleTarget ?? true;
+                const autoSingleTarget = !!options.autoSingleTarget;
                 this.player1Object.autoSingleTarget = autoSingleTarget;
                 this.player2Object.autoSingleTarget = autoSingleTarget;
 

--- a/test/scenarios/constantEffectInteractions/LosingAndGainingKeywords.spec.ts
+++ b/test/scenarios/constantEffectInteractions/LosingAndGainingKeywords.spec.ts
@@ -11,7 +11,10 @@ describe('Losing and gaining keywords', function() {
                     player2: {
                         groundArena: ['vigilant-honor-guards'],
                         hand: ['protector', 'protector', 'repair']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/scenarios/timingWindows/DefeatTiming.spec.ts
+++ b/test/scenarios/timingWindows/DefeatTiming.spec.ts
@@ -1,70 +1,76 @@
 describe('Defeat timing', function() {
     integration(function(contextRef) {
-        // describe('When a unit enters play with a constant ability that defeats other units,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 hand: ['supreme-leader-snoke#shadow-ruler'],
-        //                 groundArena: ['maz-kanata#pirate-queen'],
-        //             },
-        //             player2: {
-        //                 groundArena: ['vanguard-infantry'],
-        //             }
-        //         });
-        //     });
+        describe('When a unit enters play with a constant ability that defeats other units,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['supreme-leader-snoke#shadow-ruler'],
+                        groundArena: ['maz-kanata#pirate-queen'],
+                    },
+                    player2: {
+                        groundArena: ['vanguard-infantry'],
+                    },
 
-        //     it('"when played" and "when defeated" triggers should go in the same window', function () {
-        //         const { context } = contextRef;
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
+                });
+            });
 
-        //         context.player1.clickCard(context.supremeLeaderSnoke);
-        //         expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
-        //         expect(context.player2).toHavePrompt('Waiting for opponent to choose a player to resolve their triggers first');
+            it('"when played" and "when defeated" triggers should go in the same window', function () {
+                const { context } = contextRef;
 
-        //         context.player1.clickPrompt('You');
-        //         expect(context.mazKanata).toHaveExactUpgradeNames(['experience']);
+                context.player1.clickCard(context.supremeLeaderSnoke);
+                expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
+                expect(context.player2).toHavePrompt('Waiting for opponent to choose a player to resolve their triggers first');
 
-        //         // vanguard on-defeat trigger happens next automatically
-        //         expect(context.player2).toBeAbleToSelectExactly([context.mazKanata, context.supremeLeaderSnoke]);
-        //         context.player2.clickPrompt('Pass ability');
+                context.player1.clickPrompt('You');
+                expect(context.mazKanata).toHaveExactUpgradeNames(['experience']);
 
-        //         expect(context.player2).toBeActivePlayer();
-        //     });
-        // });
+                // vanguard on-defeat trigger happens next automatically
+                expect(context.player2).toBeAbleToSelectExactly([context.mazKanata, context.supremeLeaderSnoke]);
+                context.player2.clickPrompt('Pass ability');
 
-        // // TODO: add a similar test for Dodonna and units leaving the field due to a +hp modifier going away
-        // describe('When a unit enters play and is immediately defeated by a constant ability,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 groundArena: ['supreme-leader-snoke#shadow-ruler'],
-        //             },
-        //             player2: {
-        //                 hand: ['vanguard-infantry'],
-        //                 groundArena: [{ card: 'maz-kanata#pirate-queen', upgrades: ['experience', 'experience'] }]
-        //             }
-        //         });
-        //     });
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
 
-        //     it('"when played" and "when defeated" triggers should go in the same window', function () {
-        //         const { context } = contextRef;
+        // TODO: add a similar test for Dodonna and units leaving the field due to a +hp modifier going away
+        describe('When a unit enters play and is immediately defeated by a constant ability,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['supreme-leader-snoke#shadow-ruler'],
+                    },
+                    player2: {
+                        hand: ['vanguard-infantry'],
+                        groundArena: [{ card: 'maz-kanata#pirate-queen', upgrades: ['experience', 'experience'] }]
+                    },
 
-        //         context.player1.passAction();
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
+                });
+            });
 
-        //         context.player2.clickCard(context.vanguardInfantry);
-        //         expect(context.player2).toHavePrompt('Choose an ability to resolve:');
-        //         expect(context.player1).toHavePrompt('Waiting for opponent to use Choose Triggered Ability Resolution Order');
-        //         expect(context.vanguardInfantry).toBeInZone('discard');
+            it('"when played" and "when defeated" triggers should go in the same window', function () {
+                const { context } = contextRef;
 
-        //         context.player2.clickPrompt('Give an Experience token to a unit');
-        //         context.player2.clickPrompt('Pass ability');
+                context.player1.passAction();
 
-        //         // maz kanata on-play trigger happens next automatically
-        //         expect(context.mazKanata).toHaveExactUpgradeNames(['experience', 'experience', 'experience']);
-        //         expect(context.player1).toBeActivePlayer();
-        //     });
-        // });
+                context.player2.clickCard(context.vanguardInfantry);
+                expect(context.player2).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('Waiting for opponent to use Choose Triggered Ability Resolution Order');
+                expect(context.vanguardInfantry).toBeInZone('discard');
+
+                context.player2.clickPrompt('Give an Experience token to a unit');
+                context.player2.clickPrompt('Pass ability');
+
+                // maz kanata on-play trigger happens next automatically
+                expect(context.mazKanata).toHaveExactUpgradeNames(['experience', 'experience', 'experience']);
+                expect(context.player1).toBeActivePlayer();
+            });
+        });
 
         describe('When a unit enters play and is immediately defeated by a constant ability,', function() {
             beforeEach(function () {
@@ -75,7 +81,10 @@ describe('Defeat timing', function() {
                     },
                     player2: {
                         hand: ['vanguard-infantry', 'lieutenant-childsen#death-star-prison-warden', 'vanquish']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -92,72 +101,75 @@ describe('Defeat timing', function() {
             });
         });
 
-        // describe('When multiple units are defeated simultaneously,', function() {
-        //     beforeEach(function () {
-        //         contextRef.setupTest({
-        //             phase: 'action',
-        //             player1: {
-        //                 hand: ['superlaser-blast'],
-        //                 groundArena: ['general-krell#heartless-tactician'],
-        //                 spaceArena: ['cartel-spacer'],
-        //                 leader: { card: 'iden-versio#inferno-squad-commander', deployed: true },
-        //                 base: { card: 'administrators-tower', damage: 5 }
-        //             },
-        //             player2: {
-        //                 groundArena: ['superlaser-technician', 'yoda#old-master'],
-        //                 leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
-        //             }
-        //         });
-        //     });
+        describe('When multiple units are defeated simultaneously,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['superlaser-blast'],
+                        groundArena: ['general-krell#heartless-tactician'],
+                        spaceArena: ['cartel-spacer'],
+                        leader: { card: 'iden-versio#inferno-squad-commander', deployed: true },
+                        base: { card: 'administrators-tower', damage: 5 }
+                    },
+                    player2: {
+                        groundArena: ['superlaser-technician', 'yoda#old-master'],
+                        leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
+                    },
 
-        //     it('the active player should choose which player\'s triggers happen first, then each player should be able to choose the order of their triggers in turn', function () {
-        //         const { context } = contextRef;
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
+                });
+            });
 
-        //         context.player1.clickCard(context.superlaserBlast);
+            it('the active player should choose which player\'s triggers happen first, then each player should be able to choose the order of their triggers in turn', function () {
+                const { context } = contextRef;
 
-        //         // all units defeated
-        //         expect(context.generalKrell).toBeInZone('discard');
-        //         expect(context.cartelSpacer).toBeInZone('discard');
-        //         expect(context.superlaserTechnician).toBeInZone('discard');
-        //         expect(context.yoda).toBeInZone('discard');
-        //         expect(context.idenVersio).toBeInZone('base');
-        //         expect(context.lukeSkywalker).toBeInZone('base');
+                context.player1.clickCard(context.superlaserBlast);
 
-        //         // triggered abilities happen
-        //         expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
-        //         context.player1.clickPrompt('You');
-        //         expect(context.player1).toHavePrompt('Choose an ability to resolve:');
-        //         expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Draw a card', 'When an opponent\'s unit is defeated, heal 1 from base', 'When an opponent\'s unit is defeated, heal 1 from base', 'When an opponent\'s unit is defeated, heal 1 from base']);
-        //         context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
-        //         context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
-        //         context.player1.clickPrompt('Draw a card');
-        //         // may ability prompts the player whether or not to actually use it before it fully resolves
-        //         expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-        //         context.player1.clickPrompt('Draw a card');
-        //         expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'When an opponent\'s unit is defeated, heal 1 from base']);
-        //         context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
-        //         // last trigger is chosen automatically
-        //         expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-        //         context.player1.clickPrompt('Pass');
+                // all units defeated
+                expect(context.generalKrell).toBeInZone('discard');
+                expect(context.cartelSpacer).toBeInZone('discard');
+                expect(context.superlaserTechnician).toBeInZone('discard');
+                expect(context.yoda).toBeInZone('discard');
+                expect(context.idenVersio).toBeInZone('base');
+                expect(context.lukeSkywalker).toBeInZone('base');
 
-        //         // automatically moves to other player's triggers
-        //         expect(context.player2).toHavePrompt('Choose an ability to resolve:');
-        //         expect(context.player2).toHaveExactPromptButtons(['Put Superlaser Technician into play as a resource and ready it', 'Choose any number of players to draw 1 card']);
-        //         context.player2.clickPrompt('Choose any number of players to draw 1 card');
-        //         context.player2.clickPrompt('You');
-        //         context.player2.clickPrompt('Done');
-        //         expect(context.player2).toHavePassAbilityPrompt('Put Superlaser Technician into play as a resource and ready it');
-        //         context.player2.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+                // triggered abilities happen
+                expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
+                context.player1.clickPrompt('You');
+                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Draw a card', 'When an opponent\'s unit is defeated, heal 1 from base', 'When an opponent\'s unit is defeated, heal 1 from base', 'When an opponent\'s unit is defeated, heal 1 from base']);
+                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
+                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
+                context.player1.clickPrompt('Draw a card');
+                // may ability prompts the player whether or not to actually use it before it fully resolves
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');
+                expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'When an opponent\'s unit is defeated, heal 1 from base']);
+                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
+                // last trigger is chosen automatically
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Pass');
 
-        //         // triggers all done, action is finally over
-        //         expect(context.player2).toBeActivePlayer();
+                // automatically moves to other player's triggers
+                expect(context.player2).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player2).toHaveExactPromptButtons(['Put Superlaser Technician into play as a resource and ready it', 'Choose any number of players to draw 1 card']);
+                context.player2.clickPrompt('Choose any number of players to draw 1 card');
+                context.player2.clickPrompt('You');
+                context.player2.clickPrompt('Done');
+                expect(context.player2).toHavePassAbilityPrompt('Put Superlaser Technician into play as a resource and ready it');
+                context.player2.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
 
-        //         // checking trigger effects all happened properly
-        //         expect(context.p1Base.damage).toBe(2);
-        //         expect(context.player1.hand.length).toBe(1);
-        //         expect(context.player2.hand.length).toBe(1);
-        //         expect(context.superlaserTechnician).toBeInZone('resource');
-        //     });
-        // });
+                // triggers all done, action is finally over
+                expect(context.player2).toBeActivePlayer();
+
+                // checking trigger effects all happened properly
+                expect(context.p1Base.damage).toBe(2);
+                expect(context.player1.hand.length).toBe(1);
+                expect(context.player2.hand.length).toBe(1);
+                expect(context.superlaserTechnician).toBeInZone('resource');
+            });
+        });
     });
 });

--- a/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
+++ b/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
@@ -12,7 +12,10 @@ describe('Energy Conversion Lab', function() {
                     player2: {
                         groundArena: ['isb-agent'],
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/bases/Tarkintown.spec.ts
+++ b/test/server/cards/01_SOR/bases/Tarkintown.spec.ts
@@ -13,7 +13,10 @@ describe('Tarkintown', function() {
                             'wampa'
                         ],
                         leader: { card: 'boba-fett#daimyo', deployed: true, damage: 1 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/AttackPatternDelta.spec.ts
+++ b/test/server/cards/01_SOR/events/AttackPatternDelta.spec.ts
@@ -13,7 +13,10 @@ describe('Attack Pattern Delta', function() {
                         },
                         player2: {
                             groundArena: ['atst'],
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
 
                     const { context } = contextRef;
@@ -80,6 +83,9 @@ describe('Attack Pattern Delta', function() {
                             hand: ['attack-pattern-delta'],
                             groundArena: ['battlefield-marine', 'wampa'],
                         },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
 
                     const { context } = contextRef;
@@ -106,6 +112,9 @@ describe('Attack Pattern Delta', function() {
                             hand: ['attack-pattern-delta'],
                             groundArena: ['wampa'],
                         },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
 
                     const { context } = contextRef;

--- a/test/server/cards/01_SOR/events/Confiscate.spec.ts
+++ b/test/server/cards/01_SOR/events/Confiscate.spec.ts
@@ -36,7 +36,10 @@ describe('Confiscate', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/ForcedSurrender.spec.ts
+++ b/test/server/cards/01_SOR/events/ForcedSurrender.spec.ts
@@ -13,7 +13,10 @@ describe('Forced Surrender', function() {
                     player2: {
                         groundArena: ['maz-kanata#pirate-queen', 'gamorrean-guards'],
                         hand: ['atst', 'atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/IHadNoChoice.spec.ts
+++ b/test/server/cards/01_SOR/events/IHadNoChoice.spec.ts
@@ -48,7 +48,10 @@ describe('I Had No Choice', function() {
                         player2: {
                             groundArena: [],
                             leader: { card: 'darth-vader#dark-lord-of-the-sith', deployed: true }
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 

--- a/test/server/cards/01_SOR/events/MedalCeremony.spec.ts
+++ b/test/server/cards/01_SOR/events/MedalCeremony.spec.ts
@@ -12,7 +12,10 @@ describe('Medal Ceremony', function() {
                     player2: {
                         groundArena: ['wampa', 'consular-security-force'],
                         spaceArena: ['alliance-xwing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/OverwhelmingBarrage.spec.ts
+++ b/test/server/cards/01_SOR/events/OverwhelmingBarrage.spec.ts
@@ -13,7 +13,10 @@ describe('Overwhelming Barrage', function() {
                         groundArena: ['atst'],
                         spaceArena: ['tieln-fighter'],
                         leader: { card: 'han-solo#audacious-smuggler', deployed: true }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -104,7 +107,10 @@ describe('Overwhelming Barrage', function() {
                     },
                     player2: {
                         groundArena: ['consular-security-force']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/PowerOfTheDarkSide.spec.ts
+++ b/test/server/cards/01_SOR/events/PowerOfTheDarkSide.spec.ts
@@ -37,7 +37,10 @@ describe('Power of the Dark Side', function() {
                     },
                     player2: {
                         leader: { card: 'sabine-wren#galvanized-revolutionary', deployed: true }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/RallyingCry.spec.ts
+++ b/test/server/cards/01_SOR/events/RallyingCry.spec.ts
@@ -11,7 +11,10 @@ describe('Rallying Cry', function () {
                     },
                     player2: {
                         spaceArena: ['distant-patroller']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/RebelAssault.spec.ts
+++ b/test/server/cards/01_SOR/events/RebelAssault.spec.ts
@@ -10,7 +10,9 @@ describe('Rebel Assault', function () {
                         spaceArena: ['green-squadron-awing'],
                         leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true }
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
+++ b/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
@@ -10,7 +10,8 @@ describe('Tactical Advantage', function () {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+                    autoSingleTarget: false
                 });
             });
 
@@ -25,7 +26,7 @@ describe('Tactical Advantage', function () {
                 expect(context.pykeSentinel.getHp()).toBe(5);
 
                 context.player2.clickCard(context.wampa);
-                // pyke sentinel is automatically choose
+                context.player2.clickCard(context.pykeSentinel);
                 expect(context.wampa.damage).toBe(4);
                 expect(context.pykeSentinel.damage).toBe(4);
                 expect(context.pykeSentinel).toBeInZone('groundArena');

--- a/test/server/cards/01_SOR/events/YoureMyOnlyHope.spec.ts
+++ b/test/server/cards/01_SOR/events/YoureMyOnlyHope.spec.ts
@@ -13,7 +13,10 @@ describe('You\'re My Only Hope', function() {
                     },
                     player2: {
                         spaceArena: ['black-one#scourge-of-starkiller-base']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/BobaFettCollectingTheBounty.spec.ts
+++ b/test/server/cards/01_SOR/leaders/BobaFettCollectingTheBounty.spec.ts
@@ -15,6 +15,9 @@ describe('Boba Fett, Collecting the Bounty', function() {
                         groundArena: ['viper-probe-droid', 'cell-block-guard', 'wampa'],
                         leader: { card: 'luke-skywalker#faithful-friend', deployed: true },
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -84,7 +87,10 @@ describe('Boba Fett, Collecting the Bounty', function() {
                     },
                     player2: {
                         groundArena: ['cell-block-guard'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.spec.ts
+++ b/test/server/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.spec.ts
@@ -15,6 +15,9 @@ describe('Cassian Andor, Dedicated to the Rebellion', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['tieln-fighter'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 
@@ -83,6 +86,9 @@ describe('Cassian Andor, Dedicated to the Rebellion', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['tieln-fighter'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.spec.ts
+++ b/test/server/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.spec.ts
@@ -14,7 +14,10 @@ describe('Chewbacca, Walking Carpet', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/HeraSyndullaSpectreTwo.spec.ts
+++ b/test/server/cards/01_SOR/leaders/HeraSyndullaSpectreTwo.spec.ts
@@ -12,7 +12,10 @@ describe('Hera Syndulla, Spectre Two', function() {
                     },
                     player2: {
                         groundArena: ['pyke-sentinel']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -51,7 +54,10 @@ describe('Hera Syndulla, Spectre Two', function() {
                     },
                     player2: {
                         groundArena: ['pyke-sentinel', 'del-meeko#providing-overwatch']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -84,7 +90,10 @@ describe('Hera Syndulla, Spectre Two', function() {
                     player2: {
                         groundArena: ['pyke-sentinel'],
                         leader: { card: 'rey#more-than-a-scavenger', deployed: true }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/JynErsoResistingOppression.spec.ts
+++ b/test/server/cards/01_SOR/leaders/JynErsoResistingOppression.spec.ts
@@ -12,7 +12,10 @@ describe('Jyn Erso, Resisting Oppression', function() {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/JynErsoResistingOppression.spec.ts
+++ b/test/server/cards/01_SOR/leaders/JynErsoResistingOppression.spec.ts
@@ -12,7 +12,7 @@ describe('Jyn Erso, Resisting Oppression', function() {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                    },
+                    }
                 });
             });
 
@@ -51,6 +51,9 @@ describe('Jyn Erso, Resisting Oppression', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['system-patrol-craft']
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.spec.ts
+++ b/test/server/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.spec.ts
@@ -12,7 +12,10 @@ describe('Leia Organa, Alliance General', function() {
                     player2: {
                         groundArena: ['sundari-peacekeeper'],
                         spaceArena: ['tie-advanced']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -126,7 +129,10 @@ describe('Leia Organa, Alliance General', function() {
                     player2: {
                         groundArena: ['sundari-peacekeeper'],
                         spaceArena: ['tie-advanced']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -151,7 +157,10 @@ describe('Leia Organa, Alliance General', function() {
                     player2: {
                         groundArena: ['sundari-peacekeeper'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/leaders/LukeSkywalkerFaithfulFriend.spec.ts
+++ b/test/server/cards/01_SOR/leaders/LukeSkywalkerFaithfulFriend.spec.ts
@@ -12,7 +12,10 @@ describe('Luke Skywalker, Faithful Friend', function() {
                     player2: {
                         hand: ['alliance-dispatcher'],
                         groundArena: ['specforce-soldier'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -67,7 +70,10 @@ describe('Luke Skywalker, Faithful Friend', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['tie-advanced']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/tokens/Experience.spec.ts
+++ b/test/server/cards/01_SOR/tokens/Experience.spec.ts
@@ -9,7 +9,10 @@ describe('Experience', function() {
                     },
                     player2: {
                         spaceArena: ['valiant-assault-ship']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -50,8 +53,9 @@ describe('Experience', function() {
                         hand: ['confiscate'],
                         spaceArena: [{ card: 'cartel-spacer', upgrades: ['experience'] }]
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -75,7 +79,10 @@ describe('Experience', function() {
                     },
                     player2: {
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/tokens/Shield.spec.ts
+++ b/test/server/cards/01_SOR/tokens/Shield.spec.ts
@@ -94,7 +94,10 @@ describe('Shield', function() {
                     },
                     player2: {
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/AdmiralMottiBrazenAndScornful.spec.ts
+++ b/test/server/cards/01_SOR/units/AdmiralMottiBrazenAndScornful.spec.ts
@@ -10,7 +10,10 @@ describe('Admiral Motti', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'cell-block-guard', exhausted: true }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
+++ b/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
@@ -14,7 +14,10 @@ describe('Admiral Piett, Captain of the Executor\'s Folly', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['redemption#medical-frigate'],
                         hand: ['atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/AllianceDispatcher.spec.ts
+++ b/test/server/cards/01_SOR/units/AllianceDispatcher.spec.ts
@@ -39,8 +39,9 @@ describe('Alliance Dispatcher', function() {
                 context.player1.setResourceCount(2);
                 context.player1.clickCard(context.allianceDispatcher);
                 context.player1.clickPrompt('Play a unit from your hand. It costs 1 less');
-                expect(context.player1).toHavePassSingleTargetPrompt('Play a unit from your hand. It costs 1 less', context.consortiumStarviper);
-                context.player1.clickPrompt('Play a unit from your hand. It costs 1 less -> Consortium Starviper');
+                expect(context.player1).toBeAbleToSelectExactly([context.consortiumStarviper]);
+                expect(context.player1).toHaveChooseNoTargetButton();
+                context.player1.clickCard(context.consortiumStarviper);
                 expect(context.consortiumStarviper).toBeInZone('spaceArena');
                 expect(context.player1.exhaustedResourceCount).toBe(2);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/01_SOR/units/ArdentSympathizer.spec.ts
+++ b/test/server/cards/01_SOR/units/ArdentSympathizer.spec.ts
@@ -10,7 +10,10 @@ describe('Ardent Sympathizer', function () {
                         },
                         player2: {
                             hasInitiative: true
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 
@@ -31,7 +34,9 @@ describe('Ardent Sympathizer', function () {
                             groundArena: ['ardent-sympathizer'],
                             hasInitiative: true
                         },
-                        player2: {}
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 

--- a/test/server/cards/01_SOR/units/BazeMalbusTempleGuardian.spec.ts
+++ b/test/server/cards/01_SOR/units/BazeMalbusTempleGuardian.spec.ts
@@ -11,7 +11,10 @@ describe('Baze Malbus, Temple Guardian', function() {
                         player2: {
                             groundArena: ['wampa', 'battlefield-marine'],
                             hasInitiative: true
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 
@@ -47,7 +50,10 @@ describe('Baze Malbus, Temple Guardian', function() {
                         },
                         player2: {
                             groundArena: ['wampa', 'battlefield-marine'],
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 

--- a/test/server/cards/01_SOR/units/BenthicTwoTubes.spec.ts
+++ b/test/server/cards/01_SOR/units/BenthicTwoTubes.spec.ts
@@ -10,7 +10,10 @@ describe('Benthic Two Tubes', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.spec.ts
+++ b/test/server/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.spec.ts
@@ -10,7 +10,10 @@ describe('Black One', function() {
                     },
                     player2: {
                         hand: ['vanquish', 'rivals-fall']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/BlizzardAssaultAtat.spec.ts
+++ b/test/server/cards/01_SOR/units/BlizzardAssaultAtat.spec.ts
@@ -10,7 +10,10 @@ describe('Blizzard Assault AT-AT', function() {
                     player2: {
                         groundArena: ['wampa', 'mandalorian-warrior', 'atst', 'chewbacca#pykesbane', 'krayt-dragon'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -90,7 +93,10 @@ describe('Blizzard Assault AT-AT', function() {
                     },
                     player2: {
                         groundArena: ['jawa-scavenger']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -121,7 +127,10 @@ describe('Blizzard Assault AT-AT', function() {
                     player2: {
                         groundArena: ['wampa', 'krayt-dragon'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/C-3POProtocolDroid.spec.ts
+++ b/test/server/cards/01_SOR/units/C-3POProtocolDroid.spec.ts
@@ -7,7 +7,10 @@ describe('C-3PO, Protocol Droid', function() {
                     player1: {
                         hand: ['c3po#protocol-droid'],
                         deck: ['wampa', 'battlefield-marine', 'atst', 'atst'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -50,7 +53,10 @@ describe('C-3PO, Protocol Droid', function() {
                     player1: {
                         hand: ['c3po#protocol-droid'],
                         deck: [],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/ChewbaccaLoyalCompanion.spec.ts
+++ b/test/server/cards/01_SOR/units/ChewbaccaLoyalCompanion.spec.ts
@@ -9,7 +9,10 @@ describe('Chewbacca, Loyal Companion', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'chewbacca#loyal-companion', exhausted: true }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/ChimaeraFlagshipOfTheSeventhFleet.spec.ts
+++ b/test/server/cards/01_SOR/units/ChimaeraFlagshipOfTheSeventhFleet.spec.ts
@@ -9,7 +9,10 @@ describe('Chimaera, Flagship of the Seventh Fleet', function () {
                     },
                     player2: {
                         hand: ['vanquish', 'millennium-falcon#piece-of-junk', 'millennium-falcon#landos-pride', 'wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -40,7 +43,10 @@ describe('Chimaera, Flagship of the Seventh Fleet', function () {
                     },
                     player2: {
                         hand: ['vanquish', 'millennium-falcon#piece-of-junk', 'millennium-falcon#landos-pride', 'wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -69,7 +75,10 @@ describe('Chimaera, Flagship of the Seventh Fleet', function () {
                     },
                     player2: {
                         hand: ['vanquish', 'millennium-falcon#piece-of-junk', 'millennium-falcon#landos-pride', 'wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/01_SOR/units/ChopperMetalMenace.spec.ts
+++ b/test/server/cards/01_SOR/units/ChopperMetalMenace.spec.ts
@@ -11,7 +11,10 @@ describe('Chopper, Metal Menace', function() {
                     player2: {
                         deck: ['battlefield-marine', 'pyke-sentinel', 'underworld-thug', 'the-chaos-of-war', 'volunteer-soldier'],
                         resources: 5
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -42,7 +45,10 @@ describe('Chopper, Metal Menace', function() {
                     player2: {
                         deck: ['the-chaos-of-war', 'battlefield-marine', 'pyke-sentinel', 'underworld-thug', 'volunteer-soldier'],
                         resources: 5
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -71,7 +77,10 @@ describe('Chopper, Metal Menace', function() {
                     player2: {
                         deck: [],
                         resources: 5
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/ConsortiumStarViper.spec.ts
+++ b/test/server/cards/01_SOR/units/ConsortiumStarViper.spec.ts
@@ -10,7 +10,10 @@ describe('Consortium Star Viper', function () {
                     },
                     player2: {
                         groundArena: ['atst'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/01_SOR/units/DistantPatroller.spec.ts
+++ b/test/server/cards/01_SOR/units/DistantPatroller.spec.ts
@@ -11,7 +11,10 @@ describe('Distant Patroller', function () {
                     },
                     player2: {
                         spaceArena: ['system-patrol-craft']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/EscortSkiff.spec.ts
+++ b/test/server/cards/01_SOR/units/EscortSkiff.spec.ts
@@ -10,7 +10,10 @@ describe('Escort Skiff', function() {
                     },
                     player2: {
                         groundArena: ['grogu#irresistible'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/FettsFiresprayPursuingTheBounty.spec.ts
+++ b/test/server/cards/01_SOR/units/FettsFiresprayPursuingTheBounty.spec.ts
@@ -8,7 +8,9 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                         hand: ['fetts-firespray#pursuing-the-bounty'],
                         leader: 'boba-fett#daimyo'
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -37,7 +39,9 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                         hand: ['fetts-firespray#pursuing-the-bounty'],
                         leader: 'boba-fett#collecting-the-bounty'
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -68,7 +72,10 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                     },
                     player2: {
                         leader: 'chirrut-imwe#one-with-the-force'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -92,7 +99,10 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                     },
                     player2: {
                         leader: 'chirrut-imwe#one-with-the-force'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -116,7 +126,10 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                     },
                     player2: {
                         leader: 'chirrut-imwe#one-with-the-force'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -140,7 +153,10 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                     },
                     player2: {
                         groundArena: ['battlefield-marine', 'echo-base-defender']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -186,7 +202,10 @@ describe('Fett\'s Firespray, Pursuing The Bounty', function () {
                             { card: 'battlefield-marine', exhausted: true },
                             { card: 'echo-base-defender', exhausted: true }
                         ]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/FirstLegionSnowTrooper.spec.ts
+++ b/test/server/cards/01_SOR/units/FirstLegionSnowTrooper.spec.ts
@@ -9,7 +9,10 @@ describe('First Legion Snow Trooper', function() {
                     },
                     player2: {
                         groundArena: ['yoda#old-master'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -38,7 +41,10 @@ describe('First Legion Snow Trooper', function() {
                     player2: {
                         groundArena: [{ card: 'snowtrooper-lieutenant', damage: 1 }],
                         base: { card: 'dagobah-swamp', damage: 5 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/FrontierATRT.spec.ts
+++ b/test/server/cards/01_SOR/units/FrontierATRT.spec.ts
@@ -10,7 +10,10 @@ describe('Frontier AT-RT', function() {
                     },
                     player2: {
                         groundArena: ['grogu#irresistible'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -37,7 +40,10 @@ describe('Frontier AT-RT', function() {
                     },
                     player2: {
                         groundArena: ['grogu#irresistible'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/GamorreanGuards.spec.ts
+++ b/test/server/cards/01_SOR/units/GamorreanGuards.spec.ts
@@ -10,7 +10,10 @@ describe('Gamorrean Guards', function() {
                     },
                     player2: {
                         groundArena: ['wampa', 'battlefield-marine'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/GideonHaskRuthlessLoyalist.spec.ts
+++ b/test/server/cards/01_SOR/units/GideonHaskRuthlessLoyalist.spec.ts
@@ -10,7 +10,10 @@ describe('Gideon Hask, Ruthless Loyalist', function () {
                     player2: {
                         hand: ['rivals-fall'],
                         groundArena: ['gideon-hask#ruthless-loyalist', 'specforce-soldier', 'atst'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/GladiatorStarDestroyer.spec.ts
+++ b/test/server/cards/01_SOR/units/GladiatorStarDestroyer.spec.ts
@@ -11,7 +11,10 @@ describe('Gladiator Star Destroyer', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/GuerillaAttackPod.spec.ts
+++ b/test/server/cards/01_SOR/units/GuerillaAttackPod.spec.ts
@@ -12,7 +12,10 @@ describe('Guerilla Attack Pod', function () {
                     player2: {
                         groundArena: ['rugged-survivors'],
                         base: { card: 'echo-base', damage: 14 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/HomeOneAllianceFlagship.spec.ts
+++ b/test/server/cards/01_SOR/units/HomeOneAllianceFlagship.spec.ts
@@ -12,7 +12,10 @@ describe('Home One', function () {
                     player2: {
                         groundArena: ['rugged-survivors', 'cargo-juggernaut'],
                         spaceArena: ['bright-hope#the-last-transport']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/HomeOneAllianceFlagship.spec.ts
+++ b/test/server/cards/01_SOR/units/HomeOneAllianceFlagship.spec.ts
@@ -62,7 +62,10 @@ describe('Home One', function () {
                     },
                     player2: {
                         groundArena: ['rugged-survivors', 'cargo-juggernaut']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -114,7 +117,10 @@ describe('Home One', function () {
                     },
                     player2: {
                         groundArena: ['rugged-survivors', 'cargo-juggernaut']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/HomesteadMilitia.spec.ts
+++ b/test/server/cards/01_SOR/units/HomesteadMilitia.spec.ts
@@ -11,7 +11,10 @@ describe('Homestead Militia', function () {
                     },
                     player2: {
                         groundArena: ['rugged-survivors', 'cargo-juggernaut', 'atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/JedhaAgitator.spec.ts
+++ b/test/server/cards/01_SOR/units/JedhaAgitator.spec.ts
@@ -97,7 +97,10 @@ describe('Jedha Agitator', function() {
                     player2: {
                         groundArena: [{ card: 'wampa', upgrades: ['shield'] }],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/KananJarrusRevealedJedi.spec.ts
+++ b/test/server/cards/01_SOR/units/KananJarrusRevealedJedi.spec.ts
@@ -11,7 +11,10 @@ describe('Kanan Jarrus, Revealed Jedi', function() {
                     },
                     player2: {
                         deck: ['battlefield-marine', 'pyke-sentinel', 'underworld-thug', 'the-chaos-of-war', 'volunteer-soldier']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -42,7 +45,10 @@ describe('Kanan Jarrus, Revealed Jedi', function() {
                     },
                     player2: {
                         deck: ['battlefield-marine', 'the-chaos-of-war', 'volunteer-soldier', 'pyke-sentinel', 'underworld-thug']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -78,7 +84,10 @@ describe('Kanan Jarrus, Revealed Jedi', function() {
                     },
                     player2: {
                         deck: ['battlefield-marine', 'the-chaos-of-war']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/MillenniumFalconPieceOfJunk.spec.ts
+++ b/test/server/cards/01_SOR/units/MillenniumFalconPieceOfJunk.spec.ts
@@ -7,6 +7,9 @@ describe('Millennium Falcon, Piece of Junk', function () {
                     player1: {
                         hand: ['millennium-falcon#piece-of-junk'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -62,7 +65,7 @@ describe('Millennium Falcon, Piece of Junk', function () {
                 expect(context.millenniumFalcon).toBeInZone('hand');
             });
 
-            // TODO CHECK IF ENTERS READY WHEN PLAYED FROM RESOURCES OR DISCARD
+            // TODO CHECK IF ENTERS READY WHEN PLAYED FROM RESOURCES OR DISCARD OR RESCUED FROM CAPTURE
         });
     });
 });

--- a/test/server/cards/01_SOR/units/MiningGuildTieFighter.spec.ts
+++ b/test/server/cards/01_SOR/units/MiningGuildTieFighter.spec.ts
@@ -9,6 +9,9 @@ describe('Mining Guild TIE Fighter', function() {
                     player1: {
                         spaceArena: ['mining-guild-tie-fighter'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 context.player1.clickCard(context.miningGuildTieFighter);
@@ -40,6 +43,9 @@ describe('Mining Guild TIE Fighter', function() {
                         spaceArena: ['mining-guild-tie-fighter'],
                         resources: 1
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 context.player1.clickCard(context.miningGuildTieFighter);

--- a/test/server/cards/01_SOR/units/OuterRimHeadhunter.spec.ts
+++ b/test/server/cards/01_SOR/units/OuterRimHeadhunter.spec.ts
@@ -10,7 +10,10 @@ describe('Outer Rim Headhunter', function () {
                     },
                     player2: {
                         groundArena: ['battlefield-marine', 'scout-bike-pursuer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -40,7 +43,10 @@ describe('Outer Rim Headhunter', function () {
                     },
                     player2: {
                         groundArena: ['battlefield-marine']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/PartisanInsurgent.spec.ts
+++ b/test/server/cards/01_SOR/units/PartisanInsurgent.spec.ts
@@ -11,7 +11,10 @@ describe('Partisan Insurgent', function () {
                     },
                     player2: {
                         spaceArena: ['system-patrol-craft']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/PiratedStarfighter.spec.ts
+++ b/test/server/cards/01_SOR/units/PiratedStarfighter.spec.ts
@@ -7,6 +7,9 @@ describe('Pirated Starfighter', function () {
                     hand: ['pirated-starfighter'],
                     base: 'chopper-base',
                 },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 
@@ -23,7 +26,10 @@ describe('Pirated Starfighter', function () {
                     hand: ['pirated-starfighter'],
                     groundArena: ['pyke-sentinel', 'seasoned-shoretrooper'],
                     leader: { card: 'leia-organa#alliance-general', deployed: true }
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 

--- a/test/server/cards/01_SOR/units/ReinforcementWalker.spec.ts
+++ b/test/server/cards/01_SOR/units/ReinforcementWalker.spec.ts
@@ -9,8 +9,10 @@ describe('Reinforcement Walker', function() {
                     player1: {
                         hand: ['reinforcement-walker'],
                         deck: ['alliance-xwing', 'echo-base-defender', 'attack-pattern-delta', 'battlefield-marine']
-
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -58,8 +60,10 @@ describe('Reinforcement Walker', function() {
                         player1: {
                             hand: ['reinforcement-walker'],
                             deck: ['alliance-xwing', 'echo-base-defender', 'attack-pattern-delta', 'battlefield-marine']
-
                         },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
 
                     const { context } = contextRef;
@@ -98,6 +102,9 @@ describe('Reinforcement Walker', function() {
                         hand: ['reinforcement-walker'],
                         deck: []
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -124,7 +131,10 @@ describe('Reinforcement Walker', function() {
                     },
                     player2: {
                         groundArena: ['battlefield-marine']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/01_SOR/units/RelentlessKonstantinesFolly.spec.ts
+++ b/test/server/cards/01_SOR/units/RelentlessKonstantinesFolly.spec.ts
@@ -10,7 +10,10 @@ describe('Relentless, Konstantine\'s Folly', function() {
                     player2: {
                         hand: ['vanquish', 'repair', 'moment-of-peace'],
                         base: { card: 'dagobah-swamp', damage: 5 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/RogueSquadronSkirmisher.spec.ts
+++ b/test/server/cards/01_SOR/units/RogueSquadronSkirmisher.spec.ts
@@ -10,7 +10,10 @@ describe('Rogue Squadron Skirmisher', function () {
                     },
                     player2: {
                         groundArena: ['consular-security-force']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -59,7 +62,10 @@ describe('Rogue Squadron Skirmisher', function () {
                     },
                     player2: {
                         groundArena: ['consular-security-force']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/RuggedSurvivors.spec.ts
+++ b/test/server/cards/01_SOR/units/RuggedSurvivors.spec.ts
@@ -8,7 +8,9 @@ describe('Rugged Survivors', function () {
                         groundArena: ['rugged-survivors'],
                         leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true }
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -26,15 +28,15 @@ describe('Rugged Survivors', function () {
         });
 
         describe('Rugged Survivors\'s ability', function () {
-            const { context } = contextRef;
-
             beforeEach(function () {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
                         groundArena: ['rugged-survivors'],
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/SawGerreraExtremist.spec.ts
+++ b/test/server/cards/01_SOR/units/SawGerreraExtremist.spec.ts
@@ -10,7 +10,10 @@ describe('Saw Gerrera, Extremist', function () {
                 player2: {
                     hand: ['enforced-loyalty', 'vanquish', 'battlefield-marine'],
                     resources: ['smugglers-aid', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst'],
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 

--- a/test/server/cards/01_SOR/units/SeventhSisterImplacableInquisitor.spec.ts
+++ b/test/server/cards/01_SOR/units/SeventhSisterImplacableInquisitor.spec.ts
@@ -12,6 +12,9 @@ describe('Seventh Sister', function () {
                     leader: { card: 'boba-fett#daimyo', deployed: true },
                     base: 'chopper-base'
                 },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 
@@ -51,6 +54,9 @@ describe('Seventh Sister', function () {
                     groundArena: ['wampa', 'pyke-sentinel'],
                     base: 'chopper-base'
                 },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
             context.player1.clickCard(context.seventhSisterImplacableInquisitor);

--- a/test/server/cards/01_SOR/units/Snowspeeder.spec.ts
+++ b/test/server/cards/01_SOR/units/Snowspeeder.spec.ts
@@ -11,7 +11,10 @@ describe('Snowspeeder', function() {
                     },
                     player2: {
                         groundArena: ['cell-block-guard', 'atst', 'occupier-siege-tank']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/SpecForceSoldier.spec.ts
+++ b/test/server/cards/01_SOR/units/SpecForceSoldier.spec.ts
@@ -10,7 +10,10 @@ describe('SpecForce Soldier', function () {
                     },
                     player2: {
                         groundArena: ['cloud-city-wing-guard']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/StarWingScout.spec.ts
+++ b/test/server/cards/01_SOR/units/StarWingScout.spec.ts
@@ -11,7 +11,10 @@ describe('Star Wing Scout', function () {
                         },
                         player2: {
                             hand: ['rivals-fall']
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 
@@ -41,7 +44,10 @@ describe('Star Wing Scout', function () {
                         player2: {
                             hand: ['rivals-fall'],
                             hasInitiative: true
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 

--- a/test/server/cards/01_SOR/units/SteadfastBattalion.spec.ts
+++ b/test/server/cards/01_SOR/units/SteadfastBattalion.spec.ts
@@ -8,7 +8,9 @@ describe('Steadfast Battalion', function () {
                         groundArena: ['steadfast-battalion', 'battlefield-marine'],
                         leader: { card: 'chirrut-imwe#one-with-the-force', deployed: true }
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -33,7 +35,9 @@ describe('Steadfast Battalion', function () {
                     player1: {
                         groundArena: ['steadfast-battalion', 'battlefield-marine'],
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/VigilantHonorGuards.spec.ts
+++ b/test/server/cards/01_SOR/units/VigilantHonorGuards.spec.ts
@@ -10,7 +10,10 @@ describe('Vigilant Honor Guards', function() {
                     player2: {
                         groundArena: ['vigilant-honor-guards'],
                         hand: ['repair']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.spec.ts
+++ b/test/server/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.spec.ts
@@ -11,7 +11,10 @@ describe('Wedge Antilles, Star of the Rebellion', function() {
                     player2: {
                         spaceArena: ['hwk290-freighter'],
                         hand: ['atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/units/WolffeSuspiciousVeteran.spec.ts
+++ b/test/server/cards/01_SOR/units/WolffeSuspiciousVeteran.spec.ts
@@ -13,7 +13,10 @@ describe('Wolffe, Suspicious Veteran', function () {
                         hand: ['smugglers-aid'],
                         groundArena: ['yoda#old-master'],
                         base: { card: 'capital-city', damage: 5 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/01_SOR/units/YodaOldMaster.spec.ts
+++ b/test/server/cards/01_SOR/units/YodaOldMaster.spec.ts
@@ -10,7 +10,10 @@ describe('Yoda, Old Master', function() {
                     },
                     player2: {
                         groundArena: ['rogue-squadron-skirmisher']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/Devotion.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/Devotion.spec.ts
@@ -7,8 +7,9 @@ describe('Devotion', function() {
                     player1: {
                         groundArena: [{ card: 'wampa', upgrades: ['devotion'] }],
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/Entrenched.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/Entrenched.spec.ts
@@ -10,7 +10,10 @@ describe('Entrenched', function() {
                     },
                     player2: {
                         spaceArena: ['bright-hope#the-last-transport']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -41,7 +44,10 @@ describe('Entrenched', function() {
                     },
                     player2: {
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/FallenLightsaber.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/FallenLightsaber.spec.ts
@@ -10,7 +10,10 @@ describe('Fallen Lightsaber', function() {
                     player2: {
                         groundArena: ['snowspeeder', 'wampa'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -57,7 +60,10 @@ describe('Fallen Lightsaber', function() {
                     player2: {
                         groundArena: ['snowspeeder', 'wampa'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -85,8 +91,9 @@ describe('Fallen Lightsaber', function() {
                         hand: ['fallen-lightsaber'],
                         groundArena: ['snowspeeder', 'battlefield-marine']
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/HardpointHeavyBlaster.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/HardpointHeavyBlaster.spec.ts
@@ -11,7 +11,10 @@ describe('Hardpoint Heavy Blaster', function() {
                     player2: {
                         groundArena: ['reinforcement-walker', 'wampa'],
                         spaceArena: ['ruthless-raider']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -66,8 +69,9 @@ describe('Hardpoint Heavy Blaster', function() {
                         hand: ['hardpoint-heavy-blaster'],
                         groundArena: ['snowspeeder', 'battlefield-marine']
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/JediLightsaber.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/JediLightsaber.spec.ts
@@ -10,7 +10,10 @@ describe('Jedi Lightsaber', function() {
                     player2: {
                         groundArena: ['atst', 'wampa', 'specforce-soldier'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/JediLightsaber.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/JediLightsaber.spec.ts
@@ -81,7 +81,10 @@ describe('Jedi Lightsaber', function() {
                     },
                     player2: {
                         groundArena: ['consular-security-force']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -107,8 +110,9 @@ describe('Jedi Lightsaber', function() {
                         hand: ['jedi-lightsaber'],
                         groundArena: ['snowspeeder', 'battlefield-marine']
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/Protector.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/Protector.spec.ts
@@ -9,7 +9,10 @@ describe('Protector', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'snowspeeder', upgrades: ['protector'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/01_SOR/upgrades/SmugglingCompartment.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/SmugglingCompartment.spec.ts
@@ -9,7 +9,10 @@ describe('Smuggling Compartment', function() {
                     },
                     player2: {
                         groundArena: ['snowspeeder']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -32,7 +35,10 @@ describe('Smuggling Compartment', function() {
                     player1: {
                         hand: ['smuggling-compartment'],
                         groundArena: ['snowspeeder', 'battlefield-marine']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
+++ b/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
@@ -64,7 +64,10 @@ describe('A New Adventure', function() {
                     spaceArena: ['redemption#medical-frigate', 'patrolling-vwing'],
                     leader: { card: 'emperor-palpatine#galactic-ruler', exhausted: true },
                     hasInitiative: true
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/AlteringTheDeal.spec.ts
+++ b/test/server/cards/02_SHD/events/AlteringTheDeal.spec.ts
@@ -12,7 +12,10 @@ describe('Altering the Deal', function() {
                     groundArena: ['snowspeeder', 'specforce-soldier'],
                     spaceArena: ['ruthless-raider'],
                     hand: ['discerning-veteran', 'take-captive']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/CalculatedLethality.spec.ts
+++ b/test/server/cards/02_SHD/events/CalculatedLethality.spec.ts
@@ -17,7 +17,10 @@ describe('Calculated Lethality', function () {
                             { card: 'green-squadron-awing', upgrades: ['experience', 'shield'] },
                             'restored-arc170'
                         ]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/DetentionBlockRescue.spec.ts
+++ b/test/server/cards/02_SHD/events/DetentionBlockRescue.spec.ts
@@ -11,7 +11,10 @@ describe('Detention Block Rescue', function() {
                     player2: {
                         hand: ['take-captive'],
                         groundArena: ['wampa', 'atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/EnforcedLoyalty.spec.ts
+++ b/test/server/cards/02_SHD/events/EnforcedLoyalty.spec.ts
@@ -11,7 +11,10 @@ describe('Enforced Loyalty', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -34,7 +37,10 @@ describe('Enforced Loyalty', function() {
                 },
                 player2: {
                     groundArena: ['wampa']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;
@@ -51,7 +57,10 @@ describe('Enforced Loyalty', function() {
                     hand: ['enforced-loyalty'],
                     groundArena: ['pyke-sentinel'],
                     deck: ['atst']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;
@@ -69,7 +78,10 @@ describe('Enforced Loyalty', function() {
                     hand: ['enforced-loyalty'],
                     groundArena: ['pyke-sentinel'],
                     deck: []
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/MaKlounkee.spec.ts
+++ b/test/server/cards/02_SHD/events/MaKlounkee.spec.ts
@@ -12,7 +12,10 @@ describe('MaKlounkee', function() {
                     groundArena: ['wampa'],
                     spaceArena: [{ card: 'imperial-interceptor', upgrades: ['academy-training'] }],
                     leader: { card: 'grand-moff-tarkin#oversector-governor', deployed: true },
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 
@@ -30,7 +33,10 @@ describe('MaKlounkee', function() {
                 player1: {
                     hand: ['ma-klounkee'],
                     groundArena: ['pyke-sentinel', 'academy-defense-walker'],
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 
@@ -46,7 +52,10 @@ describe('MaKlounkee', function() {
                     hand: ['ma-klounkee'],
                     groundArena: ['academy-defense-walker'],
                     base: 'chopper-base',
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 
@@ -60,7 +69,10 @@ describe('MaKlounkee', function() {
                 player1: {
                     hand: ['ma-klounkee'],
                     groundArena: ['pyke-sentinel'],
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
             const { context } = contextRef;
 

--- a/test/server/cards/02_SHD/events/MomentOfGlory.spec.ts
+++ b/test/server/cards/02_SHD/events/MomentOfGlory.spec.ts
@@ -12,7 +12,10 @@ describe('Moment of Glory', function () {
                     player2: {
                         groundArena: ['wampa', 'atst'],
                         spaceArena: ['imperial-interceptor']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/MysticReflection.spec.ts
+++ b/test/server/cards/02_SHD/events/MysticReflection.spec.ts
@@ -11,7 +11,10 @@ describe('Mystic Reflection', function() {
                     player2: {
                         groundArena: ['specforce-soldier'],
                         spaceArena: ['green-squadron-awing'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/Outflank.spec.ts
+++ b/test/server/cards/02_SHD/events/Outflank.spec.ts
@@ -10,7 +10,10 @@ describe('Outflank', function () {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/Outflank.spec.ts
+++ b/test/server/cards/02_SHD/events/Outflank.spec.ts
@@ -39,7 +39,10 @@ describe('Outflank', function () {
                     player1: {
                         hand: ['outflank'],
                         groundArena: ['pyke-sentinel']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/PalpatinesReturn.spec.ts
+++ b/test/server/cards/02_SHD/events/PalpatinesReturn.spec.ts
@@ -13,7 +13,10 @@ describe('Palpatine\'s Return', function() {
                     },
                     player2: {
                         discard: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/RuleWithRespect.spec.ts
+++ b/test/server/cards/02_SHD/events/RuleWithRespect.spec.ts
@@ -11,7 +11,10 @@ describe('Rule With Respect', function() {
                         groundArena: ['wampa', 'atst'],
                         spaceArena: ['cartel-spacer'],
                         leader: { card: 'boba-fett#daimyo', deployed: true }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/SparkOfHope.spec.ts
+++ b/test/server/cards/02_SHD/events/SparkOfHope.spec.ts
@@ -12,7 +12,10 @@ describe('Spark of Hope', function () {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['mercenary-gunship']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/TakeCaptive.spec.ts
+++ b/test/server/cards/02_SHD/events/TakeCaptive.spec.ts
@@ -13,7 +13,10 @@ describe('Take Captive', function() {
                         groundArena: ['wampa', 'atst'],
                         spaceArena: ['cartel-spacer'],
                         leader: { card: 'boba-fett#daimyo', deployed: true }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -51,7 +54,10 @@ describe('Take Captive', function() {
                 player2: {
                     spaceArena: ['cartel-spacer', 'tie-advanced'],
                     leader: { card: 'boba-fett#daimyo', deployed: true }
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/02_SHD/events/TimelyIntervention.spec.ts
+++ b/test/server/cards/02_SHD/events/TimelyIntervention.spec.ts
@@ -12,7 +12,10 @@ describe('Timely Intervention', function () {
                     },
                     player2: {
                         groundArena: ['isb-agent'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -46,7 +49,10 @@ describe('Timely Intervention', function () {
                     },
                     player2: {
                         groundArena: ['isb-agent'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/events/UnexpectedEscape.spec.ts
+++ b/test/server/cards/02_SHD/events/UnexpectedEscape.spec.ts
@@ -13,7 +13,10 @@ describe('Unexpected Escape', function() {
                         groundArena: ['pyke-sentinel'],
                         spaceArena: ['wing-leader'],
                         hand: ['discerning-veteran', 'take-captive']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/leaders/BobaFettDaimyo.spec.ts
+++ b/test/server/cards/02_SHD/leaders/BobaFettDaimyo.spec.ts
@@ -14,6 +14,9 @@ describe('Boba Fett, Daimyo', function () {
                         hand: ['outer-rim-headhunter'],
                         groundArena: ['wampa'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -78,7 +81,9 @@ describe('Boba Fett, Daimyo', function () {
                         leader: 'boba-fett#daimyo',
                         resource: 4
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -109,7 +114,9 @@ describe('Boba Fett, Daimyo', function () {
                         leader: 'boba-fett#daimyo',
                         resource: 4
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -135,7 +142,10 @@ describe('Boba Fett, Daimyo', function () {
                     },
                     player2: {
                         spaceArena: ['outer-rim-headhunter'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/leaders/FennecShandHonoringTheDeal.spec.ts
+++ b/test/server/cards/02_SHD/leaders/FennecShandHonoringTheDeal.spec.ts
@@ -12,7 +12,10 @@ describe('Fennec Shand, Honoring the Deal', function () {
                     },
                     player2: {
                         groundArena: ['isb-agent'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -47,7 +50,10 @@ describe('Fennec Shand, Honoring the Deal', function () {
                     },
                     player2: {
                         groundArena: ['isb-agent', 'battlefield-marine'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -118,6 +124,9 @@ describe('Fennec Shand, Honoring the Deal', function () {
                         hand: ['reinforcement-walker'],
                         resources: 8
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/leaders/FinnThisIsARescue.spec.ts
+++ b/test/server/cards/02_SHD/leaders/FinnThisIsARescue.spec.ts
@@ -14,7 +14,10 @@ describe('Finn, This is a Rescue', function () {
                         hand: ['top-target'],
                         groundArena: ['wampa'],
                         resources: 5
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -77,7 +80,10 @@ describe('Finn, This is a Rescue', function () {
                         hand: ['top-target'],
                         groundArena: ['wampa', 'atst'],
                         resources: 5
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/leaders/HanSoloWorthTheRisk.spec.ts
+++ b/test/server/cards/02_SHD/leaders/HanSoloWorthTheRisk.spec.ts
@@ -11,6 +11,9 @@ describe('Han Solo, Worth the Risk', function () {
                         base: { card: 'echo-base', damage: 5 },
                         resources: 4,
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -54,6 +57,9 @@ describe('Han Solo, Worth the Risk', function () {
                         leader: { card: 'han-solo#worth-the-risk', deployed: true },
                         base: { card: 'echo-base', damage: 5 },
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -102,6 +108,9 @@ describe('Han Solo, Worth the Risk', function () {
                     player1: {
                         leader: { card: 'han-solo#worth-the-risk', deployed: true },
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/leaders/ReyMoreThanAScavenger.spec.ts
+++ b/test/server/cards/02_SHD/leaders/ReyMoreThanAScavenger.spec.ts
@@ -11,7 +11,10 @@ describe('Rey, More Than a Scavenger', function () {
                     },
                     player2: {
                         spaceArena: ['grey-squadron-ywing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -39,7 +42,10 @@ describe('Rey, More Than a Scavenger', function () {
                     },
                     player2: {
                         spaceArena: ['grey-squadron-ywing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -88,7 +94,10 @@ describe('Rey, More Than a Scavenger', function () {
                     },
                     player2: {
                         spaceArena: ['grey-squadron-ywing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/leaders/TheMandalorianSwornToTheCreed.spec.ts
+++ b/test/server/cards/02_SHD/leaders/TheMandalorianSwornToTheCreed.spec.ts
@@ -15,6 +15,9 @@ describe('The Mandalorian, Sworn To The Creed', function () {
                         groundArena: ['academy-defense-walker', 'battlefield-marine', { card: 'consular-security-force', damage: 4 }],
                         spaceArena: ['green-squadron-awing']
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -79,6 +82,9 @@ describe('The Mandalorian, Sworn To The Creed', function () {
                         groundArena: ['academy-defense-walker', 'blizzard-assault-atat', 'battlefield-marine', { card: 'consular-security-force', damage: 4 }],
                         spaceArena: ['green-squadron-awing']
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/ChainCodeCollector.spec.ts
+++ b/test/server/cards/02_SHD/units/ChainCodeCollector.spec.ts
@@ -10,7 +10,10 @@ describe('Chain Code Collector', function () {
                     },
                     player2: {
                         groundArena: [{ card: 'gideon-hask#ruthless-loyalist', upgrades: ['top-target'] }, 'battlefield-marine']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 // ambush gideon hask

--- a/test/server/cards/02_SHD/units/ClanSaxonGauntlet.spec.ts
+++ b/test/server/cards/02_SHD/units/ClanSaxonGauntlet.spec.ts
@@ -11,7 +11,10 @@ describe('Clan Saxon Gauntlet', function () {
                     player2: {
                         groundArena: ['battlefield-marine'],
                         spaceArena: ['green-squadron-awing', 'hwk290-freighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/CloneDeserter.spec.ts
+++ b/test/server/cards/02_SHD/units/CloneDeserter.spec.ts
@@ -9,7 +9,10 @@ describe('Clone Deserter', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/units/ConcordDawnInterceptors.spec.ts
+++ b/test/server/cards/02_SHD/units/ConcordDawnInterceptors.spec.ts
@@ -9,7 +9,10 @@ describe('Concord Dawn Interceptors', function() {
                     },
                     player2: {
                         spaceArena: ['pirated-starfighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/CoruscantDissident.spec.ts
+++ b/test/server/cards/02_SHD/units/CoruscantDissident.spec.ts
@@ -6,6 +6,9 @@ describe('Coruscant Dissident', function() {
                 player1: {
                     groundArena: [{ card: 'coruscant-dissident' }],
                 },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
         });
 

--- a/test/server/cards/02_SHD/units/CrosshairFollowingOrders.spec.ts
+++ b/test/server/cards/02_SHD/units/CrosshairFollowingOrders.spec.ts
@@ -10,7 +10,10 @@ describe('Crosshair', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['green-squadron-awing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/DiscerningVeteran.spec.ts
+++ b/test/server/cards/02_SHD/units/DiscerningVeteran.spec.ts
@@ -12,7 +12,10 @@ describe('Discerning Veteran', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['cartel-spacer'],
                         leader: { card: 'boba-fett#daimyo', deployed: true }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 

--- a/test/server/cards/02_SHD/units/EchoRestored.spec.ts
+++ b/test/server/cards/02_SHD/units/EchoRestored.spec.ts
@@ -12,7 +12,10 @@ describe('Echo, Restored', function () {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/units/EnfysNestMarauder.spec.ts
+++ b/test/server/cards/02_SHD/units/EnfysNestMarauder.spec.ts
@@ -12,7 +12,10 @@ describe('Enfys Nest, Marauder', function () {
                     player2: {
                         groundArena: ['consular-security-force', 'atst'],
                         hand: ['4lom#bounty-hunter-for-hire']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/EnterprisingLackeys.spec.ts
+++ b/test/server/cards/02_SHD/units/EnterprisingLackeys.spec.ts
@@ -11,7 +11,10 @@ describe('Enterprising Lackeys', function() {
                     player2: {
                         hand: ['vanquish'],
                         hasInitiative: true,
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/FugitiveWookiee.spec.ts
+++ b/test/server/cards/02_SHD/units/FugitiveWookiee.spec.ts
@@ -35,7 +35,10 @@ describe('Fugitive Wookiee', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['cartel-spacer'],
                         hand: ['take-captive']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.spec.ts
+++ b/test/server/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.spec.ts
@@ -11,7 +11,10 @@ describe('General Rieekan, Defensive Strategist', function () {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/GideonsLightCruiserDarkTroopersStation.spec.ts
+++ b/test/server/cards/02_SHD/units/GideonsLightCruiserDarkTroopersStation.spec.ts
@@ -11,7 +11,10 @@ describe('Gideon\'s Light Cruiser, Dark Troopers\' Station', function () {
                     },
                     player2: {
                         discard: ['black-sun-starfighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -32,7 +35,10 @@ describe('Gideon\'s Light Cruiser, Dark Troopers\' Station', function () {
                     },
                     player2: {
                         discard: ['black-sun-starfighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -74,7 +80,10 @@ describe('Gideon\'s Light Cruiser, Dark Troopers\' Station', function () {
                     },
                     player2: {
                         discard: ['black-sun-starfighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/units/HuntingNexu.spec.ts
+++ b/test/server/cards/02_SHD/units/HuntingNexu.spec.ts
@@ -8,7 +8,9 @@ describe('Hunting Nexu', function() {
                         groundArena: ['hunting-nexu'],
                         spaceArena: ['green-squadron-awing']
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -30,7 +32,10 @@ describe('Hunting Nexu', function() {
                     },
                     player2: {
                         spaceArena: ['green-squadron-awing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/KihraxzHeavyFighter.spec.ts
+++ b/test/server/cards/02_SHD/units/KihraxzHeavyFighter.spec.ts
@@ -10,7 +10,10 @@ describe('Kihraxz Heavy Fighter', function () {
                     },
                     player2: {
                         spaceArena: ['devastator#inescapable']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 
@@ -51,7 +54,10 @@ describe('Kihraxz Heavy Fighter', function () {
                     },
                     player2: {
                         spaceArena: ['devastator#inescapable']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 

--- a/test/server/cards/02_SHD/units/KraytDragon.spec.ts
+++ b/test/server/cards/02_SHD/units/KraytDragon.spec.ts
@@ -12,7 +12,10 @@ describe('Krayt Dragon', function () {
                         hand: ['superlaser-blast', 'privateer-crew', 'green-squadron-awing'],
                         groundArena: ['wampa'],
                         resources: ['hotshot-dl44-blaster', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst', 'atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/KyloRenKillingThePast.spec.ts
+++ b/test/server/cards/02_SHD/units/KyloRenKillingThePast.spec.ts
@@ -9,7 +9,10 @@ describe('Kylo Ren, Killing the Past', function() {
                         groundArena: ['rey#keeping-the-past', 'pyke-sentinel'],
                         base: 'kestro-city',
                         leader: 'leia-organa#alliance-general'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -31,7 +34,10 @@ describe('Kylo Ren, Killing the Past', function() {
                         hand: ['kylo-ren#killing-the-past'],
                         base: 'kestro-city',
                         leader: 'rey#more-than-a-scavenger'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -56,7 +62,10 @@ describe('Kylo Ren, Killing the Past', function() {
                     },
                     player2: {
                         spaceArena: ['concord-dawn-interceptors']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/LomPykeDealerInTruths.spec.ts
+++ b/test/server/cards/02_SHD/units/LomPykeDealerInTruths.spec.ts
@@ -10,7 +10,10 @@ describe('Lom Pyke, Dealer in Truths', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -99,7 +102,10 @@ describe('Lom Pyke, Dealer in Truths', function() {
                     phase: 'action',
                     player1: {
                         groundArena: ['lom-pyke#dealer-in-truths', 'battlefield-marine'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -121,7 +127,10 @@ describe('Lom Pyke, Dealer in Truths', function() {
                         groundArena: ['lom-pyke#dealer-in-truths'],
                     }, player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/ProtectorOfTheThrone.spec.ts
+++ b/test/server/cards/02_SHD/units/ProtectorOfTheThrone.spec.ts
@@ -9,7 +9,10 @@ describe('Protector of the Throne', function() {
                     },
                     player2: {
                         groundArena: ['wampa', 'jedha-agitator'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/ReputableHunter.spec.ts
+++ b/test/server/cards/02_SHD/units/ReputableHunter.spec.ts
@@ -8,7 +8,10 @@ describe('Reputable Hunter', function() {
                         hand: ['reputable-hunter'],
                         groundArena: ['hylobon-enforcer'],
                         base: 'energy-conversion-lab',
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 
@@ -27,7 +30,10 @@ describe('Reputable Hunter', function() {
                     },
                     player2: {
                         groundArena: ['battlefield-marine'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 

--- a/test/server/cards/02_SHD/units/RoseTicoDedicatedToTheCause.spec.ts
+++ b/test/server/cards/02_SHD/units/RoseTicoDedicatedToTheCause.spec.ts
@@ -15,7 +15,10 @@ describe('Rose Tico, Dedicated to the Cause', function () {
                     },
                     player2: {
                         groundArena: [{ card: 'atst', upgrades: ['shield'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/SugiHiredGuardian.spec.ts
+++ b/test/server/cards/02_SHD/units/SugiHiredGuardian.spec.ts
@@ -9,7 +9,10 @@ describe('Sugi, Hired Guardian', function () {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -34,7 +37,10 @@ describe('Sugi, Hired Guardian', function () {
                     },
                     player2: {
                         groundArena: ['wampa', { card: 'jedha-agitator', upgrades: ['protector'] }],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/SupercommandoSquad.spec.ts
+++ b/test/server/cards/02_SHD/units/SupercommandoSquad.spec.ts
@@ -9,7 +9,10 @@ describe('Supercommando Squad', function() {
                     },
                     player2: {
                         groundArena: ['wampa', 'jedha-agitator'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/TarffulKashyyykChieftain.spec.ts
+++ b/test/server/cards/02_SHD/units/TarffulKashyyykChieftain.spec.ts
@@ -11,7 +11,10 @@ describe('Tarfful, Kashyyyk Chieftain', function() {
                         groundArena: ['wampa', 'volunteer-soldier', 'wroshyr-tree-tender', 'atst'],
                         spaceArena: ['cartel-spacer'],
                         leader: 'qira#i-alone-survived',
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/ValLoyalToTheEnd.spec.ts
+++ b/test/server/cards/02_SHD/units/ValLoyalToTheEnd.spec.ts
@@ -10,7 +10,10 @@ describe('Val, Loyal To The End', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/ValiantAssaultShip.spec.ts
+++ b/test/server/cards/02_SHD/units/ValiantAssaultShip.spec.ts
@@ -9,7 +9,10 @@ describe('Valiant Assault Ship', function () {
                     },
                     player2: {
                         spaceArena: [{ card: 'system-patrol-craft', upgrades: ['shield'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/WarbirdStowaway.spec.ts
+++ b/test/server/cards/02_SHD/units/WarbirdStowaway.spec.ts
@@ -10,7 +10,10 @@ describe('Warbird Stowaway', function () {
                         },
                         player2: {
                             hasInitiative: true
-                        }
+                        },
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 
@@ -31,7 +34,9 @@ describe('Warbird Stowaway', function () {
                             groundArena: ['warbird-stowaway'],
                             hasInitiative: true
                         },
-                        player2: {}
+
+                        // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                        autoSingleTarget: true
                     });
                 });
 

--- a/test/server/cards/02_SHD/units/XanaduBloodCadBanesReward.spec.ts
+++ b/test/server/cards/02_SHD/units/XanaduBloodCadBanesReward.spec.ts
@@ -12,7 +12,10 @@ describe('Xanadu Blood, Cad Bane\'s Reward', function () {
                     player2: {
                         groundArena: ['cantina-braggart'],
                         spaceArena: ['green-squadron-awing'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/units/ZuckussBountyHunterForHire.spec.ts
+++ b/test/server/cards/02_SHD/units/ZuckussBountyHunterForHire.spec.ts
@@ -10,7 +10,10 @@ describe('Zuckuss, Bounty Hunter for Hire', function() {
                     },
                     player2: {
                         groundArena: ['bendu#the-one-in-the-middle', 'vigilant-honor-guards']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -45,7 +48,10 @@ describe('Zuckuss, Bounty Hunter for Hire', function() {
                     },
                     player2: {
                         hand: ['4lom#bounty-hunter-for-hire'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/upgrades/BrutalTraditions.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/BrutalTraditions.spec.ts
@@ -15,7 +15,10 @@ describe('Brutal Traditions', function() {
                     player2: {
                         groundArena: ['wampa'],
                         hand: ['confiscate', 'vanquish']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/upgrades/HotshotDL44Blaster.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/HotshotDL44Blaster.spec.ts
@@ -7,9 +7,9 @@ describe('Hotshot DL-44 Blaster', function() {
                     player1: {
                         groundArena: ['battlefield-marine'],
                         spaceArena: ['collections-starhopper'],
-                        hand: ['hotshot-dl44-blaster']
-                    },
-                    base: 'tarkintown'
+                        hand: ['hotshot-dl44-blaster'],
+                        base: 'tarkintown'
+                    }
                 });
             });
 

--- a/test/server/cards/02_SHD/upgrades/HotshotDL44Blaster.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/HotshotDL44Blaster.spec.ts
@@ -9,7 +9,10 @@ describe('Hotshot DL-44 Blaster', function() {
                         spaceArena: ['collections-starhopper'],
                         hand: ['hotshot-dl44-blaster'],
                         base: 'tarkintown'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -34,7 +37,10 @@ describe('Hotshot DL-44 Blaster', function() {
                         spaceArena: ['collections-starhopper'],
                         resources: ['hotshot-dl44-blaster', 'atst', 'atst', 'atst', 'atst', 'atst'],
                         base: 'administrators-tower'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/upgrades/InfiltratorsSkill.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/InfiltratorsSkill.spec.ts
@@ -9,7 +9,10 @@ describe('Infiltrator\'s Skill', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'niima-outpost-constables', upgrades: ['shield'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/upgrades/LegalAuthority.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/LegalAuthority.spec.ts
@@ -11,7 +11,10 @@ describe('Legal Authority', function () {
                     },
                     player2: {
                         groundArena: ['wampa', 'atst']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/upgrades/RichReward.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/RichReward.spec.ts
@@ -11,7 +11,10 @@ describe('Rich Reward', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['concord-dawn-interceptors']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -70,7 +73,10 @@ describe('Rich Reward', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'phaseiii-dark-trooper', upgrades: ['rich-reward'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/02_SHD/upgrades/VambraceGrappleshot.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/VambraceGrappleshot.spec.ts
@@ -9,7 +9,10 @@ describe('Vambrace Grappleshot', function() {
                     },
                     player2: {
                         groundArena: ['snowspeeder']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -47,8 +50,9 @@ describe('Vambrace Grappleshot', function() {
                         hand: ['vambrace-grappleshot'],
                         groundArena: ['snowspeeder', 'battlefield-marine']
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/03_TWI/events/GuardingTheWay.spec.ts
+++ b/test/server/cards/03_TWI/events/GuardingTheWay.spec.ts
@@ -10,7 +10,10 @@ describe('Guarding the Way', function () {
                     },
                     player2: {
                         groundArena: ['chewbacca#pykesbane']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -43,7 +46,10 @@ describe('Guarding the Way', function () {
                     player2: {
                         hand: ['guarding-the-way'],
                         groundArena: ['luke-skywalker#jedi-knight']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/leaders/WatTamborTechnoUnionForeman.spec.ts
+++ b/test/server/cards/03_TWI/leaders/WatTamborTechnoUnionForeman.spec.ts
@@ -13,6 +13,9 @@ describe('Wat Tambor, Techno Union Foreman', function () {
                     player2: {
                         groundArena: ['admiral-yularen#advising-caution'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -70,6 +73,9 @@ describe('Wat Tambor, Techno Union Foreman', function () {
                     player2: {
                         groundArena: ['admiral-yularen#advising-caution', 'alliance-dispatcher'],
                     },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
+++ b/test/server/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.spec.ts
@@ -10,7 +10,10 @@ describe('Anakin Skywalker, Maverick Mentor', function() {
                 },
                 player2: {
                     hand: ['vanquish']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/AurraSingCrackshotSniper.spec.ts
+++ b/test/server/cards/03_TWI/units/AurraSingCrackshotSniper.spec.ts
@@ -10,7 +10,10 @@ describe('Aurra Sing, Crackshot Sniper', function () {
                     player2: {
                         groundArena: ['atst', 'wampa'],
                         spaceArena: ['imperial-interceptor']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.spec.ts
+++ b/test/server/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.spec.ts
@@ -9,7 +9,10 @@ describe('Bo-Katan Kryze, Death Watch Lieutenant', function () {
                     },
                     player2: {
                         hand: ['rivals-fall'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.spec.ts
+++ b/test/server/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.spec.ts
@@ -36,7 +36,10 @@ describe('Bo-Katan Kryze, Death Watch Lieutenant', function () {
                     player2: {
                         hand: ['rivals-fall'],
                         groundArena: ['echo-base-defender', 'jedha-agitator'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/CloneHeavyGunner.spec.ts
+++ b/test/server/cards/03_TWI/units/CloneHeavyGunner.spec.ts
@@ -6,7 +6,10 @@ describe('Clone Heavy Gunner', function() {
                 player1: {
                     groundArena: ['clone-heavy-gunner', 'battlefield-marine'],
                     hand: ['wing-leader']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/ConfederateTriFighter.spec.ts
+++ b/test/server/cards/03_TWI/units/ConfederateTriFighter.spec.ts
@@ -15,7 +15,10 @@ describe('Confederate Tri-Fighter', function () {
                         groundArena: ['yoda#old-master'],
                         spaceArena: ['corellian-freighter'],
                         base: { card: 'capital-city', damage: 5 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/CoruscantGuard.spec.ts
+++ b/test/server/cards/03_TWI/units/CoruscantGuard.spec.ts
@@ -10,7 +10,10 @@ describe('Coruscant Guard', function() {
                 },
                 player2: {
                     groundArena: ['hylobon-enforcer']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/DaughterOfDathomir.spec.ts
+++ b/test/server/cards/03_TWI/units/DaughterOfDathomir.spec.ts
@@ -10,7 +10,10 @@ describe('Daughter of Dathomir', function () {
                     },
                     player2: {
                         groundArena: ['battlefield-marine']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/DroidCommando.spec.ts
+++ b/test/server/cards/03_TWI/units/DroidCommando.spec.ts
@@ -10,7 +10,10 @@ describe('Droid Commando', function () {
                     },
                     player2: {
                         groundArena: ['consular-security-force'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -33,7 +36,10 @@ describe('Droid Commando', function () {
                     },
                     player2: {
                         groundArena: ['wilderness-fighter'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/DuchesssChampion.spec.ts
+++ b/test/server/cards/03_TWI/units/DuchesssChampion.spec.ts
@@ -10,7 +10,10 @@ describe('Duchess\'s Champion', function () {
                     player2: {
                         groundArena: ['specforce-soldier'],
                         hasInitiative: true,
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -37,7 +40,10 @@ describe('Duchess\'s Champion', function () {
                         groundArena: ['specforce-soldier', 'battlefield-marine'],
                         spaceArena: ['green-squadron-awing'],
                         hasInitiative: true,
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/03_TWI/units/MorganElsbethKeeperOfManySecrets.spec.ts
+++ b/test/server/cards/03_TWI/units/MorganElsbethKeeperOfManySecrets.spec.ts
@@ -9,7 +9,10 @@ describe('Morgan Elsbeth, Keeper of Many Secrets', function () {
                     },
                     player2: {
                         groundArena: ['battlefield-marine']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/PloKoonKohtoyah.spec.ts
+++ b/test/server/cards/03_TWI/units/PloKoonKohtoyah.spec.ts
@@ -10,7 +10,10 @@ describe('Plo Koon Kohtoyah', function () {
                     },
                     player2: {
                         groundArena: ['consular-security-force', 'wampa'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -36,7 +39,10 @@ describe('Plo Koon Kohtoyah', function () {
                     },
                     player2: {
                         groundArena: ['wampa'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/RecklessTorrent.spec.ts
+++ b/test/server/cards/03_TWI/units/RecklessTorrent.spec.ts
@@ -12,7 +12,10 @@ describe('Reckless Torrent', function() {
                     player2: {
                         groundArena: ['wampa', 'atst'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/03_TWI/units/RepublicCommando.spec.ts
+++ b/test/server/cards/03_TWI/units/RepublicCommando.spec.ts
@@ -10,7 +10,10 @@ describe('Republic Commando', function() {
                     },
                     player2: {
                         groundArena: ['pyke-sentinel']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/cards/03_TWI/units/SeparatistCommando.spec.ts
+++ b/test/server/cards/03_TWI/units/SeparatistCommando.spec.ts
@@ -7,7 +7,9 @@ describe('Separatist Commando', function () {
                     player1: {
                         groundArena: ['separatist-commando', 'wartime-trade-official']
                     },
-                    player2: {}
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -28,7 +30,10 @@ describe('Separatist Commando', function () {
                     },
                     player2: {
                         groundArena: ['wartime-trade-official']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/03_TWI/units/SoullessOneCustomizedForGrievous.spec.ts
+++ b/test/server/cards/03_TWI/units/SoullessOneCustomizedForGrievous.spec.ts
@@ -10,7 +10,10 @@ describe('Soulless One, Customized for Grievous', function () {
                 },
                 player2: {
                     groundArena: ['r2d2#ignoring-protocol']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/cards/03_TWI/upgrades/UnshakeableWill.spec.ts
+++ b/test/server/cards/03_TWI/upgrades/UnshakeableWill.spec.ts
@@ -9,7 +9,10 @@ describe('Unshakeable Will', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'snowspeeder', upgrades: ['unshakeable-will'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/Game.spec.ts
+++ b/test/server/core/Game.spec.ts
@@ -10,7 +10,10 @@ describe('Overall game mechanics', function() {
                     },
                     player2: {
                         base: { card: 'administrators-tower', damage: 29 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -35,7 +38,10 @@ describe('Overall game mechanics', function() {
                     },
                     player2: {
                         base: { card: 'administrators-tower', damage: 29 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/abilities/keyword/Ambush.spec.ts
+++ b/test/server/core/abilities/keyword/Ambush.spec.ts
@@ -12,7 +12,10 @@ describe('Ambush keyword', function() {
                         groundArena: ['consular-security-force', 'snowspeeder'],
                         spaceArena: ['cartel-spacer'],
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -45,7 +48,10 @@ describe('Ambush keyword', function() {
                     player2: {
                         groundArena: ['consular-security-force'],
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -74,7 +80,10 @@ describe('Ambush keyword', function() {
                     },
                     player2: {
                         spaceArena: ['cartel-spacer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -97,7 +106,10 @@ describe('Ambush keyword', function() {
                         groundArena: ['consular-security-force', 'snowspeeder'],
                         spaceArena: ['cartel-spacer'],
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/abilities/keyword/Bounty.spec.ts
+++ b/test/server/core/abilities/keyword/Bounty.spec.ts
@@ -9,7 +9,10 @@ describe('Bounty', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -36,7 +39,10 @@ describe('Bounty', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -57,7 +63,10 @@ describe('Bounty', function() {
                     player1: {
                         hand: ['vanquish'],
                         groundArena: ['hylobon-enforcer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -80,7 +89,10 @@ describe('Bounty', function() {
                     },
                     player2: {
                         hand: ['discerning-veteran']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -111,7 +123,10 @@ describe('Bounty', function() {
                     },
                     player2: {
                         hand: ['discerning-veteran']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -142,7 +157,10 @@ describe('Bounty', function() {
                     player2: {
                         groundArena: ['wampa', 'hylobon-enforcer'],
                         spaceArena: ['cartel-turncoat']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -169,7 +187,10 @@ describe('Bounty', function() {
                     player2: {
                         groundArena: ['hylobon-enforcer'],
                         hand: ['waylay'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -195,7 +216,10 @@ describe('Bounty', function() {
                     },
                     player2: {
                         groundArena: ['hylobon-enforcer'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 // We now defeat it to check it doesn't trigger twice.

--- a/test/server/core/abilities/keyword/Coordinate.spec.ts
+++ b/test/server/core/abilities/keyword/Coordinate.spec.ts
@@ -61,7 +61,10 @@ describe('Coordinate keyword', function() {
                     },
                     player2: {
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/core/abilities/keyword/Coordinate.spec.ts
+++ b/test/server/core/abilities/keyword/Coordinate.spec.ts
@@ -8,7 +8,10 @@ describe('Coordinate keyword', function() {
                         groundArena: ['anakin-skywalker#maverick-mentor', 'clone-heavy-gunner'],
                         spaceArena: ['wing-leader'],
                         deck: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -34,7 +37,10 @@ describe('Coordinate keyword', function() {
                     player2: {
                         groundArena: ['atst'],
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -111,7 +117,10 @@ describe('Coordinate keyword', function() {
                     },
                     player2: {
                         hand: ['cantina-bouncer']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/core/abilities/keyword/Raid.spec.ts
+++ b/test/server/core/abilities/keyword/Raid.spec.ts
@@ -10,7 +10,10 @@ describe('Raid keyword', function() {
                     player2: {
                         groundArena: ['battlefield-marine'],
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -68,8 +71,9 @@ describe('Raid keyword', function() {
                     player1: {
                         spaceArena: ['red-three#unstoppable', 'green-squadron-awing']
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/abilities/keyword/Restore.spec.ts
+++ b/test/server/core/abilities/keyword/Restore.spec.ts
@@ -9,7 +9,10 @@ describe('Restore keyword', function() {
                     },
                     player2: {
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -51,8 +54,9 @@ describe('Restore keyword', function() {
                     player1: {
                         groundArena: [{ card: 'regional-sympathizers', upgrades: ['devotion'] }],
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/abilities/keyword/Saboteur.spec.ts
+++ b/test/server/core/abilities/keyword/Saboteur.spec.ts
@@ -13,7 +13,10 @@ describe('Saboteur keyword', function() {
                         ],
                         spaceArena: ['system-patrol-craft'],
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/abilities/keyword/Sentinel.spec.ts
+++ b/test/server/core/abilities/keyword/Sentinel.spec.ts
@@ -146,7 +146,10 @@ describe('Sentinel keyword', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/core/abilities/keyword/Sentinel.spec.ts
+++ b/test/server/core/abilities/keyword/Sentinel.spec.ts
@@ -11,7 +11,10 @@ describe('Sentinel keyword', function() {
                     player2: {
                         groundArena: ['echo-base-defender', 'battlefield-marine', 'wookiee-warrior'],
                         spaceArena: ['system-patrol-craft', 'seventh-fleet-defender', 'imperial-interceptor'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -52,7 +55,10 @@ describe('Sentinel keyword', function() {
                     player2: {
                         groundArena: ['echo-base-defender', 'pyke-sentinel', 'battlefield-marine', 'wookiee-warrior'],
                         spaceArena: ['system-patrol-craft', 'seventh-fleet-defender', 'imperial-interceptor']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -79,7 +85,10 @@ describe('Sentinel keyword', function() {
                     player2: {
                         groundArena: ['r2d2#ignoring-protocol', 'echo-base-defender'],
                         spaceArena: ['pirated-starfighter', 'corellian-freighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -120,7 +129,10 @@ describe('Sentinel keyword', function() {
                     player2: {
                         groundArena: ['r2d2#ignoring-protocol', 'echo-base-defender'],
                         spaceArena: ['pirated-starfighter']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/abilities/keyword/Shielded.spec.ts
+++ b/test/server/core/abilities/keyword/Shielded.spec.ts
@@ -9,7 +9,10 @@ describe('Shielded keyword', function() {
                     },
                     player2: {
                         hand: ['waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/card/Leader.spec.ts
+++ b/test/server/core/card/Leader.spec.ts
@@ -111,7 +111,10 @@ describe('Leader cards', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['tie-advanced']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/core/card/TakeControl.spec.ts
+++ b/test/server/core/card/TakeControl.spec.ts
@@ -1,4 +1,4 @@
-describe('Take control of a card', function() {
+describe('Take control system', function() {
     integration(function(contextRef) {
         describe('When a player takes control of a unit in the arena', function() {
             beforeEach(function () {
@@ -16,7 +16,10 @@ describe('Take control of a card', function() {
                         ],
                         hand: ['strike-true', 'vanquish', 'take-captive'],
                         leader: 'finn#this-is-a-rescue'
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -121,7 +124,10 @@ describe('Take control of a card', function() {
                     player2: {
                         groundArena: [{ card: 'wampa', damage: 1 }],
                         hand: ['attack-pattern-delta']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -156,7 +162,10 @@ describe('Take control of a card', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'regional-sympathizers', damage: 1 }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -182,7 +191,10 @@ describe('Take control of a card', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'supreme-leader-snoke#shadow-ruler', damage: 1 }, 'specforce-soldier', 'wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -215,7 +227,10 @@ describe('Take control of a card', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'bail-organa#rebel-councilor', damage: 1 }, 'wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -243,7 +258,10 @@ describe('Take control of a card', function() {
                     player2: {
                         leader: { card: 'emperor-palpatine#galactic-ruler', exhausted: true },
                         groundArena: [{ card: 'wampa', damage: 1 }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -278,7 +296,10 @@ describe('Take control of a card', function() {
                 },
                 player2: {
                     groundArena: [{ card: 'lom-pyke#dealer-in-truths', damage: 1 }]
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;
@@ -309,7 +330,10 @@ describe('Take control of a card', function() {
                 },
                 player2: {
                     groundArena: [{ card: 'wampa', damage: 1 }]
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -10,7 +10,10 @@ describe('Uniqueness rule', function() {
                     },
                     player2: {
                         groundArena: ['chopper#metal-menace']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -69,7 +72,10 @@ describe('Uniqueness rule', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'wild-rancor', upgrades: ['lukes-lightsaber'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -108,8 +114,9 @@ describe('Uniqueness rule', function() {
                         hand: ['luke-skywalker#jedi-knight'],
                         leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -133,8 +140,9 @@ describe('Uniqueness rule', function() {
                         groundArena: ['colonel-yularen#isb-director'],
                         base: { card: 'nevarro-city', damage: 3 }
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -176,8 +184,9 @@ describe('Uniqueness rule', function() {
                         hand: ['agent-kallus#seeking-the-rebels'],
                         groundArena: ['agent-kallus#seeking-the-rebels'],
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -250,8 +259,9 @@ describe('Uniqueness rule', function() {
                         groundArena: [{ card: 'admiral-motti#brazen-and-scornful', exhausted: true }],
                         base: { card: 'nevarro-city', damage: 3 }
                     },
-                    player2: {
-                    }
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -319,7 +329,10 @@ describe('Uniqueness rule', function() {
                     },
                     player2: {
                         groundArena: ['cell-block-guard']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;

--- a/test/server/core/card/Upgrade.spec.ts
+++ b/test/server/core/card/Upgrade.spec.ts
@@ -76,7 +76,10 @@ describe('Upgrade cards', function() {
                     },
                     player2: {
                         groundArena: ['atat-suppressor']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -101,7 +104,10 @@ describe('Upgrade cards', function() {
                     player2: {
                         groundArena: ['supreme-leader-snoke#shadow-ruler'],
                         hand: ['confiscate']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -135,7 +141,10 @@ describe('Upgrade cards', function() {
                         hand: ['entrenched'],
                         groundArena: [{ card: 'death-trooper', damage: 1 }, 'wampa'],
                         base: { card: 'dagobah-swamp', damage: 5 }
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/card/Upgrade.spec.ts
+++ b/test/server/core/card/Upgrade.spec.ts
@@ -12,7 +12,10 @@ describe('Upgrade cards', function() {
                     player2: {
                         spaceArena: ['bright-hope#the-last-transport'],
                         hand: ['confiscate']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/gameSteps/abilityWindow/TriggeredAbilityWindow.spec.ts
+++ b/test/server/core/gameSteps/abilityWindow/TriggeredAbilityWindow.spec.ts
@@ -9,7 +9,10 @@ describe('Simultaneous triggers', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'chewbacca#loyal-companion', exhausted: true }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -53,8 +56,6 @@ describe('Simultaneous triggers', function() {
         });
 
         describe('Two units with a when defeated ability killing each other', function () {
-            const { context } = contextRef;
-
             beforeEach(function () {
                 contextRef.setupTest({
                     phase: 'action',
@@ -65,7 +66,10 @@ describe('Simultaneous triggers', function() {
                     player2: {
                         groundArena: ['vanguard-infantry', 'battlefield-marine'],
                         spaceArena: ['alliance-xwing']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/gameSteps/actionWindow/Initiative.spec.ts
+++ b/test/server/core/gameSteps/actionWindow/Initiative.spec.ts
@@ -12,7 +12,10 @@ describe('Claiming initiative', function() {
                     player2: {
                         groundArena: ['wampa'],
                         hand: ['scout-bike-pursuer'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/core/ongoingEffects/DealsDamageBeforeDefender.spec.ts
+++ b/test/server/core/ongoingEffects/DealsDamageBeforeDefender.spec.ts
@@ -15,7 +15,10 @@ describe('Deals Damage Before Defender', function () {
                         }],
                         base: { card: 'dagobah-swamp', damage: 0 },
                         hand: ['phaseiii-dark-trooper']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -57,7 +60,10 @@ describe('Deals Damage Before Defender', function () {
                     },
                     player2: {
                         groundArena: ['phaseiii-dark-trooper'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/gameSystems/CaptureSystem.spec.ts
+++ b/test/server/gameSystems/CaptureSystem.spec.ts
@@ -1,4 +1,4 @@
-describe('Capture mechanic', function() {
+describe('Capture system', function() {
     integration(function (contextRef) {
         describe('When a unit is captured', function() {
             beforeEach(function () {
@@ -10,7 +10,10 @@ describe('Capture mechanic', function() {
                     player2: {
                         groundArena: ['wampa'],
                         hand: ['vanquish', 'waylay']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -54,7 +57,10 @@ describe('Capture mechanic', function() {
                     groundArena: ['wampa', 'atst'],
                     spaceArena: ['green-squadron-awing'],
                     hand: ['vanquish']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;
@@ -96,7 +102,10 @@ describe('Capture mechanic', function() {
                     groundArena: ['wampa'],
                     hand: ['discerning-veteran', 'vanquish'],
                     leader: { card: 'han-solo#worth-the-risk', deployed: true, exhausted: true },
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;
@@ -139,7 +148,10 @@ describe('Capture mechanic', function() {
                 player2: {
                     groundArena: [{ card: 'wampa', upgrades: ['academy-training'] }],
                     hand: ['take-captive']
-                }
+                },
+
+                // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                autoSingleTarget: true
             });
 
             const { context } = contextRef;
@@ -171,7 +183,10 @@ describe('Capture mechanic', function() {
                         groundArena: ['pyke-sentinel'],
                         spaceArena: ['tieln-fighter'],
                         hand: ['discerning-veteran', 'take-captive']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;


### PR DESCRIPTION
Since lots of people were getting tripped by the autoSingleTarget feature causing automatic selection of one available target during tests, added a feature to control the setting in the test setup and turned it off by default. For existing tests that depend on the feature, manually set the flag to true with a comment warning not to do the same in new code.

Updated a couple of the older tests to have the flag off just to confirm that everything works right.