### PR TITLE
Add Multi-Troop Transport and add Exploit parsing

### DIFF
--- a/server/game/cards/03_TWI/units/MultitroopTransport.ts
+++ b/server/game/cards/03_TWI/units/MultitroopTransport.ts
@@ -1,0 +1,20 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+
+export default class MultitroopTransport extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '1320229479',
+            internalName: 'multitroop-transport',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addOnAttackAbility({
+            title: 'Create a Battle Droid token',
+            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid()
+        });
+    }
+}
+
+MultitroopTransport.implemented = true;

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -284,6 +284,8 @@ export enum KeywordName {
     Ambush = 'ambush',
     Bounty = 'bounty',
     Coordinate = 'coordinate',
+    /** @deprecated Not yet implemented */
+    Exploit = 'exploit',
     Grit = 'grit',
     Overwhelm = 'overwhelm',
     Raid = 'raid',

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -70,6 +70,7 @@ export const isNumericType: Record<KeywordName, boolean> = {
     [KeywordName.Ambush]: false,
     [KeywordName.Bounty]: false,
     [KeywordName.Coordinate]: false,
+    [KeywordName.Exploit]: true,
     [KeywordName.Grit]: false,
     [KeywordName.Overwhelm]: false,
     [KeywordName.Raid]: true,
@@ -112,7 +113,7 @@ function isKeywordEnabled(keyword: KeywordName, cardText: string, cardName: stri
  * @returns null if the keyword is not enabled, or the numeric value if enabled
  */
 function parseNumericKeywordValueIfEnabled(keyword: KeywordName, cardText: string, cardName: string): number | null {
-    Contract.assertTrue([KeywordName.Raid, KeywordName.Restore].includes(keyword));
+    Contract.assertTrue([KeywordName.Exploit, KeywordName.Raid, KeywordName.Restore].includes(keyword));
 
     const regex = getRegexForKeyword(keyword);
     const matchIter = cardText.matchAll(regex);
@@ -170,6 +171,8 @@ function getRegexForKeyword(keyword: KeywordName) {
             return /(?:^|(?:\n))Bounty/g;
         case KeywordName.Coordinate:
             return /(?:^|(?:\n))Coordinate/g;
+        case KeywordName.Exploit:
+            return /(?:^|(?:\n))Exploit ([\d]+)/g;
         case KeywordName.Grit:
             return /(?:^|(?:\n))Grit/g;
         case KeywordName.Overwhelm:

--- a/test/server/cards/03_TWI/units/MultitroopTransport.spec.ts
+++ b/test/server/cards/03_TWI/units/MultitroopTransport.spec.ts
@@ -1,0 +1,23 @@
+describe('Multi-Troop Transport', function () {
+    integration(function (contextRef) {
+        it('Multi-Troop Transport\'s on-attack ability should create a Battle Droid token', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    groundArena: ['multitroop-transport']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.multitroopTransport);
+            context.player1.clickCard(context.p2Base);
+
+            const battleDroids = context.player1.findCardsByName('battle-droid');
+            expect(battleDroids.length).toBe(1);
+            expect(battleDroids).toAllBeInZone('groundArena');
+            expect(battleDroids.every((battleDroid) => battleDroid.exhausted)).toBeTrue();
+            expect(context.player2.getArenaCards().length).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
The engine was choking on cards with the Exploit keyword since it didn't have an entry for it to parse. Added the logic for that and tested by adding Multi-Troop Transport.

Exploit functionality is not present at all but the keyword can at least be parsed successfully and then ignored.