### PR TITLE
fix: hide opposing players cards in the gamestate

### DIFF
--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -1001,7 +1001,7 @@ class Player extends GameObject {
 
     getSummaryForHand(list, activePlayer) {
         // if (this.optionSettings.sortHandByName) {
-        //     return this.getSortedSummaryForCardList(list, activePlayer, hideWhenFaceup);
+        //     return this.getSortedSummaryForCardList(list, activePlayer);
         // }
         return this.getSummaryForZone(list, activePlayer);
     }
@@ -1012,12 +1012,12 @@ class Player extends GameObject {
         });
     }
 
-    getSortedSummaryForCardList(list, activePlayer, hideWhenFaceup) {
+    getSortedSummaryForCardList(list, activePlayer) {
         let cards = list.map((card) => card);
         cards.sort((a, b) => a.printedName.localeCompare(b.printedName));
 
         return cards.map((card) => {
-            return card.getSummary(activePlayer, hideWhenFaceup);
+            return card.getSummary(activePlayer);
         });
     }
 

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -999,16 +999,16 @@ class Player extends GameObject {
         this.promptState.clearSelectableCards();
     }
 
-    getSummaryForHand(list, activePlayer, hideWhenFaceup) {
+    getSummaryForHand(list, activePlayer) {
         // if (this.optionSettings.sortHandByName) {
         //     return this.getSortedSummaryForCardList(list, activePlayer, hideWhenFaceup);
         // }
-        return this.getSummaryForZone(list, activePlayer, hideWhenFaceup);
+        return this.getSummaryForZone(list, activePlayer);
     }
 
-    getSummaryForZone(zone, activePlayer, hideWhenFaceup) {
+    getSummaryForZone(zone, activePlayer) {
         return this.getCardsInZone(zone).map((card) => {
-            return card.getSummary(activePlayer, hideWhenFaceup);
+            return card.getSummary(activePlayer);
         });
     }
 
@@ -1085,7 +1085,7 @@ class Player extends GameObject {
         let { email, password, ...safeUser } = this.user;
         let state = {
             cardPiles: {
-                hand: this.getSummaryForZone(ZoneName.Hand, activePlayer, false),
+                hand: this.getSummaryForZone(ZoneName.Hand, activePlayer),
                 outsideTheGame: this.getSummaryForZone(ZoneName.OutsideTheGame, activePlayer),
                 resources: this.getSummaryForZone(ZoneName.Resource, activePlayer),
                 groundArena: this.getSummaryForZone(ZoneName.GroundArena, activePlayer),

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -792,7 +792,7 @@ export class Card extends OngoingEffectSource {
         const selectionState = activePlayer.getCardSelectionState(this);
 
         // If it is not the active player and in opposing hand or deck - return facedown card
-        if (!isActivePlayer && (this._zone.hiddenForPlayers === RelativePlayer.Opponent || this._zone.hiddenForPlayers === WildcardRelativePlayer.Any)) {
+        if (this._zone.hiddenForPlayers === WildcardRelativePlayer.Any || (!isActivePlayer && this._zone.hiddenForPlayers === RelativePlayer.Opponent)) {
             const state = {
                 controller: this.controller.getShortSummary(),
                 // menu: isActivePlayer ? this.getMenu() : undefined,

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -787,16 +787,13 @@ export class Card extends OngoingEffectSource {
     * This is the infomation for each card that is sent to the client.
     */
 
-    public getSummary(activePlayer, hideWhenFaceup) {
+    public getSummary(activePlayer) {
         const isActivePlayer = activePlayer === this.controller;
         const selectionState = activePlayer.getCardSelectionState(this);
 
-        // This is my facedown card, but I'm not allowed to look at it
-        // OR This is not my card, and it's either facedown or hidden from me
+        // If it is not the active player and in opposing hand or deck - return facedown card
         if (
-            isActivePlayer
-                ? this.facedown
-                : this.facedown || hideWhenFaceup
+            !isActivePlayer && (this.zoneName === ZoneName.Hand || this.zoneName === ZoneName.Deck)
         ) {
             const state = {
                 controller: this.controller.getShortSummary(),

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -5,7 +5,7 @@ import { OngoingEffectSource } from '../ongoingEffect/OngoingEffectSource';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
 import type { KeywordName, MoveZoneDestination } from '../Constants';
-import { AbilityRestriction, Aspect, CardType, Duration, EffectName, EventName, ZoneName, DeckZoneDestination, RelativePlayer, Trait, WildcardZoneName } from '../Constants';
+import { AbilityRestriction, Aspect, CardType, Duration, EffectName, EventName, ZoneName, DeckZoneDestination, RelativePlayer, Trait, WildcardZoneName, WildcardRelativePlayer } from '../Constants';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import type { AbilityContext } from '../ability/AbilityContext';
 import type { CardAbility } from '../ability/CardAbility';
@@ -792,9 +792,7 @@ export class Card extends OngoingEffectSource {
         const selectionState = activePlayer.getCardSelectionState(this);
 
         // If it is not the active player and in opposing hand or deck - return facedown card
-        if (
-            !isActivePlayer && (this.zoneName === ZoneName.Hand || this.zoneName === ZoneName.Deck)
-        ) {
+        if (!isActivePlayer && (this._zone.hiddenForPlayers === RelativePlayer.Opponent || this._zone.hiddenForPlayers === WildcardRelativePlayer.Any)) {
             const state = {
                 controller: this.controller.getShortSummary(),
                 // menu: isActivePlayer ? this.getMenu() : undefined,

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -47,9 +47,9 @@ export class UpgradeCard extends UpgradeCardParent {
         return new PlayUpgradeAction(this, properties);
     }
 
-    public override getSummary(activePlayer: Player, hideWhenFaceup: boolean) {
+    public override getSummary(activePlayer: Player) {
         return {
-            ...super.getSummary(activePlayer, hideWhenFaceup),
+            ...super.getSummary(activePlayer),
             parentCardId: this._parentCard ? this._parentCard.uuid : null
         };
     }

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -171,8 +171,8 @@ export class PlayableOrDeployableCard extends Card {
         return true;
     }
 
-    public override getSummary(activePlayer: Player, hideWhenFaceup?: boolean) {
-        return { ...super.getSummary(activePlayer, hideWhenFaceup), exhausted: this._exhausted };
+    public override getSummary(activePlayer: Player) {
+        return { ...super.getSummary(activePlayer), exhausted: this._exhausted };
     }
 
     protected setExhaustEnabled(enabledStatus: boolean) {

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -100,8 +100,8 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
             this._damage = enabledStatus ? 0 : null;
         }
 
-        public override getSummary(activePlayer: Player, hideWhenFaceup: boolean) {
-            return { ...super.getSummary(activePlayer, hideWhenFaceup), damage: this._damage };
+        public override getSummary(activePlayer: Player) {
+            return { ...super.getSummary(activePlayer), damage: this._damage };
         }
 
         protected setActiveAttackEnabled(enabledStatus: boolean) {

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -634,7 +634,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             this._upgrades.push(upgrade);
         }
 
-        public override getSummary(activePlayer: Player, hideWhenFaceup: boolean) {
+        public override getSummary(activePlayer: Player) {
             if (this.isInPlay()) {
                 // Check for sentinel keyword and no blanking effects
                 const keywords = this.keywords;
@@ -646,13 +646,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
                 const hasSentinel = !!sentinelKeyword;
 
                 return {
-                    ...super.getSummary(activePlayer, hideWhenFaceup),
+                    ...super.getSummary(activePlayer),
                     power: this.getPower(),
                     hp: this.getHp(),
                     sentinel: hasSentinel
                 };
             }
-            return super.getSummary(activePlayer, hideWhenFaceup);
+            return super.getSummary(activePlayer);
         }
     };
 }


### PR DESCRIPTION
- Removed the `hideWhenFaceup` element (remnant from jigoku engine)
- Return facedown cards with no details based off active player and zone (e.g. only show opposing cards when they are in play)