### PR TITLE
Update SelectCardSystem to respect autoSingleTarget, update tests

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -36,7 +36,8 @@ export type IReplacementEffectAbilityProps<TSource extends Card = Card> = IRepla
 /** Interface definition for addActionAbility */
 export type IActionAbilityProps<TSource extends Card = Card> = Exclude<IAbilityPropsWithSystems<AbilityContext<TSource>>, 'optional'> & {
     condition?: (context?: AbilityContext<TSource>) => boolean;
-    cost?: ICost<AbilityContext<TSource>> | ICost<AbilityContext<TSource>>[];
+    cost?: ICost<AbilityContext<TSource>> | ICost<AbilityContext<TSource>>[] |
+      ((context: AbilityContext<TSource>) => ICost<AbilityContext<TSource>> | ICost<AbilityContext<TSource>>[]);
 
     /**
      * If true, any player can trigger the ability. If false, only the card's controller can trigger it.

--- a/server/game/cards/01_SOR/units/FrontlineShuttle.ts
+++ b/server/game/cards/01_SOR/units/FrontlineShuttle.ts
@@ -13,10 +13,7 @@ export default class FrontlineShuttle extends NonLeaderUnitCard {
     protected override setupCardAbilities() {
         this.addActionAbility({
             title: 'Attack with a unit, even if it’s exhausted. It can’t attack bases for this attack.',
-            cost: AbilityHelper.costs.defeat({
-                cardCondition: (card, context) => card === context.source,
-                controller: RelativePlayer.Self,
-            }),
+            cost: (context) => AbilityHelper.costs.defeatSpecific(context.source),
             initiateAttack: {
                 targetCondition: (target) => target.isUnit(),
                 allowExhaustedAttacker: true

--- a/server/game/cards/01_SOR/units/FrontlineShuttle.ts
+++ b/server/game/cards/01_SOR/units/FrontlineShuttle.ts
@@ -13,7 +13,7 @@ export default class FrontlineShuttle extends NonLeaderUnitCard {
     protected override setupCardAbilities() {
         this.addActionAbility({
             title: 'Attack with a unit, even if it’s exhausted. It can’t attack bases for this attack.',
-            cost: (context) => AbilityHelper.costs.defeatSpecific(context.source),
+            cost: AbilityHelper.costs.defeatSelf(),
             initiateAttack: {
                 targetCondition: (target) => target.isUnit(),
                 allowExhaustedAttacker: true

--- a/server/game/cards/01_SOR/units/SawGerreraExtremist.ts
+++ b/server/game/cards/01_SOR/units/SawGerreraExtremist.ts
@@ -18,7 +18,7 @@ export default class SawGerreraExtremist extends NonLeaderUnitCard {
             sourceZoneFilter: ZoneName.GroundArena,
             ongoingEffect: OngoingEffectBuilder.player.static(EffectName.AdditionalPlayCost, (context) => {
                 if (context.ability.card.isEvent()) {
-                    return AbilityHelper.costs.dealDamage(2, { cardTypeFilter: CardType.Base });
+                    return AbilityHelper.costs.dealDamageSpecific(2, context.player.base);
                 }
                 return undefined;
             })

--- a/server/game/core/ability/CardAbility.ts
+++ b/server/game/core/ability/CardAbility.ts
@@ -11,7 +11,6 @@ import Game from '../Game';
 
 export class CardAbility extends CardAbilityStep {
     public readonly abilityController: RelativePlayer;
-    public readonly abilityCost: ICost[];
     public readonly abilityIdentifier: string;
     public readonly gainAbilitySource: Card;
     public readonly zoneFilter: ZoneFilter | ZoneFilter[];
@@ -25,7 +24,6 @@ export class CardAbility extends CardAbilityStep {
         this.limit.ability = this;
 
         this.title = properties.title;
-        this.abilityCost = this.cost;
         this.printedAbility = properties.printedAbility !== false;
         this.zoneFilter = this.zoneOrDefault(card, properties.zoneFilter);
         this.cannotTargetFirst = !!properties.cannotTargetFirst;
@@ -100,7 +98,7 @@ export class CardAbility extends CardAbilityStep {
     }
 
     public getAdjustedCost(context) {
-        const resourceCost = this.cost.find((cost) => cost.getAdjustedCost);
+        const resourceCost = this.getCosts(context).find((cost) => cost.getAdjustedCost);
         return resourceCost ? resourceCost.getAdjustedCost(context) : 0;
     }
 
@@ -152,7 +150,7 @@ export class CardAbility extends CardAbilityStep {
 
         const gainedAbility = gainAbilitySource ? '\'s gained ability from ' : '';
         let messageArgs = [context.player, ' ' + messageVerb + ' ', context.source, gainedAbility, gainAbilitySource];
-        const costMessages = this.cost
+        const costMessages = this.getCosts(context)
             .map((cost) => {
                 if (cost.getCostMessage && cost.getCostMessage(context)) {
                     let card = context.costs[cost.getActionName(context)];

--- a/server/game/core/ability/PlayCardAction.ts
+++ b/server/game/core/ability/PlayCardAction.ts
@@ -89,7 +89,7 @@ export abstract class PlayCardAction extends PlayerAction {
     }
 
     public override getAdjustedCost(context) {
-        const resourceCost = this.cost.find((cost) => cost.getAdjustedCost);
+        const resourceCost = this.getCosts(context).find((cost) => cost.getAdjustedCost);
         return resourceCost ? resourceCost.getAdjustedCost(context) : 0;
     }
 

--- a/server/game/core/ability/PlayerAction.js
+++ b/server/game/core/ability/PlayerAction.js
@@ -37,7 +37,7 @@ class PlayerAction extends PlayerOrCardAbility {
     }
 
     getAdjustedCost(context) {
-        let resourceCost = this.cost.find((cost) => cost.getAdjustedCost);
+        let resourceCost = this.getCosts(context).find((cost) => cost.getAdjustedCost);
         return resourceCost ? resourceCost.getAdjustedCost(context) : 0;
     }
 }

--- a/server/game/core/cost/ICost.ts
+++ b/server/game/core/cost/ICost.ts
@@ -17,7 +17,8 @@ export interface ICost<TContext extends AbilityContext = AbilityContext> {
 
     selectCardName?(player: Player, cardName: string, context: TContext): boolean;
     promptsPlayer?: boolean;
-    dependsOn?: string;
+    // TODO: do we still need dependsOn for costs? what would be the use case?
+    // dependsOn?: string;
     isPrintedResourceCost?: boolean;
     isPlayCost?: boolean;
     canIgnoreForTargeting?: boolean;

--- a/server/game/costs/CostLibrary.ts
+++ b/server/game/costs/CostLibrary.ts
@@ -53,6 +53,13 @@ export function defeatSpecific<TContext extends AbilityContext = AbilityContext>
     return new GameSystemCost<TContext>(GameSystems.defeat<TContext>({ target }));
 }
 
+/**
+ * Cost that requires defeating the card that initiated the ability
+ */
+export function defeatSelf<TContext extends AbilityContext = AbilityContext>(): ICost<TContext> {
+    return new GameSystemCost<TContext>(GameSystems.defeat<TContext>());
+}
+
 // TODO THIS PR: add isCost: true to all of these
 /**
  * Cost that requires discard a card from hand that matches the passed condition predicate function.

--- a/server/game/costs/CostLibrary.ts
+++ b/server/game/costs/CostLibrary.ts
@@ -7,6 +7,8 @@ import { ICost } from '../core/cost/ICost';
 import { GameSystemCost } from '../core/cost/GameSystemCost';
 import { MetaActionCost } from '../core/cost/MetaActionCost';
 import { PlayCardResourceCost } from './PlayCardResourceCost';
+import { CardWithDamageProperty } from '../core/card/CardTypes';
+import { InPlayCard } from '../core/card/baseClasses/InPlayCard';
 // import { TargetDependentFateCost } from './costs/TargetDependentFateCost';
 
 type SelectCostProperties<TContext extends AbilityContext = AbilityContext> = Omit<ISelectCardProperties<TContext>, 'innerSystem'>;
@@ -45,6 +47,14 @@ export function defeat<TContext extends AbilityContext = AbilityContext>(propert
 }
 
 /**
+ * Cost that requires defeating a specific card.
+ */
+export function defeatSpecific<TContext extends AbilityContext = AbilityContext>(target: InPlayCard): ICost<TContext> {
+    return new GameSystemCost<TContext>(GameSystems.defeat<TContext>({ target }));
+}
+
+// TODO THIS PR: add isCost: true to all of these
+/**
  * Cost that requires discard a card from hand that matches the passed condition predicate function.
  */
 export function discardCardFromOwnHand<TContext extends AbilityContext = AbilityContext>(properties: SelectCostProperties<TContext>): ICost<TContext> {
@@ -57,6 +67,13 @@ export function discardCardFromOwnHand<TContext extends AbilityContext = Ability
  */
 export function dealDamage<TContext extends AbilityContext = AbilityContext>(amount: number, properties: SelectCostProperties<TContext>): ICost<TContext> {
     return getSelectCost(GameSystems.damage<TContext>({ type: DamageType.Ability, amount: amount }), properties, `Select card to deal ${amount} damage to`);
+}
+
+/**
+ * Cost that requires dealing the given amount of damage to the specified target.
+ */
+export function dealDamageSpecific<TContext extends AbilityContext = AbilityContext>(amount: number, target: CardWithDamageProperty): ICost<TContext> {
+    return new GameSystemCost<TContext>(GameSystems.damage<TContext>({ type: DamageType.Ability, amount: amount, target }));
 }
 
 /**

--- a/server/game/costs/CostLibrary.ts
+++ b/server/game/costs/CostLibrary.ts
@@ -13,6 +13,8 @@ import { InPlayCard } from '../core/card/baseClasses/InPlayCard';
 
 type SelectCostProperties<TContext extends AbilityContext = AbilityContext> = Omit<ISelectCardProperties<TContext>, 'innerSystem'>;
 
+// TODO: we need to update the various cost generators to automatically inject { isCost: true } using additionalProperties so we don't have
+// to do it explicitly in each method. However, that requires doing a pass to make sure that additionalProperties is being respected everywhere.
 function getSelectCost<TContext extends AbilityContext = AbilityContext>(
     gameSystem: CardTargetSystem<TContext>,
     properties: undefined | SelectCostProperties<TContext>,
@@ -43,21 +45,21 @@ export function exhaustSelf<TContext extends AbilityContext = AbilityContext>():
  * predicate function.
  */
 export function defeat<TContext extends AbilityContext = AbilityContext>(properties: SelectCostProperties<TContext>): ICost<TContext> {
-    return getSelectCost(GameSystems.defeat<TContext>(), properties, 'Select card to defeat');
+    return getSelectCost(GameSystems.defeat<TContext>(), { ...properties, isCost: true }, 'Select card to defeat');
 }
 
 /**
  * Cost that requires defeating a specific card.
  */
 export function defeatSpecific<TContext extends AbilityContext = AbilityContext>(target: InPlayCard): ICost<TContext> {
-    return new GameSystemCost<TContext>(GameSystems.defeat<TContext>({ target }));
+    return new GameSystemCost<TContext>(GameSystems.defeat<TContext>({ target, isCost: true }));
 }
 
 /**
  * Cost that requires defeating the card that initiated the ability
  */
 export function defeatSelf<TContext extends AbilityContext = AbilityContext>(): ICost<TContext> {
-    return new GameSystemCost<TContext>(GameSystems.defeat<TContext>());
+    return new GameSystemCost<TContext>(GameSystems.defeat<TContext>({ isCost: true }));
 }
 
 // TODO THIS PR: add isCost: true to all of these
@@ -65,7 +67,7 @@ export function defeatSelf<TContext extends AbilityContext = AbilityContext>(): 
  * Cost that requires discard a card from hand that matches the passed condition predicate function.
  */
 export function discardCardFromOwnHand<TContext extends AbilityContext = AbilityContext>(properties: SelectCostProperties<TContext>): ICost<TContext> {
-    return getSelectCost(GameSystems.discardSpecificCard<TContext>(), { ...properties, zoneFilter: ZoneName.Hand }, 'Select card to discard');
+    return getSelectCost(GameSystems.discardSpecificCard<TContext>(), { ...properties, zoneFilter: ZoneName.Hand, isCost: true }, 'Select card to discard');
 }
 
 /**
@@ -73,14 +75,14 @@ export function discardCardFromOwnHand<TContext extends AbilityContext = Ability
  * the passed condition predicate function.
  */
 export function dealDamage<TContext extends AbilityContext = AbilityContext>(amount: number, properties: SelectCostProperties<TContext>): ICost<TContext> {
-    return getSelectCost(GameSystems.damage<TContext>({ type: DamageType.Ability, amount: amount }), properties, `Select card to deal ${amount} damage to`);
+    return getSelectCost(GameSystems.damage<TContext>({ type: DamageType.Ability, amount: amount, isCost: true }), properties, `Select card to deal ${amount} damage to`);
 }
 
 /**
  * Cost that requires dealing the given amount of damage to the specified target.
  */
 export function dealDamageSpecific<TContext extends AbilityContext = AbilityContext>(amount: number, target: CardWithDamageProperty): ICost<TContext> {
-    return new GameSystemCost<TContext>(GameSystems.damage<TContext>({ type: DamageType.Ability, amount: amount, target }));
+    return new GameSystemCost<TContext>(GameSystems.damage<TContext>({ type: DamageType.Ability, amount: amount, target, isCost: true }));
 }
 
 /**

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -1073,8 +1073,13 @@ global.integration = function (definitions) {
             // this is a hack to get around the fact that our method for checking spec failures doesn't work in parallel mode
             const parallelMode = jasmine.getEnv().configuration().random;
 
-            // if there were already failures in the test case, don't bother checking the prompts after
-            if (!parallelMode && jasmine.getEnv().currentSpec.failedExpectations.length > 0) {
+            // if there were already exceptions in the test case, don't bother checking the prompts after
+            if (
+                !parallelMode && jasmine.getEnv().currentSpec.failedExpectations.some(
+                    (expectation) => expectation.message.startsWith('Error:') ||
+                      expectation.message.startsWith('TestSetupError:')
+                )
+            ) {
                 return;
             }
 

--- a/test/scenarios/event/ReplacementEffect.spec.ts
+++ b/test/scenarios/event/ReplacementEffect.spec.ts
@@ -13,13 +13,14 @@ describe('Replacement effect', function() {
                 });
             });
 
-            it('one shield is removed', function () {
+            it('one shield is removed and the cost is considered paid', function () {
                 const { context } = contextRef;
 
                 expect(context.doctorPershing).toHaveExactUpgradeNames(['shield', 'shield']);
 
                 context.player1.clickCard(context.doctorPershing);
                 context.player1.clickPrompt('Draw a card');
+                context.player1.clickCard(context.doctorPershing);
 
                 expect(context.doctorPershing.damage).toBe(0);
                 expect(context.doctorPershing).toHaveExactUpgradeNames(['shield']);

--- a/test/server/cards/02_SHD/events/Headhunting.spec.ts
+++ b/test/server/cards/02_SHD/events/Headhunting.spec.ts
@@ -12,7 +12,10 @@ describe('Headhunting', function() {
                     },
                     player2: {
                         groundArena: ['bounty-guild-initiate', 'consular-security-force'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -103,7 +106,10 @@ describe('Headhunting', function() {
                     },
                     player2: {
                         groundArena: ['bounty-guild-initiate', 'consular-security-force'],
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 

--- a/test/server/cards/02_SHD/units/FinalizerMightOfTheFirstOrder.spec.ts
+++ b/test/server/cards/02_SHD/units/FinalizerMightOfTheFirstOrder.spec.ts
@@ -14,7 +14,10 @@ describe('Finalizer, Might of the First Order', function() {
                         groundArena: ['steadfast-battalion', 'battlefield-marine', { card: 'zuckuss#bounty-hunter-for-hire', damage: 6 }, { card: '4lom#bounty-hunter-for-hire', damage: 4 }],
                         spaceArena: ['avenger#hunting-star-destroyer'],
                         leader: { card: 'luke-skywalker#faithful-friend', deployed: true },
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
                 const { context } = contextRef;
 

--- a/test/server/cards/02_SHD/units/KetsuOnyoOldFriend.spec.ts
+++ b/test/server/cards/02_SHD/units/KetsuOnyoOldFriend.spec.ts
@@ -50,6 +50,7 @@ describe('Ketsu Onyo, Old friend', function() {
                 context.moveToNextActionPhase();
                 context.player1.clickCard(context.ketsuOnyoOldFriend);
                 context.player1.clickPrompt('Attack with this unit. It gains +4/+0 and Overwhelm for this attack.');
+                context.player1.clickCard(context.heroicResolve);
                 context.player1.clickCard(context.pykeSentinel);
                 expect(context.player1).toBeAbleToSelectExactly([context.entrenched, context.academyTraining]);
                 context.player1.clickCard(context.entrenched);

--- a/test/server/cards/02_SHD/upgrades/HeroicResolve.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/HeroicResolve.spec.ts
@@ -9,7 +9,10 @@ describe('Heroic Resolve', function() {
                     },
                     player2: {
                         groundArena: ['wampa']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
             });
 
@@ -56,7 +59,10 @@ describe('Heroic Resolve', function() {
                     },
                     player2: {
                         groundArena: ['wampa', 'specforce-soldier', { card: 'battlefield-marine', upgrades: ['heroic-resolve'] }]
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;
@@ -119,7 +125,10 @@ describe('Heroic Resolve', function() {
                     player2: {
                         hand: ['heroic-resolve'],
                         groundArena: ['wampa', 'specforce-soldier']
-                    }
+                    },
+
+                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
+                    autoSingleTarget: true
                 });
 
                 const { context } = contextRef;


### PR DESCRIPTION
Discovered that SelectCardSystem was not respecting autoSingleTarget and assuming it was true always. Updated this behavior, which broke several tests. In some cases the tests just needed updating, in other cases the abilities themselves were implemented wrong. Cleaned up everything and it is now working.