### PR TITLE
Implement Tech unit

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,9 @@ export default tseslint.config(
             "no-useless-concat": ["warn"],
             "no-useless-constructor": ["warn"],
             "array-bracket-spacing": ["error", "never"],
-            "import-x/no-cycle": ["error"],
+
+            // uncomment for checking import cycles (too slow to leave on all the time)
+            // "import-x/no-cycle": ["error"],
 
             "no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
             "unused-imports/no-unused-imports": "error",
@@ -121,11 +123,13 @@ export default tseslint.config(
             ...tseslint.configs.stylistic,
         ],
         languageOptions: {
-            parser: tsParser,
+            // uncomment for checking import cycles (too slow to leave on all the time)
+            // parser: tsParser,
+            // sourceType: 'module'
+            
             parserOptions: {
               projectService: true
-            },
-            sourceType: 'module'
+            }
         },
         rules: {
             "@typescript-eslint/no-unused-vars": ["error", {
@@ -147,7 +151,9 @@ export default tseslint.config(
             "@stylistic/type-annotation-spacing": ["error"],
             "@typescript-eslint/consistent-type-imports": "error",
             "@typescript-eslint/consistent-type-exports": "error",
-            "import-x/no-cycle": ["error"],
+
+            // uncomment for checking import cycles (too slow to leave on all the time)
+            // "import-x/no-cycle": ["error"],
         }
     },
     {

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from './core/ability/AbilityContext';
 import type { TriggeredAbilityContext } from './core/ability/TriggeredAbilityContext';
 import type { GameSystem } from './core/gameSystem/GameSystem';
 import type { Card } from './core/card/Card';
-import type { Duration, RelativePlayerFilter } from './core/Constants';
+import type { Aspect, Duration, RelativePlayerFilter } from './core/Constants';
 import { type RelativePlayer, type CardType, type EventName, type PhaseName, type ZoneFilter, type KeywordName, type AbilityType, type CardTypeFilter } from './core/Constants';
 import type { GameEvent } from './core/event/GameEvent';
 import type { IActionTargetResolver, IActionTargetsResolver, ITriggeredAbilityTargetResolver, ITriggeredAbilityTargetsResolver } from './TargetInterfaces';
@@ -164,7 +164,8 @@ export type IKeywordProperties =
   | IRestoreKeywordProperties
   | ISaboteurKeywordProperties
   | ISentinelKeywordProperties
-  | IShieldedKeywordProperties;
+  | IShieldedKeywordProperties
+  | ISmuggleKeywordProperties;
 
 export type KeywordNameOrProperties = IKeywordProperties | NonParameterKeywordName;
 
@@ -310,7 +311,7 @@ interface ISentinelKeywordProperties extends IKeywordPropertiesBase {
     keyword: KeywordName.Sentinel;
 }
 
-interface ISmuggleKeywordProperties<TSource extends UnitCard = UnitCard> extends IKeywordWithAbilityDefinitionProperties<TSource> {
+interface ISmuggleKeywordProperties extends IKeywordPropertiesBase {
     keyword: KeywordName.Smuggle;
     cost: number;
     aspects: Aspect[];

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -310,6 +310,12 @@ interface ISentinelKeywordProperties extends IKeywordPropertiesBase {
     keyword: KeywordName.Sentinel;
 }
 
+interface ISmuggleKeywordProperties<TSource extends UnitCard = UnitCard> extends IKeywordWithAbilityDefinitionProperties<TSource> {
+    keyword: KeywordName.Smuggle;
+    cost: number;
+    aspects: Aspect[];
+}
+
 interface IShieldedKeywordProperties extends IKeywordPropertiesBase {
     keyword: KeywordName.Shielded;
 }

--- a/server/game/abilities/keyword/ExploitPlayCardResourceCost.ts
+++ b/server/game/abilities/keyword/ExploitPlayCardResourceCost.ts
@@ -1,7 +1,8 @@
 import type { AbilityContext } from '../../core/ability/AbilityContext';
 import { CardTargetResolver } from '../../core/ability/abilityTargets/CardTargetResolver';
 import type { Card } from '../../core/card/Card';
-import type { PlayType } from '../../core/Constants';
+import type { CardWithCost } from '../../core/card/CardTypes';
+import type { Aspect, PlayType } from '../../core/Constants';
 import { EventName, RelativePlayer, TargetMode, WildcardCardType } from '../../core/Constants';
 import type { Result } from '../../core/cost/ICost';
 import { GameEvent } from '../../core/event/GameEvent';
@@ -18,8 +19,8 @@ export class ExploitPlayCardResourceCost extends PlayCardResourceCost {
 
     private minimumExploitCount?: number = null;
 
-    public constructor(exploitKeywordAmount: number, playType: PlayType) {
-        super(playType);
+    public constructor(card: CardWithCost, exploitKeywordAmount: number, playType: PlayType, resources: number = null, aspects: Aspect[] = null) {
+        super(card, playType, resources, aspects);
 
         this.exploitKeywordAmount = exploitKeywordAmount;
 

--- a/server/game/actions/PlayEventAction.ts
+++ b/server/game/actions/PlayEventAction.ts
@@ -17,8 +17,8 @@ export class PlayEventAction extends PlayCardAction {
         context.game.resolveAbility(context.source.getEventAbility().createContext());
     }
 
-    public override clone(overrideProperties: IPlayCardActionProperties) {
-        return new PlayEventAction({ ...this.createdWithProperties, ...overrideProperties });
+    public override clone(overrideProperties: Partial<Omit<IPlayCardActionProperties, 'playType'>>) {
+        return new PlayEventAction(this.card, { ...this.createdWithProperties, ...overrideProperties });
     }
 
     public override meetsRequirements(context = this.createContext(), ignoredRequirements: string[] = []): string {

--- a/server/game/actions/PlayUnitAction.ts
+++ b/server/game/actions/PlayUnitAction.ts
@@ -3,16 +3,17 @@ import { PutIntoPlaySystem } from '../gameSystems/PutIntoPlaySystem.js';
 import type { PlayCardContext, IPlayCardActionProperties } from '../core/ability/PlayCardAction.js';
 import { PlayCardAction } from '../core/ability/PlayCardAction.js';
 import * as Contract from '../core/utils/Contract.js';
+import type { Card } from '../core/card/Card.js';
 
-export interface IPlayUnitActionProperties extends IPlayCardActionProperties {
+export type IPlayUnitActionProperties = IPlayCardActionProperties & {
     entersReady?: boolean;
-}
+};
 
 export class PlayUnitAction extends PlayCardAction {
     private entersReady: boolean;
 
-    public constructor(properties: IPlayUnitActionProperties) {
-        super(properties);
+    public constructor(card: Card, properties: IPlayUnitActionProperties) {
+        super(card, properties);
 
         // default to false
         this.entersReady = !!properties.entersReady;
@@ -47,8 +48,8 @@ export class PlayUnitAction extends PlayCardAction {
         context.game.openEventWindow(events);
     }
 
-    public override clone(overrideProperties: IPlayUnitActionProperties) {
-        return new PlayUnitAction({ ...this.createdWithProperties, ...overrideProperties });
+    public override clone(overrideProperties: Partial<Omit<IPlayCardActionProperties, 'playType'>>) {
+        return new PlayUnitAction(this.card, { ...this.createdWithProperties, ...overrideProperties });
     }
 
     public override meetsRequirements(context = this.createContext(), ignoredRequirements: string[] = []): string {

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -1,6 +1,7 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { PlayCardContext, IPlayCardActionProperties } from '../core/ability/PlayCardAction';
 import { PlayCardAction } from '../core/ability/PlayCardAction';
+import type { Card } from '../core/card/Card';
 import type { UpgradeCard } from '../core/card/UpgradeCard';
 import { AbilityRestriction, PlayType } from '../core/Constants';
 import * as Contract from '../core/utils/Contract';
@@ -9,13 +10,15 @@ import { attachUpgrade } from '../gameSystems/GameSystemLibrary';
 
 export class PlayUpgradeAction extends PlayCardAction {
     // we pass in a targetResolver holding the attachUpgrade system so that the action will be blocked if there are no valid targets
-    public constructor(properties: IPlayCardActionProperties) {
-        super({
-            ...properties,
-            targetResolver: {
-                immediateEffect: attachUpgrade<AbilityContext<UpgradeCard>>((context) => ({ upgrade: context.source }))
+    public constructor(card: Card, properties: IPlayCardActionProperties) {
+        super(card,
+            {
+                ...properties,
+                targetResolver: {
+                    immediateEffect: attachUpgrade<AbilityContext<UpgradeCard>>((context) => ({ upgrade: context.source }))
+                }
             }
-        });
+        );
     }
 
     public override executeHandler(context: PlayCardContext) {
@@ -37,8 +40,8 @@ export class PlayUpgradeAction extends PlayCardAction {
         context.game.openEventWindow(events);
     }
 
-    public override clone(overrideProperties: IPlayCardActionProperties) {
-        return new PlayUpgradeAction({ ...this.createdWithProperties, ...overrideProperties });
+    public override clone(overrideProperties: Partial<Omit<IPlayCardActionProperties, 'playType'>>) {
+        return new PlayUpgradeAction(this.card, { ...this.createdWithProperties, ...overrideProperties });
     }
 
     public override meetsRequirements(context = this.createContext(), ignoredRequirements: string[] = []): string {

--- a/server/game/cards/01_SOR/events/Bamboozle.ts
+++ b/server/game/cards/01_SOR/events/Bamboozle.ts
@@ -4,6 +4,7 @@ import { Aspect, PlayType, WildcardCardType } from '../../../core/Constants';
 import { PlayEventAction } from '../../../actions/PlayEventAction';
 import type { IPlayCardActionProperties } from '../../../core/ability/PlayCardAction';
 import { CostAdjuster, CostAdjustType } from '../../../core/cost/CostAdjuster';
+import type { IPlayCardActionOverrides } from '../../../core/card/baseClasses/PlayableOrDeployableCard';
 
 export default class Bamboozle extends EventCard {
     protected override getImplementationId() {
@@ -13,12 +14,12 @@ export default class Bamboozle extends EventCard {
         };
     }
 
-    protected override buildPlayCardActions(playType: PlayType = PlayType.PlayFromHand) {
+    protected override buildPlayCardActions(playType: PlayType = PlayType.PlayFromHand, propertyOverrides: IPlayCardActionOverrides = null) {
         const bamboozleAction = playType === PlayType.Smuggle
             ? []
-            : [new PlayBamboozleAction({ card: this, playType })];
+            : [new PlayBamboozleAction(this, { playType })];
 
-        return super.buildPlayCardActions(playType).concat(bamboozleAction);
+        return super.buildPlayCardActions(playType, propertyOverrides).concat(bamboozleAction);
     }
 
     public override setupCardAbilities() {
@@ -38,8 +39,7 @@ export default class Bamboozle extends EventCard {
 }
 
 class PlayBamboozleAction extends PlayEventAction {
-    private static generateProperties(properties: IPlayCardActionProperties) {
-        const card = properties.card;
+    private static generateProperties(card: Bamboozle, properties: IPlayCardActionProperties) {
         const discardCost = AbilityHelper.costs.discardCardFromOwnHand({ cardCondition: (c) => c !== card && c.hasSomeAspect(Aspect.Cunning) });
 
         return {
@@ -50,15 +50,19 @@ class PlayBamboozleAction extends PlayEventAction {
         };
     }
 
-    public constructor(properties: IPlayCardActionProperties) {
-        super(PlayBamboozleAction.generateProperties(properties));
+    public constructor(card: Bamboozle, properties: IPlayCardActionProperties) {
+        super(card, PlayBamboozleAction.generateProperties(card, properties));
     }
 
-    public override clone(overrideProperties: IPlayCardActionProperties) {
-        return new PlayBamboozleAction(PlayBamboozleAction.generateProperties({
-            ...this.createdWithProperties,
-            ...overrideProperties
-        }));
+    public override clone(overrideProperties: Partial<Omit<IPlayCardActionProperties, 'playType'>>) {
+        return new PlayBamboozleAction(
+            this.card,
+            PlayBamboozleAction.generateProperties(this.card,
+                {
+                    ...this.createdWithProperties,
+                    ...overrideProperties
+                })
+        );
     }
 }
 

--- a/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
+++ b/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { KeywordName } from '../../../core/Constants';
+import { KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
 
 export default class TechSourceOfInsight extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,10 +13,13 @@ export default class TechSourceOfInsight extends NonLeaderUnitCard {
     public override setupCardAbilities() {
         this.addConstantAbility({
             title: 'Each friendly resource gains Smuggle',
-            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
+            targetZoneFilter: ZoneName.Resource,
+            targetController: RelativePlayer.Self,
+            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword((target) => ({
                 keyword: KeywordName.Smuggle,
-
-            })
+                cost: target.cost + 2,
+                aspects: target.aspects
+            }))
         });
     }
 }

--- a/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
+++ b/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
+import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
 
 export default class TechSourceOfInsight extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -15,6 +15,7 @@ export default class TechSourceOfInsight extends NonLeaderUnitCard {
             title: 'Each friendly resource gains Smuggle',
             targetZoneFilter: ZoneName.Resource,
             targetController: RelativePlayer.Self,
+            targetCardTypeFilter: WildcardCardType.Any,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword((target) => ({
                 keyword: KeywordName.Smuggle,
                 cost: target.cost + 2,

--- a/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
+++ b/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
@@ -1,0 +1,24 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { KeywordName } from '../../../core/Constants';
+
+export default class TechSourceOfInsight extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '3881257511',
+            internalName: 'tech#source-of-insight'
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addConstantAbility({
+            title: 'Each friendly resource gains Smuggle',
+            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
+                keyword: KeywordName.Smuggle,
+
+            })
+        });
+    }
+}
+
+TechSourceOfInsight.implemented = true;

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -684,31 +684,18 @@ class Player extends GameObject {
     /**
      * Checks if any Cost Adjusters on this Player apply to the passed card/target, and returns the cost to play the cost if they are used.
      * Accounts for aspect penalties and any modifiers to those specifically
-     * @param {PlayType} playingType
-     * @param card
-     * @param target
+     * @param {number} cost
+     * @param {Aspect[]} aspects
+     * @param {AbilityContext} context
      * @param {CostAdjuster[]} additionalCostAdjusters Used by abilities to add their own specific cost adjuster if necessary
      */
-    getAdjustedCost(playingType, card, target, additionalCostAdjusters = null) {
+    getAdjustedCost(cost, aspects, context, additionalCostAdjusters = null) {
+        const playingType = context.playType;
+        const card = context.source;
+        const target = context.target;
+
         // if any aspect penalties, check modifiers for them separately
         let aspectPenaltiesTotal = 0;
-        let aspects;
-        let cost;
-
-        switch (playingType) {
-            case PlayType.PlayFromOutOfPlay:
-            case PlayType.PlayFromHand:
-                aspects = card.aspects;
-                cost = card.cost;
-                break;
-            case PlayType.Smuggle:
-                const smuggleInstance = card.getKeywordWithCostValues(KeywordName.Smuggle);
-                aspects = smuggleInstance.aspects;
-                cost = smuggleInstance.cost;
-                break;
-            default:
-                Contract.fail(`Invalid Play Type ${playingType}`);
-        }
 
         let penaltyAspects = this.getPenaltyAspects(aspects);
         for (const aspect of penaltyAspects) {

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -34,20 +34,31 @@ export function parseKeywords(expectedKeywordsRaw: string[], cardText: string, c
     return keywords;
 }
 
+// "Gain Coordinate" and "gain Exploit" are not yet implemented
 export function keywordFromProperties(properties: IKeywordProperties) {
-    if (properties.keyword === KeywordName.Restore || properties.keyword === KeywordName.Raid) {
-        return new KeywordWithNumericValue(properties.keyword, properties.amount);
+    switch (properties.keyword) {
+        case KeywordName.Restore:
+        case KeywordName.Raid:
+            return new KeywordWithNumericValue(properties.keyword, properties.amount);
+
+        case KeywordName.Bounty:
+            const bountyAbilityProps = createBountyAbilityFromProps(properties.ability);
+            return new KeywordWithAbilityDefinition(properties.keyword, { ...bountyAbilityProps, type: AbilityType.Triggered });
+
+        case KeywordName.Smuggle:
+            return new KeywordWithCostValues(properties.keyword, properties.cost, properties.aspects, false);
+
+        case KeywordName.Ambush:
+        case KeywordName.Grit:
+        case KeywordName.Overwhelm:
+        case KeywordName.Saboteur:
+        case KeywordName.Sentinel:
+        case KeywordName.Shielded:
+            return new KeywordInstance(properties.keyword);
+
+        default:
+            throw new Error(`Keyword '${(properties as any).keyword}' is not implemented yet`);
     }
-
-    if (properties.keyword === KeywordName.Bounty) {
-        const bountyAbilityProps = createBountyAbilityFromProps(properties.ability);
-
-        return new KeywordWithAbilityDefinition(properties.keyword, { ...bountyAbilityProps, type: AbilityType.Triggered });
-    }
-
-    // TODO SMUGGLE: add smuggle here for "gain smuggle" abilities
-
-    return new KeywordInstance(properties.keyword);
 }
 
 export function createBountyAbilityFromProps(properties: Omit<ITriggeredAbilityProps, 'when' | 'aggregateWhen' | 'abilityController'>): ITriggeredAbilityProps {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -14,7 +14,7 @@ import type { KeywordInstance, KeywordWithCostValues } from '../ability/KeywordI
 import * as KeywordHelpers from '../ability/KeywordHelpers';
 import type { StateWatcherRegistrar } from '../stateWatcher/StateWatcherRegistrar';
 import type { EventCard } from './EventCard';
-import type { TokenCard, UnitCard, CardWithDamageProperty, TokenOrPlayableCard } from './CardTypes';
+import type { TokenCard, UnitCard, CardWithDamageProperty, TokenOrPlayableCard, CardWithCost } from './CardTypes';
 import type { UpgradeCard } from './UpgradeCard';
 import type { BaseCard } from './BaseCard';
 import type { LeaderCard } from './LeaderCard';
@@ -341,6 +341,10 @@ export class Card extends OngoingEffectSource {
         return false;
     }
 
+    public hasCost(): this is CardWithCost {
+        return false;
+    }
+
     /**
      * Returns true if the card is in a playable card (not deployable) or a token
      */
@@ -386,10 +390,13 @@ export class Card extends OngoingEffectSource {
         return keywordInstances;
     }
 
-    public getKeywordWithCostValues(keywordName: KeywordName): KeywordWithCostValues {
-        const keyword = this.getKeywords().find((keyword) => keyword.valueOf() === keywordName);
-        Contract.assertTrue(keyword.hasCostValue(), `Keyword ${keywordName} does not have cost values.`);
-        return keyword as KeywordWithCostValues;
+    public getKeywordsWithCostValues(keywordName: KeywordName): KeywordWithCostValues[] {
+        const keywords = this.getKeywords().filter((keyword) => keyword.valueOf() === keywordName);
+
+        const keywordsWithoutCostValues = keywords.filter((keyword) => !keyword.hasCostValue());
+        Contract.assertTrue(keywordsWithoutCostValues.length === 0, 'Found at least one keyword with missing cost values');
+
+        return keywords as KeywordWithCostValues[];
     }
 
     public hasSomeKeyword(keywords: Set<KeywordName> | KeywordName | KeywordName[]): boolean {

--- a/server/game/core/card/CardTypes.ts
+++ b/server/game/core/card/CardTypes.ts
@@ -37,6 +37,14 @@ export type CardWithPrintedPower =
   UpgradeCard |
   TokenUpgradeCard;
 
+export type CardWithCost =
+  NonLeaderUnitCard |
+  LeaderUnitCard |
+  TokenUnitCard |
+  UpgradeCard |
+  TokenUpgradeCard |
+  EventCard;
+
 export type CardWithTriggeredAbilities = InPlayCard;
 export type CardWithConstantAbilities = InPlayCard;
 

--- a/server/game/core/card/EventCard.ts
+++ b/server/game/core/card/EventCard.ts
@@ -33,8 +33,8 @@ export class EventCard extends EventCardParent {
         return true;
     }
 
-    public override buildPlayCardAction(properties: Omit<IPlayCardActionProperties, 'card'>) {
-        return new PlayEventAction({ card: this, ...properties });
+    public override buildPlayCardAction(properties: IPlayCardActionProperties) {
+        return new PlayEventAction(this, properties);
     }
 
     public override isTokenOrPlayable(): this is TokenOrPlayableCard {

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -23,8 +23,8 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent {
         return true;
     }
 
-    public override buildPlayCardAction(properties: Omit<IPlayCardActionProperties, 'card'>) {
-        return new PlayUnitAction({ card: this, ...properties });
+    public override buildPlayCardAction(properties: IPlayCardActionProperties) {
+        return new PlayUnitAction(this, properties);
     }
 
     public override isTokenOrPlayable(): this is TokenOrPlayableCard {

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -43,8 +43,8 @@ export class UpgradeCard extends UpgradeCardParent {
         return true;
     }
 
-    public override buildPlayCardAction(properties: Omit<IPlayCardActionProperties, 'card'>) {
-        return new PlayUpgradeAction({ card: this, ...properties });
+    public override buildPlayCardAction(properties: IPlayCardActionProperties) {
+        return new PlayUpgradeAction(this, properties);
     }
 
     public override getSummary(activePlayer: Player, hideWhenFaceup: boolean) {

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -1,8 +1,9 @@
 import type { IConstantAbilityProps, IOngoingEffectGenerator } from '../../../Interfaces';
 import OngoingEffectLibrary from '../../../ongoingEffects/OngoingEffectLibrary';
 import type { AbilityContext } from '../../ability/AbilityContext';
+import * as KeywordHelpers from '../../ability/KeywordHelpers';
 import { KeywordWithNumericValue } from '../../ability/KeywordInstance';
-import type { IPlayCardActionProperties, PlayCardAction } from '../../ability/PlayCardAction';
+import type { IPlayCardActionProperties, IPlayCardActionPropertiesBase, ISmuggleCardActionProperties, PlayCardAction } from '../../ability/PlayCardAction';
 import type PlayerOrCardAbility from '../../ability/PlayerOrCardAbility';
 import type { Aspect, MoveZoneDestination } from '../../Constants';
 import { CardType, KeywordName, PlayType, WildcardRelativePlayer, WildcardZoneName, ZoneName } from '../../Constants';
@@ -11,6 +12,8 @@ import { CostAdjustType } from '../../cost/CostAdjuster';
 import type Player from '../../Player';
 import * as Contract from '../../utils/Contract';
 import { Card } from '../Card';
+
+export type IPlayCardActionOverrides = Omit<IPlayCardActionPropertiesBase, 'playType'>;
 
 // required for mixins to be based on this class
 export type PlayableOrDeployableCardConstructor = new (...args: any[]) => PlayableOrDeployableCard;
@@ -62,41 +65,73 @@ export class PlayableOrDeployableCard extends Card {
             .concat(this.getPlayCardActions());
     }
 
-    public getPlayCardActions(): PlayCardAction[] {
+    public getPlayCardActions(propertyOverrides: IPlayCardActionOverrides = null): PlayCardAction[] {
         if (this.zoneName === ZoneName.Hand) {
-            return this.buildPlayCardActions();
+            return this.buildPlayCardActions(PlayType.PlayFromHand, propertyOverrides);
         }
 
         if (this.zoneName === ZoneName.Resource && this.hasSomeKeyword(KeywordName.Smuggle)) {
-            return this.buildPlayCardActions(PlayType.Smuggle);
+            return this.buildPlayCardActions(PlayType.Smuggle, propertyOverrides);
         }
 
         return [];
     }
 
-    public getPlayCardFromOutOfPlayActions() {
+    public getPlayCardFromOutOfPlayActions(propertyOverrides: IPlayCardActionOverrides = null) {
         Contract.assertFalse(
             [ZoneName.Hand, ZoneName.SpaceArena, ZoneName.GroundArena].includes(this.zoneName),
             `Attempting to get "play from out of play" actions for card ${this.internalName} in invalid zone: ${this.zoneName}`
         );
 
-        return this.buildPlayCardActions(PlayType.PlayFromOutOfPlay);
+        return this.buildPlayCardActions(PlayType.PlayFromOutOfPlay, propertyOverrides);
     }
 
-    protected buildPlayCardActions(playType: PlayType = PlayType.PlayFromHand): PlayCardAction[] {
-        const actions = [this.buildPlayCardAction({ playType })];
+    protected buildPlayCardActions(playType: PlayType = PlayType.PlayFromHand, propertyOverrides: IPlayCardActionOverrides = null): PlayCardAction[] {
+        let defaultPlayAction: PlayCardAction = null;
+        if (playType === PlayType.Smuggle) {
+            if (this.hasSomeKeyword(KeywordName.Smuggle)) {
+                defaultPlayAction = this.buildCheapestSmuggleAction(propertyOverrides);
+            }
+        } else {
+            defaultPlayAction = this.buildPlayCardAction({ ...propertyOverrides, playType });
+        }
 
-        // generate "play with exploit" action
+        // if there's not a basic play action available for the requested play type, return nothing
+        if (defaultPlayAction == null) {
+            return [];
+        }
+
+        const actions: PlayCardAction[] = [defaultPlayAction];
+
+        // generate "play with exploit" action from default action
         const exploitValue = this.getNumericKeywordSum(KeywordName.Exploit);
         if (exploitValue) {
-            actions.push(this.buildPlayCardAction({ playType, exploitValue }));
+            actions.push(defaultPlayAction.clone({ exploitValue }));
         }
 
         return actions;
     }
 
+    protected buildCheapestSmuggleAction(propertyOverrides: IPlayCardActionOverrides = null) {
+        Contract.assertTrue(this.hasSomeKeyword(KeywordName.Smuggle));
+
+        const smuggleKeywords = this.getKeywordsWithCostValues(KeywordName.Smuggle);
+        const smuggleActions = smuggleKeywords.map((smuggleKeyword) => {
+            const smuggleActionProps: ISmuggleCardActionProperties = {
+                ...propertyOverrides,
+                playType: PlayType.Smuggle,
+                smuggleResourceCost: smuggleKeyword.cost,
+                smuggleAspects: smuggleKeyword.aspects
+            };
+
+            return this.buildPlayCardAction(smuggleActionProps);
+        });
+
+        return KeywordHelpers.getCheapestSmuggle(smuggleActions);
+    }
+
     // can't do abstract due to mixins
-    public buildPlayCardAction(properties: Omit<IPlayCardActionProperties, 'card'>): PlayCardAction {
+    public buildPlayCardAction(properties: IPlayCardActionProperties): PlayCardAction {
         Contract.fail('This method should be overridden by the subclass');
     }
 

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -65,6 +65,12 @@ export class PlayableOrDeployableCard extends Card {
             .concat(this.getPlayCardActions());
     }
 
+    /**
+     * Get the available "play card" actions for this card in its current zone. If `propertyOverrides` is provided, will generate the actions using the included overrides.
+     *
+     * Note that if the card is currently in an out-of-play zone, by default this will return nothing since cards cannot be played from out of play in normal circumstances.
+     * If using an ability to grant an out-of-play action, use `getPlayCardFromOutOfPlayActions` which will generate the appropriate actions.
+     */
     public getPlayCardActions(propertyOverrides: IPlayCardActionOverrides = null): PlayCardAction[] {
         if (this.zoneName === ZoneName.Hand) {
             return this.buildPlayCardActions(PlayType.PlayFromHand, propertyOverrides);
@@ -77,6 +83,12 @@ export class PlayableOrDeployableCard extends Card {
         return [];
     }
 
+    /**
+     * Get the available "play card" actions for this card in the current out-of-play zone.
+     * This will generate an action to play the card from out of play even if it would normally not have one available.
+     *
+     * If `propertyOverrides` is provided, will generate the actions using the included overrides.
+     */
     public getPlayCardFromOutOfPlayActions(propertyOverrides: IPlayCardActionOverrides = null) {
         Contract.assertFalse(
             [ZoneName.Hand, ZoneName.SpaceArena, ZoneName.GroundArena].includes(this.zoneName),

--- a/server/game/core/card/propertyMixins/Cost.ts
+++ b/server/game/core/card/propertyMixins/Cost.ts
@@ -1,5 +1,6 @@
 import * as Contract from '../../utils/Contract';
 import type { CardConstructor } from '../Card';
+import type { CardWithCost } from '../CardTypes';
 
 /** Mixin function that adds the `cost` property to a base class. */
 export function WithCost<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
@@ -17,6 +18,10 @@ export function WithCost<TBaseClass extends CardConstructor>(BaseClass: TBaseCla
 
             Contract.assertNotNullLike(cardData.cost);
             this.printedCost = cardData.cost;
+        }
+
+        public override hasCost(): this is CardWithCost {
+            return true;
         }
     };
 }

--- a/server/game/core/cost/ICost.ts
+++ b/server/game/core/cost/ICost.ts
@@ -18,7 +18,7 @@ export interface ICost<TContext extends AbilityContext = AbilityContext> {
     promptsPlayer?: boolean;
     // TODO: do we still need dependsOn for costs? what would be the use case?
     // dependsOn?: string;
-    isPrintedResourceCost?: boolean;
+    // isPrintedResourceCost?: boolean;
     isPlayCost?: boolean;
     canIgnoreForTargeting?: boolean;
 

--- a/server/game/core/gameSteps/ActionWindow.js
+++ b/server/game/core/gameSteps/ActionWindow.js
@@ -2,6 +2,8 @@ const { UiPrompt } = require('./prompts/UiPrompt.js');
 const { RelativePlayer, WildcardZoneName, PromptType } = require('../Constants.js');
 const EnumHelpers = require('../utils/EnumHelpers.js');
 const Contract = require('../utils/Contract');
+const KeywordHelpers = require('../ability/KeywordHelpers.js');
+const { cardCannot } = require('../../ongoingEffects/CardCannot.js');
 
 class ActionWindow extends UiPrompt {
     constructor(game, title, windowName, prevPlayerPassed, setPassStatus, activePlayer = null) {

--- a/server/game/core/ongoingEffect/effectImpl/StaticOngoingEffectImpl.ts
+++ b/server/game/core/ongoingEffect/effectImpl/StaticOngoingEffectImpl.ts
@@ -98,11 +98,10 @@ export default class StaticOngoingEffectImpl<TValue> extends OngoingEffectImpl<T
     }
 
     // effects can't be applied to facedown cards
-    // TODO TECH: this needs to be updated for "gain smuggle"
     // TODO: can this know that it, for example, grants sentinel and so only return true here for unit cards?
-    public canBeApplied(target) {
-        return !target.facedown;
-    }
+    // public canBeApplied(target) {
+    //     return !target.facedown;
+    // }
 
     // isMilitaryModifier() {
     //     return MilitaryModifiers.includes(this.type);

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -119,3 +119,23 @@ export class IntersectingSet<T> extends Set<T> {
         }
     }
 }
+
+/**
+ * Splits an array into two based on a condition applied to each element.
+ */
+export function splitArray<T>(ara: T[], condition: (item: T) => boolean) {
+    const results = {
+        trueAra: [] as T[],
+        falseAra: [] as T[]
+    };
+
+    for (const item of ara) {
+        if (condition(item)) {
+            results.trueAra.push(item);
+        } else {
+            results.falseAra.push(item);
+        }
+    }
+
+    return results;
+}

--- a/server/game/costs/CostLibrary.ts
+++ b/server/game/costs/CostLibrary.ts
@@ -1,11 +1,9 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import type { PlayType } from '../core/Constants';
 import { DamageType, ZoneName } from '../core/Constants';
 import type { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { ICost } from '../core/cost/ICost';
 import { GameSystemCost } from '../core/cost/GameSystemCost';
 import { MetaActionCost } from '../core/cost/MetaActionCost';
-import { PlayCardResourceCost } from './PlayCardResourceCost';
 import type { CardWithDamageProperty } from '../core/card/CardTypes';
 import type { InPlayCard } from '../core/card/baseClasses/InPlayCard';
 import { DefeatCardSystem } from '../gameSystems/DefeatCardSystem';
@@ -265,14 +263,14 @@ export function returnSelfToHandFromPlay<TContext extends AbilityContext = Abili
 //     };
 // }
 
-/**
- * Cost that will pay the printed cost on the card minus any active
- * adjuster effects the play has activated. Upon playing the card, all
- * matching adjuster effects will expire, if applicable.
- */
-export function payPlayCardResourceCost<TContext extends AbilityContext = AbilityContext>(playType: PlayType): ICost<TContext> {
-    return new PlayCardResourceCost<TContext>(playType);
-}
+// /**
+//  * Cost that will pay the printed cost on the card minus any active
+//  * adjuster effects the play has activated. Upon playing the card, all
+//  * matching adjuster effects will expire, if applicable.
+//  */
+// export function payPlayCardResourceCost<TContext extends AbilityContext = AbilityContext>(playType: PlayType): ICost<TContext> {
+//     return new PlayCardResourceCost<TContext>(playType);
+// }
 
 // /**
 //  * Cost that is dependent on context.targets[targetName]

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -85,7 +85,6 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         const lastingEffectRestrictions = card.getOngoingEffectValues(EffectName.CannotApplyLastingEffects);
         return effects.filter(
             (props) =>
-                props.impl.canBeApplied(card) &&
                 !lastingEffectRestrictions.some((condition) => condition(props.impl))
         );
     }

--- a/test/server/cards/01_SOR/events/Bamboozle.spec.ts
+++ b/test/server/cards/01_SOR/events/Bamboozle.spec.ts
@@ -168,6 +168,33 @@ describe('Bamboozle', function () {
             expect(context.player1.exhaustedResourceCount).toBe(1);
         });
 
-        // TODO TECH: add test for Bamboozle in Smuggle to make sure its alternate play mode doesn't work there
+        it('Bamboozle\'s alternate play mode should not be available when smuggled', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['wampa', 'crafty-smuggler', 'lothal-insurgent'],
+                    groundArena: ['tech#source-of-insight'],
+                    leader: 'jyn-erso#resisting-oppression',
+                    resources: ['bamboozle', 'atst', 'atst', 'atst', 'atst']
+                },
+                player2: {
+                    groundArena: [{ card: 'saw-gerrera#extremist', upgrades: ['entrenched', 'shield'] }]
+                }
+            });
+
+            const { context } = contextRef;
+
+            // expect to see both play actions, choose the discard mode
+            context.player1.clickCard(context.bamboozle);
+
+            // no play modes prompt, go directly to targeting
+            expect(context.player1).toBeAbleToSelectExactly([context.tech, context.sawGerrera]);
+            context.player1.clickCard(context.sawGerrera);
+            expect(context.sawGerrera.exhausted).toBeTrue();
+            expect(context.sawGerrera.isUpgraded()).toBeFalse();
+
+            expect(context.player1.exhaustedResourceCount).toBe(4);
+            expect(context.player2).toBeActivePlayer();
+        });
     });
 });

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -8,7 +8,7 @@ describe('Tech, Source of Insight', function () {
                         leader: 'hera-syndulla#spectre-two',
                         base: 'tarkintown',
                         groundArena: ['tech#source-of-insight'],
-                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'atst', 'atst', 'atst']
+                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'collections-starhopper', 'atst', 'atst']
                     },
                     player2: {
                         resources: ['isb-agent', 'atst', 'atst', 'atst', 'atst', 'atst'],
@@ -34,11 +34,46 @@ describe('Tech, Source of Insight', function () {
 
                 reset();
 
-                expect(context.player1.exhaustedResourceCount).toBe(0);
                 context.player1.clickCard(context.momentOfPeace);
                 context.player1.clickCard(context.tech);
                 expect(context.tech).toHaveExactUpgradeNames(['shield']);
                 expect(context.player1.exhaustedResourceCount).toBe(5);
+
+                reset();
+
+                // check that the lowest-cost smuggle is automatically selected
+                context.player1.clickCard(context.collectionsStarhopper);
+                expect(context.collectionsStarhopper).toBeInZone('spaceArena');
+                expect(context.player1.exhaustedResourceCount).toBe(3);
+            });
+        });
+
+
+        describe('Tech\'s ability', function () {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        leader: 'jyn-erso#resisting-oppression',
+                        base: 'echo-base',
+                        groundArena: ['tech#source-of-insight'],
+                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'tobias-beckett#i-trust-no-one', 'atst', 'atst', 'atst']
+                    }
+                });
+            });
+
+            it('should give Smuggle to all cards in the resource zone', function () {
+                const { context } = contextRef;
+
+                const reset = () => {
+                    context.player1.readyResources(6);
+                    context.player2.passAction();
+                };
+
+                // check that the lowest-cost smuggle is automatically selected
+                context.player1.clickCard(context.tobiasBeckett);
+                expect(context.tobiasBeckett).toBeInZone('groundArena');
+                expect(context.player1.exhaustedResourceCount).toBe(6);
             });
         });
     });

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -7,8 +7,8 @@ describe('Tech, Source of Insight', function () {
                     player1: {
                         leader: 'hera-syndulla#spectre-two',
                         base: 'tarkintown',
-                        groundArena: ['tech#source-of-insight'],
                         resources: [
+                            'tech#source-of-insight',
                             'wampa',
                             'moment-of-peace',
                             'battlefield-marine',
@@ -31,10 +31,19 @@ describe('Tech, Source of Insight', function () {
                     context.player2.passAction();
                 };
 
+                // check that Tech ability is off when he's in the resource zone
+                expect(context.wampa).not.toHaveAvailableActionWhenClickedBy(context.player1);
+
+                // smuggle Tech into play
+                context.player1.clickCard(context.tech);
+
+                reset();
+
                 // test smuggle with unit
                 context.player1.clickCard(context.wampa);
                 expect(context.wampa).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(6);
+                expect(context.player1.resources.length).toBe(7);
 
                 // check that player2 doesn't gain smuggle
                 context.player2.clickCardNonChecking(context.isbAgent);
@@ -45,11 +54,15 @@ describe('Tech, Source of Insight', function () {
                 // test that card can't be smuggled if the gained smuggle cost is too expensive
                 expect(context.mercenaryCompany).not.toHaveAvailableActionWhenClickedBy(context.player1);
 
+                // test that in-play cards don't gain smuggle somehow
+                expect(context.wampa).not.toHaveAvailableActionWhenClickedBy(context.player1);
+
                 // test smuggle with off-aspect event (printed cost is 1)
                 context.player1.clickCard(context.momentOfPeace);
                 context.player1.clickCard(context.tech);
                 expect(context.tech).toHaveExactUpgradeNames(['shield']);
                 expect(context.player1.exhaustedResourceCount).toBe(5);
+                expect(context.player1.resources.length).toBe(7);
 
                 reset();
 
@@ -57,6 +70,7 @@ describe('Tech, Source of Insight', function () {
                 context.player1.clickCard(context.collectionsStarhopper);
                 expect(context.collectionsStarhopper).toBeInZone('spaceArena');
                 expect(context.player1.exhaustedResourceCount).toBe(3);
+                expect(context.player1.resources.length).toBe(7);
 
                 reset();
 
@@ -65,6 +79,7 @@ describe('Tech, Source of Insight', function () {
                 expect(context.player1).toBeAbleToSelectExactly([context.tech, context.wampa, context.collectionsStarhopper]);
                 context.player1.clickCard(context.collectionsStarhopper);
                 expect(context.collectionsStarhopper).toHaveExactUpgradeNames(['resilient']);
+                expect(context.player1.resources.length).toBe(7);
             });
         });
 
@@ -94,6 +109,7 @@ describe('Tech, Source of Insight', function () {
                 context.player1.clickCard(context.tobiasBeckett);
                 expect(context.tobiasBeckett).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(6);
+                expect(context.player1.resources.length).toBe(7);
 
                 reset();
 
@@ -113,10 +129,8 @@ describe('Tech, Source of Insight', function () {
                 expect(context.tobiasBeckett).toBeInZone('discard');
                 expect(context.infiltratingDemolisher).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(4); // 4 base cost + 2 from smuggle - 2 from exploit 1
+                expect(context.player1.resources.length).toBe(7);
             });
         });
     });
-
-    // TODO: Smuggle + Bamboozle
-    // TODO: Lando leader
 });

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -1,136 +1,128 @@
 describe('Tech, Source of Insight', function () {
     integration(function (contextRef) {
-        describe('Tech\'s ability', function () {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        leader: 'hera-syndulla#spectre-two',
-                        base: 'tarkintown',
-                        resources: [
-                            'tech#source-of-insight',
-                            'wampa',
-                            'moment-of-peace',
-                            'battlefield-marine',
-                            'collections-starhopper',
-                            'resilient',
-                            'mercenary-company'
-                        ]
-                    },
-                    player2: {
-                        resources: ['isb-agent', 'atst', 'atst', 'atst', 'atst', 'atst'],
-                    },
-                });
+        it('Tech\'s ability should give Smuggle to all cards in the resource zone', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    leader: 'hera-syndulla#spectre-two',
+                    base: 'tarkintown',
+                    resources: [
+                        'tech#source-of-insight',
+                        'wampa',
+                        'moment-of-peace',
+                        'battlefield-marine',
+                        'collections-starhopper',
+                        'resilient',
+                        'mercenary-company'
+                    ]
+                },
+                player2: {
+                    resources: ['isb-agent', 'atst', 'atst', 'atst', 'atst', 'atst'],
+                },
             });
 
-            it('should give Smuggle to all cards in the resource zone', function () {
-                const { context } = contextRef;
+            const { context } = contextRef;
 
-                const reset = () => {
-                    context.player1.readyResources(context.player1.resources.length);
-                    context.player2.passAction();
-                };
+            const reset = () => {
+                context.player1.readyResources(context.player1.resources.length);
+                context.player2.passAction();
+            };
 
-                // check that Tech ability is off when he's in the resource zone
-                expect(context.wampa).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            // check that Tech ability is off when he's in the resource zone
+            expect(context.wampa).not.toHaveAvailableActionWhenClickedBy(context.player1);
 
-                // smuggle Tech into play
-                context.player1.clickCard(context.tech);
+            // smuggle Tech into play
+            context.player1.clickCard(context.tech);
 
-                reset();
+            reset();
 
-                // test smuggle with unit
-                context.player1.clickCard(context.wampa);
-                expect(context.wampa).toBeInZone('groundArena');
-                expect(context.player1.exhaustedResourceCount).toBe(6);
-                expect(context.player1.resources.length).toBe(7);
+            // test smuggle with unit
+            context.player1.clickCard(context.wampa);
+            expect(context.wampa).toBeInZone('groundArena');
+            expect(context.player1.exhaustedResourceCount).toBe(6);
+            expect(context.player1.resources.length).toBe(7);
 
-                // check that player2 doesn't gain smuggle
-                context.player2.clickCardNonChecking(context.isbAgent);
-                expect(context.isbAgent).toBeInZone('resource');
+            // check that player2 doesn't gain smuggle
+            context.player2.clickCardNonChecking(context.isbAgent);
+            expect(context.isbAgent).toBeInZone('resource');
 
-                reset();
+            reset();
 
-                // test that card can't be smuggled if the gained smuggle cost is too expensive
-                expect(context.mercenaryCompany).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            // test that card can't be smuggled if the gained smuggle cost is too expensive
+            expect(context.mercenaryCompany).not.toHaveAvailableActionWhenClickedBy(context.player1);
 
-                // test that in-play cards don't gain smuggle somehow
-                expect(context.wampa).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            // test that in-play cards don't gain smuggle somehow
+            expect(context.wampa).not.toHaveAvailableActionWhenClickedBy(context.player1);
 
-                // test smuggle with off-aspect event (printed cost is 1)
-                context.player1.clickCard(context.momentOfPeace);
-                context.player1.clickCard(context.tech);
-                expect(context.tech).toHaveExactUpgradeNames(['shield']);
-                expect(context.player1.exhaustedResourceCount).toBe(5);
-                expect(context.player1.resources.length).toBe(7);
+            // test smuggle with off-aspect event (printed cost is 1)
+            context.player1.clickCard(context.momentOfPeace);
+            context.player1.clickCard(context.tech);
+            expect(context.tech).toHaveExactUpgradeNames(['shield']);
+            expect(context.player1.exhaustedResourceCount).toBe(5);
+            expect(context.player1.resources.length).toBe(7);
 
-                reset();
+            reset();
 
-                // check that the printed smuggle is used since it's lower cost
-                context.player1.clickCard(context.collectionsStarhopper);
-                expect(context.collectionsStarhopper).toBeInZone('spaceArena');
-                expect(context.player1.exhaustedResourceCount).toBe(3);
-                expect(context.player1.resources.length).toBe(7);
+            // check that the printed smuggle is used since it's lower cost
+            context.player1.clickCard(context.collectionsStarhopper);
+            expect(context.collectionsStarhopper).toBeInZone('spaceArena');
+            expect(context.player1.exhaustedResourceCount).toBe(3);
+            expect(context.player1.resources.length).toBe(7);
 
-                reset();
+            reset();
 
-                // test smuggle with upgrade
-                context.player1.clickCard(context.resilient);
-                expect(context.player1).toBeAbleToSelectExactly([context.tech, context.wampa, context.collectionsStarhopper]);
-                context.player1.clickCard(context.collectionsStarhopper);
-                expect(context.collectionsStarhopper).toHaveExactUpgradeNames(['resilient']);
-                expect(context.player1.resources.length).toBe(7);
-            });
+            // test smuggle with upgrade
+            context.player1.clickCard(context.resilient);
+            expect(context.player1).toBeAbleToSelectExactly([context.tech, context.wampa, context.collectionsStarhopper]);
+            context.player1.clickCard(context.collectionsStarhopper);
+            expect(context.collectionsStarhopper).toHaveExactUpgradeNames(['resilient']);
+            expect(context.player1.resources.length).toBe(7);
         });
 
 
-        describe('Tech\'s ability', function () {
-            beforeEach(function () {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        leader: 'asajj-ventress#unparalleled-adversary',
-                        base: 'echo-base',
-                        groundArena: ['tech#source-of-insight'],
-                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'tobias-beckett#i-trust-no-one', 'infiltrating-demolisher', 'atst', 'atst']
-                    }
-                });
+        it('Tech\'s ability should give Smuggle to all cards in the resource zone and handle alternate costs correctly', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    leader: 'asajj-ventress#unparalleled-adversary',
+                    base: 'echo-base',
+                    groundArena: ['tech#source-of-insight'],
+                    resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'tobias-beckett#i-trust-no-one', 'infiltrating-demolisher', 'atst', 'atst']
+                }
             });
 
-            it('should give Smuggle to all cards in the resource zone', function () {
-                const { context } = contextRef;
+            const { context } = contextRef;
 
-                const reset = () => {
-                    context.player1.readyResources(context.player1.resources.length);
-                    context.player2.passAction();
-                };
+            const reset = () => {
+                context.player1.readyResources(context.player1.resources.length);
+                context.player2.passAction();
+            };
 
-                // check that the gained smuggle is used since it's the lower cost
-                context.player1.clickCard(context.tobiasBeckett);
-                expect(context.tobiasBeckett).toBeInZone('groundArena');
-                expect(context.player1.exhaustedResourceCount).toBe(6);
-                expect(context.player1.resources.length).toBe(7);
+            // check that the gained smuggle is used since it's the lower cost
+            context.player1.clickCard(context.tobiasBeckett);
+            expect(context.tobiasBeckett).toBeInZone('groundArena');
+            expect(context.player1.exhaustedResourceCount).toBe(6);
+            expect(context.player1.resources.length).toBe(7);
 
-                reset();
+            reset();
 
-                // test smuggle + exploit
-                context.player1.clickCard(context.infiltratingDemolisher);
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Play Infiltrating Demolisher with Smuggle',
-                    'Play Infiltrating Demolisher with Smuggle using Exploit',
-                    'Cancel'
-                ]);
-                context.player1.clickPrompt('Play Infiltrating Demolisher with Smuggle using Exploit');
+            // test smuggle + exploit
+            context.player1.clickCard(context.infiltratingDemolisher);
+            expect(context.player1).toHaveExactPromptButtons([
+                'Play Infiltrating Demolisher with Smuggle',
+                'Play Infiltrating Demolisher with Smuggle using Exploit',
+                'Cancel'
+            ]);
+            context.player1.clickPrompt('Play Infiltrating Demolisher with Smuggle using Exploit');
 
-                expect(context.player1).toBeAbleToSelectExactly([context.tech, context.tobiasBeckett]);
-                context.player1.clickCard(context.tobiasBeckett);
-                context.player1.clickPrompt('Done');
+            expect(context.player1).toBeAbleToSelectExactly([context.tech, context.tobiasBeckett]);
+            context.player1.clickCard(context.tobiasBeckett);
+            context.player1.clickPrompt('Done');
 
-                expect(context.tobiasBeckett).toBeInZone('discard');
-                expect(context.infiltratingDemolisher).toBeInZone('groundArena');
-                expect(context.player1.exhaustedResourceCount).toBe(4); // 4 base cost + 2 from smuggle - 2 from exploit 1
-                expect(context.player1.resources.length).toBe(7);
-            });
+            expect(context.tobiasBeckett).toBeInZone('discard');
+            expect(context.infiltratingDemolisher).toBeInZone('groundArena');
+            expect(context.player1.exhaustedResourceCount).toBe(4); // 4 base cost + 2 from smuggle - 2 from exploit 1
+            expect(context.player1.resources.length).toBe(7);
         });
     });
 });

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -8,7 +8,14 @@ describe('Tech, Source of Insight', function () {
                         leader: 'hera-syndulla#spectre-two',
                         base: 'tarkintown',
                         groundArena: ['tech#source-of-insight'],
-                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'collections-starhopper', 'atst', 'atst']
+                        resources: [
+                            'wampa',
+                            'moment-of-peace',
+                            'battlefield-marine',
+                            'collections-starhopper',
+                            'resilient',
+                            'mercenary-company'
+                        ]
                     },
                     player2: {
                         resources: ['isb-agent', 'atst', 'atst', 'atst', 'atst', 'atst'],
@@ -24,6 +31,7 @@ describe('Tech, Source of Insight', function () {
                     context.player2.passAction();
                 };
 
+                // test smuggle with unit
                 context.player1.clickCard(context.wampa);
                 expect(context.wampa).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(6);
@@ -34,6 +42,10 @@ describe('Tech, Source of Insight', function () {
 
                 reset();
 
+                // test that card can't be smuggled if the gained smuggle cost is too expensive
+                expect(context.mercenaryCompany).not.toHaveAvailableActionWhenClickedBy(context.player1);
+
+                // test smuggle with off-aspect event (printed cost is 1)
                 context.player1.clickCard(context.momentOfPeace);
                 context.player1.clickCard(context.tech);
                 expect(context.tech).toHaveExactUpgradeNames(['shield']);
@@ -41,10 +53,18 @@ describe('Tech, Source of Insight', function () {
 
                 reset();
 
-                // check that the lowest-cost smuggle is automatically selected
+                // check that the printed smuggle is used since it's lower cost
                 context.player1.clickCard(context.collectionsStarhopper);
                 expect(context.collectionsStarhopper).toBeInZone('spaceArena');
                 expect(context.player1.exhaustedResourceCount).toBe(3);
+
+                reset();
+
+                // test smuggle with upgrade
+                context.player1.clickCard(context.resilient);
+                expect(context.player1).toBeAbleToSelectExactly([context.tech, context.wampa, context.collectionsStarhopper]);
+                context.player1.clickCard(context.collectionsStarhopper);
+                expect(context.collectionsStarhopper).toHaveExactUpgradeNames(['resilient']);
             });
         });
 
@@ -70,14 +90,14 @@ describe('Tech, Source of Insight', function () {
                     context.player2.passAction();
                 };
 
-                // check that the lowest-cost smuggle is automatically selected
+                // check that the gained smuggle is used since it's the lower cost
                 context.player1.clickCard(context.tobiasBeckett);
                 expect(context.tobiasBeckett).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(6);
 
                 reset();
 
-                // check smuggle + exploit
+                // test smuggle + exploit
                 context.player1.clickCard(context.infiltratingDemolisher);
                 expect(context.player1).toHaveExactPromptButtons([
                     'Play Infiltrating Demolisher with Smuggle',
@@ -97,8 +117,6 @@ describe('Tech, Source of Insight', function () {
         });
     });
 
-    // TODO: Smuggle + Exploit
     // TODO: Smuggle + Bamboozle
-    // TODO: Smuggle an upgrade
     // TODO: Lando leader
 });

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -20,7 +20,7 @@ describe('Tech, Source of Insight', function () {
                 const { context } = contextRef;
 
                 const reset = () => {
-                    context.player1.readyResources(6);
+                    context.player1.readyResources(context.player1.resources.length);
                     context.player2.passAction();
                 };
 
@@ -54,10 +54,10 @@ describe('Tech, Source of Insight', function () {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
-                        leader: 'jyn-erso#resisting-oppression',
+                        leader: 'asajj-ventress#unparalleled-adversary',
                         base: 'echo-base',
                         groundArena: ['tech#source-of-insight'],
-                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'tobias-beckett#i-trust-no-one', 'atst', 'atst', 'atst']
+                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'tobias-beckett#i-trust-no-one', 'infiltrating-demolisher', 'atst', 'atst']
                     }
                 });
             });
@@ -66,7 +66,7 @@ describe('Tech, Source of Insight', function () {
                 const { context } = contextRef;
 
                 const reset = () => {
-                    context.player1.readyResources(6);
+                    context.player1.readyResources(context.player1.resources.length);
                     context.player2.passAction();
                 };
 
@@ -74,7 +74,31 @@ describe('Tech, Source of Insight', function () {
                 context.player1.clickCard(context.tobiasBeckett);
                 expect(context.tobiasBeckett).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(6);
+
+                reset();
+
+                // check smuggle + exploit
+                context.player1.clickCard(context.infiltratingDemolisher);
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Play Infiltrating Demolisher with Smuggle',
+                    'Play Infiltrating Demolisher with Smuggle using Exploit',
+                    'Cancel'
+                ]);
+                context.player1.clickPrompt('Play Infiltrating Demolisher with Smuggle using Exploit');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.tech, context.tobiasBeckett]);
+                context.player1.clickCard(context.tobiasBeckett);
+                context.player1.clickPrompt('Done');
+
+                expect(context.tobiasBeckett).toBeInZone('discard');
+                expect(context.infiltratingDemolisher).toBeInZone('groundArena');
+                expect(context.player1.exhaustedResourceCount).toBe(4); // 4 base cost + 2 from smuggle - 2 from exploit 1
             });
         });
     });
+
+    // TODO: Smuggle + Exploit
+    // TODO: Smuggle + Bamboozle
+    // TODO: Smuggle an upgrade
+    // TODO: Lando leader
 });

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -1,0 +1,46 @@
+describe('Tech, Source of Insight', function () {
+    integration(function (contextRef) {
+        describe('Tech\'s ability', function () {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        leader: 'hera-syndulla#spectre-two',
+                        base: 'tarkintown',
+                        groundArena: ['tech#source-of-insight'],
+                        resources: ['wampa', 'moment-of-peace', 'battlefield-marine', 'atst', 'atst', 'atst']
+                    },
+                    player2: {
+                        resources: ['isb-agent', 'atst', 'atst', 'atst', 'atst', 'atst'],
+                    },
+                });
+            });
+
+            it('should give Smuggle to all cards in the resource zone', function () {
+                const { context } = contextRef;
+
+                const reset = () => {
+                    context.player1.readyResources(6);
+                    context.player2.passAction();
+                };
+
+                context.player1.clickCard(context.wampa);
+                expect(context.wampa).toBeInZone('groundArena');
+                expect(context.player1.exhaustedResourceCount).toBe(6);
+
+                // check that player2 doesn't gain smuggle
+                context.player2.clickCardNonChecking(context.isbAgent);
+                expect(context.isbAgent).toBeInZone('resource');
+
+                reset();
+
+                // TODO THIS PR: for some reason events can't gain smuggle?
+                expect(context.player1.exhaustedResourceCount).toBe(0);
+                context.player1.clickCard(context.momentOfPeace);
+                context.player1.clickCard(context.tech);
+                expect(context.tech).toHaveExactUpgradeNames(['shield']);
+                expect(context.player1.exhaustedResourceCount).toBe(5);
+            });
+        });
+    });
+});

--- a/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
+++ b/test/server/cards/02_SHD/units/TechSourceOfInsight.spec.ts
@@ -34,7 +34,6 @@ describe('Tech, Source of Insight', function () {
 
                 reset();
 
-                // TODO THIS PR: for some reason events can't gain smuggle?
                 expect(context.player1.exhaustedResourceCount).toBe(0);
                 context.player1.clickCard(context.momentOfPeace);
                 context.player1.clickCard(context.tech);


### PR DESCRIPTION
Added Tech unit, which required refactoring the methods for generating smuggle actions since they were hardcoded to assume only one smuggle keyword existed. Now it will automatically determine the best 