### PR TITLE
Fix delayed effect targeting bug

### DIFF
--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -166,7 +166,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
     }
 
     protected addLeavesPlayPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {
-        Contract.assertTrue(card.canBeInPlay() && card.isInPlay(), `Attempting to add leaves play contingent events to card ${card} but is in zone ${card.zone}`);
+        Contract.assertTrue(card.canBeInPlay() && card.isInPlay(), `Attempting to add leaves play contingent events to card ${card.internalName} but is in zone ${card.zone}`);
 
         event.setContingentEventsGenerator((event) => {
             const onCardLeavesPlayEvent = new GameEvent(EventName.OnCardLeavesPlay, context, {


### PR DESCRIPTION
We hit an issue with the Sneak Attack branch where a delayed effect weren't correctly having its `target` property set but the error was extremely unclear. In addition, the target resolution wasn't being handled correctly if `selectCard` is used. Added better error checking and a clearer message, and fixed the target resolution.