### PR TITLE
Don't do open prompt check if test failed

### DIFF
--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -864,6 +864,15 @@ beforeEach(function () {
     jasmine.addMatchers(customMatchers);
 });
 
+jasmine.getEnv().addReporter({
+    specStarted(result) {
+        jasmine.getEnv().currentSpec = result;
+    },
+    specDone() {
+        jasmine.getEnv().currentSpec = null;
+    }
+});
+
 global.integration = function (definitions) {
     describe('- integration -', function () {
         /**
@@ -1005,6 +1014,11 @@ global.integration = function (definitions) {
 
         afterEach(function() {
             const { context } = contextRef;
+
+            // if there were already failures in the test case, don't bother checking the prompts after
+            if (jasmine.getEnv().currentSpec.failedExpectations.length > 0) {
+                return;
+            }
 
             if (context.game.currentPhase !== 'action' || context.allowTestToEndWithOpenPrompt) {
                 return;

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -864,14 +864,17 @@ beforeEach(function () {
     jasmine.addMatchers(customMatchers);
 });
 
-jasmine.getEnv().addReporter({
-    specStarted(result) {
-        jasmine.getEnv().currentSpec = result;
-    },
-    specDone() {
-        jasmine.getEnv().currentSpec = null;
-    }
-});
+// this is a hack to get around the fact that our method for checking spec failures doesn't work in parallel mode
+if (!jasmine.getEnv().configuration().random) {
+    jasmine.getEnv().addReporter({
+        specStarted(result) {
+            jasmine.getEnv().currentSpec = result;
+        },
+        specDone() {
+            jasmine.getEnv().currentSpec = null;
+        }
+    });
+}
 
 global.integration = function (definitions) {
     describe('- integration -', function () {
@@ -1015,8 +1018,11 @@ global.integration = function (definitions) {
         afterEach(function() {
             const { context } = contextRef;
 
+            // this is a hack to get around the fact that our method for checking spec failures doesn't work in parallel mode
+            const parallelMode = jasmine.getEnv().configuration().random;
+
             // if there were already failures in the test case, don't bother checking the prompts after
-            if (jasmine.getEnv().currentSpec.failedExpectations.length > 0) {
+            if (!parallelMode && jasmine.getEnv().currentSpec.failedExpectations.length > 0) {
                 return;
             }
 
@@ -1033,6 +1039,10 @@ global.integration = function (definitions) {
                 .filter((player) => player.currentPrompt().menuTitle !== 'Choose an action' && !player.currentPrompt().menuTitle.startsWith('Waiting for opponent'));
 
             if (playersWithUnresolvedPrompts.length > 0) {
+                if (parallelMode) {
+                    throw new TestSetupError('The test ended with an unresolved prompt for one or both players. If the test had other errors / failures, disregard this error. Run the test in non-parallel mode for additional details.');
+                }
+
                 let activePromptsText = playersWithUnresolvedPrompts.map((player) =>
                     `\n******* ${player.name.toUpperCase()} PROMPT *******\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}\n`
                 ).join('');


### PR DESCRIPTION
We had an issue where the open prompt check at the end of a test would trigger even if the test failed due to known reasons (exception or expectation failure). This creates confusion so I added a check to keep it from happening.

Unfortunately the mechanism for this doesn't work in parallel mode, so in that case I added an error message indicating that we need to run in serial for more details.