### PR TITLE
Implement Aayla Secura, Master of the Blade

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -227,7 +227,7 @@ export interface ISetId {
 interface IReplacementEffectAbilityBaseProps<TSource extends Card = Card> extends Omit<ITriggeredAbilityBaseProps<TSource>,
         'immediateEffect' | 'targetResolver' | 'targetResolvers' | 'handler'
 > {
-    replaceWith: IReplacementEffectSystemProperties<TriggeredAbilityContext<TSource>>;
+    replaceWith?: IReplacementEffectSystemProperties<TriggeredAbilityContext<TSource>>;
 }
 
 type ITriggeredAbilityWhenProps<TSource extends Card> = ITriggeredAbilityBaseProps<TSource> & {

--- a/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
+++ b/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
@@ -1,0 +1,39 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { AbilityType, DamageType } from '../../../core/Constants';
+
+export default class AaylaSecuraMasterOfTheBlade extends NonLeaderUnitCard {
+    protected override getImplementationId () {
+        return {
+            id: '6190335038',
+            internalName: 'aayla-secura#master-of-the-blade',
+        };
+    }
+    
+    public override setupCardAbilities () {
+        this.addCoordinateAbility({
+            type: AbilityType.Triggered,
+            title: "Prevent all combat damage that would be dealt to this unit for this attack.",
+            when: {
+                onAttackDeclared: (event, context) => event.attack.attacker === context.source
+            },
+            immediateEffect: AbilityHelper.immediateEffects.forThisAttackCardEffect((context) => ({
+                target: context.source,
+                effect: AbilityHelper.ongoingEffects.gainAbility({
+                    title: "Prevent all combat damage that would be dealt to this unit",
+                    type: AbilityType.ReplacementEffect,
+                    when: {
+                        onDamageDealt: (event, context) => 
+                            event.card === context.source && event.type === DamageType.Combat
+                    },
+                    replaceWith: {
+                        target: context.source,
+                        replacementImmediateEffect: null
+                    }
+                }),
+            })),
+        });
+    }
+}
+
+AaylaSecuraMasterOfTheBlade.implemented = true;

--- a/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
+++ b/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
@@ -26,10 +26,7 @@ export default class AaylaSecuraMasterOfTheBlade extends NonLeaderUnitCard {
                         onDamageDealt: (event, context) =>
                             event.card === context.source && event.type === DamageType.Combat
                     },
-                    replaceWith: {
-                        target: context.source,
-                        replacementImmediateEffect: null
-                    }
+                    replaceWith: { /* replace with nothing */ }
                 }),
             })),
         });

--- a/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
+++ b/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
@@ -9,21 +9,21 @@ export default class AaylaSecuraMasterOfTheBlade extends NonLeaderUnitCard {
             internalName: 'aayla-secura#master-of-the-blade',
         };
     }
-    
+
     public override setupCardAbilities () {
         this.addCoordinateAbility({
             type: AbilityType.Triggered,
-            title: "Prevent all combat damage that would be dealt to this unit for this attack.",
+            title: 'Prevent all combat damage that would be dealt to this unit for this attack.',
             when: {
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source
             },
             immediateEffect: AbilityHelper.immediateEffects.forThisAttackCardEffect((context) => ({
                 target: context.source,
                 effect: AbilityHelper.ongoingEffects.gainAbility({
-                    title: "Prevent all combat damage that would be dealt to this unit",
+                    title: 'Prevent all combat damage that would be dealt to this unit',
                     type: AbilityType.ReplacementEffect,
                     when: {
-                        onDamageDealt: (event, context) => 
+                        onDamageDealt: (event, context) =>
                             event.card === context.source && event.type === DamageType.Combat
                     },
                     replaceWith: {

--- a/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
+++ b/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
@@ -25,8 +25,7 @@ export default class AaylaSecuraMasterOfTheBlade extends NonLeaderUnitCard {
                     when: {
                         onDamageDealt: (event, context) =>
                             event.card === context.source && event.type === DamageType.Combat
-                    },
-                    replaceWith: { /* replace with nothing */ }
+                    }
                 }),
             })),
         });

--- a/test/server/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.spec.ts
+++ b/test/server/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.spec.ts
@@ -1,0 +1,75 @@
+describe('Aayla Secura, Master of the Blade', function() {
+    integration(function(contextRef) {
+        describe('Aayla Secura\'s on attack Coordinate ability', function() {
+            it('should prevent combat damage to Aayla when Coordinate condition is met', function() {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'aayla-secura#master-of-the-blade',
+                            'battlefield-marine',
+                            'clone-trooper'
+                        ],
+                    },
+                    player2: {
+                        groundArena: ['consular-security-force']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.aaylaSecura);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.aaylaSecura.damage).toBe(0);
+                expect(context.consularSecurityForce.damage).toBe(6);
+            });
+
+            it('should not prevent combat damage to Aayla when Coordinate condition is not met', function() {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['aayla-secura#master-of-the-blade', 'battlefield-marine'],
+                    },
+                    player2: {
+                        groundArena: ['consular-security-force']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.aaylaSecura);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.aaylaSecura.damage).toBe(3);
+                expect(context.consularSecurityForce.damage).toBe(6);
+            });
+
+            it('should not prevent combat damage to Aayla when Coordinate condition is met but Aayla is not attacking', function() {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'aayla-secura#master-of-the-blade',
+                            'battlefield-marine',
+                            'clone-trooper'
+                        ],
+                    },
+                    player2: {
+                        groundArena: ['consular-security-force']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickPrompt('Pass');
+
+                context.player2.clickCard(context.consularSecurityForce);
+                context.player2.clickCard(context.aaylaSecura);
+
+                expect(context.aaylaSecura.damage).toBe(3);
+                expect(context.consularSecurityForce.damage).toBe(6);
+            });
+        });
+    });
+});

--- a/test/server/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.spec.ts
+++ b/test/server/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.spec.ts
@@ -1,73 +1,165 @@
 describe('Aayla Secura, Master of the Blade', function() {
     integration(function(contextRef) {
-        describe('Aayla Secura\'s on attack Coordinate ability', function() {
+        describe('Aayla Secura\'s on attack ability', function() {
             it('should prevent combat damage to Aayla when Coordinate condition is met', function() {
                 contextRef.setupTest({
                     phase: 'action',
                     player1: {
+                        hand: ['timely-intervention'],
                         groundArena: [
                             'aayla-secura#master-of-the-blade',
                             'battlefield-marine',
-                            'clone-trooper'
-                        ],
+                            'clone-trooper',
+                        ]
                     },
                     player2: {
-                        groundArena: ['consular-security-force']
+                        hand: ['waylay', 'waylay', 'waylay'],
+                        groundArena: [
+                            'consular-security-force',
+                            'tarfful#kashyyyk-chieftain',
+                            'krrsantan#muscle-for-hire'
+                        ]
                     }
                 });
 
                 const { context } = contextRef;
+                context.firstWaylay = context.player2.hand[0];
+                context.secondWaylay = context.player2.hand[1];
+                context.thirdWaylay = context.player2.hand[2];
+
+                const reset = (pass = true) => {
+                    context.setDamage(context.aaylaSecura, 0);
+                    context.setDamage(context.consularSecurityForce, 0);
+                    context.aaylaSecura.exhausted = false;
+
+                    if (pass) {
+                        context.player2.passAction();
+                    }
+                };
+
+                // CASE 1: Aayla is in play and attacks while Coordinate is active
 
                 context.player1.clickCard(context.aaylaSecura);
                 context.player1.clickCard(context.consularSecurityForce);
 
                 expect(context.aaylaSecura.damage).toBe(0);
                 expect(context.consularSecurityForce.damage).toBe(6);
-            });
 
-            it('should not prevent combat damage to Aayla when Coordinate condition is not met', function() {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        groundArena: ['aayla-secura#master-of-the-blade', 'battlefield-marine'],
-                    },
-                    player2: {
-                        groundArena: ['consular-security-force']
-                    }
-                });
+                reset(false);
 
-                const { context } = contextRef;
+                // CASE 2: Aayla is in play and attacks while Coordinate is not active
+
+                // Remove Battlefield Marine from the board to take coordinate offline
+                context.player2.clickCard(context.firstWaylay);
+                context.player2.clickCard(context.battlefieldMarine);
 
                 context.player1.clickCard(context.aaylaSecura);
                 context.player1.clickCard(context.consularSecurityForce);
 
                 expect(context.aaylaSecura.damage).toBe(3);
                 expect(context.consularSecurityForce.damage).toBe(6);
-            });
 
-            it('should not prevent combat damage to Aayla when Coordinate condition is met but Aayla is not attacking', function() {
-                contextRef.setupTest({
-                    phase: 'action',
-                    player1: {
-                        groundArena: [
-                            'aayla-secura#master-of-the-blade',
-                            'battlefield-marine',
-                            'clone-trooper'
-                        ],
-                    },
-                    player2: {
-                        groundArena: ['consular-security-force']
-                    }
-                });
+                reset();
 
-                const { context } = contextRef;
+                // CASE 3: Opponent attacks Aayla while Coordinate is active
 
-                context.player1.clickPrompt('Pass');
+                context.player1.clickCard(context.battlefieldMarine);
 
                 context.player2.clickCard(context.consularSecurityForce);
                 context.player2.clickCard(context.aaylaSecura);
 
                 expect(context.aaylaSecura.damage).toBe(3);
+                expect(context.consularSecurityForce.damage).toBe(6);
+
+                reset(false);
+
+                // CASE 4: Aayla ambushes to activate Coordinate
+
+                // Set up - Player 1 passes and player 2 waylays Aayla
+                context.player1.passAction();
+                context.player2.clickCard(context.secondWaylay);
+                context.player2.clickCard(context.aaylaSecura);
+
+                expect(context.player1.groundArena.length).toBe(2);
+
+                // Player 1 ambushes Aayla back into play, activating Coordinate and preventing combat damage
+                context.player1.clickCard(context.timelyIntervention);
+                context.player1.clickCard(context.aaylaSecura);
+                context.player1.clickPrompt('Ambush');
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.aaylaSecura.damage).toBe(0);
+                expect(context.consularSecurityForce.damage).toBe(6);
+
+                // CASE 5: Aayla's ability does not block non-combat damage when she attacks (The Tarfful Situation)
+                reset();
+
+                context.player1.clickCard(context.aaylaSecura);
+                context.player1.clickCard(context.krrsantan);
+
+                expect(context.aaylaSecura.damage).toBe(0);
+                expect(context.krrsantan.damage).toBe(6);
+
+                context.player2.clickCard(context.aaylaSecura);
+
+                expect(context.aaylaSecura).toBeInZone('discard');
+            });
+
+            it('works correctly when Aayla is shielded', function() {
+                contextRef.setupTest({
+                    phase: 'action',
+                    player1: {
+                        hand: ['moment-of-peace'],
+                        groundArena: [
+                            { card: 'aayla-secura#master-of-the-blade', upgrades: ['shield'] },
+                            'battlefield-marine',
+                            'clone-trooper',
+                        ]
+                    },
+                    player2: {
+                        groundArena: [
+                            'consular-security-force',
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // CASE 1: User chooses to resolve Aayla's ability, preserving the shield
+
+                context.player1.clickCard(context.aaylaSecura);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat shield to prevent attached unit from taking damage',
+                    'Prevent all combat damage that would be dealt to this unit'
+                ]);
+
+                context.player1.clickPrompt('Prevent all combat damage that would be dealt to this unit');
+
+                expect(context.aaylaSecura.damage).toBe(0);
+                expect(context.aaylaSecura.isUpgraded()).toBeTrue();
+                expect(context.consularSecurityForce.damage).toBe(6);
+
+                // Reset
+                context.setDamage(context.consularSecurityForce, 0);
+                context.aaylaSecura.exhausted = false;
+                context.player2.passAction();
+
+                // CASE 2: User chooses to defeat shield instead of preventing damage
+
+                context.player1.clickCard(context.aaylaSecura);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat shield to prevent attached unit from taking damage',
+                    'Prevent all combat damage that would be dealt to this unit'
+                ]);
+
+                context.player1.clickPrompt('Defeat shield to prevent attached unit from taking damage');
+
+                expect(context.aaylaSecura.damage).toBe(0);
+                expect(context.aaylaSecura.isUpgraded()).toBeFalse();
                 expect(context.consularSecurityForce.damage).toBe(6);
             });
         });


### PR DESCRIPTION
<img width=250 src=https://github.com/user-attachments/assets/4e5a33d1-809b-4a9a-b64b-1742bb53cf27>

-----

### Notes on implementation

I had hoped to land on a solution that would work for other similar damage prevention abilities (like [Boba Fett's Armor](https://swudb.com/card/shd/224/boba-fetts-armor) and [Finn, On the Run](https://swudb.com/card/twi/053/finn)), but ultimately the only `replacementImmediateEffect` that I could get to work was `null`. Interestingly, neither of the following strategies worked for me, but maybe there is someone who knows more about these that could help me understand why:

```typescript
// Did not work
AbilityHelper.immediateEffects.noAction()

// Did not work
AbilityHelper.immediateEffects.combatDamage(
    (damageContext) => ({
        amount: 0,
        sourceAttack: damageContext.event.damageSource.attack
    })
)
```