### PR TITLE
Fix token units bug

### DIFF
--- a/server/game/gameSystems/CreateTokenUnitSystem.ts
+++ b/server/game/gameSystems/CreateTokenUnitSystem.ts
@@ -2,6 +2,7 @@ import { AbilityContext } from '../core/ability/AbilityContext';
 import { EventName, TokenUnitName } from '../core/Constants';
 import { IPlayerTargetSystemProperties, PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem';
 import Player from '../core/Player';
+import * as Helpers from '../core/utils/Helpers';
 import { PutIntoPlaySystem } from './PutIntoPlaySystem';
 
 export interface ICreateTokenUnitProperties extends IPlayerTargetSystemProperties {
@@ -40,8 +41,10 @@ export abstract class CreateTokenUnitSystem<TContext extends AbilityContext = Ab
         // generate the tokens here so they can be used in the contingent events
         // it's fine if this event ends up being cancelled, unused tokens are cleaned up at the end of every round
         event.generatedTokens = [];
-        for (let i = 0; i < properties.amount; i++) {
-            event.generatedTokens.push(context.game.generateToken(context.source.controller, this.getTokenType()));
+        for (const player of Helpers.asArray(properties.target)) {
+            for (let i = 0; i < properties.amount; i++) {
+                event.generatedTokens.push(context.game.generateToken(player, this.getTokenType()));
+            }
         }
 
         // add contingent events for putting the generated unit token(s) into play


### PR DESCRIPTION
Targeting for token unit generation was broken, they would always be created for the triggering player. Confirmed this fix works in another branch.