### PR TITLE
Fix bug in SelectCardSystem

### DIFF
--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -69,10 +69,11 @@ export class SelectCardSystem<TContext extends AbilityContext = AbilityContext> 
         properties.innerSystem.setDefaultTargetFn(() => properties.target);
         if (!properties.selector) {
             const cardCondition = (card, context) =>
+                properties.cardCondition(card, context) &&
                 properties.innerSystem.allTargetsLegal(
                     context,
                     Object.assign({}, additionalProperties, properties.innerSystemProperties(card))
-                ) && properties.cardCondition(card, context);
+                );
             properties.selector = CardSelectorFactory.create(Object.assign({}, properties, { cardCondition }));
         }
 


### PR DESCRIPTION
SelectCardSystem was checking if targets were legal for the system before checking the condition in the properties, which was causing failures in another barnch