### PR TITLE
Add support for token units

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -34,7 +34,7 @@ jobs:
           with:
             path: ./test/json
             # IMPORTANT: if you change the cache key name below, also change it in update-cache.yml
-            key: sor-shd-twi-manual-v09-duplicateaspects
+            key: sor-shd-twi-manual-v10-shield
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards
 

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -25,7 +25,7 @@ jobs:
           with:
             path: ./test/json
             # IMPORTANT: if you change the cache key name below, also change it in pullrequest.yml
-            key: sor-shd-twi-manual-v09-duplicateaspects
+            key: sor-shd-twi-manual-v10-shield
 
         - if: ${{ steps.cache-card-data.outputs.cache-hit != 'true' }}
           run: npm run get-cards

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -27,6 +27,10 @@ function populateMissingData(attributes, id) {
                 }
             };
             break;
+        case '8752877738': // shield
+            attributes.upgradeHp = 0;
+            attributes.upgradePower = 0;
+            break;
     }
 }
 
@@ -56,6 +60,10 @@ function filterValues(card) {
 
     let filteredObj = filterAttributes(card.attributes);
 
+    filteredObj.id = card.attributes.cardId || card.attributes.cardUid;
+
+    populateMissingData(card.attributes, filteredObj.id);
+
     if (card.attributes.upgradeHp != null) {
         filteredObj.hp = card.attributes.upgradeHp;
     }
@@ -63,10 +71,6 @@ function filterValues(card) {
     if (card.attributes.upgradePower != null) {
         filteredObj.power = card.attributes.upgradePower;
     }
-
-    filteredObj.id = card.attributes.cardId || card.attributes.cardUid;
-
-    populateMissingData(card.attributes, filteredObj.id);
 
     filteredObj.aspects = getAttributeNames(card.attributes.aspects).concat(getAttributeNames(card.attributes.aspectDuplicates));
     filteredObj.traits = getAttributeNames(card.attributes.traits);

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -50,7 +50,7 @@ function filterValues(card) {
     }
 
     // filtering out C24 for now since we do not handle variants
-    if (card.attributes.expansion.data.attributes.code === 'C24') {
+    if (card.attributes.expansion.data.attributes.code === 'C24' || card.attributes.expansion.data.attributes.code === 'JTL') {
         return null;
     }
 

--- a/server/game/cards/01_SOR/tokens/Shield.ts
+++ b/server/game/cards/01_SOR/tokens/Shield.ts
@@ -17,12 +17,7 @@ export default class Shield extends TokenUpgradeCard {
         /** Indicates that the shield be prioritized for removal if multiple shields are present (currently only for Jetpack) */
         public readonly highPriorityRemoval: boolean = false
     ) {
-        // even though shield is printed as 0/0 its cardData has nulls for stats
-        const cardDataWithStats = { ...cardData };
-        cardDataWithStats.power = 0;
-        cardDataWithStats.hp = 0;
-
-        super(owner, cardDataWithStats);
+        super(owner, cardData);
     }
 
     public override isShield(): this is Shield {

--- a/server/game/cards/03_TWI/events/DroidDeployment.ts
+++ b/server/game/cards/03_TWI/events/DroidDeployment.ts
@@ -12,9 +12,7 @@ export default class DroidDeployment extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Create 2 Battle Droid tokens',
-            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid(
-                (context) => ({ amount: 2, target: context.source.controller })
-            )
+            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid({ amount: 2 })
         });
     }
 }

--- a/server/game/cards/03_TWI/events/DroidDeployment.ts
+++ b/server/game/cards/03_TWI/events/DroidDeployment.ts
@@ -1,0 +1,22 @@
+import { EventCard } from '../../../core/card/EventCard';
+import AbilityHelper from '../../../AbilityHelper';
+
+export default class DroidDeployment extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: '6826668370',
+            internalName: 'droid-deployment',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Create 2 Battle Droid tokens',
+            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid(
+                (context) => ({ amount: 2, target: context.source.controller })
+            )
+        });
+    }
+}
+
+DroidDeployment.implemented = true;

--- a/server/game/cards/03_TWI/events/DropIn.ts
+++ b/server/game/cards/03_TWI/events/DropIn.ts
@@ -12,9 +12,7 @@ export default class DropIn extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Create 2 Clone Trooper tokens',
-            immediateEffect: AbilityHelper.immediateEffects.createCloneTrooper(
-                (context) => ({ amount: 2, target: context.source.controller })
-            )
+            immediateEffect: AbilityHelper.immediateEffects.createCloneTrooper({ amount: 2 })
         });
     }
 }

--- a/server/game/cards/03_TWI/events/DropIn.ts
+++ b/server/game/cards/03_TWI/events/DropIn.ts
@@ -1,0 +1,22 @@
+import { EventCard } from '../../../core/card/EventCard';
+import AbilityHelper from '../../../AbilityHelper';
+
+export default class DropIn extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: '5074877594',
+            internalName: 'drop-in',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Create 2 Clone Trooper tokens',
+            immediateEffect: AbilityHelper.immediateEffects.createCloneTrooper(
+                (context) => ({ amount: 2, target: context.source.controller })
+            )
+        });
+    }
+}
+
+DropIn.implemented = true;

--- a/server/game/cards/03_TWI/events/OnTheDoorstep.ts
+++ b/server/game/cards/03_TWI/events/OnTheDoorstep.ts
@@ -12,9 +12,7 @@ export default class OnTheDoorstep extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Create 3 Battle Droid tokens and ready them',
-            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid(
-                (context) => ({ amount: 3, target: context.source.controller, entersReady: true })
-            )
+            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid({ amount: 3, entersReady: true })
         });
     }
 }

--- a/server/game/cards/03_TWI/events/OnTheDoorstep.ts
+++ b/server/game/cards/03_TWI/events/OnTheDoorstep.ts
@@ -1,0 +1,22 @@
+import { EventCard } from '../../../core/card/EventCard';
+import AbilityHelper from '../../../AbilityHelper';
+
+export default class OnTheDoorstep extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: '2483302291',
+            internalName: 'on-the-doorstep',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Create 3 Battle Droid tokens and ready them',
+            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid(
+                (context) => ({ amount: 3, target: context.source.controller, entersReady: true })
+            )
+        });
+    }
+}
+
+OnTheDoorstep.implemented = true;

--- a/server/game/cards/03_TWI/tokens/BattleDroid.ts
+++ b/server/game/cards/03_TWI/tokens/BattleDroid.ts
@@ -1,0 +1,12 @@
+import { TokenUnitCard } from '../../../core/card/TokenCards';
+
+export default class BattleDroid extends TokenUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '3463348370',
+            internalName: 'battle-droid',
+        };
+    }
+}
+
+BattleDroid.implemented = true;

--- a/server/game/cards/03_TWI/tokens/CloneTrooper.ts
+++ b/server/game/cards/03_TWI/tokens/CloneTrooper.ts
@@ -1,0 +1,12 @@
+import { TokenUnitCard } from '../../../core/card/TokenCards';
+
+export default class CloneTrooper extends TokenUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '3941784506',
+            internalName: 'clone-trooper',
+        };
+    }
+}
+
+CloneTrooper.implemented = true;

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -174,11 +174,16 @@ export enum WildcardCardType {
 export type CardTypeFilter = CardType | WildcardCardType;
 
 export enum TokenUpgradeName {
-    Shield = 'shield',
-    Experience = 'experience'
+    Experience = 'experience',
+    Shield = 'shield'
 }
 
-export type TokenName = TokenUpgradeName;
+export enum TokenUnitName {
+    BattleDroid = 'battleDroid',
+    CloneTrooper = 'cloneTrooper'
+}
+
+export type TokenName = TokenUpgradeName | TokenUnitName;
 
 // TODO: start removing these if they aren't used
 export enum EventName {
@@ -231,7 +236,7 @@ export enum EventName {
     OnStatusTokenGained = 'onStatusTokenGained',
     OnStatusTokenMoved = 'onStatusTokenMoved',
     OnTakeControl = 'onTakeControl',
-    OnTokenCreated = 'onTokenCreated',
+    OnTokensCreated = 'OnTokensCreated',
     OnUnitEntersPlay = 'onUnitEntersPlay',
     OnUpgradeAttached = 'onUpgradeAttached',
 }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -173,10 +173,12 @@ export enum WildcardCardType {
 
 export type CardTypeFilter = CardType | WildcardCardType;
 
-export enum TokenName {
+export enum TokenUpgradeName {
     Shield = 'shield',
     Experience = 'experience'
 }
+
+export type TokenName = TokenUpgradeName;
 
 // TODO: start removing these if they aren't used
 export enum EventName {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -28,7 +28,7 @@ const { cards } = require('../cards/Index.js');
 // const ConflictFlow = require('./gamesteps/conflict/conflictflow');
 // const MenuCommands = require('./MenuCommands');
 
-const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName } = require('./Constants.js');
+const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName, TokenUnitName } = require('./Constants.js');
 const { BaseStepWithPipeline } = require('./gameSteps/BaseStepWithPipeline.js');
 const { default: Shield } = require('../cards/01_SOR/tokens/Shield.js');
 const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
@@ -1187,11 +1187,8 @@ class Game extends EventEmitter {
      * @param {*} tokenCardsData object in the form `{ tokenName: tokenCardData }`
      */
     initialiseTokens(tokenCardsData) {
-        for (const tokenName of Object.values(TokenUpgradeName)) {
-            if (!(tokenName in tokenCardsData)) {
-                throw new Error(`Token type '${tokenName}' was not included in token data for game initialization`);
-            }
-        }
+        this.checkTokenDataProvided(TokenUpgradeName, tokenCardsData);
+        this.checkTokenDataProvided(TokenUnitName, tokenCardsData);
 
         this.tokenFactories = {};
 
@@ -1199,6 +1196,14 @@ class Game extends EventEmitter {
             const tokenConstructor = cards.get(cardData.id);
 
             this.tokenFactories[tokenName] = (player) => new tokenConstructor(player, cardData);
+        }
+    }
+
+    checkTokenDataProvided(tokenTypeNames, tokenCardsData) {
+        for (const tokenName of Object.values(tokenTypeNames)) {
+            if (!(tokenName in tokenCardsData)) {
+                throw new Error(`Token type '${tokenName}' was not included in token data for game initialization`);
+            }
         }
     }
 

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -28,7 +28,7 @@ const { cards } = require('../cards/Index.js');
 // const ConflictFlow = require('./gamesteps/conflict/conflictflow');
 // const MenuCommands = require('./MenuCommands');
 
-const { EventName, ZoneName, TokenName, Trait, WildcardZoneName } = require('./Constants.js');
+const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName } = require('./Constants.js');
 const { BaseStepWithPipeline } = require('./gameSteps/BaseStepWithPipeline.js');
 const { default: Shield } = require('../cards/01_SOR/tokens/Shield.js');
 const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
@@ -1187,7 +1187,7 @@ class Game extends EventEmitter {
      * @param {*} tokenCardsData object in the form `{ tokenName: tokenCardData }`
      */
     initialiseTokens(tokenCardsData) {
-        for (const tokenName of Object.values(TokenName)) {
+        for (const tokenName of Object.values(TokenUpgradeName)) {
             if (!(tokenName in tokenCardsData)) {
                 throw new Error(`Token type '${tokenName}' was not included in token data for game initialization`);
             }
@@ -1203,11 +1203,11 @@ class Game extends EventEmitter {
     }
 
     /**
-     * Creates a new shield token in an out of play zone owned by the player and
+     * Creates a new token in an out of play zone owned by the player and
      * adds it to all relevant card lists
      * @param {Player} player
-     * @param {TokenName} tokenName
-     * @returns {Shield}
+     * @param {import('./Constants.js').TokenName} tokenName
+     * @returns {Card}
      */
     generateToken(player, tokenName) {
         const token = this.tokenFactories[tokenName](player);

--- a/server/game/core/card/EventCard.ts
+++ b/server/game/core/card/EventCard.ts
@@ -2,7 +2,7 @@ import Player from '../Player';
 import { WithCost } from './propertyMixins/Cost';
 import { CardType, KeywordName, ZoneName, PlayType } from '../Constants';
 import * as Contract from '../utils/Contract';
-import { IDecreaseEventCostAbilityProps, PlayableOrDeployableCard } from './baseClasses/PlayableOrDeployableCard';
+import { IDecreaseCostAbilityProps, PlayableOrDeployableCard } from './baseClasses/PlayableOrDeployableCard';
 import { IEventAbilityProps } from '../../Interfaces';
 import { EventAbility } from '../ability/EventAbility';
 import { PlayEventAction } from '../../actions/PlayEventAction';
@@ -76,7 +76,7 @@ export class EventCard extends EventCardParent {
 
 
     /** Add a constant ability on the card that decreases its cost under the given condition */
-    protected addDecreaseCostAbility(properties: IDecreaseEventCostAbilityProps<this>): void {
+    protected addDecreaseCostAbility(properties: IDecreaseCostAbilityProps<this>): void {
         this.constantAbilities.push(this.createConstantAbility(this.generateDecreaseCostAbilityProps(properties)));
     }
 }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -3,7 +3,7 @@ import TriggeredAbility from '../../ability/TriggeredAbility';
 import { CardType, ZoneName, RelativePlayer, WildcardZoneName } from '../../Constants';
 import Player from '../../Player';
 import * as EnumHelpers from '../../utils/EnumHelpers';
-import { IDecreaseEventCostAbilityProps, IIgnoreAllAspectPenaltiesProps, IIgnoreSpecificAspectPenaltyProps, PlayableOrDeployableCard } from './PlayableOrDeployableCard';
+import { IDecreaseCostAbilityProps, IIgnoreAllAspectPenaltiesProps, IIgnoreSpecificAspectPenaltyProps, PlayableOrDeployableCard } from './PlayableOrDeployableCard';
 import * as Contract from '../../utils/Contract';
 import ReplacementEffectAbility from '../../ability/ReplacementEffectAbility';
 import { Card } from '../Card';
@@ -133,7 +133,7 @@ export class InPlayCard extends PlayableOrDeployableCard {
     }
 
     /** Add a constant ability on the card that decreases its cost under the given condition */
-    protected addDecreaseCostAbility(properties: IDecreaseEventCostAbilityProps<this>): void {
+    protected addDecreaseCostAbility(properties: IDecreaseCostAbilityProps<this>): void {
         this.addConstantAbility(this.createConstantAbility(this.generateDecreaseCostAbilityProps(properties)));
     }
 

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -11,7 +11,7 @@ import { Card } from '../Card';
 // required for mixins to be based on this class
 export type PlayableOrDeployableCardConstructor = new (...args: any[]) => PlayableOrDeployableCard;
 
-export interface IDecreaseEventCostAbilityProps<TSource extends Card = Card> extends Omit<IIncreaseOrDecreaseCostAdjusterProperties, 'cardTypeFilter' | 'match' | 'costAdjustType'> {
+export interface IDecreaseCostAbilityProps<TSource extends Card = Card> extends Omit<IIncreaseOrDecreaseCostAdjusterProperties, 'cardTypeFilter' | 'match' | 'costAdjustType'> {
     title: string;
     condition?: (context: AbilityContext<TSource>) => boolean;
 }
@@ -139,7 +139,7 @@ export class PlayableOrDeployableCard extends Card {
     }
 
     /** Create constant ability props on the card that decreases its cost under the given condition */
-    protected generateDecreaseCostAbilityProps(properties: IDecreaseEventCostAbilityProps<this>): IConstantAbilityProps {
+    protected generateDecreaseCostAbilityProps(properties: IDecreaseCostAbilityProps<this>): IConstantAbilityProps {
         const { title, condition, ...otherProps } = properties;
 
         const costAdjusterProps: ICostAdjusterProperties = {

--- a/server/game/core/gameSystem/PlayerTargetSystem.ts
+++ b/server/game/core/gameSystem/PlayerTargetSystem.ts
@@ -1,4 +1,7 @@
 import type { AbilityContext } from '../ability/AbilityContext';
+import { Card } from '../card/Card';
+import { TriggerHandlingMode } from '../event/EventWindow';
+import { GameEvent } from '../event/GameEvent';
 import Player from '../Player';
 import { GameSystem, type IGameSystemProperties } from './GameSystem';
 
@@ -20,6 +23,18 @@ export abstract class PlayerTargetSystem<TContext extends AbilityContext = Abili
 
     public override checkEventCondition(event, additionalProperties): boolean {
         return this.canAffect(event.player, event.context, additionalProperties);
+    }
+
+    public override resolve(target: undefined | Player | Player[], context: TContext, triggerHandlingMode?: TriggerHandlingMode) {
+        super.resolve(target, context, triggerHandlingMode);
+    }
+
+    protected override updateEvent(event: GameEvent, player: Player, context: TContext, additionalProperties?: any): void {
+        super.updateEvent(event, player, context, additionalProperties);
+    }
+
+    protected override createEvent(player: Player, context: TContext, additionalProperties: any) {
+        return super.createEvent(player, context, additionalProperties);
     }
 
     protected override addPropertiesToEvent(event, player: Player, context: TContext, additionalProperties = {}): void {

--- a/server/game/core/gameSystem/PlayerTargetSystem.ts
+++ b/server/game/core/gameSystem/PlayerTargetSystem.ts
@@ -25,14 +25,17 @@ export abstract class PlayerTargetSystem<TContext extends AbilityContext = Abili
         return this.canAffect(event.player, event.context, additionalProperties);
     }
 
+    // override to force the argument type to be Player
     public override resolve(target: undefined | Player | Player[], context: TContext, triggerHandlingMode?: TriggerHandlingMode) {
         super.resolve(target, context, triggerHandlingMode);
     }
 
+    // override to force the argument type to be Player
     protected override updateEvent(event: GameEvent, player: Player, context: TContext, additionalProperties?: any): void {
         super.updateEvent(event, player, context, additionalProperties);
     }
 
+    // override to force the argument type to be Player
     protected override createEvent(player: Player, context: TContext, additionalProperties: any) {
         return super.createEvent(player, context, additionalProperties);
     }

--- a/server/game/gameSystems/CreateBattleDroidSystem.ts
+++ b/server/game/gameSystems/CreateBattleDroidSystem.ts
@@ -1,0 +1,13 @@
+import { AbilityContext } from '../core/ability/AbilityContext';
+import { TokenUnitName } from '../core/Constants';
+import { CreateTokenUnitSystem, ICreateTokenUnitProperties } from './CreateTokenUnitSystem';
+
+export type ICreateBattleDroidProperties = Omit<ICreateTokenUnitProperties, 'tokenType'>;
+
+export class CreateBattleDroidSystem<TContext extends AbilityContext = AbilityContext> extends CreateTokenUnitSystem<TContext> {
+    public override readonly name = 'create battle droid';
+
+    protected override getTokenType() {
+        return TokenUnitName.BattleDroid;
+    }
+}

--- a/server/game/gameSystems/CreateCloneTrooperSystem.ts
+++ b/server/game/gameSystems/CreateCloneTrooperSystem.ts
@@ -1,0 +1,13 @@
+import { AbilityContext } from '../core/ability/AbilityContext';
+import { TokenUnitName } from '../core/Constants';
+import { CreateTokenUnitSystem, ICreateTokenUnitProperties } from './CreateTokenUnitSystem';
+
+export type ICreateCloneTrooperProperties = Omit<ICreateTokenUnitProperties, 'tokenType'>;
+
+export class CreateCloneTrooperSystem<TContext extends AbilityContext = AbilityContext> extends CreateTokenUnitSystem<TContext> {
+    public override readonly name = 'create clone trooper';
+
+    protected override getTokenType() {
+        return TokenUnitName.CloneTrooper;
+    }
+}

--- a/server/game/gameSystems/CreateTokenUnitSystem.ts
+++ b/server/game/gameSystems/CreateTokenUnitSystem.ts
@@ -1,0 +1,75 @@
+import { AbilityContext } from '../core/ability/AbilityContext';
+import { EventName, TokenUnitName } from '../core/Constants';
+import { IPlayerTargetSystemProperties, PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem';
+import Player from '../core/Player';
+import { PutIntoPlaySystem } from './PutIntoPlaySystem';
+
+export interface ICreateTokenUnitProperties extends IPlayerTargetSystemProperties {
+    amount?: number;
+    entersReady?: boolean;
+}
+
+/** Base class for managing the logic for creating token units and putting them into play */
+export abstract class CreateTokenUnitSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, ICreateTokenUnitProperties> {
+    public override readonly eventName = EventName.OnTokensCreated;
+    protected override readonly defaultProperties: ICreateTokenUnitProperties = {
+        amount: 1,
+        entersReady: false
+    };
+
+    // event handler doesn't do anything since the tokens were generated in updateEvent
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override eventHandler(event, additionalProperties = {}): void { }
+
+    public override getEffectMessage(context: TContext): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context);
+
+        if (properties.amount === 1) {
+            return ['{0} creates a {1}', [properties.target, this.getTokenType()]];
+        }
+        return ['{0} creates {1} {2}s', [properties.target, properties.amount, this.getTokenType()]];
+    }
+
+    protected abstract getTokenType(): TokenUnitName;
+
+    protected override updateEvent(event, player: Player, context: TContext, additionalProperties): void {
+        super.updateEvent(event, player, context, additionalProperties);
+
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        // generate the tokens here so they can be used in the contingent events
+        // it's fine if this event ends up being cancelled, unused tokens are cleaned up at the end of every round
+        event.generatedTokens = [];
+        for (let i = 0; i < properties.amount; i++) {
+            event.generatedTokens.push(context.game.generateToken(context.source.controller, this.getTokenType()));
+        }
+
+        // add contingent events for putting the generated unit token(s) into play
+        event.setContingentEventsGenerator((event) => {
+            const events = [];
+
+            for (const token of event.generatedTokens) {
+                const putIntoPlayEvent = new PutIntoPlaySystem({
+                    target: token,
+                    entersReady: event.entersReady
+                }).generateEvent(event.context);
+
+                putIntoPlayEvent.order = event.order + 1;
+
+                events.push(putIntoPlayEvent);
+            }
+
+            return events;
+        });
+    }
+
+    public override addPropertiesToEvent(event: any, player: Player, context: TContext, additionalProperties?: any): void {
+        super.addPropertiesToEvent(event, player, context, additionalProperties);
+
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        event.amount = properties.amount;
+        event.tokenType = this.getTokenType();
+        event.entersReady = properties.entersReady;
+    }
+}

--- a/server/game/gameSystems/CreateTokenUnitSystem.ts
+++ b/server/game/gameSystems/CreateTokenUnitSystem.ts
@@ -63,6 +63,10 @@ export abstract class CreateTokenUnitSystem<TContext extends AbilityContext = Ab
         });
     }
 
+    public override defaultTargets(context: TContext): Player[] {
+        return [context.player];
+    }
+
     public override addPropertiesToEvent(event: any, player: Player, context: TContext, additionalProperties?: any): void {
         super.addPropertiesToEvent(event, player, context, additionalProperties);
 

--- a/server/game/gameSystems/DrawSystem.ts
+++ b/server/game/gameSystems/DrawSystem.ts
@@ -43,8 +43,8 @@ export class DrawSystem<TContext extends AbilityContext = AbilityContext> extend
         event.amount = amount;
     }
 
-    protected override updateEvent(event, card: Card, context: TContext, additionalProperties): void {
-        super.updateEvent(event, card, context, additionalProperties);
+    protected override updateEvent(event, player: Player, context: TContext, additionalProperties): void {
+        super.updateEvent(event, player, context, additionalProperties);
 
         // TODO: convert damage on draw to be a real replacement effect once we have partial replacement working
         event.setContingentEventsGenerator((event) => {

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -1,87 +1,59 @@
 import { GameSystem } from '../core/gameSystem/GameSystem';
 import { AbilityContext } from '../core/ability/AbilityContext';
 import { ZoneName, DeckZoneDestination, PlayType } from '../core/Constants';
+import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
 
-// import { AddTokenAction, AddTokenProperties } from './AddTokenAction';
+import { AggregateSystem, ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
 import { AttachUpgradeSystem, IAttachUpgradeProperties } from './AttachUpgradeSystem';
 import { CaptureSystem, ICaptureProperties } from './CaptureSystem';
+import { CardAttackLastingEffectSystem, ICardAttackLastingEffectProperties } from './CardAttackLastingEffectSystem';
 import { CardLastingEffectSystem, ICardLastingEffectProperties } from './CardLastingEffectSystem';
 import { CardPhaseLastingEffectSystem, ICardPhaseLastingEffectProperties } from './CardPhaseLastingEffectSystem';
 import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
+import { ChooseModalEffectsSystem, IPlayModalCardProperties } from './ChooseModalEffectsSystem';
 import { ConditionalSystem, IConditionalSystemProperties } from './ConditionalSystem';
+import { CreateBattleDroidSystem, ICreateBattleDroidProperties } from './CreateBattleDroidSystem';
+import { CreateCloneTrooperSystem, ICreateCloneTrooperProperties } from './CreateCloneTrooperSystem';
 import { DamageSystem, IDamageProperties } from './DamageSystem';
-import { DeployLeaderSystem, IDeployLeaderProperties } from './DeployLeaderSystem';
 import { DefeatCardSystem, IDefeatCardProperties } from './DefeatCardSystem';
-import { DistributeDamageSystem, IDistributeDamageSystemProperties } from './DistributeDamageSystem';
-import { DistributeHealingSystem, IDistributeHealingSystemProperties } from './DistributeHealingSystem';
-// import { CardMenuAction, CardMenuProperties } from './CardMenuAction';
-// import { ChooseActionProperties, ChooseGameAction } from './ChooseGameAction';
-// import { ChosenDiscardAction, ChosenDiscardProperties } from './ChosenDiscardAction';
-// import { ChosenReturnToDeckAction, ChosenReturnToDeckProperties } from './ChosenReturnToDeckAction';
-// import { CreateTokenAction, CreateTokenProperties } from './CreateTokenAction';
-// import { DetachAction, DetachActionProperties } from './DetachAction';
-// import { DiscardCardAction, DiscardCardProperties } from './DiscardSpecificCardAction';
-// import { DiscardFromPlayAction, DiscardFromPlayProperties } from './DiscardFromPlayAction';
-// import { DiscardStatusAction, DiscardStatusProperties } from './DiscardStatusAction';
+import { DeployLeaderSystem, IDeployLeaderProperties } from './DeployLeaderSystem';
+import { DiscardCardsFromHandSystem, IDiscardCardsFromHandProperties } from './DiscardCardsFromHandSystem';
+import { DiscardEntireHandSystem, IDiscardEntireHandSystemProperties } from './DiscardEntireHandSystem';
+import { DiscardFromDeckSystem, IDiscardFromDeckProperties } from './DiscardFromDeckSystem';
 import { DiscardSpecificCardSystem, IDiscardSpecificCardProperties } from './DiscardSpecificCardSystem';
-import { DrawSystem, IDrawProperties } from './DrawSystem';
+import { DistributeDamageSystem, IDistributeDamageSystemProperties } from './DistributeDamageSystem';
+import { DistributeExperienceSystem, IDistributeExperienceSystemProperties } from './DistributeExperienceSystem';
+import { DistributeHealingSystem, IDistributeHealingSystemProperties } from './DistributeHealingSystem';
 import { DrawSpecificCardSystem, IDrawSpecificCardProperties } from './DrawSpecificCardSystem';
-import { ExhaustSystem, IExhaustSystemProperties } from './ExhaustSystem';
-// import { GainStatusTokenAction, GainStatusTokenProperties } from './GainStatusTokenAction';
+import { DrawSystem, IDrawProperties } from './DrawSystem';
 import { ExecuteHandlerSystem, IExecuteHandlerSystemProperties } from './ExecuteHandlerSystem';
-// import { IfAbleAction, IfAbleActionProperties } from './IfAbleAction';
+import { ExhaustResourcesSystem, IExhaustResourcesProperties } from './ExhaustResourcesSystem';
+import { ExhaustSystem, IExhaustSystemProperties } from './ExhaustSystem';
 import { GiveExperienceSystem, IGiveExperienceProperties } from './GiveExperienceSystem';
 import { GiveShieldSystem, IGiveShieldProperties } from './GiveShieldSystem';
 import { HealSystem, IHealProperties } from './HealSystem';
 import { InitiateAttackSystem, IInitiateAttackProperties } from './InitiateAttackSystem';
-// import { JointGameAction } from './JointGameAction';
-// import { LastingEffectAction, LastingEffectProperties } from './LastingEffectAction';
-// import { LastingEffectRingAction, LastingEffectRingProperties } from './LastingEffectRingAction';
 import { LookAtSystem, ILookAtProperties } from './LookAtSystem';
-// import { MatchingDiscardAction, MatchingDiscardProperties } from './MatchingDiscardAction';
-// import { MenuPromptAction, MenuPromptProperties } from './MenuPromptAction';
+import { LookMoveDeckCardsTopOrBottomSystem, ILookMoveDeckCardsTopOrBottomProperties } from './LookMoveDeckCardsTopOrBottomSystem';
 import { MoveCardSystem, IMoveCardProperties } from './MoveCardSystem';
-// import { MoveTokenAction, MoveTokenProperties } from './MoveTokenAction';
-// import { MultipleContextActionProperties, MultipleContextGameAction } from './MultipleContextGameAction';
-// import { MultipleGameAction } from './MultipleGameAction';
 import { NoActionSystem, INoActionSystemProperties } from './NoActionSystem';
-// import { OpponentPutIntoPlayAction, OpponentPutIntoPlayProperties } from './OpponentPutIntoPlayAction';
-// import { PlaceCardUnderneathAction, PlaceCardUnderneathProperties } from './PlaceCardUnderneathAction';
 import { PlayCardSystem, IPlayCardProperties } from '../gameSystems/PlayCardSystem';
+import { PlayerLastingEffectSystem, IPlayerLastingEffectProperties } from './PlayerLastingEffectSystem';
+import { PlayerPhaseLastingEffectSystem, IPlayerPhaseLastingEffectProperties } from './PlayerPhaseLastingEffectSystem';
 import { PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem';
 import { PutIntoPlaySystem, IPutIntoPlayProperties } from './PutIntoPlaySystem';
-import { ReadySystem, IReadySystemProperties } from './ReadySystem';
 import { ReadyResourcesSystem, IReadyResourcesSystemProperties } from './ReadyResourcesSystem';
-// import { RemoveFromGameAction, RemoveFromGameProperties } from './RemoveFromGameAction';
+import { ReadySystem, IReadySystemProperties } from './ReadySystem';
 import { ReplacementEffectSystem, IReplacementEffectSystemProperties } from './ReplacementEffectSystem';
+import { RescueSystem, IRescueProperties } from './RescueSystem';
 import { ResourceCardSystem, IResourceCardProperties } from './ResourceCardSystem';
-// import { ResolveAbilityAction, ResolveAbilityProperties } from './ResolveAbilityAction';
-// import { ReturnToDeckSystem, IReturnToDeckProperties } from './ReturnToDeckSystem';
 import { RevealSystem, IRevealProperties } from './RevealSystem';
-import { ExhaustResourcesSystem, IExhaustResourcesProperties } from './ExhaustResourcesSystem';
 import { SearchDeckSystem, ISearchDeckProperties } from './SearchDeckSystem';
 import { SelectCardSystem, ISelectCardProperties } from './SelectCardSystem';
-// import { SelectTokenAction, SelectTokenProperties } from './SelectTokenAction';
-// import { SequentialContextAction, SequentialContextProperties } from './SequentialContextAction';
 import { SequentialSystem } from './SequentialSystem';
 import { ShuffleDeckSystem, IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { SimultaneousGameSystem } from './SimultaneousSystem';
-import { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
-import { IPlayerLastingEffectProperties, PlayerLastingEffectSystem } from './PlayerLastingEffectSystem';
-import { IPlayerPhaseLastingEffectProperties, PlayerPhaseLastingEffectSystem } from './PlayerPhaseLastingEffectSystem';
-import { ILookMoveDeckCardsTopOrBottomProperties, LookMoveDeckCardsTopOrBottomSystem } from './LookMoveDeckCardsTopOrBottomSystem';
-import { DiscardFromDeckSystem, IDiscardFromDeckProperties } from './DiscardFromDeckSystem';
-import { DiscardCardsFromHandSystem, IDiscardCardsFromHandProperties } from './DiscardCardsFromHandSystem';
-import { DiscardEntireHandSystem, IDiscardEntireHandSystemProperties } from './DiscardEntireHandSystem';
-import { AggregateSystem, ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
-import { CardAttackLastingEffectSystem, ICardAttackLastingEffectProperties } from './CardAttackLastingEffectSystem';
-import { IRescueProperties, RescueSystem } from './RescueSystem';
-import { ITakeControlProperties, TakeControlOfUnitSystem } from './TakeControlOfUnitSystem';
-import { ChooseModalEffectsSystem, IPlayModalCardProperties } from './ChooseModalEffectsSystem';
-import { DistributeExperienceSystem, IDistributeExperienceSystemProperties } from './DistributeExperienceSystem';
-// import { TakeControlAction, TakeControlProperties } from './TakeControlAction';
-// import { TriggerAbilityAction, TriggerAbilityProperties } from './TriggerAbilityAction';
-// import { TurnCardFacedownAction, TurnCardFacedownProperties } from './TurnCardFacedownAction';
+import { TakeControlOfUnitSystem, ITakeControlProperties } from './TakeControlOfUnitSystem';
 
 type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
 
@@ -106,9 +78,12 @@ export function capture<TContext extends AbilityContext = AbilityContext>(proper
 export function cardLastingEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardLastingEffectProperties, TContext>): GameSystem<TContext> {
     return new CardLastingEffectSystem<TContext>(propertyFactory);
 }
-// export function createToken(propertyFactory: PropsFactory<CreateTokenProperties> = {}): GameSystem {
-//     return new CreateTokenAction(propertyFactory);
-// }
+export function createBattleDroid<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICreateBattleDroidProperties, TContext> = {}) {
+    return new CreateBattleDroidSystem<TContext>(propertyFactory);
+}
+export function createCloneTrooper<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICreateCloneTrooperProperties, TContext> = {}) {
+    return new CreateCloneTrooperSystem<TContext>(propertyFactory);
+}
 export function damage<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDamageProperties, TContext>) {
     return new DamageSystem<TContext, IDamageProperties>(propertyFactory);
 }

--- a/server/game/gameSystems/GiveExperienceSystem.ts
+++ b/server/game/gameSystems/GiveExperienceSystem.ts
@@ -1,20 +1,13 @@
 import { AbilityContext } from '../core/ability/AbilityContext';
-import { TokenName } from '../core/Constants';
-import { GameSystem } from '../core/gameSystem/GameSystem';
+import { TokenUpgradeName } from '../core/Constants';
 import { GiveTokenUpgradeSystem, IGiveTokenUpgradeProperties } from './GiveTokenUpgradeSystem';
 
 export type IGiveExperienceProperties = Omit<IGiveTokenUpgradeProperties, 'tokenType'>;
 
 export class GiveExperienceSystem<TContext extends AbilityContext = AbilityContext> extends GiveTokenUpgradeSystem<TContext> {
     public override readonly name = 'give experience';
-    protected override readonly defaultProperties: IGiveTokenUpgradeProperties = {
-        amount: 1,
-        tokenType: TokenName.Experience
-    };
 
-    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
-    public constructor(propertiesOrPropertyFactory: IGiveExperienceProperties | ((context?: AbilityContext) => IGiveExperienceProperties)) {
-        const propsWithTokenType = GameSystem.appendToPropertiesOrPropertyFactory<IGiveTokenUpgradeProperties, 'tokenType'>(propertiesOrPropertyFactory, { tokenType: TokenName.Experience });
-        super(propsWithTokenType);
+    protected override getTokenType() {
+        return TokenUpgradeName.Experience;
     }
 }

--- a/server/game/gameSystems/GiveShieldSystem.ts
+++ b/server/game/gameSystems/GiveShieldSystem.ts
@@ -1,20 +1,13 @@
 import { AbilityContext } from '../core/ability/AbilityContext';
-import { TokenName } from '../core/Constants';
-import { GameSystem } from '../core/gameSystem/GameSystem';
+import { TokenUpgradeName } from '../core/Constants';
 import { GiveTokenUpgradeSystem, IGiveTokenUpgradeProperties } from './GiveTokenUpgradeSystem';
 
 export type IGiveShieldProperties = Omit<IGiveTokenUpgradeProperties, 'tokenType'>;
 
 export class GiveShieldSystem<TContext extends AbilityContext = AbilityContext> extends GiveTokenUpgradeSystem<TContext> {
     public override readonly name = 'give shield';
-    protected override readonly defaultProperties: IGiveTokenUpgradeProperties = {
-        amount: 1,
-        tokenType: TokenName.Shield
-    };
 
-    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
-    public constructor(propertiesOrPropertyFactory: IGiveShieldProperties | ((context?: AbilityContext) => IGiveShieldProperties)) {
-        const propsWithTokenType = GameSystem.appendToPropertiesOrPropertyFactory<IGiveTokenUpgradeProperties, 'tokenType'>(propertiesOrPropertyFactory, { tokenType: TokenName.Shield });
-        super(propsWithTokenType);
+    protected override getTokenType() {
+        return TokenUpgradeName.Shield;
     }
 }

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -1,12 +1,11 @@
 import { AbilityContext } from '../core/ability/AbilityContext';
 import { Card } from '../core/card/Card';
-import { CardTypeFilter, EventName, TokenName, WildcardCardType } from '../core/Constants';
+import { CardTypeFilter, EventName, TokenUpgradeName, WildcardCardType } from '../core/Constants';
 import { CardTargetSystem, ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import * as Contract from '../core/utils/Contract';
 import { AttachUpgradeSystem } from './AttachUpgradeSystem';
 
 export interface IGiveTokenUpgradeProperties extends ICardTargetSystemProperties {
-    tokenType: TokenName;
     amount?: number;
 }
 
@@ -14,6 +13,9 @@ export interface IGiveTokenUpgradeProperties extends ICardTargetSystemProperties
 export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IGiveTokenUpgradeProperties> {
     public override readonly eventName = EventName.OnTokenCreated;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit];
+    protected override readonly defaultProperties: IGiveTokenUpgradeProperties = {
+        amount: 1
+    };
 
     // event handler doesn't do anything since the tokens were generated in updateEvent
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -23,9 +25,9 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         const properties = this.generatePropertiesFromContext(context);
 
         if (properties.amount === 1) {
-            return ['attach a {0} to {1}', [properties.tokenType, properties.target]];
+            return ['attach a {0} to {1}', [this.getTokenType(), properties.target]];
         }
-        return ['attach {0} {1}s to {2}', [properties.amount, properties.tokenType, properties.target]];
+        return ['attach {0} {1}s to {2}', [properties.amount, this.getTokenType(), properties.target]];
     }
 
     public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
@@ -46,9 +48,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         return super.canAffect(card, context);
     }
 
-    public override checkEventCondition(event, additionalProperties): boolean {
-        return this.canAffect(event.card, event.context, additionalProperties);
-    }
+    protected abstract getTokenType(): TokenUpgradeName;
 
     protected override updateEvent(event, card: Card, context: TContext, additionalProperties): void {
         super.updateEvent(event, card, context, additionalProperties);
@@ -59,7 +59,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         // it's fine if this event ends up being cancelled, unused tokens are cleaned up at the end of every round
         event.generatedTokens = [];
         for (let i = 0; i < properties.amount; i++) {
-            event.generatedTokens.push(event.context.game.generateToken(event.context.source.controller, properties.tokenType));
+            event.generatedTokens.push(event.context.game.generateToken(event.context.source.controller, this.getTokenType()));
         }
 
         // add contingent events for attaching the generated upgrade token(s)
@@ -90,6 +90,6 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         event.amount = properties.amount;
-        event.tokenType = properties.tokenType;
+        event.tokenType = this.getTokenType();
     }
 }

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -11,7 +11,7 @@ export interface IGiveTokenUpgradeProperties extends ICardTargetSystemProperties
 
 /** Base class for managing the logic for giving token upgrades to cards (currently shield and experience) */
 export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, IGiveTokenUpgradeProperties> {
-    public override readonly eventName = EventName.OnTokenCreated;
+    public override readonly eventName = EventName.OnTokensCreated;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit];
     protected override readonly defaultProperties: IGiveTokenUpgradeProperties = {
         amount: 1
@@ -59,7 +59,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         // it's fine if this event ends up being cancelled, unused tokens are cleaned up at the end of every round
         event.generatedTokens = [];
         for (let i = 0; i < properties.amount; i++) {
-            event.generatedTokens.push(event.context.game.generateToken(event.context.source.controller, this.getTokenType()));
+            event.generatedTokens.push(context.game.generateToken(context.source.controller, this.getTokenType()));
         }
 
         // add contingent events for attaching the generated upgrade token(s)
@@ -67,10 +67,10 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
             const events = [];
 
             for (let i = 0; i < properties.amount; i++) {
-                const attachUpgradeEvent = new AttachUpgradeSystem(() => ({
+                const attachUpgradeEvent = new AttachUpgradeSystem({
                     upgrade: event.generatedTokens[i],
                     target: card
-                })).generateEvent(event.context);
+                }).generateEvent(event.context);
 
                 attachUpgradeEvent.order = event.order + 1;
 

--- a/test/helpers/DeckBuilder.js
+++ b/test/helpers/DeckBuilder.js
@@ -219,8 +219,10 @@ class DeckBuilder {
 
     getTokenData() {
         return {
+            battleDroid: this.getCard('battle-droid'),
+            cloneTrooper: this.getCard('clone-trooper'),
+            experience: this.getCard('experience'),
             shield: this.getCard('shield'),
-            experience: this.getCard('experience')
         };
     }
 

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -89,6 +89,7 @@ declare namespace jasmine {
         toBeInBottomOfDeck(player: PlayerInteractionWrapper, numCards: number): boolean;
         toAllBeInBottomOfDeck(player: PlayerInteractionWrapper, numCards: number): boolean;
         toBeInZone(zone, player?: PlayerInteractionWrapper): boolean;
+        toAllBeInZone(zone, player?: PlayerInteractionWrapper): boolean;
         toBeCapturedBy(card: any): boolean;
         toHaveExactUpgradeNames(upgradeNames: any[]): boolean;
         toHaveExactPromptButtons<T extends PlayerInteractionWrapper>(this: Matchers<T>, buttons: any[]): boolean;

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -626,6 +626,10 @@ class PlayerInteractionWrapper {
         return this.player.getCardsInZone(zone);
     }
 
+    getArenaCards() {
+        return this.player.getArenaCards();
+    }
+
     dragCard(card, targetZone) {
         this.game.drop(this.player.name, card.uuid, card.zoneName, targetZone);
         this.game.continue();

--- a/test/server/cards/01_SOR/tokens/TokenUnits.spec.ts
+++ b/test/server/cards/01_SOR/tokens/TokenUnits.spec.ts
@@ -1,0 +1,142 @@
+describe('Token units', function() {
+    integration(function(contextRef) {
+        describe('Token units', function() {
+            it('should enter exhausted by default and function in the arena like normal units', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['drop-in', 'droid-deployment'],
+                    },
+                    player2: {
+                        groundArena: ['regional-governor']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // test with Battle Droids
+                context.player1.clickCard(context.droidDeployment);
+                const battleDroids = context.player1.findCardsByName('battle-droid');
+                expect(battleDroids.length).toBe(2);
+                expect(battleDroids).toAllBeInZone('groundArena');
+                expect(battleDroids.every((battleDroid) => battleDroid.exhausted)).toBeTrue();
+
+                context.player2.passAction();
+
+                // test with Clone Troopers
+                context.player1.clickCard(context.dropIn);
+                const cloneTroopers = context.player1.findCardsByName('clone-trooper');
+                expect(cloneTroopers.length).toBe(2);
+                expect(cloneTroopers).toAllBeInZone('groundArena');
+                expect(cloneTroopers.every((cloneTrooper) => cloneTrooper.exhausted)).toBeTrue();
+
+                context.moveToNextActionPhase();
+
+                expect(battleDroids.every((battleDroid) => !battleDroid.exhausted)).toBeTrue();
+                expect(cloneTroopers.every((cloneTrooper) => !cloneTrooper.exhausted)).toBeTrue();
+
+                // do combat, Battle Droid is exhausted and takes damage
+                context.player1.clickCard(battleDroids[0]);
+                expect(context.player1).toBeAbleToSelectExactly([context.regionalGovernor, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+                expect(context.p2Base.damage).toBe(1);
+                expect(battleDroids[0].exhausted).toBeTrue();
+
+                context.player2.passAction();
+
+                // do combat, Clone Trooper is exhausted and takes damage
+                context.player1.clickCard(cloneTroopers[0]);
+                expect(context.player1).toBeAbleToSelectExactly([context.regionalGovernor, context.p2Base]);
+                context.player1.clickCard(context.regionalGovernor);
+                expect(context.regionalGovernor.damage).toBe(2);
+                expect(cloneTroopers[0].damage).toBe(1);
+                expect(cloneTroopers[0].exhausted).toBeTrue();
+            });
+
+            it('should correctly register as defeated when defeated due to effects or damage, and then be moved outside the game', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['general-krell#heartless-tactician'],
+                        hand: ['on-the-doorstep', 'vanquish'],
+                    },
+                    player2: {
+                        groundArena: ['regional-governor'],
+                        hand: ['supreme-leader-snoke#shadow-ruler']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.onTheDoorstep);
+                const battleDroids = context.player1.findCardsByName('battle-droid');
+
+                // CASE 1: defeat due to combat
+                context.player2.clickCard(context.regionalGovernor);
+                expect(context.player2).toBeAbleToSelectExactly([...battleDroids, context.p1Base, context.generalKrell]);
+                context.player2.clickCard(battleDroids[0]);
+                expect(battleDroids[0]).toBeInZone('outsideTheGame');
+                expect(context.regionalGovernor.damage).toBe(1);
+
+                // confirm that Battle Droid defeat event registered correctly and triggered Krell ability
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');
+
+                // CASE 2: defeat due to direct defeat effect
+                context.player1.clickCard(context.vanquish);
+                expect(context.player1).toBeAbleToSelectExactly([battleDroids[1], battleDroids[2], context.generalKrell, context.regionalGovernor]);
+                context.player1.clickCard(battleDroids[1]);
+                expect(battleDroids[1]).toBeInZone('outsideTheGame');
+
+                // confirm that Battle Droid defeat event registered correctly and triggered Krell ability
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');
+
+                // CASE 3: defeat to -hp effect
+                context.player2.clickCard(context.supremeLeaderSnoke);
+                expect(battleDroids[2]).toBeInZone('outsideTheGame');
+
+                // confirm that Battle Droid defeat event registered correctly and triggered Krell ability
+                expect(context.player1).toHavePassAbilityPrompt('Draw a card');
+                context.player1.clickPrompt('Draw a card');
+            });
+
+            it('should be moved outside the game if they would be moved out of the arena, but not register as defeated', function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['general-krell#heartless-tactician'],
+                        hand: ['drop-in', 'waylay'],
+                    },
+                    player2: {
+                        groundArena: ['regional-governor'],
+                        hand: ['take-captive']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.dropIn);
+                const cloneTroopers = context.player1.findCardsByName('clone-trooper');
+                context.player2.passAction();
+
+                // CASE 1: return to hand
+                context.player1.clickCard(context.waylay);
+                expect(context.player1).toBeAbleToSelectExactly([...cloneTroopers, context.regionalGovernor, context.generalKrell]);
+                context.player1.clickCard(cloneTroopers[0]);
+                expect(cloneTroopers[0]).toBeInZone('outsideTheGame');
+                expect(context.player1.handSize).toBe(0);
+                expect(context.player2).toBeActivePlayer();     // should be no Krell trigger since there was no defeat
+
+                // CASE 2: capture
+                context.player2.clickCard(context.takeCaptive);
+                context.player2.clickCard(context.regionalGovernor);
+                expect(context.player2).toBeAbleToSelectExactly([cloneTroopers[1], context.generalKrell]);
+                context.player2.clickCard(cloneTroopers[1]);
+                expect(cloneTroopers[1]).toBeInZone('outsideTheGame');
+                expect(context.regionalGovernor.capturedUnits.length).toBe(0);
+                expect(context.player1).toBeActivePlayer();     // should be no Krell trigger since there was no defeat
+            });
+        });
+    });
+});

--- a/test/server/cards/01_SOR/units/BrightHopeTheLastTransport.spec.ts
+++ b/test/server/cards/01_SOR/units/BrightHopeTheLastTransport.spec.ts
@@ -46,8 +46,30 @@ describe('Bright Hope, The Last Transport', function() {
                 expect(context.specforceSoldier.zoneName).toBe('groundArena');
                 expect(context.player2).toBeActivePlayer();
             });
+        });
 
-            // TODO CHECK WITH TOKEN UNIT
+        it('Bright Hope, The Last Transport\'s ability should return a friendly token ground unit to hand and draw', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['bright-hope#the-last-transport', 'drop-in'],
+                    deck: ['atst']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.dropIn);
+            const cloneTroopers = context.player1.findCardsByName('clone-trooper');
+
+            context.player2.passAction();
+            context.player1.clickCard(context.brightHope);
+            expect(context.player1).toBeAbleToSelectExactly(cloneTroopers);
+
+            context.player1.clickCard(cloneTroopers[0]);
+            expect(cloneTroopers[0]).toBeInZone('outsideTheGame');
+            expect(context.player1.handSize).toBe(1);
+            expect(context.atst).toBeInZone('hand');
         });
     });
 });

--- a/test/server/cards/03_TWI/events/DroidDeployment.spec.ts
+++ b/test/server/cards/03_TWI/events/DroidDeployment.spec.ts
@@ -1,0 +1,22 @@
+describe('Droid Deployment', function () {
+    integration(function (contextRef) {
+        it('Droid Deployment\'s ability should create two Battle Droid tokens for the controller', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['droid-deployment'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.droidDeployment);
+
+            const battleDroids = context.player1.findCardsByName('battle-droid');
+            expect(battleDroids.length).toBe(2);
+            // TODO THIS PR: zone check
+            expect(battleDroids.every((battleDroid) => battleDroid.exhausted)).toBeTrue();
+            expect(context.player2.getArenaCards().length).toBe(0);
+        });
+    });
+});

--- a/test/server/cards/03_TWI/events/DroidDeployment.spec.ts
+++ b/test/server/cards/03_TWI/events/DroidDeployment.spec.ts
@@ -14,7 +14,7 @@ describe('Droid Deployment', function () {
 
             const battleDroids = context.player1.findCardsByName('battle-droid');
             expect(battleDroids.length).toBe(2);
-            // TODO THIS PR: zone check
+            expect(battleDroids).toAllBeInZone('groundArena');
             expect(battleDroids.every((battleDroid) => battleDroid.exhausted)).toBeTrue();
             expect(context.player2.getArenaCards().length).toBe(0);
         });

--- a/test/server/cards/03_TWI/events/DropIn.spec.ts
+++ b/test/server/cards/03_TWI/events/DropIn.spec.ts
@@ -14,7 +14,7 @@ describe('Drop In', function () {
 
             const cloneTroopers = context.player1.findCardsByName('clone-trooper');
             expect(cloneTroopers.length).toBe(2);
-            // TODO THIS PR: zone check
+            expect(cloneTroopers).toAllBeInZone('groundArena');
             expect(cloneTroopers.every((cloneTrooper) => cloneTrooper.exhausted)).toBeTrue();
             expect(context.player2.getArenaCards().length).toBe(0);
         });

--- a/test/server/cards/03_TWI/events/DropIn.spec.ts
+++ b/test/server/cards/03_TWI/events/DropIn.spec.ts
@@ -1,0 +1,22 @@
+describe('Drop In', function () {
+    integration(function (contextRef) {
+        it('Drop In\'s ability should create two Clone Trooper tokens for the controller', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['drop-in'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.dropIn);
+
+            const cloneTroopers = context.player1.findCardsByName('clone-trooper');
+            expect(cloneTroopers.length).toBe(2);
+            // TODO THIS PR: zone check
+            expect(cloneTroopers.every((cloneTrooper) => cloneTrooper.exhausted)).toBeTrue();
+            expect(context.player2.getArenaCards().length).toBe(0);
+        });
+    });
+});

--- a/test/server/cards/03_TWI/events/OnTheDoorstep.spec.ts
+++ b/test/server/cards/03_TWI/events/OnTheDoorstep.spec.ts
@@ -1,0 +1,22 @@
+describe('On the Doorstep', function () {
+    integration(function (contextRef) {
+        it('On the Doorstep\'s ability should create three Battle Droid tokens for the controller and ready them', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['on-the-doorstep'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.onTheDoorstep);
+
+            const battleDroids = context.player1.findCardsByName('battle-droid');
+            expect(battleDroids.length).toBe(3);
+            expect(battleDroids).toAllBeInZone('groundArena');
+            expect(battleDroids.every((battleDroid) => !battleDroid.exhausted)).toBeTrue();
+            expect(context.player2.getArenaCards().length).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
Added support for creating Battle Droid and Clone Trooper units. Created a test suite for validating all of the interactions specific to those card types, particularly the rules for defeat / leaving the arena. Slightly cleaned up the token upgrade system as well.