### PR TITLE
Add the "invalid" selection state

### DIFF
--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -9,7 +9,8 @@ import type Player from '../Player';
 export enum DisplayCardSelectionState {
     Selectable = 'selectable',
     Selected = 'selected',
-    Unselectable = 'unselectable'
+    Unselectable = 'unselectable',
+    Invalid = 'invalid'
 }
 
 export interface IButton {

--- a/server/game/core/gameSteps/prompts/DisplayCardsForSelectionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsForSelectionPrompt.ts
@@ -25,7 +25,7 @@ export class DisplayCardsForSelectionPrompt extends DisplayCardPrompt<IDisplayCa
             card,
             selectionState: this.selectableCondition(card)
                 ? DisplayCardSelectionState.Selectable
-                : DisplayCardSelectionState.Unselectable,
+                : DisplayCardSelectionState.Invalid,
         }));
 
         this.canChooseNothing = !!properties.canChooseNothing;
@@ -87,6 +87,7 @@ export class DisplayCardsForSelectionPrompt extends DisplayCardPrompt<IDisplayCa
                 selectedCard.selectionState = DisplayCardSelectionState.Selectable;
                 break;
             case DisplayCardSelectionState.Unselectable:
+            case DisplayCardSelectionState.Invalid:
                 return false;
             default:
                 Contract.fail(`Unexpected selection state: '${selectedCard.selectionState}'`);
@@ -117,7 +118,7 @@ export class DisplayCardsForSelectionPrompt extends DisplayCardPrompt<IDisplayCa
 
             card.selectionState = this.selectableCondition(card.card)
                 ? DisplayCardSelectionState.Selectable
-                : DisplayCardSelectionState.Unselectable;
+                : DisplayCardSelectionState.Invalid;
         }
 
         // update done button state

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -78,6 +78,7 @@ interface ICardDisplaySelectionState {
     selectable?: Card[];
     selected?: Card[];
     unselectable?: Card[];
+    invalid?: Card[];
 }
 
 declare namespace jasmine {

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -571,7 +571,7 @@ class PlayerInteractionWrapper {
             (cardEntry) => cardEntry.cardUuid === card.uuid
         );
 
-        if (!clickingCard || (!allowClickUnselectable && clickingCard.selectionState === 'unselectable')) {
+        if (!clickingCard || (!allowClickUnselectable && (clickingCard.selectionState === 'unselectable' || clickingCard.selectionState === 'invalid'))) {
             throw new TestSetupError(
                 `Couldn't click on '${card.internalName}' in card display prompt for ${this.player.name}. Current prompt is:\n${Util.formatBothPlayerPrompts(this.testContext)}`
             );

--- a/test/server/cards/01_SOR/events/PrepareForTakeoff.spec.ts
+++ b/test/server/cards/01_SOR/events/PrepareForTakeoff.spec.ts
@@ -18,7 +18,7 @@ describe('Prepare for Takeoff', function () {
                 expect(context.player1).toHavePrompt('Select up to 2 cards to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.greenSquadronAwing, context.restoredArc170, context.infernoFour, context.escortSkiff],
-                    unselectable: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
+                    invalid: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -26,7 +26,7 @@ describe('Prepare for Takeoff', function () {
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing],
                     selectable: [context.restoredArc170, context.infernoFour, context.escortSkiff],
-                    unselectable: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
+                    invalid: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
 
@@ -34,7 +34,7 @@ describe('Prepare for Takeoff', function () {
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing, context.restoredArc170],
                     selectable: [context.infernoFour, context.escortSkiff],
-                    unselectable: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
+                    invalid: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
 
@@ -62,7 +62,7 @@ describe('Prepare for Takeoff', function () {
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.greenSquadronAwing, context.restoredArc170, context.infernoFour, context.escortSkiff],
-                    unselectable: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
+                    invalid: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -70,7 +70,7 @@ describe('Prepare for Takeoff', function () {
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing],
                     selectable: [context.restoredArc170, context.infernoFour, context.escortSkiff],
-                    unselectable: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
+                    invalid: [context.battlefieldMarine, context.pykeSentinel, context.consularSecurityForce, context.echoBaseDefender]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
 

--- a/test/server/cards/01_SOR/events/Recruit.spec.ts
+++ b/test/server/cards/01_SOR/events/Recruit.spec.ts
@@ -19,7 +19,7 @@ describe('Recruit', function () {
                     expect(context.player1).toHavePrompt('Select a card to reveal');
                     expect(context.player1).toHaveExactDisplayPromptCards({
                         selectable: [context.viperProbeDroid],
-                        unselectable: [context.confiscate, context.iAmYourFather, context.surpriseStrike, context.vanquish]
+                        invalid: [context.confiscate, context.iAmYourFather, context.surpriseStrike, context.vanquish]
                     });
                     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -50,7 +50,7 @@ describe('Recruit', function () {
 
                     expect(context.player1).toHaveExactDisplayPromptCards({
                         selectable: [context.viperProbeDroid],
-                        unselectable: [context.confiscate, context.iAmYourFather]
+                        invalid: [context.confiscate, context.iAmYourFather]
                     });
                     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -101,7 +101,7 @@ describe('Recruit', function () {
                     context.player1.clickCard(context.recruit);
                     expect(context.player1).toHavePrompt('Select a card to reveal');
                     expect(context.player1).toHaveExactDisplayPromptCards({
-                        unselectable: [context.disarm, context.confiscate, context.iAmYourFather, context.surpriseStrike, context.vanquish]
+                        invalid: [context.disarm, context.confiscate, context.iAmYourFather, context.surpriseStrike, context.vanquish]
                     });
                     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
                     context.player1.clickPrompt('Take nothing');
@@ -129,7 +129,7 @@ describe('Recruit', function () {
                     expect(context.player1).toHavePrompt('Select a card to reveal');
                     expect(context.player1).toHaveExactDisplayPromptCards({
                         selectable: [context.viperProbeDroid, context.cellBlockGuard],
-                        unselectable: [context.confiscate, context.iAmYourFather, context.surpriseStrike]
+                        invalid: [context.confiscate, context.iAmYourFather, context.surpriseStrike]
                     });
                     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 

--- a/test/server/cards/01_SOR/units/GrandMoffTarkinDeathStarOverseer.spec.ts
+++ b/test/server/cards/01_SOR/units/GrandMoffTarkinDeathStarOverseer.spec.ts
@@ -27,7 +27,7 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.academyDefenseWalker, context.cellBlockGuard, context.scoutBikePursuer],
-                    unselectable: [context.battlefieldMarine, context.wampa]
+                    invalid: [context.battlefieldMarine, context.wampa]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -35,7 +35,7 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.cellBlockGuard],
                     selectable: [context.academyDefenseWalker, context.scoutBikePursuer],
-                    unselectable: [context.battlefieldMarine, context.wampa]
+                    invalid: [context.battlefieldMarine, context.wampa]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
 
@@ -43,7 +43,7 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.cellBlockGuard, context.scoutBikePursuer],
                     selectable: [context.academyDefenseWalker],
-                    unselectable: [context.battlefieldMarine, context.wampa]
+                    invalid: [context.battlefieldMarine, context.wampa]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
                 context.player1.clickPrompt('Done');
@@ -66,7 +66,7 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.academyDefenseWalker, context.cellBlockGuard, context.scoutBikePursuer],
-                    unselectable: [context.battlefieldMarine, context.wampa]
+                    invalid: [context.battlefieldMarine, context.wampa]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
                 context.player1.clickCardInDisplayCardPrompt(context.cellBlockGuard);
@@ -75,7 +75,7 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.cellBlockGuard],
                     selectable: [context.academyDefenseWalker, context.scoutBikePursuer],
-                    unselectable: [context.battlefieldMarine, context.wampa]
+                    invalid: [context.battlefieldMarine, context.wampa]
                 });
 
                 // Click Done
@@ -105,7 +105,7 @@ describe('Grand Moff Tarkin, Death Star Overseer', function() {
                 context.player2.clickCard(context.p2tarkin);
 
                 expect(context.player2).toHaveExactDisplayPromptCards({
-                    unselectable: [context.clanWrenRescuer, context.concordDawnInterceptors, context.gentleGiant, context.systemPatrolCraft, context.villageProtectors]
+                    invalid: [context.clanWrenRescuer, context.concordDawnInterceptors, context.gentleGiant, context.systemPatrolCraft, context.villageProtectors]
                 });
                 expect(context.player2).toHaveEnabledPromptButton('Take nothing');
                 context.player2.clickPrompt('Take nothing');

--- a/test/server/cards/01_SOR/units/JabbaTheHuttCunningDaimyo.spec.ts
+++ b/test/server/cards/01_SOR/units/JabbaTheHuttCunningDaimyo.spec.ts
@@ -26,7 +26,7 @@ describe('Jabba the Hutt, Cunning Daimyo', function () {
                 // select a trick event on the top 8 cards
                 expect(context.player1).toHavePrompt('Select a card to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.battlefieldMarine, context.echoBaseDefender, context.cantinaBraggart, context.ardentSympathizer, context.pykeSentinel],
+                    invalid: [context.battlefieldMarine, context.echoBaseDefender, context.cantinaBraggart, context.ardentSympathizer, context.pykeSentinel],
                     selectable: [context.waylay, p1ShootFirst, context.asteroidSanctuary]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');

--- a/test/server/cards/01_SOR/units/MonMothmaVoiceoftheRebellion.spec.ts
+++ b/test/server/cards/01_SOR/units/MonMothmaVoiceoftheRebellion.spec.ts
@@ -17,7 +17,7 @@ describe('Mon Mothma, Voice of the Rebellion', function() {
                 context.player1.clickCard(context.monMothma);
                 expect(context.player1).toHavePrompt('Select a card to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.cartelSpacer, context.cellBlockGuard, context.pykeSentinel, context.volunteerSoldier],
+                    invalid: [context.cartelSpacer, context.cellBlockGuard, context.pykeSentinel, context.volunteerSoldier],
                     selectable: [context.battlefieldMarine]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -52,7 +52,7 @@ describe('Mon Mothma, Voice of the Rebellion', function() {
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine],
-                    unselectable: [context.cartelSpacer, context.cellBlockGuard],
+                    invalid: [context.cartelSpacer, context.cellBlockGuard],
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
                 context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
@@ -96,7 +96,7 @@ describe('Mon Mothma, Voice of the Rebellion', function() {
                 context.player1.clickCard(context.monMothma);
                 expect(context.player1).toHavePrompt('Select a card to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.academyDefenseWalker, context.cartelSpacer, context.cellBlockGuard, context.pykeSentinel, context.volunteerSoldier]
+                    invalid: [context.academyDefenseWalker, context.cartelSpacer, context.cellBlockGuard, context.pykeSentinel, context.volunteerSoldier]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 

--- a/test/server/cards/02_SHD/events/BountyPosting.spec.ts
+++ b/test/server/cards/02_SHD/events/BountyPosting.spec.ts
@@ -21,7 +21,7 @@ describe('Bounty Posting', function() {
                 context.player1.clickCard(context.bountyPosting);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.deathMark, context.topTarget],
-                    unselectable: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
+                    invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -62,7 +62,7 @@ describe('Bounty Posting', function() {
                 context.player1.clickCard(context.bountyPosting);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.deathMark, context.topTarget],
-                    unselectable: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
+                    invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -89,7 +89,7 @@ describe('Bounty Posting', function() {
 
                 context.player1.clickCard(context.bountyPosting);
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
+                    invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 

--- a/test/server/cards/02_SHD/events/Commission.spec.ts
+++ b/test/server/cards/02_SHD/events/Commission.spec.ts
@@ -18,7 +18,7 @@ describe('Commission', function () {
                     context.player1.clickCard(context.commission);
                     expect(context.player1).toHavePrompt('Select a card to reveal');
                     expect(context.player1).toHaveExactDisplayPromptCards({
-                        unselectable: [context.viperProbeDroid, context.confiscate, context.iAmYourFather, context.surpriseStrike, context.cellBlockGuard, context.tieAdvanced],
+                        invalid: [context.viperProbeDroid, context.confiscate, context.iAmYourFather, context.surpriseStrike, context.cellBlockGuard, context.tieAdvanced],
                         selectable: [context.frontlineShuttle, context.electrostaff, context.greedo, context.mandalorianArmor]
                     });
                     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -65,7 +65,7 @@ describe('Commission', function () {
                     context.player1.clickCard(context.commission);
                     expect(context.player1).toHaveExactDisplayPromptCards({
                         selectable: [context.mandalorianArmor],
-                        unselectable: [context.confiscate, context.iAmYourFather]
+                        invalid: [context.confiscate, context.iAmYourFather]
                     });
                     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
                     context.player1.clickCardInDisplayCardPrompt(context.mandalorianArmor);
@@ -116,7 +116,7 @@ describe('Commission', function () {
                     context.player1.clickCard(context.commission);
                     expect(context.player1).toHavePrompt('Select a card to reveal');
                     expect(context.player1).toHaveExactDisplayPromptCards({
-                        unselectable: [
+                        invalid: [
                             context.disarm,
                             context.confiscate,
                             context.iAmYourFather,

--- a/test/server/cards/02_SHD/events/RemnantReserves.spec.ts
+++ b/test/server/cards/02_SHD/events/RemnantReserves.spec.ts
@@ -18,7 +18,7 @@ describe('Remnant Reserves', function () {
                 expect(context.player1).toHavePrompt('Select up to 3 cards to reveal');
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.recruit, context.prepareForTakeoff],
+                    invalid: [context.recruit, context.prepareForTakeoff],
                     selectable: [context.greenSquadronAwing, context.restoredArc170, context.infernoFour]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -26,7 +26,7 @@ describe('Remnant Reserves', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.greenSquadronAwing);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing],
-                    unselectable: [context.recruit, context.prepareForTakeoff],
+                    invalid: [context.recruit, context.prepareForTakeoff],
                     selectable: [context.restoredArc170, context.infernoFour]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -34,7 +34,7 @@ describe('Remnant Reserves', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.restoredArc170);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing, context.restoredArc170],
-                    unselectable: [context.recruit, context.prepareForTakeoff],
+                    invalid: [context.recruit, context.prepareForTakeoff],
                     selectable: [context.infernoFour]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -42,7 +42,7 @@ describe('Remnant Reserves', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.infernoFour);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing, context.restoredArc170, context.infernoFour],
-                    unselectable: [context.recruit, context.prepareForTakeoff]
+                    invalid: [context.recruit, context.prepareForTakeoff]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
 
@@ -62,7 +62,7 @@ describe('Remnant Reserves', function () {
                 context.player1.clickCard(context.remnantReserves);
                 expect(context.player1).toHavePrompt('Select up to 3 cards to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.recruit, context.prepareForTakeoff],
+                    invalid: [context.recruit, context.prepareForTakeoff],
                     selectable: [context.greenSquadronAwing, context.restoredArc170, context.infernoFour]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -70,7 +70,7 @@ describe('Remnant Reserves', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.greenSquadronAwing);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.greenSquadronAwing],
-                    unselectable: [context.recruit, context.prepareForTakeoff],
+                    invalid: [context.recruit, context.prepareForTakeoff],
                     selectable: [context.restoredArc170, context.infernoFour]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -90,7 +90,7 @@ describe('Remnant Reserves', function () {
 
                 context.player1.clickCard(context.remnantReserves);
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.recruit, context.prepareForTakeoff],
+                    invalid: [context.recruit, context.prepareForTakeoff],
                     selectable: [context.greenSquadronAwing, context.restoredArc170, context.infernoFour]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');

--- a/test/server/cards/02_SHD/events/ThisIsTheWay.spec.ts
+++ b/test/server/cards/02_SHD/events/ThisIsTheWay.spec.ts
@@ -17,7 +17,7 @@ describe('This is the Way', function () {
                 context.player1.clickCard(context.thisIsTheWay);
                 expect(context.player1).toHavePrompt('Select up to 2 cards to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
                     selectable: [context.sabineWren, context.supercommandoSquad, context.protector, context.devotion]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -25,7 +25,7 @@ describe('This is the Way', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.devotion);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
                     selectable: [context.sabineWren, context.supercommandoSquad, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -33,7 +33,7 @@ describe('This is the Way', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.sabineWren);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion, context.sabineWren],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
                     selectable: [context.supercommandoSquad, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -57,7 +57,7 @@ describe('This is the Way', function () {
                 context.player1.clickCard(context.thisIsTheWay);
                 expect(context.player1).toHavePrompt('Select up to 2 cards to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
                     selectable: [context.sabineWren, context.supercommandoSquad, context.protector, context.devotion]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -65,7 +65,7 @@ describe('This is the Way', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.devotion);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
                     selectable: [context.sabineWren, context.supercommandoSquad, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -88,7 +88,7 @@ describe('This is the Way', function () {
 
                 context.player1.clickCard(context.thisIsTheWay);
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender],
                     selectable: [context.sabineWren, context.supercommandoSquad, context.protector, context.devotion]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');

--- a/test/server/cards/02_SHD/units/CobbVanthTheMarshal.spec.ts
+++ b/test/server/cards/02_SHD/units/CobbVanthTheMarshal.spec.ts
@@ -22,7 +22,7 @@ describe('Cobb Vanth, The Marshal', function() {
                 context.player2.clickCard(context.cobbVanth);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.sabineWren, context.battlefieldMarine, context.patrollingVwing],
-                    unselectable: [context.waylay, context.protector, context.devotion, context.consularSecurityForce, context.echoBaseDefender, context.swoopRacer, context.resupply]
+                    invalid: [context.waylay, context.protector, context.devotion, context.consularSecurityForce, context.echoBaseDefender, context.swoopRacer, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 

--- a/test/server/cards/02_SHD/units/GreefKargaAffableCommissioner.spec.ts
+++ b/test/server/cards/02_SHD/units/GreefKargaAffableCommissioner.spec.ts
@@ -18,7 +18,7 @@ describe('Greef Karga, Affable Commissioner', function() {
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.foundling],
-                    unselectable: [context.pykeSentinel, context.atst, context.battlefieldMarine, context.cartelSpacer]
+                    invalid: [context.pykeSentinel, context.atst, context.battlefieldMarine, context.cartelSpacer]
                 });
                 expect(context.player1).not.toHaveEnabledPromptButton('Done');
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');

--- a/test/server/cards/02_SHD/units/OmegaPartOfTheSquad.spec.ts
+++ b/test/server/cards/02_SHD/units/OmegaPartOfTheSquad.spec.ts
@@ -24,7 +24,7 @@ describe('Omega, Part of the Squad', function() {
                 expect(context.player1).toHavePrompt('Select a card to reveal');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.crosshair],
-                    unselectable: [context.atst, context.battlefieldMarine, context.cartelSpacer, context.pykeSentinel]
+                    invalid: [context.atst, context.battlefieldMarine, context.cartelSpacer, context.pykeSentinel]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 

--- a/test/server/cards/02_SHD/upgrades/BountyHuntersQuarry.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/BountyHuntersQuarry.spec.ts
@@ -29,7 +29,7 @@ describe('Bounty hunter\'s quarry', function () {
                 context.player1.clickPrompt(prompt);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine, context.infernoFour, context.sabineWren],
-                    unselectable: [context.waylay, context.protector]
+                    invalid: [context.waylay, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -57,7 +57,7 @@ describe('Bounty hunter\'s quarry', function () {
                 context.player1.clickPrompt(prompt);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.sabineWren, context.infernoFour, context.superlaserTechnician, context.echoBaseDefender, context.swoopRacer],
-                    unselectable: [context.devotion, context.waylay, context.protector, context.consularSecurityForce, context.resupply]
+                    invalid: [context.devotion, context.waylay, context.protector, context.consularSecurityForce, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 

--- a/test/server/cards/02_SHD/upgrades/EnticingReward.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/EnticingReward.spec.ts
@@ -28,7 +28,7 @@ describe('Enticing Reward', function () {
 
                 // choose up to 2 non-units cards
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
                     selectable: [context.waylay, context.protector, context.devotion, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -36,7 +36,7 @@ describe('Enticing Reward', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.devotion);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
                     selectable: [context.waylay, context.protector, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -44,7 +44,7 @@ describe('Enticing Reward', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.waylay);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion, context.waylay],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
                     selectable: [context.protector, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -101,7 +101,7 @@ describe('Enticing Reward', function () {
 
                 // choose up to 2 non-units cards
                 expect(context.player1).toHaveExactDisplayPromptCards({
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
                     selectable: [context.waylay, context.protector, context.devotion, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -109,7 +109,7 @@ describe('Enticing Reward', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.devotion);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
                     selectable: [context.waylay, context.protector, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -117,7 +117,7 @@ describe('Enticing Reward', function () {
                 context.player1.clickCardInDisplayCardPrompt(context.waylay);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selected: [context.devotion, context.waylay],
-                    unselectable: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
+                    invalid: [context.battlefieldMarine, context.infernoFour, context.consularSecurityForce, context.echoBaseDefender, context.sabineWren, context.swoopRacer],
                     selectable: [context.protector, context.resupply]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Done');

--- a/test/server/cards/03_TWI/leaders/BosskHuntingHisPrey.spec.ts
+++ b/test/server/cards/03_TWI/leaders/BosskHuntingHisPrey.spec.ts
@@ -395,7 +395,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickPrompt(prompt);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine, context.snowtrooperLieutenant, context.sabineWren],
-                    unselectable: [context.waylay, context.protector]
+                    invalid: [context.waylay, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -409,7 +409,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickPrompt('Collect the Bounty again');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.infernoFour, context.sabineWren, context.snowtrooperLieutenant],
-                    unselectable: [context.waylay, context.protector]
+                    invalid: [context.waylay, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -441,7 +441,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickPrompt(prompt);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine, context.snowtrooperLieutenant, context.sabineWren],
-                    unselectable: [context.waylay, context.protector]
+                    invalid: [context.waylay, context.protector]
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 


### PR DESCRIPTION
 Added a new "invalid" selection state to separate it out from "unselectable" which will have a different meaning in the vader / u-wing context. Switch the basic search prompts to use that by default for non-matching cards.