### PR TITLE
Add support for gaining Saboteur for attack duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .idea/
 test/**/json/
 .env
+*.zip

--- a/server/game/cards/03_TWI/events/BreakingIn.ts
+++ b/server/game/cards/03_TWI/events/BreakingIn.ts
@@ -1,0 +1,26 @@
+import { EventCard } from '../../../core/card/EventCard';
+import AbilityHelper from '../../../AbilityHelper';
+import { KeywordName } from '../../../core/Constants';
+
+export default class BreakingIn extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: '4910017138',
+            internalName: 'breaking-in',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.setEventAbility({
+            title: 'Attack with a unit. It gets +2/+0 and gains Saboteur for this attack.',
+            initiateAttack: {
+                attackerLastingEffects: [
+                    { effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur) },
+                    { effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 }) },
+                ]
+            }
+        });
+    }
+}
+
+BreakingIn.implemented = true;

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -34,6 +34,7 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         }
     }
 
+    /** Returns the effects that would be applied to {@link card} by this system's configured lasting effects */
     public getApplicableEffects(card: Card, context: TContext) {
         const { effectFactories, effectProperties } = this.getEffectFactoriesAndProperties(card, context);
 

--- a/test/server/cards/03_TWI/events/BreakingIn.spec.ts
+++ b/test/server/cards/03_TWI/events/BreakingIn.spec.ts
@@ -1,0 +1,34 @@
+describe('Breaking In', function () {
+    integration(function (contextRef) {
+        it('Breaking In\'s ability should initiate an attack and give +2/+0 and Saboteur', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['breaking-in'],
+                    groundArena: ['battlefield-marine']
+                },
+                player2: {
+                    groundArena: ['niima-outpost-constables']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.breakingIn);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.niimaOutpostConstables, context.p2Base]);
+            context.player1.clickCard(context.p2Base);
+            expect(context.p2Base.damage).toBe(5);
+
+            // second to attack to confirm the effect is gone
+            context.player2.passAction();
+            context.battlefieldMarine.exhausted = false;
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.niimaOutpostConstables]);
+            context.player1.clickCard(context.niimaOutpostConstables);
+            expect(context.niimaOutpostConstables.damage).toBe(3);
+        });
+    });
+});

--- a/test/server/cards/03_TWI/events/BreakingIn.spec.ts
+++ b/test/server/cards/03_TWI/events/BreakingIn.spec.ts
@@ -21,7 +21,7 @@ describe('Breaking In', function () {
             context.player1.clickCard(context.p2Base);
             expect(context.p2Base.damage).toBe(5);
 
-            // second to attack to confirm the effect is gone
+            // second attack to confirm the effect is gone
             context.player2.passAction();
             context.battlefieldMarine.exhausted = false;
             context.player1.clickCard(context.battlefieldMarine);


### PR DESCRIPTION
There was an issue preventing us from implementing cards that allow a unit to attack and gain Saboteur for that attack. Specifically, the "gain Saboteur" effect would not be applied until after targeting, meaning that it wouldn't have any impact on sentinel.

Hardcoded support for this into the AttackStepsSystem and implemented Breaking In to test it. Also did some general cleanup of the CardLastingEffectSystem and AttackStepsSystem.