### PR TITLE
Add "last known information" to defeat system

### DIFF
--- a/server/game/cards/02_SHD/events/CalculatedLethality.ts
+++ b/server/game/cards/02_SHD/events/CalculatedLethality.ts
@@ -19,9 +19,9 @@ export default class CalculatedLethality extends EventCard {
             },
             then: (thenContext) => ({
                 title: 'For each upgrade that was on that unit, give an Experience token to a friendly unit.',
-                thenCondition: () => thenContext.events?.length > 0 && thenContext.events[0].lastKnownInformation.upgrades.length > 0,
+                thenCondition: () => thenContext.events?.length > 0,
                 immediateEffect: AbilityHelper.immediateEffects.distributeExperienceAmong({
-                    amountToDistribute: thenContext.targets.upgradeAmount,
+                    amountToDistribute: thenContext.events[0].lastKnownInformation.upgrades.length,
                     cardTypeFilter: WildcardCardType.Unit,
                     controller: RelativePlayer.Self,
                     canChooseNoTargets: false,

--- a/server/game/cards/02_SHD/events/CalculatedLethality.ts
+++ b/server/game/cards/02_SHD/events/CalculatedLethality.ts
@@ -15,18 +15,11 @@ export default class CalculatedLethality extends EventCard {
             title: 'Defeat a non-leader unit that costs 3 or less',
             targetResolver: {
                 cardCondition: (card) => card.isNonLeaderUnit() && card.cost <= 3,
-                immediateEffect: AbilityHelper.immediateEffects.sequential([
-                    // TODO: this is a hack to store data before it's defeated.
-                    // once last known state is implemented, we need to read data from that
-                    AbilityHelper.immediateEffects.handler((context) => ({
-                        handler: () => context.targets.upgradeAmount = context.target.upgrades.length
-                    })),
-                    AbilityHelper.immediateEffects.defeat()
-                ])
+                immediateEffect: AbilityHelper.immediateEffects.defeat(),
             },
             then: (thenContext) => ({
                 title: 'For each upgrade that was on that unit, give an Experience token to a friendly unit.',
-                thenCondition: () => thenContext.targets.upgradeAmount != null,
+                thenCondition: () => thenContext.events?.length > 0 && thenContext.events[0].lastKnownInformation.upgrades.length > 0,
                 immediateEffect: AbilityHelper.immediateEffects.distributeExperienceAmong({
                     amountToDistribute: thenContext.targets.upgradeAmount,
                     cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/leaders/FinnThisIsARescue.ts
+++ b/server/game/cards/02_SHD/leaders/FinnThisIsARescue.ts
@@ -17,18 +17,11 @@ export default class FinnThisIsARescue extends LeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Upgrade,
                 cardCondition: (card, context) => card.controller === context.source.controller,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    // TODO: this is a hack to store the parent card of the upgrade before it's defeated.
-                    // once last known state is implemented, we need to read the upgrade's parent card from that (same for on-attack)
-                    AbilityHelper.immediateEffects.handler((context) => ({
-                        handler: () => context.targets.upgradeParentCard = context.target.parentCard
-                    })),
-                    AbilityHelper.immediateEffects.defeat()
-                ]),
+                immediateEffect: AbilityHelper.immediateEffects.defeat(),
             },
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Give a Shield token to that unit',
-                immediateEffect: AbilityHelper.immediateEffects.giveShield({ target: ifYouDoContext.targets.upgradeParentCard }),
+                immediateEffect: AbilityHelper.immediateEffects.giveShield({ target: ifYouDoContext.events[0].lastKnownInformation.parentCard }),
             })
         });
     }
@@ -40,16 +33,11 @@ export default class FinnThisIsARescue extends LeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Upgrade,
                 cardCondition: (card, context) => card.controller === context.source.controller,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.handler((context) => ({
-                        handler: () => context.targets.upgradeParentCard = context.target.parentCard
-                    })),
-                    AbilityHelper.immediateEffects.defeat()
-                ]),
+                immediateEffect: AbilityHelper.immediateEffects.defeat(),
             },
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Give a Shield token to that unit',
-                immediateEffect: AbilityHelper.immediateEffects.giveShield({ target: ifYouDoContext.targets.upgradeParentCard }),
+                immediateEffect: AbilityHelper.immediateEffects.giveShield({ target: ifYouDoContext.events[0].lastKnownInformation.parentCard }),
             })
         });
     }

--- a/server/game/cards/02_SHD/leaders/FinnThisIsARescue.ts
+++ b/server/game/cards/02_SHD/leaders/FinnThisIsARescue.ts
@@ -21,7 +21,9 @@ export default class FinnThisIsARescue extends LeaderUnitCard {
             },
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Give a Shield token to that unit',
-                immediateEffect: AbilityHelper.immediateEffects.giveShield({ target: ifYouDoContext.events[0].lastKnownInformation.parentCard }),
+                immediateEffect: AbilityHelper.immediateEffects.giveShield({
+                    target: ifYouDoContext.events[0].lastKnownInformation.parentCard
+                }),
             })
         });
     }
@@ -37,7 +39,9 @@ export default class FinnThisIsARescue extends LeaderUnitCard {
             },
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Give a Shield token to that unit',
-                immediateEffect: AbilityHelper.immediateEffects.giveShield({ target: ifYouDoContext.events[0].lastKnownInformation.parentCard }),
+                immediateEffect: AbilityHelper.immediateEffects.giveShield({
+                    target: ifYouDoContext.events[0].lastKnownInformation.parentCard
+                }),
             })
         });
     }

--- a/server/game/cards/02_SHD/units/RoseTicoDedicatedToTheCause.ts
+++ b/server/game/cards/02_SHD/units/RoseTicoDedicatedToTheCause.ts
@@ -17,19 +17,12 @@ export default class RoseTicoDedicatedToTheCause extends NonLeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Upgrade,
                 cardCondition: (card, context) => card.isShield() && card.parentCard.controller === context.source.controller,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    // TODO: this is a hack to store the parent card of the upgrade before it's defeated.
-                    // once last known state is implemented, we need to read the upgrade's parent card from that
-                    AbilityHelper.immediateEffects.handler((context) => ({
-                        handler: () => context.targets.upgradeParentCard = context.target.parentCard
-                    })),
-                    AbilityHelper.immediateEffects.defeat()
-                ]),
+                immediateEffect: AbilityHelper.immediateEffects.defeat(),
             },
-            ifYouDo: (context) => ({
+            ifYouDo: (ifYouDoContext) => ({
                 title: 'Give 2 Experience tokens to that unit',
                 immediateEffect: AbilityHelper.immediateEffects.giveExperience({
-                    target: context.targets.upgradeParentCard,
+                    target: ifYouDoContext.events[0].lastKnownInformation.parentCard,
                     amount: 2
                 })
             })

--- a/server/game/core/event/GameEvent.ts
+++ b/server/game/core/event/GameEvent.ts
@@ -21,7 +21,7 @@ export class GameEvent {
     private cleanupHandlers: (() => void)[] = [];
     private _context = null;
     private contingentEventsGenerator?: () => any[] = null;
-    private preResolutionEffect = () => true;
+    private _preResolutionEffect = null;
     private replacementEvent: any = null;
     private resolutionStatus: EventResolutionStatus = EventResolutionStatus.CREATED;
     private _window: EventWindow = null;
@@ -170,6 +170,18 @@ export class GameEvent {
         }
 
         return contingentEvents;
+    }
+
+    public setPreResolutionEffect(preResolutionEffect: (event) => void) {
+        Contract.assertIsNullLike(this._preResolutionEffect, 'Attempting to set preResolutionEffect but it already has a value');
+
+        this._preResolutionEffect = preResolutionEffect;
+    }
+
+    public preResolutionEffect() {
+        if (this._preResolutionEffect) {
+            this._preResolutionEffect(this);
+        }
     }
 
     public addCleanupHandler(handler) {

--- a/server/game/core/event/GameEvent.ts
+++ b/server/game/core/event/GameEvent.ts
@@ -17,11 +17,11 @@ export class GameEvent {
     public condition = (event) => true;
     public order = 0;
     public isContingent = false;
-    public preResolutionEffect = () => true;
 
     private cleanupHandlers: (() => void)[] = [];
     private _context = null;
     private contingentEventsGenerator?: () => any[] = null;
+    private preResolutionEffect = () => true;
     private replacementEvent: any = null;
     private resolutionStatus: EventResolutionStatus = EventResolutionStatus.CREATED;
     private _window: EventWindow = null;

--- a/server/game/core/gameSteps/prompts/DistributeAmongTargetsPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DistributeAmongTargetsPrompt.ts
@@ -22,6 +22,8 @@ export class DistributeAmongTargetsPrompt extends UiPrompt {
     ) {
         super(game);
 
+        Contract.assertNonNegative(properties.amount);
+
         if (!properties.waitingPromptTitle) {
             properties.waitingPromptTitle = 'Waiting for opponent to choose targets for ' + properties.source.name;
         }

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -1,7 +1,10 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
+import { UnitCard } from '../core/card/CardTypes';
+import { UpgradeCard } from '../core/card/UpgradeCard';
 import { EventName, WildcardCardType, ZoneName } from '../core/Constants';
 import { CardTargetSystem, type ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
+import Player from '../core/Player';
 import * as Contract from '../core/utils/Contract';
 import { DamageSourceType, DefeatSourceType, IDamageSource, IDefeatSource } from '../IDamageOrDefeatSource';
 
@@ -18,6 +21,17 @@ export interface IDefeatCardProperties extends IDefeatCardPropertiesBase {
     defeatSource?: IDamageSource | DefeatSourceType.Ability;
 }
 
+/** Records the "last known information" of a card before it left the arena, in case ability text needs to refer back to it. See SWU 8.12. */
+export interface ILastKnownInformation {
+    power: number;
+    hp: number;
+    arena: ZoneName.GroundArena | ZoneName.SpaceArena;
+    controller: Player;
+    damage?: number;
+    parentCard?: UnitCard;
+    upgrades?: UpgradeCard[];
+}
+
 export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, TProperties extends IDefeatCardPropertiesBase = IDefeatCardProperties> extends CardTargetSystem<TContext, TProperties> {
     public override readonly name = 'defeat';
     public override readonly eventName = EventName.OnCardDefeated;
@@ -29,17 +43,21 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
     };
 
     public eventHandler(event): void {
-        if (event.card.zoneName !== ZoneName.Resource && event.card.isUpgrade()) {
-            event.card.unattach();
+        const card: Card = event.card;
+
+        event.lastKnownInformation = this.buildLastKnownInformation(card);
+
+        if (card.zoneName !== ZoneName.Resource && card.isUpgrade()) {
+            card.unattach();
         }
 
-        if (event.card.isToken()) {
+        if (card.isToken()) {
             // move the token out of the play area so that effect cleanup happens, then remove it from all card lists
-            event.card.moveTo(ZoneName.OutsideTheGame);
-        } else if (event.card.isLeader()) {
-            event.card.undeploy();
+            card.moveTo(ZoneName.OutsideTheGame);
+        } else if (card.isLeaderUnit()) {
+            card.undeploy();
         } else {
-            event.card.moveTo(ZoneName.Discard);
+            card.moveTo(ZoneName.Discard);
         }
     }
 
@@ -99,5 +117,31 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
         if (card.zoneName !== ZoneName.Resource) {
             this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties);
         }
+    }
+
+    private buildLastKnownInformation(card: Card): ILastKnownInformation {
+        Contract.assertTrue(card.canBeInPlay());
+        Contract.assertTrue(card.zoneName === ZoneName.GroundArena || card.zoneName === ZoneName.SpaceArena);
+
+        if (card.isUnit()) {
+            return {
+                power: card.getPower(),
+                hp: card.getHp(),
+                arena: card.zoneName,
+                controller: card.controller,
+                damage: card.damage,
+                upgrades: card.upgrades
+            };
+        } else if (card.isUpgrade()) {
+            return {
+                power: card.getPower(),
+                hp: card.getHp(),
+                arena: card.zoneName,
+                controller: card.controller,
+                parentCard: card.parentCard
+            };
+        }
+
+        Contract.fail(`Unexpected card type: ${card.type}`);
     }
 }

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -146,7 +146,9 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
                 damage: card.damage,
                 upgrades: card.upgrades
             };
-        } else if (card.isUpgrade()) {
+        }
+
+        if (card.isUpgrade()) {
             return {
                 power: card.getPower(),
                 hp: card.getHp(),


### PR DESCRIPTION
Per the SWU rules, if a defeated card is referred to later in the same ability then any properties referred to are as if it was still in the arena. We were using a workaround to handle this out but added a feature to handle it more elegantly.