### PR TITLE
DJ and Huyang

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "mkdirp": "^3.0.1",
         "node-ts": "^6.1.0",
         "path": "^0.12.7",
+        "seedrandom": "^3.0.5",
         "socket.io": "^4.7.5",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.0.1",
@@ -6423,6 +6424,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mkdirp": "^3.0.1",
     "node-ts": "^6.1.0",
     "path": "^0.12.7",
+    "seedrandom": "^3.0.5",
     "socket.io": "^4.7.5",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.0.1",

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -18,8 +18,19 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
                     event.card === context.source &&
                     event.playType === PlayType.Smuggle
             },
-            immediateEffect: AbilityHelper.immediateEffects.sequential([
-                AbilityHelper.immediateEffects.takeControlOfResource((context) => ({ target: context.player }))
+            immediateEffect: AbilityHelper.immediateEffects.sequential((sequentialContext) => [
+                AbilityHelper.immediateEffects.takeControlOfResource((context) => ({ target: context.player })),
+                AbilityHelper.immediateEffects.delayedCardEffect((delayedEffectContext) => ({
+                    title: 'Return the stolen resource to its owner',
+                    when: {
+                        onCardLeavesPlay: (event, context) => event.card === context.source
+                    },
+                    target: delayedEffectContext.source,
+                    immediateEffect: AbilityHelper.immediateEffects.takeControlOfResource({
+                        target: sequentialContext.events[0].card.owner,
+                        specificResource: sequentialContext.events[0].card
+                    })
+                }))
             ])
         });
     }

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { PlayType } from '../../../core/Constants';
+import { PlayType, RelativePlayer } from '../../../core/Constants';
 
 export default class DjBlatantThief extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -26,9 +26,9 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
                         onCardLeavesPlay: (event, context) => event.card === context.source
                     },
                     target: delayedEffectContext.source,
-                    immediateEffect: AbilityHelper.immediateEffects.takeControlOfResource({
-                        target: sequentialContext.events[0].card.owner,
-                        specificResource: sequentialContext.events[0].card
+                    immediateEffect: AbilityHelper.immediateEffects.resourceCard({
+                        targetPlayer: RelativePlayer.Opponent,
+                        target: sequentialContext.events[0].card
                     })
                 }))
             ])

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -1,0 +1,28 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { PlayType } from '../../../core/Constants';
+
+export default class DjBlatantThief extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '4002861992',
+            internalName: 'dj#blatant-thief',
+        };
+    }
+
+    public override setupCardAbilities() {
+        this.addTriggeredAbility({
+            title: 'Take control of an enemy resource. When this unit leaves play, that resource\'s owner takes control of it.',
+            when: {
+                onCardPlayed: (event, context) =>
+                    event.card === context.source &&
+                    event.playType === PlayType.Smuggle
+            },
+            immediateEffect: AbilityHelper.immediateEffects.sequential([
+                AbilityHelper.immediateEffects.takeControlOfResource((context) => ({ target: context.player }))
+            ])
+        });
+    }
+}
+
+DjBlatantThief.implemented = true;

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { Duration, PlayType, RelativePlayer } from '../../../core/Constants';
+import { PlayType, RelativePlayer } from '../../../core/Constants';
 
 export default class DjBlatantThief extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -20,19 +20,16 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
             },
             immediateEffect: AbilityHelper.immediateEffects.sequential((sequentialContext) => [
                 AbilityHelper.immediateEffects.takeControlOfResource((context) => ({ target: context.player })),
-                AbilityHelper.immediateEffects.delayedCardEffect((delayedEffectContext) => ({
+                AbilityHelper.immediateEffects.whenSourceLeavesPlayDelayedCardEffect({
                     title: 'Return the stolen resource to its owner',
-                    when: {
-                        onCardLeavesPlay: (event, context) => event.card === context.source
-                    },
-                    duration: Duration.WhileSourceInPlay,
-                    target: delayedEffectContext.source,
+                    // we use a context handler here to force evaluation of the target's exhausted state to happen when the delayed effect resolves,
+                    // instead of when it's created
                     immediateEffect: AbilityHelper.immediateEffects.resourceCard((_context) => ({
                         targetPlayer: RelativePlayer.Opponent,
                         target: sequentialContext.events[0].card,
                         readyResource: !sequentialContext.events[0].card.exhausted
                     }))
-                }))
+                })
             ])
         });
     }

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { PlayType, RelativePlayer } from '../../../core/Constants';
+import { Duration, PlayType, RelativePlayer } from '../../../core/Constants';
 
 export default class DjBlatantThief extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -25,6 +25,7 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
                     when: {
                         onCardLeavesPlay: (event, context) => event.card === context.source
                     },
+                    duration: Duration.WhileSourceInPlay,
                     target: delayedEffectContext.source,
                     immediateEffect: AbilityHelper.immediateEffects.resourceCard((_context) => ({
                         targetPlayer: RelativePlayer.Opponent,

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -26,10 +26,11 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
                         onCardLeavesPlay: (event, context) => event.card === context.source
                     },
                     target: delayedEffectContext.source,
-                    immediateEffect: AbilityHelper.immediateEffects.resourceCard({
+                    immediateEffect: AbilityHelper.immediateEffects.resourceCard((_context) => ({
                         targetPlayer: RelativePlayer.Opponent,
-                        target: sequentialContext.events[0].card
-                    })
+                        target: sequentialContext.events[0].card,
+                        readyResource: !sequentialContext.events[0].card.exhausted
+                    }))
                 }))
             ])
         });

--- a/server/game/cards/03_TWI/units/HuyangEnduringInstructor.ts
+++ b/server/game/cards/03_TWI/units/HuyangEnduringInstructor.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { Duration, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class HuyangEnduringInstructor extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -17,9 +17,8 @@ export default class HuyangEnduringInstructor extends NonLeaderUnitCard {
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,
                 cardCondition: (card, context) => card !== context.source,
-                immediateEffect: AbilityHelper.immediateEffects.cardLastingEffect({
-                    effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 }),
-                    duration: Duration.WhileSourceInPlay
+                immediateEffect: AbilityHelper.immediateEffects.whileSourceInPlayCardEffect({
+                    effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })
                 })
             }
         });

--- a/server/game/cards/03_TWI/units/HuyangEnduringInstructor.ts
+++ b/server/game/cards/03_TWI/units/HuyangEnduringInstructor.ts
@@ -1,0 +1,29 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Duration, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+
+export default class HuyangEnduringInstructor extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '8418001763',
+            internalName: 'huyang#enduring-instructor',
+        };
+    }
+
+    public override setupCardAbilities () {
+        this.addWhenPlayedAbility({
+            title: 'Choose another friendly unit. While this unit is in play, the chosen unit gets +2/+2.',
+            targetResolver: {
+                controller: RelativePlayer.Self,
+                cardTypeFilter: WildcardCardType.Unit,
+                cardCondition: (card, context) => card !== context.source,
+                immediateEffect: AbilityHelper.immediateEffects.cardLastingEffect({
+                    effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 }),
+                    duration: Duration.WhileSourceInPlay
+                })
+            }
+        });
+    }
+}
+
+HuyangEnduringInstructor.implemented = true;

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -101,6 +101,7 @@ export enum Duration {
     UntilEndOfAttack = 'untilEndOfAttack',
     UntilEndOfPhase = 'untilEndOfPhase',
     UntilEndOfRound = 'untilEndOfRound',
+    WhileSourceInPlay = 'whileSourceInPlay'
 }
 
 export enum Stage {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1156,6 +1156,11 @@ class Game extends EventEmitter {
         }
         this.movedCards = [];
 
+        if (events.length > 0) {
+            // check for any delayed effects which need to fire
+            this.ongoingEffectEngine.checkDelayedEffects(events);
+        }
+
         // check for a game state change (recalculating attack stats if necessary)
         if (
             // (!this.currentAttack && this.ongoingEffectEngine.resolveEffects(hasChanged)) ||
@@ -1166,10 +1171,6 @@ class Game extends EventEmitter {
 
             // - any defeated units
             this.findAnyCardsInPlay((card) => card.isUnit()).forEach((card) => card.checkDefeatedByOngoingEffect());
-        }
-        if (events.length > 0) {
-            // check for any delayed effects which need to fire
-            this.ongoingEffectEngine.checkDelayedEffects(events);
         }
     }
 

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1,4 +1,6 @@
 const EventEmitter = require('events');
+const seedrandom = require('seedrandom');
+
 const { GameChat } = require('./chat/GameChat.js');
 const { OngoingEffectEngine } = require('./ongoingEffect/OngoingEffectEngine.js');
 const Player = require('./Player.js');
@@ -71,6 +73,7 @@ class Game extends EventEmitter {
         this.tokenFactories = null;
         this.stateWatcherRegistrar = new StateWatcherRegistrar(this);
         this.movedCards = [];
+        this.randomGenerator = seedrandom();
 
         this.registerGlobalRulesListeners();
 
@@ -248,6 +251,10 @@ class Game extends EventEmitter {
         }
 
         // by default, if the opponent has passed and the active player has not, they remain the active player and play continues
+    }
+
+    setRandomSeed(seed) {
+        this.randomGenerator = seedrandom(seed);
     }
 
     /**

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -1149,6 +1149,11 @@ class Player extends GameObject {
 
         return state;
     }
+
+    /** @override */
+    toString() {
+        return this.name;
+    }
 }
 
 module.exports = Player;

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -224,6 +224,29 @@ class Player extends GameObject {
         return this.leader.title === title || this.hasSomeArenaUnit({ condition: (card) => card.title === title });
     }
 
+    getZone(zoneName) {
+        switch (zoneName) {
+            case ZoneName.Hand:
+                return this.handZone;
+            case ZoneName.Deck:
+                return this.deckZone;
+            case ZoneName.Discard:
+                return this.discardZone;
+            case ZoneName.Resource:
+                return this.resourceZone;
+            case ZoneName.Base:
+                return this.baseZone;
+            case ZoneName.OutsideTheGame:
+                return this.outsideTheGameZone;
+            case ZoneName.SpaceArena:
+                return this.game.spaceArena;
+            case ZoneName.GroundArena:
+                return this.game.groundArena;
+            default:
+                Contract.fail(`Unknown zone: ${zoneName}`);
+        }
+    }
+
     getCardsInZone(zoneName) {
         switch (zoneName) {
             case ZoneName.Hand:

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -605,7 +605,7 @@ class Player extends GameObject {
      */
     shuffleDeck(context = null) {
         this.game.addMessage('{0} is shuffling their deck', this);
-        this.deckZone.shuffle();
+        this.deckZone.shuffle(this.game.randomGenerator);
     }
 
     /**

--- a/server/game/core/ability/PlayCardAction.ts
+++ b/server/game/core/ability/PlayCardAction.ts
@@ -170,7 +170,10 @@ export abstract class PlayCardAction extends PlayerAction {
     }
 
     protected generateSmuggleEvent(context: PlayCardContext) {
-        return resourceCard({ target: context.player.getTopCardOfDeck() }).generateEvent(context);
+        return resourceCard({
+            target: context.player.getTopCardOfDeck(),
+            readyResource: !this.card.exhausted,
+        }).generateEvent(context);
     }
 
     protected generateOnPlayEvent(context: PlayCardContext, additionalProps: any = {}) {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -856,4 +856,8 @@ export class Card extends OngoingEffectSource {
                 return false;
         }
     }
+
+    public override toString() {
+        return this.internalName;
+    }
 }

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -463,17 +463,23 @@ export class Card extends OngoingEffectSource {
     /**
      * Moves a card to a new zone, optionally resetting the card's controller back to its owner.
      *
-     * @param targetZone Zone to move to
+     * @param targetZoneName Zone to move to
      * @param resetController If true (default behavior), sets `card.controller = card.owner` on move. Set to
      * false for a hypothetical situation where a controlled opponent unit is being moved between zones and
      * needs to not change hands back to the owner.
      */
-    public moveTo(targetZone: MoveZoneDestination, resetController = true) {
+    public moveTo(targetZoneName: MoveZoneDestination, resetController = true) {
         Contract.assertNotNullLike(this._zone, `Attempting to move card ${this.internalName} before initializing zone`);
 
-        const originalZone = this.zoneName;
-        if (originalZone === targetZone) {
-            return;
+        // if we're moving to deck top / bottom, don't bother checking if we're already in the zone
+        if (!([DeckZoneDestination.DeckBottom, DeckZoneDestination.DeckTop] as MoveZoneDestination[]).includes(targetZoneName)) {
+            const originalZone = this._zone;
+            const moveToZone = (resetController ? this.owner : this.controller)
+                .getZone(EnumHelpers.asConcreteZone(targetZoneName));
+
+            if (originalZone === moveToZone) {
+                return;
+            }
         }
 
         const prevZone = this.zoneName;
@@ -483,7 +489,7 @@ export class Card extends OngoingEffectSource {
             this._controller = this.owner;
         }
 
-        this.addSelfToZone(targetZone);
+        this.addSelfToZone(targetZoneName);
 
         this.postMoveSteps(prevZone);
     }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -66,11 +66,11 @@ export class UpgradeCard extends UpgradeCardParent {
         return true;
     }
 
-    public override moveTo(targetZone: MoveZoneDestination, resetController?: boolean) {
-        Contract.assertFalse(this._parentCard && targetZone !== this._parentCard.zoneName,
+    public override moveTo(targetZoneName: MoveZoneDestination, resetController?: boolean) {
+        Contract.assertFalse(this._parentCard && targetZoneName !== this._parentCard.zoneName,
             `Attempting to move upgrade ${this.internalName} while it is still attached to ${this._parentCard?.internalName}`);
 
-        super.moveTo(targetZone, resetController);
+        super.moveTo(targetZoneName, resetController);
     }
 
     public attachTo(newParentCard: UnitCard) {

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -5,7 +5,7 @@ import * as KeywordHelpers from '../../ability/KeywordHelpers';
 import { KeywordWithNumericValue } from '../../ability/KeywordInstance';
 import type { IPlayCardActionProperties, IPlayCardActionPropertiesBase, ISmuggleCardActionProperties, PlayCardAction } from '../../ability/PlayCardAction';
 import type PlayerOrCardAbility from '../../ability/PlayerOrCardAbility';
-import type { Aspect, MoveZoneDestination } from '../../Constants';
+import type { Aspect } from '../../Constants';
 import { CardType, KeywordName, PlayType, WildcardRelativePlayer, WildcardZoneName, ZoneName } from '../../Constants';
 import type { ICostAdjusterProperties, IIgnoreAllAspectsCostAdjusterProperties, IIgnoreSpecificAspectsCostAdjusterProperties, IIncreaseOrDecreaseCostAdjusterProperties } from '../../cost/CostAdjuster';
 import { CostAdjustType } from '../../cost/CostAdjuster';
@@ -155,16 +155,6 @@ export class PlayableOrDeployableCard extends Card {
     public ready() {
         this.assertPropertyEnabled(this._exhausted, 'exhausted');
         this._exhausted = false;
-    }
-
-    public override moveTo(targetZoneName: MoveZoneDestination, resetController?: boolean): void {
-        // If this card is a resource and it is ready, try to ready another resource instead
-        // and exhaust this one. This should be the desired behavior for most cases.
-        if (this.zoneName === ZoneName.Resource && !this.exhausted) {
-            this.controller.swapResourceReadyState(this);
-        }
-
-        super.moveTo(targetZoneName, resetController);
     }
 
     public override canBeExhausted(): this is PlayableOrDeployableCard {

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -157,14 +157,14 @@ export class PlayableOrDeployableCard extends Card {
         this._exhausted = false;
     }
 
-    public override moveTo(targetZone: MoveZoneDestination, resetController?: boolean): void {
+    public override moveTo(targetZoneName: MoveZoneDestination, resetController?: boolean): void {
         // If this card is a resource and it is ready, try to ready another resource instead
         // and exhaust this one. This should be the desired behavior for most cases.
         if (this.zoneName === ZoneName.Resource && !this.exhausted) {
             this.controller.swapResourceReadyState(this);
         }
 
-        super.moveTo(targetZone, resetController);
+        super.moveTo(targetZoneName, resetController);
     }
 
     public override canBeExhausted(): this is PlayableOrDeployableCard {

--- a/server/game/core/cost/MetaActionCost.ts
+++ b/server/game/core/cost/MetaActionCost.ts
@@ -29,7 +29,8 @@ export class MetaActionCost<TContext extends AbilityContext = AbilityContext> ex
         const properties = this.gameSystem.generatePropertiesFromContext(context) as ISelectCardProperties;
         if (properties.checkTarget && context.choosingPlayerOverride) {
             context.costs[properties.innerSystem.name] = randomItem(
-                properties.selector.getAllLegalTargets(context, context.player)
+                properties.selector.getAllLegalTargets(context, context.player),
+                context.game.randomGenerator
             );
             context.costs[properties.innerSystem.name + 'StateWhenChosen'] =
                 context.costs[properties.innerSystem.name].createSnapshot();

--- a/server/game/core/gameSteps/phases/SetupPhase.ts
+++ b/server/game/core/gameSteps/phases/SetupPhase.ts
@@ -23,7 +23,7 @@ export class SetupPhase extends Phase {
     }
 
     private chooseFirstPlayer() {
-        const firstPlayer = randomItem(this.game.getPlayers());
+        const firstPlayer = randomItem(this.game.getPlayers(), this.game.randomGenerator);
 
         this.game.promptWithHandlerMenu(firstPlayer, {
             promptType: PromptType.Initiative,

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -10,6 +10,7 @@ import * as Helpers from '../utils/Helpers';
 import * as Contract from '../utils/Contract';
 import type { UnitCard } from '../card/CardTypes';
 import type { GameObject } from '../GameObject';
+import type { PlayableOrDeployableCard } from '../card/baseClasses/PlayableOrDeployableCard';
 
 export interface ICardTargetSystemProperties extends IGameSystemProperties {
     target?: Card | Card[];
@@ -260,7 +261,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
      * @param context context
      * @param defaultMoveAction A handler that will move the card to its destination if none of the special cases apply
      */
-    protected leavesPlayEventHandler(card: UnitCard, destination: ZoneName, context: TContext, defaultMoveAction: () => void): void {
+    protected leavesPlayEventHandler(card: PlayableOrDeployableCard, destination: ZoneName, context: TContext, defaultMoveAction: () => void): void {
         // Attached upgrades should be unattached before move
         if (card.isUpgrade()) {
             Contract.assertTrue(card.isAttached(), `Attempting to unattach upgrade card ${card} due to leaving play but it is already unattached.`);
@@ -275,6 +276,26 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
             card.moveTo(ZoneName.OutsideTheGame);
         } else {
             defaultMoveAction();
+        }
+    }
+
+    /**
+     * Manages side effects for when resources leave the resource zone.
+     * Specifically, if the resource is leaving due to a friendly effect, we will ensure that it
+     * is exhausted before leaving the zone by swapping its ready state with an exhausted resource (if available).
+     *
+     * @param card Resource card leaving play
+     * @param context context
+     */
+    protected leavesResourceZoneEventHandler(card: PlayableOrDeployableCard, context: TContext): void {
+        Contract.assertTrue(card.zoneName === ZoneName.Resource);
+        if (card.controller !== context.player) {
+            return;
+        }
+
+        Contract.assertTrue(card.canBeExhausted());
+        if (!card.exhausted) {
+            card.controller.swapResourceReadyState(card);
         }
     }
 

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -36,7 +36,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties = {}): void {
         let { target } = this.generatePropertiesFromContext(context, additionalProperties);
-        target = this.processTargets(target);
+        target = this.processTargets(target, context);
         for (const card of Helpers.asArray(target)) {
             let allCostsPaid = true;
             const additionalCosts = card
@@ -303,7 +303,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
      * You can override this method in case you need to make operations on targets before queuing events
      * (for example you can look MoveCardSystem.ts for shuffleMovedCards part)
      */
-    protected processTargets(target: Card | Card[]) {
+    protected processTargets(target: Card | Card[], context: TContext): Card | Card[] {
         return target;
     }
 }

--- a/server/game/core/gameSystem/LastingEffectPropertiesBase.ts
+++ b/server/game/core/gameSystem/LastingEffectPropertiesBase.ts
@@ -1,13 +1,28 @@
+import type { WhenType } from '../../Interfaces';
 import type { AbilityContext } from '../ability/AbilityContext';
 import type PlayerOrCardAbility from '../ability/PlayerOrCardAbility';
 import type { Duration } from '../Constants';
-import type { WhenType } from '../../Interfaces';
 import { type IGameSystemProperties } from './GameSystem';
 
-export interface ILastingEffectPropertiesBase extends IGameSystemProperties {
+interface ILastingEffectPropertiesAnyDuration extends IGameSystemProperties {
     duration: Duration;
-    condition?: (context: AbilityContext) => boolean;
-    until?: WhenType;
-    effect?: any;
     ability?: PlayerOrCardAbility;
+    condition?: (context: AbilityContext) => boolean;
+    effect?: any;
 }
+
+interface ILastingEffectPropertiesSetDuration extends ILastingEffectPropertiesAnyDuration {
+    duration:
+      Duration.Persistent |
+      Duration.UntilEndOfAttack |
+      Duration.UntilEndOfPhase |
+      Duration.UntilEndOfRound |
+      Duration.WhileSourceInPlay;
+}
+
+interface ILastingEffectPropertiesCustomDuration extends ILastingEffectPropertiesAnyDuration {
+    duration: Duration.Custom;
+    until: WhenType;
+}
+
+export type ILastingEffectPropertiesBase = ILastingEffectPropertiesSetDuration | ILastingEffectPropertiesCustomDuration;

--- a/server/game/core/gameSystem/PlayerTargetSystem.ts
+++ b/server/game/core/gameSystem/PlayerTargetSystem.ts
@@ -1,4 +1,5 @@
 import type { AbilityContext } from '../ability/AbilityContext';
+import type { GameStateChangeRequired } from '../Constants';
 import type { TriggerHandlingMode } from '../event/EventWindow';
 import type { GameEvent } from '../event/GameEvent';
 import type { GameObject } from '../GameObject';
@@ -26,6 +27,11 @@ export abstract class PlayerTargetSystem<TContext extends AbilityContext = Abili
 
     public override checkEventCondition(event, additionalProperties): boolean {
         return this.canAffect(event.player, event.context, additionalProperties);
+    }
+
+    // override to force the argument type to be Player
+    public override canAffect(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
+        return super.canAffect(target, context, additionalProperties, mustChangeGameState);
     }
 
     // override to force the argument type to be Player

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -6,6 +6,7 @@ import type { ZoneFilter } from '../Constants';
 import { Duration, WildcardZoneName, EffectName } from '../Constants';
 import type Game from '../Game';
 import type Player from '../Player';
+import * as Contract from '../utils/Contract';
 import type { OngoingEffectImpl } from './effectImpl/OngoingEffectImpl';
 
 /**
@@ -51,6 +52,11 @@ export abstract class OngoingEffect {
     public context: AbilityContext;
 
     public constructor(game: Game, source: Card, properties: IOngoingEffectProps, effectImpl: OngoingEffectImpl<any>) {
+        Contract.assertFalse(
+            properties.duration === Duration.WhileSourceInPlay && !source.canBeInPlay(),
+            `${source.internalName} is not a legal target for an effect with duration '${Duration.WhileSourceInPlay}'`
+        );
+
         this.game = game;
         this.source = source;
         this.matchTarget = properties.matchTarget || (() => true);

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -4,6 +4,7 @@ import type { OngoingEffect } from './OngoingEffect';
 import type { OngoingEffectSource } from './OngoingEffectSource';
 import { EventRegistrar } from '../event/EventRegistrar';
 import type Game from '../Game';
+import * as Contract from '../utils/Contract';
 
 interface ICustomDurationEvent {
     name: string;
@@ -125,8 +126,10 @@ export class OngoingEffectEngine {
         if (!prevStateChanged && !this.effectsChangedSinceLastCheck) {
             return false;
         }
-        let stateChanged = false;
         this.effectsChangedSinceLastCheck = false;
+
+        let stateChanged = this.checkWhileSourceInPlayEffectExpirations();
+
         // Check each effect's condition and find new targets
         stateChanged = this.effects.reduce((stateChanged, effect) => effect.resolveEffectTargets(stateChanged), stateChanged);
         if (loops === 10) {
@@ -135,6 +138,20 @@ export class OngoingEffectEngine {
             this.resolveEffects(stateChanged, loops + 1);
         }
         return stateChanged;
+    }
+
+    private checkWhileSourceInPlayEffectExpirations() {
+        return this.unapplyAndRemove((effect) => {
+            if (effect.duration === Duration.WhileSourceInPlay) {
+                Contract.assertTrue(effect.source.canBeInPlay(), `${effect.source.internalName} is not a legal target for an effect with duration '${Duration.WhileSourceInPlay}'`);
+
+                if (!effect.source.isInPlay() || effect.source.disableOngoingEffectsForDefeat) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
     }
 
     public unapplyAndRemove(match: (effect: OngoingEffect) => boolean) {

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -145,7 +145,7 @@ export class OngoingEffectEngine {
             if (effect.duration === Duration.WhileSourceInPlay) {
                 Contract.assertTrue(effect.source.canBeInPlay(), `${effect.source.internalName} is not a legal target for an effect with duration '${Duration.WhileSourceInPlay}'`);
 
-                if (!effect.source.isInPlay() || effect.source.disableOngoingEffectsForDefeat) {
+                if (!effect.source.isInPlay()) {
                     return true;
                 }
             }

--- a/server/game/core/ongoingEffect/OngoingEffectSource.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectSource.ts
@@ -43,6 +43,15 @@ export class OngoingEffectSource extends GameObject {
     }
 
     /**
+     * Applies an effect which lasts while the source card of the effect is in play.
+     */
+    public whileSourceInPlay(propertyFactory) {
+        const properties = propertyFactory();
+        this.addEffectToEngine(Object.assign({ duration: Duration.WhileSourceInPlay, zoneFilter: WildcardZoneName.Any }, properties));
+    }
+
+
+    /**
      * Applies a 'lasting effect' (SWU 7.7.3) which lasts until an event contained in the `until` property for the effect has occurred.
      */
     public lastingEffect(propertyFactory) {

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -1,3 +1,4 @@
+import type seedrandom from 'seedrandom';
 import type { Card } from '../card/Card';
 import type { Aspect, CardTypeFilter } from '../Constants';
 import { CardType, ZoneName } from '../Constants';
@@ -5,17 +6,17 @@ import * as Contract from './Contract';
 import * as EnumHelpers from './EnumHelpers';
 
 /* Randomize array in-place using Durstenfeld shuffle algorithm */
-export function shuffleArray<T>(array: T[]): void {
+export function shuffleArray<T>(array: T[], randomGenerator: seedrandom): void {
     for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(randomGenerator() * (i + 1));
         const temp = array[i];
         array[i] = array[j];
         array[j] = temp;
     }
 }
 
-export function randomItem<T>(array: T[]): undefined | T {
-    const j = Math.floor(Math.random() * array.length);
+export function randomItem<T>(array: T[], randomGenerator: seedrandom): undefined | T {
+    const j = Math.floor(randomGenerator() * array.length);
     return array[j];
 }
 
@@ -36,10 +37,10 @@ export function countUniqueAspects(cards: Card | Card[]): number {
 
 // TODO: remove this
 /** @deprecated Use `shuffleArray` instead */
-export function shuffle<T>(array: T[]): T[] {
+export function shuffle<T>(array: T[], randomGenerator: seedrandom): T[] {
     const shuffleArray = [...array];
     for (let i = shuffleArray.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(randomGenerator() * (i + 1));
         [shuffleArray[i], shuffleArray[j]] = [shuffleArray[j], shuffleArray[i]];
     }
     return shuffleArray;
@@ -96,12 +97,12 @@ export function asArray<T>(val: T | T[]): T[] {
     return Array.isArray(val) ? val : [val];
 }
 
-export function getRandomArrayElements(array: any[], nValues: number) {
+export function getRandomArrayElements(array: any[], nValues: number, randomGenerator: seedrandom) {
     Contract.assertTrue(nValues <= array.length, `Attempting to retrieve ${nValues} random elements from an array of length ${array.length}`);
 
     const chosenItems = [];
     for (let i = 0; i < nValues; i++) {
-        const index = Math.floor(Math.random() * array.length);
+        const index = Math.floor(randomGenerator() * array.length);
         const choice = array.splice(index, 1)[0];
 
         chosenItems.push(choice);

--- a/server/game/core/zone/DeckZone.ts
+++ b/server/game/core/zone/DeckZone.ts
@@ -1,3 +1,4 @@
+import type seedrandom from 'seedrandom';
 import type { Card } from '../card/Card';
 import type { TokenOrPlayableCard } from '../card/CardTypes';
 import type { MoveZoneDestination } from '../Constants';
@@ -87,8 +88,8 @@ export class DeckZone extends ZoneAbstract<TokenOrPlayableCard> implements IAddR
         this.deck.splice(cardIdx, 1);
     }
 
-    public shuffle() {
-        this.deck = Helpers.shuffle(this.deck);
+    public shuffle(randomGenerator: seedrandom) {
+        this.deck = Helpers.shuffle(this.deck, randomGenerator);
     }
 
     protected override checkZoneMatches(card: Card, zone: MoveZoneDestination | null) {

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -1,14 +1,11 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
-import type { ZoneName } from '../core/Constants';
 import { EffectName, EventName, WildcardZoneName } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { ILastingEffectPropertiesBase } from '../core/gameSystem/LastingEffectPropertiesBase';
 
-export interface ICardLastingEffectProperties extends Omit<ILastingEffectPropertiesBase, 'target'>, ICardTargetSystemProperties {
-    targetZoneFilter?: ZoneName | ZoneName[];
-}
+export interface ICardLastingEffectProperties extends Omit<ILastingEffectPropertiesBase, 'target'>, ICardTargetSystemProperties {}
 
 /**
  * For a definition, see SWU 7.7.3 'Lasting Effects': "A lasting effect is a part of an ability that affects the game for a specified duration of time.

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -1,10 +1,9 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
-import { Duration, EffectName, EventName, WildcardZoneName } from '../core/Constants';
+import { EffectName, EventName, WildcardZoneName } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { ILastingEffectPropertiesBase } from '../core/gameSystem/LastingEffectPropertiesBase';
-import * as Contract from '../core/utils/Contract';
 
 export interface ICardLastingEffectProperties extends Omit<ILastingEffectPropertiesBase, 'target'>, ICardTargetSystemProperties {}
 
@@ -79,25 +78,11 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         return { effectFactories: effect, effectProperties };
     }
 
-    private filterApplicableEffects(card: Card, effects: any[]) {
+    protected filterApplicableEffects(card: Card, effects: any[]) {
         const lastingEffectRestrictions = card.getOngoingEffectValues(EffectName.CannotApplyLastingEffects);
         return effects.filter(
             (props) =>
-                !lastingEffectRestrictions.some((condition) => condition(props.impl)) &&
-                this.whileSourceInPlayCondition(props)
+                !lastingEffectRestrictions.some((condition) => condition(props.impl))
         );
-    }
-
-    /**
-     * If the duration is {@link Duration.WhileSourceInPlay}, checks if the source unit is still in play. Returns true if so, or if the duration is not `WhileSourceInPlay`.
-     * */
-    private whileSourceInPlayCondition(props: any) {
-        if (props.duration !== Duration.WhileSourceInPlay) {
-            return true;
-        }
-
-        Contract.assertTrue(props.source.canBeInPlay(), `${props.source.internalName} is not a legal target for an effect with duration '${Duration.WhileSourceInPlay}'`);
-
-        return props.source.isInPlay();
     }
 }

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -1,9 +1,10 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
-import { EffectName, EventName, WildcardZoneName } from '../core/Constants';
+import { Duration, EffectName, EventName, WildcardZoneName } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { ILastingEffectPropertiesBase } from '../core/gameSystem/LastingEffectPropertiesBase';
+import * as Contract from '../core/utils/Contract';
 
 export interface ICardLastingEffectProperties extends Omit<ILastingEffectPropertiesBase, 'target'>, ICardTargetSystemProperties {}
 
@@ -82,7 +83,21 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         const lastingEffectRestrictions = card.getOngoingEffectValues(EffectName.CannotApplyLastingEffects);
         return effects.filter(
             (props) =>
-                !lastingEffectRestrictions.some((condition) => condition(props.impl))
+                !lastingEffectRestrictions.some((condition) => condition(props.impl)) &&
+                this.whileSourceInPlayCondition(props)
         );
+    }
+
+    /**
+     * If the duration is {@link Duration.WhileSourceInPlay}, checks if the source unit is still in play. Returns true if so, or if the duration is not `WhileSourceInPlay`.
+     * */
+    private whileSourceInPlayCondition(props: any) {
+        if (props.duration !== Duration.WhileSourceInPlay) {
+            return true;
+        }
+
+        Contract.assertTrue(props.source.canBeInPlay(), `${props.source.internalName} is not a legal target for an effect with duration '${Duration.WhileSourceInPlay}'`);
+
+        return props.source.isInPlay();
     }
 }

--- a/server/game/gameSystems/CardWhileSourceInPlayLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardWhileSourceInPlayLastingEffectSystem.ts
@@ -1,0 +1,47 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import { Duration, EventName } from '../core/Constants';
+import { GameSystem } from '../core/gameSystem/GameSystem';
+import type { ICardLastingEffectProperties } from './CardLastingEffectSystem';
+import { CardLastingEffectSystem } from './CardLastingEffectSystem';
+import * as Contract from '../core/utils/Contract';
+import type { Card } from '../core/card/Card';
+
+export type ICardWhileSourceInPlayLastingEffectProperties = Omit<ICardLastingEffectProperties, 'duration'>;
+
+/**
+ * Helper subclass of {@link CardLastingEffectSystem} that specifically creates lasting effects targeting cards
+ * which will last while the source of the effect is in play.
+ */
+export class CardWhileSourceInPlayLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardLastingEffectSystem<TContext> {
+    public override readonly name = 'applyCardWhileSourceInPlayLastingEffect';
+    public override readonly eventName = EventName.OnEffectApplied;
+    protected override readonly defaultProperties: ICardLastingEffectProperties = {
+        duration: null,
+        effect: [],
+        ability: null
+    };
+
+    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
+    public constructor(propertiesOrPropertyFactory: ICardWhileSourceInPlayLastingEffectProperties | ((context?: AbilityContext) => ICardWhileSourceInPlayLastingEffectProperties)) {
+        const propertyWithDurationType = GameSystem.appendToPropertiesOrPropertyFactory<ICardLastingEffectProperties, 'duration'>(propertiesOrPropertyFactory, { duration: Duration.WhileSourceInPlay });
+        super(propertyWithDurationType);
+    }
+
+    protected override filterApplicableEffects(card: Card, effects: any[]) {
+        return super.filterApplicableEffects(card, effects)
+            .filter((effect) => this.whileSourceInPlayCondition(effect));
+    }
+
+    /**
+     * If the duration is {@link Duration.WhileSourceInPlay}, checks if the source unit is still in play. Returns true if so, or if the duration is not `WhileSourceInPlay`.
+     * */
+    private whileSourceInPlayCondition(props: any) {
+        if (props.duration !== Duration.WhileSourceInPlay) {
+            return true;
+        }
+
+        Contract.assertTrue(props.source.canBeInPlay(), `${props.source.internalName} is not a legal target for an effect with duration '${Duration.WhileSourceInPlay}'`);
+
+        return props.source.isInPlay();
+    }
+}

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -47,8 +47,11 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
 
     public eventHandler(event): void {
         const card: Card = event.card;
+        Contract.assertTrue(card.canBeExhausted());
 
-        if (card.zoneName !== ZoneName.Resource && card.isUpgrade()) {
+        if (card.zoneName === ZoneName.Resource) {
+            this.leavesResourceZoneEventHandler(card, event.context);
+        } else if (card.isUpgrade()) {
             card.unattach();
         }
 

--- a/server/game/gameSystems/DelayedEffectSystem.ts
+++ b/server/game/gameSystems/DelayedEffectSystem.ts
@@ -41,11 +41,6 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
     };
 
     public eventHandler(event: any, additionalProperties: any): void {
-        // TODO Remove this if we don't need it
-        // if (!properties.ability) {
-        //     properties.ability = event.context.ability;
-        // }
-
         const delayedEffectSource = event.sourceCard as OngoingEffectSource;
 
         const renamedProperties = event.renamedProperties;
@@ -64,6 +59,9 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
             case Duration.UntilEndOfRound:
                 delayedEffectSource.untilEndOfRound(() => renamedProperties);
                 break;
+            case Duration.WhileSourceInPlay:
+                delayedEffectSource.whileSourceInPlay(() => renamedProperties);
+                break;
             case Duration.Custom:
                 throw new Error(`Duration ${duration} not implemented yet`);
             default:
@@ -73,6 +71,9 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
 
     public override addPropertiesToEvent(event: any, target: any, context: TContext, additionalProperties?: any): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        // TODO THIS PR: add guards here for WhileSourceInPlay
+
         event.sourceCard = this.getDelayedEffectSource(event, context, additionalProperties);
         Contract.assertNotNullLike(properties.immediateEffect, 'Immediate Effect cannot be null');
 

--- a/server/game/gameSystems/DelayedEffectSystem.ts
+++ b/server/game/gameSystems/DelayedEffectSystem.ts
@@ -10,6 +10,7 @@ import type { WhenType } from '../Interfaces';
 import * as Contract from '../core/utils/Contract';
 import OngoingEffectLibrary from '../ongoingEffects/OngoingEffectLibrary';
 import type { GameObject } from '../core/GameObject';
+import type { OngoingEffectSource } from '../core/ongoingEffect/OngoingEffectSource';
 
 export enum DelayedEffectType {
     Card = 'card',
@@ -45,7 +46,7 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
         //     properties.ability = event.context.ability;
         // }
 
-        const delayedEffectSource = event.sourceCard;
+        const delayedEffectSource = event.sourceCard as OngoingEffectSource;
 
         const renamedProperties = event.renamedProperties;
         const duration = renamedProperties.duration;

--- a/server/game/gameSystems/DelayedEffectSystem.ts
+++ b/server/game/gameSystems/DelayedEffectSystem.ts
@@ -17,7 +17,7 @@ export enum DelayedEffectType {
     Player = 'player'
 }
 
-export interface IDelayedEffectSystemProperties extends IGameSystemProperties {
+export interface IDelayedEffectProperties extends IGameSystemProperties {
     title: string;
     when: WhenType;
     duration?: Duration;
@@ -26,12 +26,12 @@ export interface IDelayedEffectSystemProperties extends IGameSystemProperties {
     effectType: DelayedEffectType;
 }
 
-export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, IDelayedEffectSystemProperties> {
+export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, IDelayedEffectProperties> {
     public override readonly name: string = 'applyDelayedEffect';
     public override readonly eventName: EventName = EventName.OnEffectApplied;
     public override readonly effectDescription: string = 'apply a delayed effect';
 
-    protected override defaultProperties: IDelayedEffectSystemProperties = {
+    protected override defaultProperties: IDelayedEffectProperties = {
         title: null,
         when: null,
         duration: Duration.Persistent,
@@ -40,39 +40,25 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
         effectType: null
     };
 
-    public eventHandler(event: any, additionalProperties: any): void {
+    public eventHandler(event: any, _additionalProperties: any): void {
         const delayedEffectSource = event.sourceCard as Card;
 
-        const renamedProperties = event.renamedProperties;
-        const duration = renamedProperties.duration;
+        const effectProperties = event.effectProperties;
+        const duration = effectProperties.duration;
 
         switch (duration) {
             case Duration.Persistent:
-                delayedEffectSource.persistent(() => renamedProperties);
+                delayedEffectSource.persistent(() => effectProperties);
                 break;
             case Duration.UntilEndOfAttack:
-                delayedEffectSource.untilEndOfAttack(() => renamedProperties);
+                delayedEffectSource.untilEndOfAttack(() => effectProperties);
                 break;
             case Duration.UntilEndOfPhase:
-                delayedEffectSource.untilEndOfPhase(() => renamedProperties);
+                delayedEffectSource.untilEndOfPhase(() => effectProperties);
                 break;
             case Duration.UntilEndOfRound:
-                delayedEffectSource.untilEndOfRound(() => renamedProperties);
+                delayedEffectSource.untilEndOfRound(() => effectProperties);
                 break;
-            case Duration.WhileSourceInPlay:
-                // if the source card has already left play, trigger the effects immediately
-                Contract.assertTrue(delayedEffectSource.canBeInPlay());
-                if (!delayedEffectSource.isInPlay()) {
-                    event.context.game.addSubwindowEvents(
-                        event.immediateEffect.generateEvent(event.context, additionalProperties)
-                    );
-                    break;
-                }
-
-                delayedEffectSource.whileSourceInPlay(() => renamedProperties);
-                break;
-            case Duration.Custom:
-                throw new Error(`Duration ${duration} not implemented yet`);
             default:
                 Contract.fail(`Invalid Duration ${duration} for DelayedEffect`);
         }
@@ -81,14 +67,14 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
     public override addPropertiesToEvent(event: any, target: any, context: TContext, additionalProperties?: any): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
-        // TODO THIS PR: add guards here for WhileSourceInPlay
+        this.checkDuration(properties.duration);
 
-        event.sourceCard = this.getDelayedEffectSource(event, context, additionalProperties);
+        event.sourceCard = this.getDelayedEffectSource(context, additionalProperties);
         Contract.assertNotNullLike(properties.immediateEffect, 'Immediate Effect cannot be null');
 
         const { title, when, limit, immediateEffect, ...otherProperties } = properties;
 
-        const renamedProperties = { ...otherProperties, ongoingEffect:
+        const effectProperties = { ...otherProperties, ongoingEffect:
             OngoingEffectLibrary.delayedEffect({
                 title,
                 when,
@@ -96,7 +82,7 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
                 limit
             }) };
 
-        event.renamedProperties = renamedProperties;
+        event.effectProperties = effectProperties;
         event.immediateEffect = properties.immediateEffect;
     }
 
@@ -116,7 +102,19 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
         return false;
     }
 
-    private getDelayedEffectSource (event: any, context: TContext, additionalProperties?: any) {
+    protected checkDuration(duration: Duration) {
+        Contract.assertFalse(
+            duration === Duration.WhileSourceInPlay,
+            'Do not use DelayedEffectSystem for "while in play" delayed effects, use WhileSourceInPlayDelayedEffectSystem instead'
+        );
+
+        Contract.assertFalse(
+            duration === Duration.Custom,
+            'Custom duration not implemented yet'
+        );
+    }
+
+    protected getDelayedEffectSource(context: TContext, additionalProperties?: any) {
         const { effectType, target } = this.generatePropertiesFromContext(context, additionalProperties);
 
         switch (effectType) {
@@ -133,7 +131,7 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
 
                 return nonArrayTarget;
             case DelayedEffectType.Player:
-                return event.context.source;
+                return context.source;
             default:
                 Contract.fail(`Unknown delayed effect type: ${effectType}`);
         }

--- a/server/game/gameSystems/DiscardCardsFromHandSystem.ts
+++ b/server/game/gameSystems/DiscardCardsFromHandSystem.ts
@@ -88,7 +88,7 @@ export class DiscardCardsFromHandSystem<TContext extends AbilityContext = Abilit
             }
 
             if (properties.random) {
-                const randomCards = Helpers.getRandomArrayElements(availableHand, amount);
+                const randomCards = Helpers.getRandomArrayElements(availableHand, amount, context.game.randomGenerator);
                 this.generateEventsForCards(randomCards, context, events, additionalProperties);
                 continue;
             }

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -15,6 +15,8 @@ import { CardLastingEffectSystem } from './CardLastingEffectSystem';
 import type { ICardPhaseLastingEffectProperties } from './CardPhaseLastingEffectSystem';
 import { CardPhaseLastingEffectSystem } from './CardPhaseLastingEffectSystem';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
+import type { ICardWhileSourceInPlayLastingEffectProperties } from './CardWhileSourceInPlayLastingEffectSystem';
+import { CardWhileSourceInPlayLastingEffectSystem } from './CardWhileSourceInPlayLastingEffectSystem';
 import type { IPlayModalCardProperties } from './ChooseModalEffectsSystem';
 import { ChooseModalEffectsSystem } from './ChooseModalEffectsSystem';
 import type { ICollectBountyProperties } from './CollectBountySystem';
@@ -337,6 +339,9 @@ export function takeControlOfUnit<TContext extends AbilityContext = AbilityConte
 // export function placeCardUnderneath(propertyFactory: PropsFactory<PlaceCardUnderneathProperties>) {
 //     return new PlaceCardUnderneathAction(propertyFactory);
 // }
+export function whileSourceInPlayCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardWhileSourceInPlayLastingEffectProperties, TContext>) {
+    return new CardWhileSourceInPlayLastingEffectSystem<TContext>(propertyFactory);
+}
 
 // //////////////
 // // PLAYER

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -31,7 +31,7 @@ import type { IDamageProperties } from './DamageSystem';
 import { DamageSystem } from './DamageSystem';
 import type { IDefeatCardProperties } from './DefeatCardSystem';
 import { DefeatCardSystem } from './DefeatCardSystem';
-import type { IDelayedEffectSystemProperties } from './DelayedEffectSystem';
+import type { IDelayedEffectProperties } from './DelayedEffectSystem';
 import { DelayedEffectSystem, DelayedEffectType } from './DelayedEffectSystem';
 import type { IDeployLeaderProperties } from './DeployLeaderSystem';
 import { DeployLeaderSystem } from './DeployLeaderSystem';
@@ -107,6 +107,7 @@ import type { ITakeControlOfResourceProperties } from './TakeControlOfResourceSy
 import { TakeControlOfResourceSystem } from './TakeControlOfResourceSystem';
 import type { ITakeControlOfUnitProperties } from './TakeControlOfUnitSystem';
 import { TakeControlOfUnitSystem } from './TakeControlOfUnitSystem';
+import { WhenSourceLeavesPlayDelayedEffectSystem, type IWhenSourceLeavesPlayDelayedEffectProperties } from './WhileSourceInPlayDelayedEffectSystem';
 
 
 type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
@@ -143,6 +144,13 @@ export function createCloneTrooper<TContext extends AbilityContext = AbilityCont
 }
 export function damage<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDamageProperties, TContext>) {
     return new DamageSystem<TContext, IDamageProperties>(propertyFactory);
+}
+export function delayedCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IDelayedEffectProperties, 'effectType'>>) {
+    return new DelayedEffectSystem<TContext>(
+        GameSystem.appendToPropertiesOrPropertyFactory<IDelayedEffectProperties, 'effectType'>(
+            propertyFactory,
+            { effectType: DelayedEffectType.Card }
+        ));
 }
 export function distributeDamageAmong<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IDistributeDamageSystemProperties, TContext>) {
     return new DistributeDamageSystem<TContext>(propertyFactory);
@@ -344,6 +352,13 @@ export function takeControlOfUnit<TContext extends AbilityContext = AbilityConte
 export function whileSourceInPlayCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardWhileSourceInPlayLastingEffectProperties, TContext>) {
     return new CardWhileSourceInPlayLastingEffectSystem<TContext>(propertyFactory);
 }
+export function whenSourceLeavesPlayDelayedCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IWhenSourceLeavesPlayDelayedEffectProperties, 'effectType'>>) {
+    return new WhenSourceLeavesPlayDelayedEffectSystem<TContext>(
+        GameSystem.appendToPropertiesOrPropertyFactory<IWhenSourceLeavesPlayDelayedEffectProperties, 'effectType'>(
+            propertyFactory,
+            { effectType: DelayedEffectType.Card }
+        ));
+}
 
 // //////////////
 // // PLAYER
@@ -434,16 +449,9 @@ export function readyResources<TContext extends AbilityContext = AbilityContext>
 export function playerLastingEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IPlayerLastingEffectProperties>) {
     return new PlayerLastingEffectSystem<TContext>(propertyFactory);
 }
-export function delayedCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IDelayedEffectSystemProperties, 'effectType'>>) {
+export function delayedPlayerEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IDelayedEffectProperties, 'effectType'>>) {
     return new DelayedEffectSystem<TContext>(
-        GameSystem.appendToPropertiesOrPropertyFactory<IDelayedEffectSystemProperties, 'effectType'>(
-            propertyFactory,
-            { effectType: DelayedEffectType.Card }
-        ));
-}
-export function delayedPlayerEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IDelayedEffectSystemProperties, 'effectType'>>) {
-    return new DelayedEffectSystem<TContext>(
-        GameSystem.appendToPropertiesOrPropertyFactory<IDelayedEffectSystemProperties, 'effectType'>(
+        GameSystem.appendToPropertiesOrPropertyFactory<IDelayedEffectProperties, 'effectType'>(
             propertyFactory,
             { effectType: DelayedEffectType.Player }
         ));

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -103,7 +103,9 @@ import { SequentialSystem } from './SequentialSystem';
 import type { IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { ShuffleDeckSystem } from './ShuffleDeckSystem';
 import { SimultaneousGameSystem } from './SimultaneousSystem';
-import type { ITakeControlProperties } from './TakeControlOfUnitSystem';
+import type { ITakeControlOfResourceProperties } from './TakeControlOfResourceSystem';
+import { TakeControlOfResourceSystem } from './TakeControlOfResourceSystem';
+import type { ITakeControlOfUnitProperties } from './TakeControlOfUnitSystem';
 import { TakeControlOfUnitSystem } from './TakeControlOfUnitSystem';
 
 
@@ -321,7 +323,7 @@ export function reveal<TContext extends AbilityContext = AbilityContext>(propert
 // export function sacrifice(propertyFactory: PropsFactory<DiscardFromPlayProperties> = {}) {
 //     return new DiscardFromPlayAction(propertyFactory, true);
 // }
-export function takeControlOfUnit<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ITakeControlProperties, TContext>) {
+export function takeControlOfUnit<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ITakeControlOfUnitProperties, TContext>) {
     return new TakeControlOfUnitSystem(propertyFactory);
 }
 // export function triggerAbility(propertyFactory: PropsFactory<TriggerAbilityProperties>) {
@@ -445,6 +447,9 @@ export function delayedPlayerEffect<TContext extends AbilityContext = AbilityCon
             propertyFactory,
             { effectType: DelayedEffectType.Player }
         ));
+}
+export function takeControlOfResource<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ITakeControlOfResourceProperties, TContext> = {}) {
+    return new TakeControlOfResourceSystem(propertyFactory);
 }
 
 // //////////////

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -130,9 +130,9 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
         return super.canAffect(card, context, additionalProperties, mustChangeGameState);
     }
 
-    protected override processTargets(target: Card | Card[]) {
+    protected override processTargets(target: Card | Card[], context: TContext) {
         if (this.properties?.shuffleMovedCards && Array.isArray(target)) {
-            Helpers.shuffleArray(target);
+            Helpers.shuffleArray(target, context.game.randomGenerator);
         }
         return target;
     }

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -44,14 +44,17 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
     };
 
     public eventHandler(event: any, additionalProperties = {}): void {
-        // Check if the card is leaving play
-        if (EnumHelpers.isArena(event.card.zoneName) && !EnumHelpers.isArena(event.destination)) {
-            this.leavesPlayEventHandler(event.card, event.destination, event.context, () => event.card.moveTo(event.destination));
-        } else {
-            // TODO: remove this completely if determined we don't need card snapshots
-            // event.cardStateWhenMoved = card.createSnapshot();
-            const card = event.card as Card;
+        const card = event.card as Card;
+        Contract.assertTrue(card.canBeExhausted());
 
+        if (card.zoneName === ZoneName.Resource) {
+            this.leavesResourceZoneEventHandler(card, event.context);
+        }
+
+        // Check if the card is leaving play
+        if (EnumHelpers.isArena(card.zoneName) && !EnumHelpers.isArena(event.destination)) {
+            this.leavesPlayEventHandler(card, event.destination, event.context, () => card.moveTo(event.destination));
+        } else {
             card.moveTo(event.destination);
 
             // TODO: use ShuffleDeckSystem instead

--- a/server/game/gameSystems/PlayerLastingEffectSystem.ts
+++ b/server/game/gameSystems/PlayerLastingEffectSystem.ts
@@ -7,11 +7,11 @@ import { GameSystem } from '../core/gameSystem/GameSystem';
 import type { ILastingEffectPropertiesBase } from '../core/gameSystem/LastingEffectPropertiesBase';
 import type Player from '../core/Player';
 
-export interface IPlayerLastingEffectProperties extends ILastingEffectPropertiesBase {
+export type IPlayerLastingEffectProperties = ILastingEffectPropertiesBase & {
 
     /** Default is `RelativePlayer.Self` */
     targetPlayer?: RelativePlayer | Player;
-}
+};
 
 export class PlayerLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, IPlayerLastingEffectProperties> {
     public override readonly name: string = 'applyPlayerLastingEffect';

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -222,7 +222,7 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext> 
 
     private remainingCardsDefaultHandler(context: TContext, event: any, cardsToMove: Card[]) {
         if (cardsToMove.length > 0) {
-            shuffleArray(cardsToMove);
+            shuffleArray(cardsToMove, context.game.randomGenerator);
             for (const card of cardsToMove) {
                 card.moveTo(DeckZoneDestination.DeckBottom);
             }

--- a/server/game/gameSystems/TakeControlOfResourceSystem.ts
+++ b/server/game/gameSystems/TakeControlOfResourceSystem.ts
@@ -1,21 +1,15 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import type { Card } from '../core/card/Card';
-import { GameStateChangeRequired, EventName, ZoneName } from '../core/Constants';
+import { GameStateChangeRequired, EventName } from '../core/Constants';
 import { PlayerTargetSystem, type IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTargetSystem';
 import type Player from '../core/Player';
 import * as Contract from '../core/utils/Contract';
 import * as Helpers from '../core/utils/Helpers';
 
-
-export interface ITakeControlOfResourceProperties extends IPlayerTargetSystemProperties {
-    specificResource?: Card;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ITakeControlOfResourceProperties extends IPlayerTargetSystemProperties {}
 
 /**
- * Used for taking control of a resource from a player.
- *
- * A specific resource card can be specified for taking control. If it is not specified, a resource of the player's will be selected at random
- * (but always a ready resource if available).
+ * Used for taking control of a resource from a player. The selected resource is random, but always a ready resource if available.
  *
  * The `target` player is the player who will be _taking_ the resource, and their opponent will be losing it.
  */
@@ -34,18 +28,6 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
             return false;
         }
 
-        const { specificResource } = this.generatePropertiesFromContext(context);
-        if (specificResource) {
-            if (specificResource.zoneName !== ZoneName.Resource) {
-                return false;
-            }
-
-            // if a specific resource is specified and the player already controls it, there will be no game state change
-            if (specificResource.controller === takingResourcePlayer && mustChangeGameState !== GameStateChangeRequired.None) {
-                return false;
-            }
-        }
-
         return super.canAffect(takingResourcePlayer, context);
     }
 
@@ -62,12 +44,6 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
 
         event.newController = player;
 
-        const { specificResource } = this.generatePropertiesFromContext(context);
-        if (specificResource) {
-            event.card = specificResource;
-            return;
-        }
-
         // TODO: randomize player resource ready / exhausted state in accordance with new rules
         // (should probably prioritize making Smuggle cards exhausted)
         const opponentReadyResources = player.opponent.resources.filter((resource) => !resource.exhausted);
@@ -77,7 +53,7 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
             return;
         }
 
-        // randomly select a ready resource if possible; if none is available then randomly select from all resources
+        // randomly select a ready resource if possible; otherwise randomly select from all resources
         const resourcesToChooseFrom = opponentReadyResources.length > 0 ? opponentReadyResources : player.opponent.resources;
         event.card = Helpers.randomItem(resourcesToChooseFrom);
     }

--- a/server/game/gameSystems/TakeControlOfResourceSystem.ts
+++ b/server/game/gameSystems/TakeControlOfResourceSystem.ts
@@ -1,0 +1,69 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import { GameStateChangeRequired, EventName } from '../core/Constants';
+import { PlayerTargetSystem, type IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTargetSystem';
+import type Player from '../core/Player';
+import * as Contract from '../core/utils/Contract';
+import * as Helpers from '../core/utils/Helpers';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ITakeControlOfResourceProperties extends IPlayerTargetSystemProperties {}
+
+/**
+ * Used for taking control of a resource from a player. The selected resource is random, but always a ready resource if available.
+ *
+ * The `target` player is the player who will be _taking_ the resource, and their opponent will be losing it.
+ */
+export class TakeControlOfResourceSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, ITakeControlOfResourceProperties> {
+    public override readonly name = 'takeControl';
+    public override readonly eventName = EventName.OnTakeControl;
+
+    public eventHandler(event): void {
+        event.card.takeControl(event.newController);
+    }
+
+    public override canAffect(player: Player | Player[], context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const takingResourcePlayer = this.playerFromArray(player);
+
+        if (mustChangeGameState !== GameStateChangeRequired.None && takingResourcePlayer.opponent.resources.length === 0) {
+            return false;
+        }
+
+        return super.canAffect(takingResourcePlayer, context);
+    }
+
+    public override getEffectMessage(context: TContext): [string, any[]] {
+        const { target } = this.generatePropertiesFromContext(context);
+
+        const takingResourcePlayer = this.playerFromArray(target);
+
+        return ['{0} takes control of a resource from {1}', [takingResourcePlayer, takingResourcePlayer.opponent]];
+    }
+
+    public override addPropertiesToEvent(event: any, player: Player, context: TContext, additionalProperties?: any): void {
+        super.addPropertiesToEvent(event, player, context, additionalProperties);
+
+        event.newController = player;
+
+        // TODO: randomize player resource ready / exhausted state in accordance with new rules
+        // (should probably prioritize making Smuggle cards exhausted)
+        const opponentReadyResources = player.opponent.resources.filter((resource) => !resource.exhausted);
+
+        if (opponentReadyResources.length === 1) {
+            event.card = opponentReadyResources[0];
+            return;
+        }
+
+        // randomly select a ready resource if possible; otherwise randomly select from all resources
+        const resourcesToChooseFrom = opponentReadyResources.length > 0 ? opponentReadyResources : player.opponent.resources;
+        event.card = Helpers.randomItem(resourcesToChooseFrom);
+    }
+
+    private playerFromArray(player: Player | Player[]) {
+        if (!Array.isArray(player)) {
+            return player;
+        }
+
+        Contract.assertArraySize(player, 1, `TakeControlOfResourceSystem must have exactly one player target, instead found ${player.length}`);
+        return player[0];
+    }
+}

--- a/server/game/gameSystems/TakeControlOfResourceSystem.ts
+++ b/server/game/gameSystems/TakeControlOfResourceSystem.ts
@@ -67,7 +67,7 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
 
         // randomly select a ready resource if possible; otherwise randomly select from all resources
         const resourcesToChooseFrom = opponentReadyResources.length > 0 ? opponentReadyResources : player.opponent.resources;
-        event.card = Helpers.randomItem(resourcesToChooseFrom);
+        event.card = Helpers.randomItem(resourcesToChooseFrom, context.game.randomGenerator);
     }
 
     private playerFromArray(player: Player | Player[]) {

--- a/server/game/gameSystems/TakeControlOfResourceSystem.ts
+++ b/server/game/gameSystems/TakeControlOfResourceSystem.ts
@@ -1,15 +1,21 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import { GameStateChangeRequired, EventName } from '../core/Constants';
+import type { Card } from '../core/card/Card';
+import { GameStateChangeRequired, EventName, ZoneName } from '../core/Constants';
 import { PlayerTargetSystem, type IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTargetSystem';
 import type Player from '../core/Player';
 import * as Contract from '../core/utils/Contract';
 import * as Helpers from '../core/utils/Helpers';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ITakeControlOfResourceProperties extends IPlayerTargetSystemProperties {}
+
+export interface ITakeControlOfResourceProperties extends IPlayerTargetSystemProperties {
+    specificResource?: Card;
+}
 
 /**
- * Used for taking control of a resource from a player. The selected resource is random, but always a ready resource if available.
+ * Used for taking control of a resource from a player.
+ *
+ * A specific resource card can be specified for taking control. If it is not specified, a resource of the player's will be selected at random
+ * (but always a ready resource if available).
  *
  * The `target` player is the player who will be _taking_ the resource, and their opponent will be losing it.
  */
@@ -28,6 +34,18 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
             return false;
         }
 
+        const { specificResource } = this.generatePropertiesFromContext(context);
+        if (specificResource) {
+            if (specificResource.zoneName !== ZoneName.Resource) {
+                return false;
+            }
+
+            // if a specific resource is specified and the player already controls it, there will be no game state change
+            if (specificResource.controller === takingResourcePlayer && mustChangeGameState !== GameStateChangeRequired.None) {
+                return false;
+            }
+        }
+
         return super.canAffect(takingResourcePlayer, context);
     }
 
@@ -44,6 +62,12 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
 
         event.newController = player;
 
+        const { specificResource } = this.generatePropertiesFromContext(context);
+        if (specificResource) {
+            event.card = specificResource;
+            return;
+        }
+
         // TODO: randomize player resource ready / exhausted state in accordance with new rules
         // (should probably prioritize making Smuggle cards exhausted)
         const opponentReadyResources = player.opponent.resources.filter((resource) => !resource.exhausted);
@@ -53,7 +77,7 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
             return;
         }
 
-        // randomly select a ready resource if possible; otherwise randomly select from all resources
+        // randomly select a ready resource if possible; if none is available then randomly select from all resources
         const resourcesToChooseFrom = opponentReadyResources.length > 0 ? opponentReadyResources : player.opponent.resources;
         event.card = Helpers.randomItem(resourcesToChooseFrom);
     }

--- a/server/game/gameSystems/TakeControlOfUnitSystem.ts
+++ b/server/game/gameSystems/TakeControlOfUnitSystem.ts
@@ -1,27 +1,27 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
-import { CardType, GameStateChangeRequired, ZoneName, WildcardCardType, EventName } from '../core/Constants';
+import { GameStateChangeRequired, WildcardCardType, EventName } from '../core/Constants';
 import { type ICardTargetSystemProperties, CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type Player from '../core/Player';
 
-export interface ITakeControlProperties extends ICardTargetSystemProperties {
+export interface ITakeControlOfUnitProperties extends ICardTargetSystemProperties {
     newController: Player;
 }
 
 /**
  * Used for taking control of a unit in the arena
  */
-export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityContext, TProperties extends ITakeControlProperties = ITakeControlProperties> extends CardTargetSystem<TContext, TProperties> {
+export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, ITakeControlOfUnitProperties> {
     public override readonly name = 'takeControl';
     public override readonly eventName = EventName.OnTakeControl;
-    protected override readonly targetTypeFilter = [WildcardCardType.NonLeaderUnit, CardType.Event, WildcardCardType.Upgrade];
+    protected override readonly targetTypeFilter = [WildcardCardType.NonLeaderUnit];
 
     public eventHandler(event): void {
         event.card.takeControl(event.newController);
     }
 
     public override canAffect(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
-        if (![ZoneName.Resource, ZoneName.SpaceArena, ZoneName.GroundArena].includes(card.zoneName)) {
+        if (!card.canBeInPlay() || !card.isInPlay()) {
             return false;
         }
 

--- a/server/game/gameSystems/WhileSourceInPlayDelayedEffectSystem.ts
+++ b/server/game/gameSystems/WhileSourceInPlayDelayedEffectSystem.ts
@@ -1,0 +1,55 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import type { Card } from '../core/card/Card';
+import { Duration } from '../core/Constants';
+import { GameSystem } from '../core/gameSystem/GameSystem';
+import * as Contract from '../core/utils/Contract';
+import type { IDelayedEffectProperties } from './DelayedEffectSystem';
+import { DelayedEffectSystem } from './DelayedEffectSystem';
+
+export type IWhenSourceLeavesPlayDelayedEffectProperties = Omit<IDelayedEffectProperties, 'duration' | 'when' | 'target'>;
+
+/**
+ * Subclass of the {@link DelayedEffectSystem} specifically for creating delayed effects that happen when the source leaves play
+ */
+export class WhenSourceLeavesPlayDelayedEffectSystem<TContext extends AbilityContext = AbilityContext> extends DelayedEffectSystem<TContext> {
+    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
+    public constructor(propertiesOrPropertyFactory: IWhenSourceLeavesPlayDelayedEffectProperties | ((context?: AbilityContext) => IWhenSourceLeavesPlayDelayedEffectProperties)) {
+        const propsWithWhen = GameSystem.appendToPropertiesOrPropertyFactory<IDelayedEffectProperties, 'when' | 'duration'>(
+            propertiesOrPropertyFactory,
+            {
+                when: { onCardLeavesPlay: (event, context) => event.card === context.source },
+                duration: Duration.WhileSourceInPlay
+            }
+        );
+        super(propsWithWhen);
+    }
+
+    public override eventHandler(event: any, additionalProperties: any): void {
+        const delayedEffectSource = event.sourceCard as Card;
+
+        const effectProperties = event.effectProperties;
+
+        Contract.assertTrue(effectProperties.duration === Duration.WhileSourceInPlay);
+        Contract.assertTrue(delayedEffectSource.canBeInPlay());
+
+        // if the source card has already left play, trigger the effects immediately
+        if (!delayedEffectSource.isInPlay()) {
+            event.context.game.addSubwindowEvents(
+                event.immediateEffect.generateEvent(event.context, additionalProperties)
+            );
+            return;
+        }
+
+        delayedEffectSource.whileSourceInPlay(() => effectProperties);
+    }
+
+    protected override checkDuration(duration: Duration) {
+        Contract.assertTrue(duration === Duration.WhileSourceInPlay || duration == null, `Expected duration to be WhileSourceInPlay or null, instead found ${duration}`);
+    }
+
+    protected override getDelayedEffectSource(context: TContext, additionalProperties?: any) {
+        Contract.assertTrue(context.source.canBeInPlay());
+
+        return context.source;
+    }
+}

--- a/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
+++ b/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
@@ -6,29 +6,57 @@ describe('DJ, Blatant Thief', function() {
                     phase: 'action',
                     player1: {
                         base: 'chopper-base',
+                        leader: 'han-solo#audacious-smuggler',
+                        hand: ['strafing-gunship'],
                         resources: [
                             'dj#blatant-thief', 'atst', 'atst', 'atst', 'atst',
                             'atst', 'atst', 'atst', 'atst', 'atst'
                         ]
                     },
                     player2: {
-                        hand: ['vanquish'],
+                        groundArena: ['atat-suppressor'],
                         resources: 10
                     }
                 });
             });
 
-            it('should take control of a resource until he leaves play', function () {
+            it('should take control of a resource until he leaves play, taking a ready resource if available', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.djBlatantThief);
+
                 expect(context.player1.resources.length).toBe(11);
                 expect(context.player2.resources.length).toBe(9);
+                expect(context.player1.readyResourceCount).toBe(4);
+                expect(context.player1.exhaustedResourceCount).toBe(7);
+                expect(context.player2.readyResourceCount).toBe(9);
+                expect(context.player2.exhaustedResourceCount).toBe(0);
 
-                context.player2.clickCard(context.vanquish);
+                // check that stolen resource maintained its ready state
+                const stolenResourceList = context.player1.resources.filter((resource) => resource.owner === context.player2Object);
+                expect(stolenResourceList.length).toBe(1);
+                const stolenResource = stolenResourceList[0];
+                expect(stolenResource.exhausted).toBeFalse();
+
+                // confirm that player1 can spend with it
+                context.player2.passAction();
+                expect(context.player1.readyResourceCount).toBe(4);
+                context.player1.clickCard(context.strafingGunship);
+                expect(context.strafingGunship).toBeInZone('spaceArena');
+                expect(context.player1.exhaustedResourceCount).toBe(11);
+                expect(stolenResource.exhausted).toBeTrue();
+
+                // DJ is defeated, resource goes back to owner's resource zone and stays exhausted
+                context.player2.clickCard(context.atatSuppressor);
                 context.player2.clickCard(context.dj);
+
                 expect(context.player1.resources.length).toBe(10);
                 expect(context.player2.resources.length).toBe(10);
+                expect(context.player2.exhaustedResourceCount).toBe(1);
+                expect(context.player2.readyResourceCount).toBe(9);
+
+                expect(stolenResource.controller).toBe(context.player2Object);
+                expect(stolenResource.exhausted).toBeTrue();
             });
         });
     });

--- a/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
+++ b/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
@@ -8,6 +8,7 @@ describe('DJ, Blatant Thief', function() {
                         base: 'chopper-base',
                         leader: 'han-solo#audacious-smuggler',
                         hand: ['strafing-gunship'],
+                        // 10 resources total
                         resources: [
                             'dj#blatant-thief', 'atst', 'atst', 'atst', 'atst',
                             'atst', 'atst', 'atst', 'atst', 'atst'
@@ -100,5 +101,39 @@ describe('DJ, Blatant Thief', function() {
                 expect(stolenResource.exhausted).toBeFalse();
             });
         });
+
+        it('DJ\'s when played ability should do nothing if he is played from hand or discard', function() {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    base: 'chopper-base',
+                    hand: ['dj#blatant-thief', 'palpatines-return'],
+                    resources: 20
+                },
+                player2: {
+                    groundArena: ['atat-suppressor'],
+                    resources: 20
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.djBlatantThief);
+            expect(context.player1.resources.length).toBe(20);
+            expect(context.player2.resources.length).toBe(20);
+
+            // defeat DJ and play him from discard
+            context.player2.clickCard(context.atatSuppressor);
+            context.player2.clickCard(context.dj);
+            context.player1.clickCard(context.palpatinesReturn);
+            context.player1.clickCard(context.dj);
+
+            expect(context.player1.resources.length).toBe(20);
+            expect(context.player2.resources.length).toBe(20);
+        });
+
+        // TODO: test with Endless Legions to confirm that DJ doesn't take control of the card back after it's played
+        // TODO: test with Endless Legions to confirm that the DJ ability doesn't trigger if he is played
+        // TODO: once Han1 is implemented, set up a test scenario with Tech + DJ + Han1
     });
 });

--- a/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
+++ b/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
@@ -12,17 +12,23 @@ describe('DJ, Blatant Thief', function() {
                         ]
                     },
                     player2: {
+                        hand: ['vanquish'],
                         resources: 10
                     }
                 });
             });
 
-            it('should give an experience token to a unit', function () {
+            it('should take control of a resource until he leaves play', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.djBlatantThief);
                 expect(context.player1.resources.length).toBe(11);
                 expect(context.player2.resources.length).toBe(9);
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.dj);
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
             });
         });
     });

--- a/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
+++ b/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
@@ -1,0 +1,29 @@
+describe('DJ, Blatant Thief', function() {
+    integration(function(contextRef) {
+        describe('DJ\'s when played ability', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        base: 'chopper-base',
+                        resources: [
+                            'dj#blatant-thief', 'atst', 'atst', 'atst', 'atst',
+                            'atst', 'atst', 'atst', 'atst', 'atst'
+                        ]
+                    },
+                    player2: {
+                        resources: 10
+                    }
+                });
+            });
+
+            it('should give an experience token to a unit', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.djBlatantThief);
+                expect(context.player1.resources.length).toBe(11);
+                expect(context.player2.resources.length).toBe(9);
+            });
+        });
+    });
+});

--- a/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
+++ b/test/server/cards/02_SHD/units/DjBlatantThief.spec.ts
@@ -54,9 +54,50 @@ describe('DJ, Blatant Thief', function() {
                 expect(context.player2.resources.length).toBe(10);
                 expect(context.player2.exhaustedResourceCount).toBe(1);
                 expect(context.player2.readyResourceCount).toBe(9);
+                expect(context.player1.exhaustedResourceCount).toBe(10);
+                expect(context.player1.readyResourceCount).toBe(0);
 
                 expect(stolenResource.controller).toBe(context.player2Object);
                 expect(stolenResource.exhausted).toBeTrue();
+            });
+
+            it('should take control of a resource until he leaves play, taking an exhausted resource if required', function () {
+                const { context } = contextRef;
+
+                context.player2.exhaustResources(10);
+
+                context.player1.clickCard(context.djBlatantThief);
+
+                expect(context.player1.resources.length).toBe(11);
+                expect(context.player2.resources.length).toBe(9);
+                expect(context.player1.readyResourceCount).toBe(3);
+                expect(context.player1.exhaustedResourceCount).toBe(8);
+                expect(context.player2.readyResourceCount).toBe(0);
+                expect(context.player2.exhaustedResourceCount).toBe(9);
+
+                // check that stolen resource maintained its ready state
+                const stolenResourceList = context.player1.resources.filter((resource) => resource.owner === context.player2Object);
+                expect(stolenResourceList.length).toBe(1);
+                const stolenResource = stolenResourceList[0];
+                expect(stolenResource.exhausted).toBeTrue();
+
+                // move to next action phase so that resources are all readied
+                context.moveToNextActionPhase();
+
+                // DJ is defeated, resource goes back to owner's resource zone and stays ready
+                context.player1.passAction();
+                context.player2.clickCard(context.atatSuppressor);
+                context.player2.clickCard(context.dj);
+
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
+                expect(context.player2.exhaustedResourceCount).toBe(0);
+                expect(context.player2.readyResourceCount).toBe(10);
+                expect(context.player1.exhaustedResourceCount).toBe(0);
+                expect(context.player1.readyResourceCount).toBe(10);
+
+                expect(stolenResource.controller).toBe(context.player2Object);
+                expect(stolenResource.exhausted).toBeFalse();
             });
         });
     });

--- a/test/server/cards/03_TWI/units/HuyangEnduringInstructor.spec.ts
+++ b/test/server/cards/03_TWI/units/HuyangEnduringInstructor.spec.ts
@@ -1,0 +1,31 @@
+describe('Huyang, Enduring Instructor', function() {
+    integration(function(contextRef) {
+        it('Huyang\'s ability gives another friendly unit +2/+2 until he leaves play', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['huyang#enduring-instructor'],
+                    groundArena: ['wampa']
+                },
+                player2: {
+                    groundArena: ['atst', 'atat-suppressor'],
+                    spaceArena: ['cartel-spacer'],
+                    hand: ['republic-attack-pod']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.huyang);
+            expect(context.player1).toBeAbleToSelect(context.wampa);
+            context.player1.clickCard(context.wampa);
+            expect(context.wampa.getPower()).toBe(6);
+            expect(context.wampa.getHp()).toBe(7);
+
+            context.player2.clickCard(context.atst);
+            context.player2.clickCard(context.huyang);
+            expect(context.wampa.getPower()).toBe(4);
+            expect(context.wampa.getHp()).toBe(5);
+        });
+    });
+});

--- a/test/server/cards/03_TWI/units/HuyangEnduringInstructor.spec.ts
+++ b/test/server/cards/03_TWI/units/HuyangEnduringInstructor.spec.ts
@@ -19,11 +19,16 @@ describe('Huyang, Enduring Instructor', function() {
             context.player1.clickCard(context.huyang);
             expect(context.player1).toBeAbleToSelect(context.wampa);
             context.player1.clickCard(context.wampa);
+
             expect(context.wampa.getPower()).toBe(6);
             expect(context.wampa.getHp()).toBe(7);
+            expect(context.huyang.getPower()).toBe(2);
+            expect(context.huyang.getHp()).toBe(4);
 
+            // Defeat Huyang, effect goes away
             context.player2.clickCard(context.atst);
             context.player2.clickCard(context.huyang);
+
             expect(context.wampa.getPower()).toBe(4);
             expect(context.wampa.getHp()).toBe(5);
         });

--- a/test/server/cards/03_TWI/units/HuyangEnduringInstructor.spec.ts
+++ b/test/server/cards/03_TWI/units/HuyangEnduringInstructor.spec.ts
@@ -8,9 +8,7 @@ describe('Huyang, Enduring Instructor', function() {
                     groundArena: ['wampa']
                 },
                 player2: {
-                    groundArena: ['atst', 'atat-suppressor'],
-                    spaceArena: ['cartel-spacer'],
-                    hand: ['republic-attack-pod']
+                    groundArena: ['atst'],
                 }
             });
 

--- a/test/server/gameSystems/CardLastingEffectSystem.spec.ts
+++ b/test/server/gameSystems/CardLastingEffectSystem.spec.ts
@@ -75,6 +75,14 @@ describe('Card lasting effects', function() {
                 expect(context.wampa.getHp()).toBe(5);
             });
 
+            it('not cause any error if the target is defeated while under the effect', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.wampa);
+                expect(context.player1).toBeActivePlayer();
+            });
+
             it('persist across rounds', function () {
                 const { context } = contextRef;
 

--- a/test/server/gameSystems/CardLastingEffectSystem.spec.ts
+++ b/test/server/gameSystems/CardLastingEffectSystem.spec.ts
@@ -1,12 +1,12 @@
 describe('Card lasting effects', function() {
     integration(function (contextRef) {
-        describe('A card lasting effect with duration "while source is in play"', function() {
+        describe('A card lasting effect with duration "while source is in play" should', function() {
             beforeEach(function () {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
                         hand: ['huyang#enduring-instructor'],
-                        groundArena: ['wampa']
+                        groundArena: ['wampa', 'snowspeeder']
                     },
                     player2: {
                         hand: ['vanquish', 'discerning-veteran', 'waylay', 'change-of-heart']
@@ -20,7 +20,7 @@ describe('Card lasting effects', function() {
                 context.player1.clickCard(context.wampa);
             });
 
-            it('should have effect while the source is in play and go away when it is defeated', function () {
+            it('have effect while the source is in play and go away when it is defeated', function () {
                 const { context } = contextRef;
 
                 expect(context.wampa.getPower()).toBe(6);
@@ -43,7 +43,7 @@ describe('Card lasting effects', function() {
                 expect(context.wampa.getHp()).toBe(5);
             });
 
-            it('go away when when the source is returned to hand', function () {
+            it('expire when the source is returned to hand, and not return if the source comes back into play', function () {
                 const { context } = contextRef;
 
                 context.player2.clickCard(context.waylay);
@@ -51,9 +51,31 @@ describe('Card lasting effects', function() {
 
                 expect(context.wampa.getPower()).toBe(4);
                 expect(context.wampa.getHp()).toBe(5);
+
+                // choose snowspeeder as effect target
+                context.player1.clickCard(context.huyang);
+                context.player1.clickCard(context.snowspeeder);
+
+                // wampa does not have effect, snowspeeder does
+                expect(context.wampa.getPower()).toBe(4);
+                expect(context.wampa.getHp()).toBe(5);
+                expect(context.snowspeeder.getPower()).toBe(5);
+                expect(context.snowspeeder.getHp()).toBe(8);
             });
 
-            it('should persist across rounds', function () {
+            it('stop affecting the target if it is returned to hand, and not resume if the target comes back into play', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.wampa);
+
+                context.player1.clickCard(context.wampa);
+
+                expect(context.wampa.getPower()).toBe(4);
+                expect(context.wampa.getHp()).toBe(5);
+            });
+
+            it('persist across rounds', function () {
                 const { context } = contextRef;
 
                 context.moveToNextActionPhase();
@@ -62,7 +84,7 @@ describe('Card lasting effects', function() {
                 expect(context.wampa.getHp()).toBe(7);
             });
 
-            it('should persist even if the source changes controllers', function () {
+            it('persist even if the source changes controllers', function () {
                 const { context } = contextRef;
 
                 context.player2.clickCard(context.changeOfHeart);

--- a/test/server/gameSystems/CardLastingEffectSystem.spec.ts
+++ b/test/server/gameSystems/CardLastingEffectSystem.spec.ts
@@ -1,0 +1,100 @@
+describe('Card lasting effects', function() {
+    integration(function (contextRef) {
+        describe('A card lasting effect with duration "while source is in play"', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['huyang#enduring-instructor'],
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        hand: ['vanquish', 'discerning-veteran', 'waylay', 'change-of-heart']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // play out Huyang and target Wampa with his effect
+                context.player1.clickCard(context.huyang);
+                context.player1.clickCard(context.wampa);
+            });
+
+            it('should have effect while the source is in play and go away when it is defeated', function () {
+                const { context } = contextRef;
+
+                expect(context.wampa.getPower()).toBe(6);
+                expect(context.wampa.getHp()).toBe(7);
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.huyang);
+
+                expect(context.wampa.getPower()).toBe(4);
+                expect(context.wampa.getHp()).toBe(5);
+            });
+
+            it('go away when when the source is captured', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.discerningVeteran);
+                context.player2.clickCard(context.huyang);
+
+                expect(context.wampa.getPower()).toBe(4);
+                expect(context.wampa.getHp()).toBe(5);
+            });
+
+            it('go away when when the source is returned to hand', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.huyang);
+
+                expect(context.wampa.getPower()).toBe(4);
+                expect(context.wampa.getHp()).toBe(5);
+            });
+
+            it('should persist across rounds', function () {
+                const { context } = contextRef;
+
+                context.moveToNextActionPhase();
+
+                expect(context.wampa.getPower()).toBe(6);
+                expect(context.wampa.getHp()).toBe(7);
+            });
+
+            it('should persist even if the source changes controllers', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.changeOfHeart);
+                context.player2.clickCard(context.huyang);
+
+                expect(context.wampa.getPower()).toBe(6);
+                expect(context.wampa.getHp()).toBe(7);
+            });
+        });
+
+        it('A triggered card lasting effect with duration "while source is in play" should not activate if the source is defeated before the trigger resolves', function() {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['huyang#enduring-instructor'],
+                    groundArena: ['wampa'],
+                    leader: 'han-solo#worth-the-risk'
+                },
+                player2: {
+                    groundArena: ['supreme-leader-snoke#shadow-ruler']
+                }
+            });
+
+            const { context } = contextRef;
+
+            // play out Huyang - between Snoke effect and Han damage, he is immediately defeated
+            context.player1.clickCard(context.hanSolo);
+            context.player1.clickPrompt('Play a unit from your hand. It costs 1 resource less. Deal 2 damage to it.');
+            context.player1.clickCard(context.huyang);
+
+            // check that the player is never prompted for the trigger since Huyang is defeated by the time it happens
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/gameSystems/DelayedEffectSystem.spec.ts
+++ b/test/server/gameSystems/DelayedEffectSystem.spec.ts
@@ -1,0 +1,121 @@
+describe('Delayed effects', function() {
+    integration(function (contextRef) {
+        describe('A delayed effect with duration "while source is in play" should', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        base: 'chopper-base',
+                        leader: 'han-solo#audacious-smuggler',
+                        // 10 resources total
+                        resources: [
+                            'dj#blatant-thief', 'atst', 'atst', 'atst', 'atst',
+                            'atst', 'atst', 'atst', 'atst', 'atst'
+                        ]
+                    },
+                    player2: {
+                        hand: ['vanquish', 'discerning-veteran', 'waylay', 'change-of-heart'],
+                        resources: 10
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // play out DJ and steal a resource
+                context.player1.clickCard(context.dj);
+                expect(context.player1.resources.length).toBe(11);
+                expect(context.player2.resources.length).toBe(9);
+            });
+
+            it('trigger when the source card is defeated', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.dj);
+
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
+            });
+
+            it('trigger when when the source is captured', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.discerningVeteran);
+                context.player2.clickCard(context.dj);
+
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
+            });
+
+            it('trigger when the source is returned to hand', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.dj);
+
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
+            });
+
+            it('persist across rounds', function () {
+                const { context } = contextRef;
+
+                context.moveToNextActionPhase();
+
+                context.player1.passAction();
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.dj);
+
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
+            });
+
+            it('persist even if the source changes controllers', function () {
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.changeOfHeart);
+                context.player2.clickCard(context.dj);
+
+                context.player1.passAction();
+                context.player2.readyResources(10);
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.dj);
+
+                expect(context.player1.resources.length).toBe(10);
+                expect(context.player2.resources.length).toBe(10);
+            });
+        });
+
+        it('A delayed effect with duration "while source is in play" should immediately activate if the source is defeated before the trigger resolves', function() {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    base: 'chopper-base',
+                    leader: 'han-solo#audacious-smuggler',
+                    // 10 resources total
+                    resources: [
+                        'dj#blatant-thief', 'atst', 'atst', 'atst', 'atst',
+                        'atst', 'atst', 'atst', 'atst', 'atst'
+                    ]
+                },
+                player2: {
+                    groundArena: ['supreme-leader-snoke#shadow-ruler', 'krayt-dragon'],
+                    resources: 10
+                }
+            });
+
+            const { context } = contextRef;
+
+            // play out DJ and assign Krayt damage to him - between that and Snoke effect he is defeated before ability resolves
+            context.player1.clickCard(context.dj);
+            context.player1.clickPrompt('Opponent');
+            context.player2.clickCard(context.dj);
+
+            // the resource should be returned to the opponent immediately
+            expect(context.player1.resources.length).toBe(10);
+            expect(context.player2.resources.length).toBe(10);
+
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/gameSystems/DelayedEffectSystem.spec.ts
+++ b/test/server/gameSystems/DelayedEffectSystem.spec.ts
@@ -117,5 +117,67 @@ describe('Delayed effects', function() {
 
             expect(context.player2).toBeActivePlayer();
         });
+
+        describe('A delayed effect with duration "while source is in play", when the unique rule is triggered,', function() {
+            beforeEach(function () {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        base: 'chopper-base',
+                        leader: 'han-solo#audacious-smuggler',
+                        // 10 resources total
+                        resources: [
+                            'dj#blatant-thief', 'dj#blatant-thief', 'atst', 'atst', 'atst',
+                            'atst', 'atst', 'atst', 'atst', 'atst'
+                        ]
+                    },
+                    player2: {
+                        resources: 10
+                    }
+                });
+
+                const { context } = contextRef;
+
+                const [djInPlay, djInHand] = context.player1.findCardsByName('dj#blatant-thief');
+                context.djInPlay = djInPlay;
+                context.djInHand = djInHand;
+
+                context.player1.clickCard(djInPlay);
+                context.stolenResource1 = context.player1.resources.filter((resource) => resource.owner === context.player2Object)[0];
+                context.player2.passAction();
+                context.player1.readyResources(7);
+
+                // set an explicit random seed so we can guarantee that different "random" cards are stolen between the two DJs
+                context.game.setRandomSeed('12345');
+            });
+
+            it('should activate if the in-play card is defeated due to the uniqueness rule', function() {
+                const { context } = contextRef;
+
+                // play DJ from hand, defeat the DJ in play
+                context.player1.clickCard(context.djInHand);
+                context.player1.clickCard(context.djInPlay);
+
+                // since a new DJ came in, the original resource was returned and a new one was stolen
+                expect(context.player1.resources.length).toBe(11);
+                expect(context.player2.resources.length).toBe(9);
+                const stolenResource2 = context.player1.resources.filter((resource) => resource.owner === context.player2Object)[0];
+                expect(context.stolenResource1).not.toBe(stolenResource2);
+            });
+
+            it('should immediately activate if the from-hand card is defeated due to the uniqueness rule', function() {
+                const { context } = contextRef;
+
+                // play DJ from hand, defeat that same DJ
+                context.player1.clickCard(context.djInHand);
+                context.player1.clickCard(context.djInHand);
+
+                // since the new one was defeated, the newly stolen resource goes back immediately
+                expect(context.player1.resources.length).toBe(11);
+                expect(context.player2.resources.length).toBe(9);
+                const stolenResource2 = context.player1.resources.filter((resource) => resource.owner === context.player2Object)[0];
+                expect(context.stolenResource1).toBe(stolenResource2);
+            });
+        });
     });
 });

--- a/test/server/gameSystems/DelayedEffectSystem.spec.ts
+++ b/test/server/gameSystems/DelayedEffectSystem.spec.ts
@@ -151,7 +151,7 @@ describe('Delayed effects', function() {
                 context.game.setRandomSeed('12345');
             });
 
-            it('should activate if the in-play card is defeated due to the uniqueness rule', function() {
+            it('should activate if the in-play card is defeated', function() {
                 const { context } = contextRef;
 
                 // play DJ from hand, defeat the DJ in play
@@ -165,7 +165,7 @@ describe('Delayed effects', function() {
                 expect(context.stolenResource1).not.toBe(stolenResource2);
             });
 
-            it('should immediately activate if the from-hand card is defeated due to the uniqueness rule', function() {
+            it('should immediately activate if the from-hand card is defeated', function() {
                 const { context } = contextRef;
 
                 // play DJ from hand, defeat that same DJ


### PR DESCRIPTION
Added general support for cards that have an effect that lasts "while this card is in play." Implemented Huyang and DJ to test out the implementations for lasting effects and delayed effects, respectively.

Added some new game systems to support the effects for these cards. Additionally, switched over to using a single random generator object that is used throughout the engine to support testing effects that use randomness.