### PR TITLE
Remove static "implemented" property from card classes

### DIFF
--- a/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
+++ b/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
@@ -26,5 +26,3 @@ export default class EnergyConversionLab extends BaseCard {
         });
     }
 }
-
-EnergyConversionLab.implemented = true;

--- a/server/game/cards/01_SOR/bases/JedhaCity.ts
+++ b/server/game/cards/01_SOR/bases/JedhaCity.ts
@@ -22,5 +22,3 @@ export default class JedhaCity extends BaseCard {
         });
     }
 }
-
-JedhaCity.implemented = true;

--- a/server/game/cards/01_SOR/bases/SecurityComplex.ts
+++ b/server/game/cards/01_SOR/bases/SecurityComplex.ts
@@ -20,5 +20,3 @@ export default class SecurityComplex extends BaseCard {
         });
     }
 }
-
-SecurityComplex.implemented = true;

--- a/server/game/cards/01_SOR/events/Aggression.ts
+++ b/server/game/cards/01_SOR/events/Aggression.ts
@@ -38,5 +38,3 @@ export default class Aggression extends EventCard {
         });
     }
 }
-
-Aggression.implemented = true;

--- a/server/game/cards/01_SOR/events/AsteroidSanctuary.ts
+++ b/server/game/cards/01_SOR/events/AsteroidSanctuary.ts
@@ -28,5 +28,3 @@ export default class AsteroidSanctuary extends EventCard {
         });
     }
 }
-
-AsteroidSanctuary.implemented = true;

--- a/server/game/cards/01_SOR/events/AttackPatternDelta.ts
+++ b/server/game/cards/01_SOR/events/AttackPatternDelta.ts
@@ -51,5 +51,3 @@ export default class AttackPatternDelta extends EventCard {
         });
     }
 }
-
-AttackPatternDelta.implemented = true;

--- a/server/game/cards/01_SOR/events/Bamboozle.ts
+++ b/server/game/cards/01_SOR/events/Bamboozle.ts
@@ -65,5 +65,3 @@ class PlayBamboozleAction extends PlayEventAction {
         );
     }
 }
-
-Bamboozle.implemented = true;

--- a/server/game/cards/01_SOR/events/Cunning.ts
+++ b/server/game/cards/01_SOR/events/Cunning.ts
@@ -41,5 +41,3 @@ export default class Cunning extends EventCard {
         });
     }
 }
-
-Cunning.implemented = true;

--- a/server/game/cards/01_SOR/events/Disarm.ts
+++ b/server/game/cards/01_SOR/events/Disarm.ts
@@ -23,5 +23,3 @@ export default class Disarm extends EventCard {
         });
     }
 }
-
-Disarm.implemented = true;

--- a/server/game/cards/01_SOR/events/DontGetCocky.ts
+++ b/server/game/cards/01_SOR/events/DontGetCocky.ts
@@ -73,5 +73,3 @@ export default class DontGetCocky extends EventCard {
         return context.source.controller.getTopCardsOfDeck(cardsRevealedCount).reduce((total, card) => total + card.printedCost, 0);
     }
 }
-
-DontGetCocky.implemented = true;

--- a/server/game/cards/01_SOR/events/ForceChoke.ts
+++ b/server/game/cards/01_SOR/events/ForceChoke.ts
@@ -30,5 +30,3 @@ export default class ForceChoke extends EventCard {
         });
     }
 }
-
-ForceChoke.implemented = true;

--- a/server/game/cards/01_SOR/events/ForceThrow.ts
+++ b/server/game/cards/01_SOR/events/ForceThrow.ts
@@ -32,5 +32,3 @@ export default class ForceThrow extends EventCard {
         });
     }
 }
-
-ForceThrow.implemented = true;

--- a/server/game/cards/01_SOR/events/ForcedSurrender.ts
+++ b/server/game/cards/01_SOR/events/ForcedSurrender.ts
@@ -37,5 +37,3 @@ export default class ForcedSurrender extends EventCard {
         });
     }
 }
-
-ForcedSurrender.implemented = true;

--- a/server/game/cards/01_SOR/events/GalacticAmbition.ts
+++ b/server/game/cards/01_SOR/events/GalacticAmbition.ts
@@ -33,4 +33,3 @@ export default class GalacticAmbition extends EventCard {
         });
     }
 }
-GalacticAmbition.implemented = true;

--- a/server/game/cards/01_SOR/events/HeroicSacrifice.ts
+++ b/server/game/cards/01_SOR/events/HeroicSacrifice.ts
@@ -40,5 +40,3 @@ export default class HeroicSacrifice extends EventCard {
         });
     }
 }
-
-HeroicSacrifice.implemented = true;

--- a/server/game/cards/01_SOR/events/IAmYourFather.ts
+++ b/server/game/cards/01_SOR/events/IAmYourFather.ts
@@ -34,5 +34,3 @@ export default class IAmYourFather extends EventCard {
         });
     }
 }
-
-IAmYourFather.implemented = true;

--- a/server/game/cards/01_SOR/events/ItBindsAllThings.ts
+++ b/server/game/cards/01_SOR/events/ItBindsAllThings.ts
@@ -34,5 +34,3 @@ export default class ItBindsAllThings extends EventCard {
         });
     }
 }
-
-ItBindsAllThings.implemented = true;

--- a/server/game/cards/01_SOR/events/Karabast.ts
+++ b/server/game/cards/01_SOR/events/Karabast.ts
@@ -37,5 +37,3 @@ export default class Karabast extends EventCard {
         });
     }
 }
-
-Karabast.implemented = true;

--- a/server/game/cards/01_SOR/events/KeepFighting.ts
+++ b/server/game/cards/01_SOR/events/KeepFighting.ts
@@ -19,5 +19,3 @@ export default class KeepFighting extends EventCard {
         });
     }
 }
-
-KeepFighting.implemented = true;

--- a/server/game/cards/01_SOR/events/MakeAnOpening.ts
+++ b/server/game/cards/01_SOR/events/MakeAnOpening.ts
@@ -25,5 +25,3 @@ export default class MakeAnOpening extends EventCard {
         });
     }
 }
-
-MakeAnOpening.implemented = true;

--- a/server/game/cards/01_SOR/events/MaximumFirePower.ts
+++ b/server/game/cards/01_SOR/events/MaximumFirePower.ts
@@ -54,5 +54,3 @@ export default class MaximumFirePower extends EventCard {
         });
     }
 }
-
-MaximumFirePower.implemented = true;

--- a/server/game/cards/01_SOR/events/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/events/MedalCeremony.ts
@@ -34,5 +34,3 @@ export default class MedalCeremony extends EventCard {
         });
     }
 }
-
-MedalCeremony.implemented = true;

--- a/server/game/cards/01_SOR/events/MissionBriefing.ts
+++ b/server/game/cards/01_SOR/events/MissionBriefing.ts
@@ -20,5 +20,3 @@ export default class MissionBriefing extends EventCard {
         });
     }
 }
-
-MissionBriefing.implemented = true;

--- a/server/game/cards/01_SOR/events/MomentOfPeace.ts
+++ b/server/game/cards/01_SOR/events/MomentOfPeace.ts
@@ -18,5 +18,3 @@ export default class MomentOfPeace extends EventCard {
         });
     }
 }
-
-MomentOfPeace.implemented = true;

--- a/server/game/cards/01_SOR/events/NoGoodToMeDead.ts
+++ b/server/game/cards/01_SOR/events/NoGoodToMeDead.ts
@@ -26,5 +26,3 @@ export default class NoGoodToMeDead extends EventCard {
         });
     }
 }
-
-NoGoodToMeDead.implemented = true;

--- a/server/game/cards/01_SOR/events/OpenFire.ts
+++ b/server/game/cards/01_SOR/events/OpenFire.ts
@@ -20,5 +20,3 @@ export default class OpenFire extends EventCard {
         });
     }
 }
-
-OpenFire.implemented = true;

--- a/server/game/cards/01_SOR/events/OverwhelmingBarrage.ts
+++ b/server/game/cards/01_SOR/events/OverwhelmingBarrage.ts
@@ -33,5 +33,3 @@ export default class OverwhelmingBarrage extends EventCard {
         });
     }
 }
-
-OverwhelmingBarrage.implemented = true;

--- a/server/game/cards/01_SOR/events/PowerOfTheDarkSide.ts
+++ b/server/game/cards/01_SOR/events/PowerOfTheDarkSide.ts
@@ -22,5 +22,3 @@ export default class PowerOfTheDarkSide extends EventCard {
         });
     }
 }
-
-PowerOfTheDarkSide.implemented = true;

--- a/server/game/cards/01_SOR/events/PrecisionFire.ts
+++ b/server/game/cards/01_SOR/events/PrecisionFire.ts
@@ -25,5 +25,3 @@ export default class PrecisionFire extends EventCard {
         });
     }
 }
-
-PrecisionFire.implemented = true;

--- a/server/game/cards/01_SOR/events/PrepareForTakeoff.ts
+++ b/server/game/cards/01_SOR/events/PrepareForTakeoff.ts
@@ -23,5 +23,3 @@ export default class PrepareForTakeoff extends EventCard {
         });
     }
 }
-
-PrepareForTakeoff.implemented = true;

--- a/server/game/cards/01_SOR/events/RebelAssault.ts
+++ b/server/game/cards/01_SOR/events/RebelAssault.ts
@@ -31,5 +31,3 @@ export default class RebelAssault extends EventCard {
         });
     }
 }
-
-RebelAssault.implemented = true;

--- a/server/game/cards/01_SOR/events/Recruit.ts
+++ b/server/game/cards/01_SOR/events/Recruit.ts
@@ -21,5 +21,3 @@ export default class Recruit extends EventCard {
     }
 }
 
-Recruit.implemented = true;
-

--- a/server/game/cards/01_SOR/events/Restock.ts
+++ b/server/game/cards/01_SOR/events/Restock.ts
@@ -34,5 +34,3 @@ export default class Restock extends EventCard {
         return true;
     }
 }
-
-Restock.implemented = true;

--- a/server/game/cards/01_SOR/events/Resupply.ts
+++ b/server/game/cards/01_SOR/events/Resupply.ts
@@ -16,5 +16,3 @@ export default class Resupply extends EventCard {
         });
     }
 }
-
-Resupply.implemented = true;

--- a/server/game/cards/01_SOR/events/ShootFirst.ts
+++ b/server/game/cards/01_SOR/events/ShootFirst.ts
@@ -22,5 +22,3 @@ export default class ShootFirst extends EventCard {
         });
     }
 }
-
-ShootFirst.implemented = true;

--- a/server/game/cards/01_SOR/events/SmokeAndCinders.ts
+++ b/server/game/cards/01_SOR/events/SmokeAndCinders.ts
@@ -19,5 +19,3 @@ export default class SmokeAndCinders extends EventCard {
         });
     }
 }
-
-SmokeAndCinders.implemented = true;

--- a/server/game/cards/01_SOR/events/SneakAttack.ts
+++ b/server/game/cards/01_SOR/events/SneakAttack.ts
@@ -37,5 +37,3 @@ export default class SneakAttack extends EventCard {
         });
     }
 }
-
-SneakAttack.implemented = true;

--- a/server/game/cards/01_SOR/events/SparkOfRebellion.ts
+++ b/server/game/cards/01_SOR/events/SparkOfRebellion.ts
@@ -25,5 +25,3 @@ export default class SparkOfRebellion extends EventCard {
         });
     }
 }
-
-SparkOfRebellion.implemented = true;

--- a/server/game/cards/01_SOR/events/SurpriseStrike.ts
+++ b/server/game/cards/01_SOR/events/SurpriseStrike.ts
@@ -20,5 +20,3 @@ export default class SurpriseStrike extends EventCard {
         });
     }
 }
-
-SurpriseStrike.implemented = true;

--- a/server/game/cards/01_SOR/events/TacticalAdvantage.ts
+++ b/server/game/cards/01_SOR/events/TacticalAdvantage.ts
@@ -22,5 +22,3 @@ export default class TacticalAdvantage extends EventCard {
         });
     }
 }
-
-TacticalAdvantage.implemented = true;

--- a/server/game/cards/01_SOR/events/Takedown.ts
+++ b/server/game/cards/01_SOR/events/Takedown.ts
@@ -21,5 +21,3 @@ export default class Takedown extends EventCard {
         });
     }
 }
-
-Takedown.implemented = true;

--- a/server/game/cards/01_SOR/events/TheEmperorsLegion.ts
+++ b/server/game/cards/01_SOR/events/TheEmperorsLegion.ts
@@ -34,5 +34,3 @@ export default class TheEmperorsLegion extends EventCard {
         });
     }
 }
-
-TheEmperorsLegion.implemented = true;

--- a/server/game/cards/01_SOR/events/TheForceIsWithMe.ts
+++ b/server/game/cards/01_SOR/events/TheForceIsWithMe.ts
@@ -28,5 +28,3 @@ export default class TheForceIsWithMe extends EventCard {
         });
     }
 }
-
-TheForceIsWithMe.implemented = true;

--- a/server/game/cards/01_SOR/events/UWingReinforcement.ts
+++ b/server/game/cards/01_SOR/events/UWingReinforcement.ts
@@ -33,5 +33,3 @@ export default class UWingReinforcement extends EventCard {
         return costSum;
     }
 }
-
-UWingReinforcement.implemented = true;

--- a/server/game/cards/01_SOR/events/Vigilance.ts
+++ b/server/game/cards/01_SOR/events/Vigilance.ts
@@ -38,5 +38,3 @@ export default class Vigilance extends EventCard {
         });
     }
 }
-
-Vigilance.implemented = true;

--- a/server/game/cards/01_SOR/leaders/BobaFettCollectingTheBounty.ts
+++ b/server/game/cards/01_SOR/leaders/BobaFettCollectingTheBounty.ts
@@ -61,5 +61,3 @@ export default class BobaFettCollectingTheBounty extends LeaderUnitCard {
         });
     }
 }
-
-BobaFettCollectingTheBounty.implemented = true;

--- a/server/game/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.ts
+++ b/server/game/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.ts
@@ -50,5 +50,3 @@ export default class CassionAndorDedicatedToTheRebellion extends LeaderUnitCard 
     }
 }
 
-
-CassionAndorDedicatedToTheRebellion.implemented = true;

--- a/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
+++ b/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
@@ -26,5 +26,3 @@ export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
         });
     }
 }
-
-ChewbaccaWalkingCarpet.implemented = true;

--- a/server/game/cards/01_SOR/leaders/ChirrutImweOneWithTheForce.ts
+++ b/server/game/cards/01_SOR/leaders/ChirrutImweOneWithTheForce.ts
@@ -31,5 +31,3 @@ export default class ChirrutImweOneWithTheForce extends LeaderUnitCard {
         });
     }
 }
-
-ChirrutImweOneWithTheForce.implemented = true;

--- a/server/game/cards/01_SOR/leaders/DarthVaderDarkLordOfTheSith.ts
+++ b/server/game/cards/01_SOR/leaders/DarthVaderDarkLordOfTheSith.ts
@@ -61,5 +61,3 @@ export default class DarthVaderDarkLordOfTheSith extends LeaderUnitCard {
         );
     }
 }
-
-DarthVaderDarkLordOfTheSith.implemented = true;

--- a/server/game/cards/01_SOR/leaders/DirectorKrennicAspiringToAuthority.ts
+++ b/server/game/cards/01_SOR/leaders/DirectorKrennicAspiringToAuthority.ts
@@ -25,5 +25,3 @@ export default class DirectorKrennicAspiringToAuthority extends LeaderUnitCard {
         this.addConstantAbility(this.buildKrennicAbilityProperties());
     }
 }
-
-DirectorKrennicAspiringToAuthority.implemented = true;

--- a/server/game/cards/01_SOR/leaders/EmperorPalpatineGalacticRuler.ts
+++ b/server/game/cards/01_SOR/leaders/EmperorPalpatineGalacticRuler.ts
@@ -66,5 +66,3 @@ export default class EmperorPalpatineGalacticRuler extends LeaderUnitCard {
         });
     }
 }
-
-EmperorPalpatineGalacticRuler.implemented = true;

--- a/server/game/cards/01_SOR/leaders/GrandInquisitorHuntingTheJedi.ts
+++ b/server/game/cards/01_SOR/leaders/GrandInquisitorHuntingTheJedi.ts
@@ -42,5 +42,3 @@ export default class GrandInquisitorHuntingTheJedi extends LeaderUnitCard {
         });
     }
 }
-
-GrandInquisitorHuntingTheJedi.implemented = true;

--- a/server/game/cards/01_SOR/leaders/GrandMoffTarkinOversectorGovernor.ts
+++ b/server/game/cards/01_SOR/leaders/GrandMoffTarkinOversectorGovernor.ts
@@ -34,5 +34,3 @@ export default class GrandMoffTarkinOversectorGovernor extends LeaderUnitCard {
         });
     }
 }
-
-GrandMoffTarkinOversectorGovernor.implemented = true;

--- a/server/game/cards/01_SOR/leaders/HeraSyndullaSpectreTwo.ts
+++ b/server/game/cards/01_SOR/leaders/HeraSyndullaSpectreTwo.ts
@@ -39,5 +39,3 @@ export default class HeraSyndullaSpectreTwo extends LeaderUnitCard {
         });
     }
 }
-
-HeraSyndullaSpectreTwo.implemented = true;

--- a/server/game/cards/01_SOR/leaders/IG88RuthlessBountyHunter.ts
+++ b/server/game/cards/01_SOR/leaders/IG88RuthlessBountyHunter.ts
@@ -38,5 +38,3 @@ export default class IG88RuthlessBountyHunter extends LeaderUnitCard {
         });
     }
 }
-
-IG88RuthlessBountyHunter.implemented = true;

--- a/server/game/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.ts
+++ b/server/game/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.ts
@@ -43,5 +43,3 @@ export default class IdenVersioInfernoSquadCommander extends LeaderUnitCard {
         });
     }
 }
-
-IdenVersioInfernoSquadCommander.implemented = true;

--- a/server/game/cards/01_SOR/leaders/JynErsoResistingOppression.ts
+++ b/server/game/cards/01_SOR/leaders/JynErsoResistingOppression.ts
@@ -31,5 +31,3 @@ export default class JynErsoResistingOppression extends LeaderUnitCard {
         });
     }
 }
-
-JynErsoResistingOppression.implemented = true;

--- a/server/game/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.ts
+++ b/server/game/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.ts
@@ -40,5 +40,3 @@ export default class LeiaOrganaAllianceGeneral extends LeaderUnitCard {
         });
     }
 }
-
-LeiaOrganaAllianceGeneral.implemented = true;

--- a/server/game/cards/01_SOR/leaders/LukeSkywalkerFaithfulFriend.ts
+++ b/server/game/cards/01_SOR/leaders/LukeSkywalkerFaithfulFriend.ts
@@ -48,5 +48,3 @@ export default class LukeSkywalkerFaithfulFriend extends LeaderUnitCard {
         });
     }
 }
-
-LukeSkywalkerFaithfulFriend.implemented = true;

--- a/server/game/cards/01_SOR/leaders/SabineWrenGalvanizedRevolutionary.ts
+++ b/server/game/cards/01_SOR/leaders/SabineWrenGalvanizedRevolutionary.ts
@@ -30,5 +30,3 @@ export default class SabineWrenGalvanizedRevolutionary extends LeaderUnitCard {
         });
     }
 }
-
-SabineWrenGalvanizedRevolutionary.implemented = true;

--- a/server/game/cards/01_SOR/tokens/Experience.ts
+++ b/server/game/cards/01_SOR/tokens/Experience.ts
@@ -8,5 +8,3 @@ export default class Experience extends TokenUpgradeCard {
         };
     }
 }
-
-Experience.implemented = true;

--- a/server/game/cards/01_SOR/tokens/Shield.ts
+++ b/server/game/cards/01_SOR/tokens/Shield.ts
@@ -39,5 +39,3 @@ export default class Shield extends TokenUpgradeCard {
         });
     }
 }
-
-Shield.implemented = true;

--- a/server/game/cards/01_SOR/units/97thLegionKeepingThePeaceOnSullust.ts
+++ b/server/game/cards/01_SOR/units/97thLegionKeepingThePeaceOnSullust.ts
@@ -19,5 +19,3 @@ export default class _97thLegionKeepingThePeaceOnSullust extends NonLeaderUnitCa
         });
     }
 }
-
-_97thLegionKeepingThePeaceOnSullust.implemented = true;

--- a/server/game/cards/01_SOR/units/AT-ATSuppressor.ts
+++ b/server/game/cards/01_SOR/units/AT-ATSuppressor.ts
@@ -22,5 +22,3 @@ export default class AtAtSuppressor extends NonLeaderUnitCard {
         });
     }
 }
-
-AtAtSuppressor.implemented = true;

--- a/server/game/cards/01_SOR/units/AcademyDefenseWalker.ts
+++ b/server/game/cards/01_SOR/units/AcademyDefenseWalker.ts
@@ -20,5 +20,3 @@ export default class AcademyDefenseWalker extends NonLeaderUnitCard {
         });
     }
 }
-
-AcademyDefenseWalker.implemented = true;

--- a/server/game/cards/01_SOR/units/AdmiralAckbarBrilliantStrategist.ts
+++ b/server/game/cards/01_SOR/units/AdmiralAckbarBrilliantStrategist.ts
@@ -33,5 +33,3 @@ export default class AdmiralAckbarBrilliantStrategist extends NonLeaderUnitCard 
         });
     }
 }
-
-AdmiralAckbarBrilliantStrategist.implemented = true;

--- a/server/game/cards/01_SOR/units/AdmiralMottiBrazenAndScornful.ts
+++ b/server/game/cards/01_SOR/units/AdmiralMottiBrazenAndScornful.ts
@@ -22,5 +22,3 @@ export default class AdmiralMottiBrazenAndScornful extends NonLeaderUnitCard {
         });
     }
 }
-
-AdmiralMottiBrazenAndScornful.implemented = true;

--- a/server/game/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.ts
+++ b/server/game/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.ts
@@ -19,5 +19,3 @@ export default class AdmiralPiettCaptainOfTheExecutor extends NonLeaderUnitCard 
         });
     }
 }
-
-AdmiralPiettCaptainOfTheExecutor.implemented = true;

--- a/server/game/cards/01_SOR/units/AgentKallusSeekingTheRebels.ts
+++ b/server/game/cards/01_SOR/units/AgentKallusSeekingTheRebels.ts
@@ -24,5 +24,3 @@ export default class AgentKallusSeekingTheRebels extends NonLeaderUnitCard {
         });
     }
 }
-
-AgentKallusSeekingTheRebels.implemented = true;

--- a/server/game/cards/01_SOR/units/AllianceDispatcher.ts
+++ b/server/game/cards/01_SOR/units/AllianceDispatcher.ts
@@ -26,5 +26,3 @@ export default class AllianceDispatcher extends NonLeaderUnitCard {
         });
     }
 }
-
-AllianceDispatcher.implemented = true;

--- a/server/game/cards/01_SOR/units/ArdentSympathizer.ts
+++ b/server/game/cards/01_SOR/units/ArdentSympathizer.ts
@@ -17,5 +17,3 @@ export default class ArdentSympathizer extends NonLeaderUnitCard {
         });
     }
 }
-
-ArdentSympathizer.implemented = true;

--- a/server/game/cards/01_SOR/units/BailOrganaRebelCouncilor.ts
+++ b/server/game/cards/01_SOR/units/BailOrganaRebelCouncilor.ts
@@ -22,5 +22,3 @@ export default class BailOrganaRebelCouncilor extends NonLeaderUnitCard {
         });
     }
 }
-
-BailOrganaRebelCouncilor.implemented = true;

--- a/server/game/cards/01_SOR/units/BazeMalbusTempleGuardian.ts
+++ b/server/game/cards/01_SOR/units/BazeMalbusTempleGuardian.ts
@@ -18,5 +18,3 @@ export default class BazeMalbusTempleGuardian extends NonLeaderUnitCard {
         });
     }
 }
-
-BazeMalbusTempleGuardian.implemented = true;

--- a/server/game/cards/01_SOR/units/BenduTheOneInTheMiddle.ts
+++ b/server/game/cards/01_SOR/units/BenduTheOneInTheMiddle.ts
@@ -25,5 +25,3 @@ export default class BenduTheOneInTheMiddle extends NonLeaderUnitCard {
         });
     }
 }
-
-BenduTheOneInTheMiddle.implemented = true;

--- a/server/game/cards/01_SOR/units/BenthicTwoTubes.ts
+++ b/server/game/cards/01_SOR/units/BenthicTwoTubes.ts
@@ -23,5 +23,3 @@ export default class BenthicTwoTubes extends NonLeaderUnitCard {
         });
     }
 }
-
-BenthicTwoTubes.implemented = true;

--- a/server/game/cards/01_SOR/units/BibFortunaJabbasMajordomo.ts
+++ b/server/game/cards/01_SOR/units/BibFortunaJabbasMajordomo.ts
@@ -26,5 +26,3 @@ export default class BibFortunaJabbasMajordomo extends NonLeaderUnitCard {
         });
     }
 }
-
-BibFortunaJabbasMajordomo.implemented = true;

--- a/server/game/cards/01_SOR/units/BlizzardAssaultAtat.ts
+++ b/server/game/cards/01_SOR/units/BlizzardAssaultAtat.ts
@@ -32,5 +32,3 @@ export default class BlizzardAssaultAtat extends NonLeaderUnitCard {
         });
     }
 }
-
-BlizzardAssaultAtat.implemented = true;

--- a/server/game/cards/01_SOR/units/BodhiRook.ts
+++ b/server/game/cards/01_SOR/units/BodhiRook.ts
@@ -26,5 +26,3 @@ export default class BodhiRook extends NonLeaderUnitCard {
         });
     }
 }
-
-BodhiRook.implemented = true;

--- a/server/game/cards/01_SOR/units/BosskDeadlyStalker.ts
+++ b/server/game/cards/01_SOR/units/BosskDeadlyStalker.ts
@@ -24,5 +24,3 @@ export default class BosskDeadlyStalker extends NonLeaderUnitCard {
         });
     }
 }
-
-BosskDeadlyStalker.implemented = true;

--- a/server/game/cards/01_SOR/units/BountyHunterCrew.ts
+++ b/server/game/cards/01_SOR/units/BountyHunterCrew.ts
@@ -22,5 +22,3 @@ export default class BountyHunterCrew extends NonLeaderUnitCard {
         });
     }
 }
-
-BountyHunterCrew.implemented = true;

--- a/server/game/cards/01_SOR/units/BrightHopeTheLastTransport.ts
+++ b/server/game/cards/01_SOR/units/BrightHopeTheLastTransport.ts
@@ -27,5 +27,3 @@ export default class BrightHopeTheLastTransport extends NonLeaderUnitCard {
         });
     }
 }
-
-BrightHopeTheLastTransport.implemented = true;

--- a/server/game/cards/01_SOR/units/C-3POProtocolDroid.ts
+++ b/server/game/cards/01_SOR/units/C-3POProtocolDroid.ts
@@ -45,5 +45,3 @@ export default class C3POProtocolDroid extends NonLeaderUnitCard {
         });
     }
 }
-
-C3POProtocolDroid.implemented = true;

--- a/server/game/cards/01_SOR/units/CantinaBouncer.ts
+++ b/server/game/cards/01_SOR/units/CantinaBouncer.ts
@@ -21,5 +21,3 @@ export default class CantinaBouncer extends NonLeaderUnitCard {
         });
     }
 }
-
-CantinaBouncer.implemented = true;

--- a/server/game/cards/01_SOR/units/CargoJuggernaut.ts
+++ b/server/game/cards/01_SOR/units/CargoJuggernaut.ts
@@ -21,5 +21,3 @@ export default class CargoJuggernaut extends NonLeaderUnitCard {
         });
     }
 }
-
-CargoJuggernaut.implemented = true;

--- a/server/game/cards/01_SOR/units/CartelSpacer.ts
+++ b/server/game/cards/01_SOR/units/CartelSpacer.ts
@@ -25,5 +25,3 @@ export default class CartelSpacer extends NonLeaderUnitCard {
         });
     }
 }
-
-CartelSpacer.implemented = true;

--- a/server/game/cards/01_SOR/units/ChimaeraFlagshipOfTheSeventhFleet.ts
+++ b/server/game/cards/01_SOR/units/ChimaeraFlagshipOfTheSeventhFleet.ts
@@ -34,5 +34,3 @@ export default class ChimaeraFlagshipOfTheSeventhFleet extends NonLeaderUnitCard
         });
     }
 }
-
-ChimaeraFlagshipOfTheSeventhFleet.implemented = true;

--- a/server/game/cards/01_SOR/units/ColonelYularenIsbDirector.ts
+++ b/server/game/cards/01_SOR/units/ColonelYularenIsbDirector.ts
@@ -26,5 +26,3 @@ export default class ColonelYularenIsbDirector extends NonLeaderUnitCard {
         });
     }
 }
-
-ColonelYularenIsbDirector.implemented = true;

--- a/server/game/cards/01_SOR/units/ConsortiumStarViper.ts
+++ b/server/game/cards/01_SOR/units/ConsortiumStarViper.ts
@@ -18,5 +18,3 @@ export default class ConsortiumStarViper extends NonLeaderUnitCard {
         });
     }
 }
-
-ConsortiumStarViper.implemented = true;

--- a/server/game/cards/01_SOR/units/CountDookuDarthTyranus.ts
+++ b/server/game/cards/01_SOR/units/CountDookuDarthTyranus.ts
@@ -20,5 +20,3 @@ export default class CountDookuDarthTyranus extends NonLeaderUnitCard {
         });
     }
 }
-
-CountDookuDarthTyranus.implemented = true;

--- a/server/game/cards/01_SOR/units/DelMeekoProvidingOverwatch.ts
+++ b/server/game/cards/01_SOR/units/DelMeekoProvidingOverwatch.ts
@@ -21,5 +21,3 @@ export default class DelMeekoProvidingOverwatch extends NonLeaderUnitCard {
         });
     }
 }
-
-DelMeekoProvidingOverwatch.implemented = true;

--- a/server/game/cards/01_SOR/units/DevastatorInescapable.ts
+++ b/server/game/cards/01_SOR/units/DevastatorInescapable.ts
@@ -21,5 +21,3 @@ export default class DevastatorInescapable extends NonLeaderUnitCard {
         });
     }
 }
-
-DevastatorInescapable.implemented = true;

--- a/server/game/cards/01_SOR/units/DisablingFangFighter.ts
+++ b/server/game/cards/01_SOR/units/DisablingFangFighter.ts
@@ -21,5 +21,3 @@ export default class DisablingFangFighter extends NonLeaderUnitCard {
         });
     }
 }
-
-DisablingFangFighter.implemented = true;

--- a/server/game/cards/01_SOR/units/DistantPatroller.ts
+++ b/server/game/cards/01_SOR/units/DistantPatroller.ts
@@ -21,5 +21,3 @@ export default class DistantPatroller extends NonLeaderUnitCard {
         });
     }
 }
-
-DistantPatroller.implemented = true;

--- a/server/game/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.ts
+++ b/server/game/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.ts
@@ -22,5 +22,3 @@ export default class EmperorPalpatineMasterOfTheDarkSide extends NonLeaderUnitCa
         });
     }
 }
-
-EmperorPalpatineMasterOfTheDarkSide.implemented = true;

--- a/server/game/cards/01_SOR/units/EscortSkiff.ts
+++ b/server/game/cards/01_SOR/units/EscortSkiff.ts
@@ -18,5 +18,3 @@ export default class EscortSkiff extends NonLeaderUnitCard {
         });
     }
 }
-
-EscortSkiff.implemented = true;

--- a/server/game/cards/01_SOR/units/FettsFiresprayPursuingTheBounty.ts
+++ b/server/game/cards/01_SOR/units/FettsFiresprayPursuingTheBounty.ts
@@ -33,5 +33,3 @@ export default class FettsFiresprayPursuingTheBounty extends NonLeaderUnitCard {
         });
     }
 }
-
-FettsFiresprayPursuingTheBounty.implemented = true;

--- a/server/game/cards/01_SOR/units/FifthBrotherFearHunter.ts
+++ b/server/game/cards/01_SOR/units/FifthBrotherFearHunter.ts
@@ -36,5 +36,3 @@ export default class FifthBrotherFearHunter extends NonLeaderUnitCard {
         });
     }
 }
-
-FifthBrotherFearHunter.implemented = true;

--- a/server/game/cards/01_SOR/units/FightersForFreedom.ts
+++ b/server/game/cards/01_SOR/units/FightersForFreedom.ts
@@ -27,5 +27,3 @@ export default class FightersForFreedom extends NonLeaderUnitCard {
         });
     }
 }
-
-FightersForFreedom.implemented = true;

--- a/server/game/cards/01_SOR/units/FleetLieutenant.ts
+++ b/server/game/cards/01_SOR/units/FleetLieutenant.ts
@@ -24,5 +24,3 @@ export default class FleetLieutenant extends NonLeaderUnitCard {
         });
     }
 }
-
-FleetLieutenant.implemented = true;

--- a/server/game/cards/01_SOR/units/FrontierATRT.ts
+++ b/server/game/cards/01_SOR/units/FrontierATRT.ts
@@ -18,5 +18,3 @@ export default class FrontierATRT extends NonLeaderUnitCard {
         });
     }
 }
-
-FrontierATRT.implemented = true;

--- a/server/game/cards/01_SOR/units/FrontlineShuttle.ts
+++ b/server/game/cards/01_SOR/units/FrontlineShuttle.ts
@@ -20,5 +20,3 @@ export default class FrontlineShuttle extends NonLeaderUnitCard {
         });
     }
 }
-
-FrontlineShuttle.implemented = true;

--- a/server/game/cards/01_SOR/units/GamorreanGuards.ts
+++ b/server/game/cards/01_SOR/units/GamorreanGuards.ts
@@ -19,5 +19,3 @@ export default class GamorreanGuards extends NonLeaderUnitCard {
         });
     }
 }
-
-GamorreanGuards.implemented = true;

--- a/server/game/cards/01_SOR/units/GeneralDodonnaMassassiGroupCommander.ts
+++ b/server/game/cards/01_SOR/units/GeneralDodonnaMassassiGroupCommander.ts
@@ -19,5 +19,3 @@ export default class GeneralDodonnaMassassiGroupCommander extends NonLeaderUnitC
         });
     }
 }
-
-GeneralDodonnaMassassiGroupCommander.implemented = true;

--- a/server/game/cards/01_SOR/units/GeneralKrellHeartlessTactician.ts
+++ b/server/game/cards/01_SOR/units/GeneralKrellHeartlessTactician.ts
@@ -25,5 +25,3 @@ export default class GeneralKrellHeartlessTactician extends NonLeaderUnitCard {
         });
     }
 }
-
-GeneralKrellHeartlessTactician.implemented = true;

--- a/server/game/cards/01_SOR/units/GeneralTaggeConcernedCommander.ts
+++ b/server/game/cards/01_SOR/units/GeneralTaggeConcernedCommander.ts
@@ -22,5 +22,3 @@ export default class GeneralTaggeConcernedCommander extends NonLeaderUnitCard {
         });
     }
 }
-
-GeneralTaggeConcernedCommander.implemented = true;

--- a/server/game/cards/01_SOR/units/GeneralVeersBlizzardForceCommander.ts
+++ b/server/game/cards/01_SOR/units/GeneralVeersBlizzardForceCommander.ts
@@ -19,5 +19,3 @@ export default class GeneralVeersBlizzardForceCommander extends NonLeaderUnitCar
         });
     }
 }
-
-GeneralVeersBlizzardForceCommander.implemented = true;

--- a/server/game/cards/01_SOR/units/GideonHaskRuthlessLoyalist.ts
+++ b/server/game/cards/01_SOR/units/GideonHaskRuthlessLoyalist.ts
@@ -23,5 +23,3 @@ export default class GideonHaskRuthlessLoyalist extends NonLeaderUnitCard {
         });
     }
 }
-
-GideonHaskRuthlessLoyalist.implemented = true;

--- a/server/game/cards/01_SOR/units/GreedoSlowOnTheDraw.ts
+++ b/server/game/cards/01_SOR/units/GreedoSlowOnTheDraw.ts
@@ -32,5 +32,3 @@ export default class GreedoSlowOnTheDraw extends NonLeaderUnitCard {
         });
     }
 }
-
-GreedoSlowOnTheDraw.implemented = true;

--- a/server/game/cards/01_SOR/units/GuardianOfTheWhills.ts
+++ b/server/game/cards/01_SOR/units/GuardianOfTheWhills.ts
@@ -43,5 +43,3 @@ export default class GuardianOfTheWhills extends NonLeaderUnitCard {
         });
     }
 }
-
-GuardianOfTheWhills.implemented = true;

--- a/server/game/cards/01_SOR/units/GuerillaAttackPod.ts
+++ b/server/game/cards/01_SOR/units/GuerillaAttackPod.ts
@@ -20,5 +20,3 @@ export default class GuerillaAttackPod extends NonLeaderUnitCard {
         });
     }
 }
-
-GuerillaAttackPod.implemented = true;

--- a/server/game/cards/01_SOR/units/HanSoloReluctantHero.ts
+++ b/server/game/cards/01_SOR/units/HanSoloReluctantHero.ts
@@ -16,5 +16,3 @@ export default class HanSoloReluctantHero extends NonLeaderUnitCard {
         });
     }
 }
-
-HanSoloReluctantHero.implemented = true;

--- a/server/game/cards/01_SOR/units/HomeOneAllianceFlagship.ts
+++ b/server/game/cards/01_SOR/units/HomeOneAllianceFlagship.ts
@@ -31,5 +31,3 @@ export default class HomeOneAllianceFlagship extends NonLeaderUnitCard {
         });
     }
 }
-
-HomeOneAllianceFlagship.implemented = true;

--- a/server/game/cards/01_SOR/units/HomesteadMilitia.ts
+++ b/server/game/cards/01_SOR/units/HomesteadMilitia.ts
@@ -18,5 +18,3 @@ export default class HomesteadMilitia extends NonLeaderUnitCard {
         });
     }
 }
-
-HomesteadMilitia.implemented = true;

--- a/server/game/cards/01_SOR/units/InfernoFourUnforgetting.ts
+++ b/server/game/cards/01_SOR/units/InfernoFourUnforgetting.ts
@@ -21,5 +21,3 @@ export default class InfernoFourUnforgetting extends NonLeaderUnitCard {
         });
     }
 }
-
-InfernoFourUnforgetting.implemented = true;

--- a/server/game/cards/01_SOR/units/JabbaTheHuttCunningDaimyo.ts
+++ b/server/game/cards/01_SOR/units/JabbaTheHuttCunningDaimyo.ts
@@ -30,5 +30,3 @@ export default class JabbaTheHuttCunningDaimyo extends NonLeaderUnitCard {
         });
     }
 }
-
-JabbaTheHuttCunningDaimyo.implemented = true;

--- a/server/game/cards/01_SOR/units/JedhaAgitator.ts
+++ b/server/game/cards/01_SOR/units/JedhaAgitator.ts
@@ -24,5 +24,3 @@ export default class JedhaAgitator extends NonLeaderUnitCard {
         });
     }
 }
-
-JedhaAgitator.implemented = true;

--- a/server/game/cards/01_SOR/units/K2SOCassiansCounterpart.ts
+++ b/server/game/cards/01_SOR/units/K2SOCassiansCounterpart.ts
@@ -30,5 +30,3 @@ export default class K2SOCassiansCounterpart extends NonLeaderUnitCard {
         });
     }
 }
-
-K2SOCassiansCounterpart.implemented = true;

--- a/server/game/cards/01_SOR/units/LeiaOrganaDefiantPrincess.ts
+++ b/server/game/cards/01_SOR/units/LeiaOrganaDefiantPrincess.ts
@@ -26,5 +26,3 @@ export default class LeiaOrganaDefiantPrincess extends NonLeaderUnitCard {
         });
     }
 }
-
-LeiaOrganaDefiantPrincess.implemented = true;

--- a/server/game/cards/01_SOR/units/LothalInsurgent.ts
+++ b/server/game/cards/01_SOR/units/LothalInsurgent.ts
@@ -41,5 +41,3 @@ export default class LothalInsurgent extends NonLeaderUnitCard {
         });
     }
 }
-
-LothalInsurgent.implemented = true;

--- a/server/game/cards/01_SOR/units/LukeSkywalkerJediKnight.ts
+++ b/server/game/cards/01_SOR/units/LukeSkywalkerJediKnight.ts
@@ -36,5 +36,3 @@ export default class LukeSkywalkerJediKnight extends NonLeaderUnitCard {
         });
     }
 }
-
-LukeSkywalkerJediKnight.implemented = true;

--- a/server/game/cards/01_SOR/units/MaceWinduPartyCrasher.ts
+++ b/server/game/cards/01_SOR/units/MaceWinduPartyCrasher.ts
@@ -22,5 +22,3 @@ export default class MaceWinduPartyCrasher extends NonLeaderUnitCard {
         });
     }
 }
-
-MaceWinduPartyCrasher.implemented = true;

--- a/server/game/cards/01_SOR/units/MillenniumFalconPieceOfJunk.ts
+++ b/server/game/cards/01_SOR/units/MillenniumFalconPieceOfJunk.ts
@@ -38,5 +38,3 @@ export default class MillenniumFalconPieceOfJunk extends NonLeaderUnitCard {
         });
     }
 }
-
-MillenniumFalconPieceOfJunk.implemented = true;

--- a/server/game/cards/01_SOR/units/MiningGuildTieFighter.ts
+++ b/server/game/cards/01_SOR/units/MiningGuildTieFighter.ts
@@ -24,5 +24,3 @@ export default class MiningGuildTieFighter extends NonLeaderUnitCard {
         });
     }
 }
-
-MiningGuildTieFighter.implemented = true;

--- a/server/game/cards/01_SOR/units/OuterRimHeadhunter.ts
+++ b/server/game/cards/01_SOR/units/OuterRimHeadhunter.ts
@@ -25,5 +25,3 @@ export default class OuterRimHeadhunter extends NonLeaderUnitCard {
         });
     }
 }
-
-OuterRimHeadhunter.implemented = true;

--- a/server/game/cards/01_SOR/units/PartisanInsurgent.ts
+++ b/server/game/cards/01_SOR/units/PartisanInsurgent.ts
@@ -18,5 +18,3 @@ export default class PartisanInsurgent extends NonLeaderUnitCard {
         });
     }
 }
-
-PartisanInsurgent.implemented = true;

--- a/server/game/cards/01_SOR/units/PatrollingVWing.ts
+++ b/server/game/cards/01_SOR/units/PatrollingVWing.ts
@@ -16,5 +16,3 @@ export default class PatrollingVWing extends NonLeaderUnitCard {
         });
     }
 }
-
-PatrollingVWing.implemented = true;

--- a/server/game/cards/01_SOR/units/PiratedStarfighter.ts
+++ b/server/game/cards/01_SOR/units/PiratedStarfighter.ts
@@ -21,5 +21,3 @@ export default class PiratedStarfighter extends NonLeaderUnitCard {
         });
     }
 }
-
-PiratedStarfighter.implemented = true;

--- a/server/game/cards/01_SOR/units/R2D2IgnoringProtocol.ts
+++ b/server/game/cards/01_SOR/units/R2D2IgnoringProtocol.ts
@@ -21,5 +21,3 @@ export default class R2D2IgnoringProtocol extends NonLeaderUnitCard {
         });
     }
 }
-
-R2D2IgnoringProtocol.implemented = true;

--- a/server/game/cards/01_SOR/units/RedThreeUnstoppable.ts
+++ b/server/game/cards/01_SOR/units/RedThreeUnstoppable.ts
@@ -18,5 +18,3 @@ export default class RedThreeUnstoppable extends NonLeaderUnitCard {
         });
     }
 }
-
-RedThreeUnstoppable.implemented = true;

--- a/server/game/cards/01_SOR/units/RedemptionMedicalFrigate.ts
+++ b/server/game/cards/01_SOR/units/RedemptionMedicalFrigate.ts
@@ -27,5 +27,3 @@ export default class RedemptionMedicalFrigate extends NonLeaderUnitCard {
         });
     }
 }
-
-RedemptionMedicalFrigate.implemented = true;

--- a/server/game/cards/01_SOR/units/ReinforcementWalker.ts
+++ b/server/game/cards/01_SOR/units/ReinforcementWalker.ts
@@ -40,5 +40,3 @@ export default class ReinforcementWalker extends NonLeaderUnitCard {
         });
     }
 }
-
-ReinforcementWalker.implemented = true;

--- a/server/game/cards/01_SOR/units/RelentlessKonstantinesFolly.ts
+++ b/server/game/cards/01_SOR/units/RelentlessKonstantinesFolly.ts
@@ -37,5 +37,3 @@ export default class RelentlessKonstantinesFolly extends NonLeaderUnitCard {
             playedCardEntry.card !== card);
     }
 }
-
-RelentlessKonstantinesFolly.implemented = true;

--- a/server/game/cards/01_SOR/units/RogueSquadronSkirmisher.ts
+++ b/server/game/cards/01_SOR/units/RogueSquadronSkirmisher.ts
@@ -22,5 +22,3 @@ export default class RogueSquadronSkirmisher extends NonLeaderUnitCard {
         });
     }
 }
-
-RogueSquadronSkirmisher.implemented = true;

--- a/server/game/cards/01_SOR/units/RuggedSurvivors.ts
+++ b/server/game/cards/01_SOR/units/RuggedSurvivors.ts
@@ -21,5 +21,3 @@ export default class RuggedSurvivors extends NonLeaderUnitCard {
         });
     }
 }
-
-RuggedSurvivors.implemented = true;

--- a/server/game/cards/01_SOR/units/RukhThrawnsAssassin.ts
+++ b/server/game/cards/01_SOR/units/RukhThrawnsAssassin.ts
@@ -24,5 +24,3 @@ export default class RukhThrawnsAssassin extends NonLeaderUnitCard {
         });
     }
 }
-
-RukhThrawnsAssassin.implemented = true;

--- a/server/game/cards/01_SOR/units/SabineWrenExplosivesArtist.ts
+++ b/server/game/cards/01_SOR/units/SabineWrenExplosivesArtist.ts
@@ -27,5 +27,3 @@ export default class SabineWrenExplosivesArtist extends NonLeaderUnitCard {
         });
     }
 }
-
-SabineWrenExplosivesArtist.implemented = true;

--- a/server/game/cards/01_SOR/units/SawGerreraExtremist.ts
+++ b/server/game/cards/01_SOR/units/SawGerreraExtremist.ts
@@ -25,5 +25,3 @@ export default class SawGerreraExtremist extends NonLeaderUnitCard {
         });
     }
 }
-
-SawGerreraExtremist.implemented = true;

--- a/server/game/cards/01_SOR/units/SeasonedShoretrooper.ts
+++ b/server/game/cards/01_SOR/units/SeasonedShoretrooper.ts
@@ -18,5 +18,3 @@ export default class SeasonedShoretrooper extends NonLeaderUnitCard {
         });
     }
 }
-
-SeasonedShoretrooper.implemented = true;

--- a/server/game/cards/01_SOR/units/SeventhSisterImplacableInquisitor.ts
+++ b/server/game/cards/01_SOR/units/SeventhSisterImplacableInquisitor.ts
@@ -31,5 +31,3 @@ export default class SeventhSisterImplacableInquisitor extends NonLeaderUnitCard
         });
     }
 }
-
-SeventhSisterImplacableInquisitor.implemented = true;

--- a/server/game/cards/01_SOR/units/Snowspeeder.ts
+++ b/server/game/cards/01_SOR/units/Snowspeeder.ts
@@ -22,5 +22,3 @@ export default class Snowspeeder extends NonLeaderUnitCard {
         });
     }
 }
-
-Snowspeeder.implemented = true;

--- a/server/game/cards/01_SOR/units/SteadfastBattalion.ts
+++ b/server/game/cards/01_SOR/units/SteadfastBattalion.ts
@@ -27,5 +27,3 @@ export default class SteadfastBattalion extends NonLeaderUnitCard {
         });
     }
 }
-
-SteadfastBattalion.implemented = true;

--- a/server/game/cards/01_SOR/units/StrafingGunship.ts
+++ b/server/game/cards/01_SOR/units/StrafingGunship.ts
@@ -26,5 +26,3 @@ export default class StrafingGunship extends NonLeaderUnitCard {
         });
     }
 }
-
-StrafingGunship.implemented = true;

--- a/server/game/cards/01_SOR/units/TheGhostSpectreHomeBase.ts
+++ b/server/game/cards/01_SOR/units/TheGhostSpectreHomeBase.ts
@@ -25,5 +25,3 @@ export default class TheGhostSpectreHomeBase extends NonLeaderUnitCard {
         });
     }
 }
-
-TheGhostSpectreHomeBase.implemented = true;

--- a/server/game/cards/01_SOR/units/TieAdvanced.ts
+++ b/server/game/cards/01_SOR/units/TieAdvanced.ts
@@ -21,5 +21,3 @@ export default class TieAdvanced extends NonLeaderUnitCard {
         });
     }
 }
-
-TieAdvanced.implemented = true;

--- a/server/game/cards/01_SOR/units/VanguardAce.ts
+++ b/server/game/cards/01_SOR/units/VanguardAce.ts
@@ -32,5 +32,3 @@ export default class VanguardAce extends NonLeaderUnitCard {
         });
     }
 }
-
-VanguardAce.implemented = true;

--- a/server/game/cards/01_SOR/units/VanguardInfantry.ts
+++ b/server/game/cards/01_SOR/units/VanguardInfantry.ts
@@ -19,5 +19,3 @@ export default class VanguardInfantry extends NonLeaderUnitCard {
         });
     }
 }
-
-VanguardInfantry.implemented = true;

--- a/server/game/cards/01_SOR/units/VolunteerSoldier.ts
+++ b/server/game/cards/01_SOR/units/VolunteerSoldier.ts
@@ -17,5 +17,3 @@ export default class VolunteerSoldier extends NonLeaderUnitCard {
         });
     }
 }
-
-VolunteerSoldier.implemented = true;

--- a/server/game/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.ts
+++ b/server/game/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.ts
@@ -23,5 +23,3 @@ export default class WedgeAntillesStarOfTheRebellion extends NonLeaderUnitCard {
         });
     }
 }
-
-WedgeAntillesStarOfTheRebellion.implemented = true;

--- a/server/game/cards/01_SOR/units/WolffeSuspiciousVeteran.ts
+++ b/server/game/cards/01_SOR/units/WolffeSuspiciousVeteran.ts
@@ -24,5 +24,3 @@ export default class WolffeSuspiciousVeteran extends NonLeaderUnitCard {
         });
     }
 }
-
-WolffeSuspiciousVeteran.implemented = true;

--- a/server/game/cards/01_SOR/units/YodaOldMaster.ts
+++ b/server/game/cards/01_SOR/units/YodaOldMaster.ts
@@ -20,5 +20,3 @@ export default class YodaOldMaster extends NonLeaderUnitCard {
         });
     }
 }
-
-YodaOldMaster.implemented = true;

--- a/server/game/cards/01_SOR/units/ZebOrreliosHeadstrongWarrior.ts
+++ b/server/game/cards/01_SOR/units/ZebOrreliosHeadstrongWarrior.ts
@@ -38,5 +38,3 @@ export default class ZebOrreliosHeadstrongWarrior extends NonLeaderUnitCard {
         });
     }
 }
-
-ZebOrreliosHeadstrongWarrior.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/Devotion.ts
+++ b/server/game/cards/01_SOR/upgrades/Devotion.ts
@@ -16,5 +16,3 @@ export default class Devotion extends UpgradeCard {
         });
     }
 }
-
-Devotion.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/Electrostaff.ts
+++ b/server/game/cards/01_SOR/upgrades/Electrostaff.ts
@@ -19,5 +19,3 @@ export default class Electrostaff extends UpgradeCard {
         });
     }
 }
-
-Electrostaff.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/Entrenched.ts
+++ b/server/game/cards/01_SOR/upgrades/Entrenched.ts
@@ -16,5 +16,3 @@ export default class Entrenched extends UpgradeCard {
         });
     }
 }
-
-Entrenched.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/FallenLightsaber.ts
@@ -23,5 +23,3 @@ export default class FallenLightsaber extends UpgradeCard {
         });
     }
 }
-
-FallenLightsaber.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/HardpointHeavyBlaster.ts
+++ b/server/game/cards/01_SOR/upgrades/HardpointHeavyBlaster.ts
@@ -30,5 +30,3 @@ export default class HardpointHeavyBlaster extends UpgradeCard {
         });
     }
 }
-
-HardpointHeavyBlaster.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/InfiltratorsSkill.ts
+++ b/server/game/cards/01_SOR/upgrades/InfiltratorsSkill.ts
@@ -15,5 +15,3 @@ export default class InfiltratorsSkill extends UpgradeCard {
         });
     }
 }
-
-InfiltratorsSkill.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/JediLightsaber.ts
@@ -31,5 +31,3 @@ export default class JediLightsaber extends UpgradeCard {
         });
     }
 }
-
-JediLightsaber.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/LukesLightsaber.ts
@@ -27,5 +27,3 @@ export default class LukesLightsaber extends UpgradeCard {
         });
     }
 }
-
-LukesLightsaber.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/Protector.ts
+++ b/server/game/cards/01_SOR/upgrades/Protector.ts
@@ -15,5 +15,3 @@ export default class Protector extends UpgradeCard {
         });
     }
 }
-
-Protector.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/SmugglingCompartment.ts
+++ b/server/game/cards/01_SOR/upgrades/SmugglingCompartment.ts
@@ -23,5 +23,3 @@ export default class SmugglingCompartment extends UpgradeCard {
         });
     }
 }
-
-SmugglingCompartment.implemented = true;

--- a/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
+++ b/server/game/cards/01_SOR/upgrades/VadersLightsaber.ts
@@ -29,5 +29,3 @@ export default class VadersLightsaber extends UpgradeCard {
         });
     }
 }
-
-VadersLightsaber.implemented = true;

--- a/server/game/cards/02_SHD/events/AlteringTheDeal.ts
+++ b/server/game/cards/02_SHD/events/AlteringTheDeal.ts
@@ -21,5 +21,3 @@ export default class AlteringTheDeal extends EventCard {
         });
     }
 }
-
-AlteringTheDeal.implemented = true;

--- a/server/game/cards/02_SHD/events/CalculatedLethality.ts
+++ b/server/game/cards/02_SHD/events/CalculatedLethality.ts
@@ -30,5 +30,3 @@ export default class CalculatedLethality extends EventCard {
         });
     }
 }
-
-CalculatedLethality.implemented = true;

--- a/server/game/cards/02_SHD/events/ChooseSides.ts
+++ b/server/game/cards/02_SHD/events/ChooseSides.ts
@@ -41,5 +41,3 @@ export default class ChooseSides extends EventCard {
         });
     }
 }
-
-ChooseSides.implemented = true;

--- a/server/game/cards/02_SHD/events/Commission.ts
+++ b/server/game/cards/02_SHD/events/Commission.ts
@@ -21,5 +21,3 @@ export default class Commission extends EventCard {
         });
     }
 }
-
-Commission.implemented = true;

--- a/server/game/cards/02_SHD/events/CovertStrength.ts
+++ b/server/game/cards/02_SHD/events/CovertStrength.ts
@@ -23,5 +23,3 @@ export default class CovertStrength extends EventCard {
         });
     }
 }
-
-CovertStrength.implemented = true;

--- a/server/game/cards/02_SHD/events/CrippleAuthority.ts
+++ b/server/game/cards/02_SHD/events/CrippleAuthority.ts
@@ -31,5 +31,3 @@ export default class CrippleAuthority extends EventCard {
         });
     }
 }
-
-CrippleAuthority.implemented = true;

--- a/server/game/cards/02_SHD/events/DesperateAttack.ts
+++ b/server/game/cards/02_SHD/events/DesperateAttack.ts
@@ -21,5 +21,3 @@ export default class DesperateAttack extends EventCard {
         });
     }
 }
-
-DesperateAttack.implemented = true;

--- a/server/game/cards/02_SHD/events/DetentionBlockRescue.ts
+++ b/server/game/cards/02_SHD/events/DetentionBlockRescue.ts
@@ -25,5 +25,3 @@ export default class DetentionBlockRescue extends EventCard {
         });
     }
 }
-
-DetentionBlockRescue.implemented = true;

--- a/server/game/cards/02_SHD/events/EnforcedLoyalty.ts
+++ b/server/game/cards/02_SHD/events/EnforcedLoyalty.ts
@@ -25,5 +25,3 @@ export default class EnforcedLoyalty extends EventCard {
         });
     }
 }
-
-EnforcedLoyalty.implemented = true;

--- a/server/game/cards/02_SHD/events/FellTheDragon.ts
+++ b/server/game/cards/02_SHD/events/FellTheDragon.ts
@@ -19,5 +19,3 @@ export default class FellTheDragon extends EventCard {
         });
     }
 }
-
-FellTheDragon.implemented = true;

--- a/server/game/cards/02_SHD/events/Headhunting.ts
+++ b/server/game/cards/02_SHD/events/Headhunting.ts
@@ -35,5 +35,3 @@ export default class Headhunting extends EventCard {
         });
     }
 }
-
-Headhunting.implemented = true;

--- a/server/game/cards/02_SHD/events/LetTheWookieeWin.ts
+++ b/server/game/cards/02_SHD/events/LetTheWookieeWin.ts
@@ -37,5 +37,3 @@ export default class LetTheWookieeWin extends EventCard {
         });
     }
 }
-
-LetTheWookieeWin.implemented = true;

--- a/server/game/cards/02_SHD/events/LookTheOtherWay.ts
+++ b/server/game/cards/02_SHD/events/LookTheOtherWay.ts
@@ -35,5 +35,3 @@ export default class LookTheOtherWay extends EventCard {
         });
     }
 }
-
-LookTheOtherWay.implemented = true;

--- a/server/game/cards/02_SHD/events/MidnightRepairs.ts
+++ b/server/game/cards/02_SHD/events/MidnightRepairs.ts
@@ -22,5 +22,3 @@ export default class MidnightRepairs extends EventCard {
         });
     }
 }
-
-MidnightRepairs.implemented = true;

--- a/server/game/cards/02_SHD/events/MomentOfGlory.ts
+++ b/server/game/cards/02_SHD/events/MomentOfGlory.ts
@@ -22,5 +22,3 @@ export default class MomentOfGlory extends EventCard {
         });
     }
 }
-
-MomentOfGlory.implemented = true;

--- a/server/game/cards/02_SHD/events/MysticReflection.ts
+++ b/server/game/cards/02_SHD/events/MysticReflection.ts
@@ -29,5 +29,3 @@ export default class MysticReflection extends EventCard {
         });
     }
 }
-
-MysticReflection.implemented = true;

--- a/server/game/cards/02_SHD/events/NoBargain.ts
+++ b/server/game/cards/02_SHD/events/NoBargain.ts
@@ -19,5 +19,3 @@ export default class NoBargain extends EventCard {
         });
     }
 }
-
-NoBargain.implemented = true;

--- a/server/game/cards/02_SHD/events/Outflank.ts
+++ b/server/game/cards/02_SHD/events/Outflank.ts
@@ -24,5 +24,3 @@ export default class Outflank extends EventCard {
         });
     }
 }
-
-Outflank.implemented = true;

--- a/server/game/cards/02_SHD/events/PalpatinesReturn.ts
+++ b/server/game/cards/02_SHD/events/PalpatinesReturn.ts
@@ -32,5 +32,3 @@ export default class PalpatinesReturn extends EventCard {
         });
     }
 }
-
-PalpatinesReturn.implemented = true;

--- a/server/game/cards/02_SHD/events/Pillage.ts
+++ b/server/game/cards/02_SHD/events/Pillage.ts
@@ -20,5 +20,3 @@ export default class Pillage extends EventCard {
         });
     }
 }
-
-Pillage.implemented = true;

--- a/server/game/cards/02_SHD/events/RelentlessPursuit.ts
+++ b/server/game/cards/02_SHD/events/RelentlessPursuit.ts
@@ -37,5 +37,3 @@ export default class RelentlessPursuit extends EventCard {
         });
     }
 }
-
-RelentlessPursuit.implemented = true;

--- a/server/game/cards/02_SHD/events/RemnantReserves.ts
+++ b/server/game/cards/02_SHD/events/RemnantReserves.ts
@@ -23,5 +23,3 @@ export default class RemnantReserves extends EventCard {
         });
     }
 }
-
-RemnantReserves.implemented = true;

--- a/server/game/cards/02_SHD/events/RivalsFall.ts
+++ b/server/game/cards/02_SHD/events/RivalsFall.ts
@@ -20,5 +20,3 @@ export default class RivalsFall extends EventCard {
         });
     }
 }
-
-RivalsFall.implemented = true;

--- a/server/game/cards/02_SHD/events/RuleWithRespect.ts
+++ b/server/game/cards/02_SHD/events/RuleWithRespect.ts
@@ -37,5 +37,3 @@ export default class RuleWithRespect extends EventCard {
         });
     }
 }
-
-RuleWithRespect.implemented = true;

--- a/server/game/cards/02_SHD/events/SparkOfHope.ts
+++ b/server/game/cards/02_SHD/events/SparkOfHope.ts
@@ -32,5 +32,3 @@ export default class SparkOfHope extends EventCard {
         });
     }
 }
-
-SparkOfHope.implemented = true;

--- a/server/game/cards/02_SHD/events/SwoopDown.ts
+++ b/server/game/cards/02_SHD/events/SwoopDown.ts
@@ -32,5 +32,3 @@ export default class SwoopDown extends EventCard {
         });
     }
 }
-
-SwoopDown.implemented = true;

--- a/server/game/cards/02_SHD/events/TakeCaptive.ts
+++ b/server/game/cards/02_SHD/events/TakeCaptive.ts
@@ -29,5 +29,3 @@ export default class TakeCaptive extends EventCard {
         });
     }
 }
-
-TakeCaptive.implemented = true;

--- a/server/game/cards/02_SHD/events/TheChaosOfWar.ts
+++ b/server/game/cards/02_SHD/events/TheChaosOfWar.ts
@@ -25,5 +25,3 @@ export default class TheChaosOfWar extends EventCard {
         });
     }
 }
-
-TheChaosOfWar.implemented = true;

--- a/server/game/cards/02_SHD/events/ThisIsTheWay.ts
+++ b/server/game/cards/02_SHD/events/ThisIsTheWay.ts
@@ -23,5 +23,3 @@ export default class ThisIsTheWay extends EventCard {
         });
     }
 }
-
-ThisIsTheWay.implemented = true;

--- a/server/game/cards/02_SHD/events/TimelyIntervention.ts
+++ b/server/game/cards/02_SHD/events/TimelyIntervention.ts
@@ -27,5 +27,3 @@ export default class TimelyIntervention extends EventCard {
         });
     }
 }
-
-TimelyIntervention.implemented = true;

--- a/server/game/cards/02_SHD/events/TripleDarkRaid.ts
+++ b/server/game/cards/02_SHD/events/TripleDarkRaid.ts
@@ -34,5 +34,3 @@ export default class TripleDarkRaid extends EventCard {
         });
     }
 }
-
-TripleDarkRaid.implemented = true;

--- a/server/game/cards/02_SHD/events/UnexpectedEscape.ts
+++ b/server/game/cards/02_SHD/events/UnexpectedEscape.ts
@@ -31,5 +31,3 @@ export default class UnexpectedEscape extends EventCard {
         });
     }
 }
-
-UnexpectedEscape.implemented = true;

--- a/server/game/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.ts
+++ b/server/game/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.ts
@@ -64,5 +64,3 @@ export default class BoKatanKryzePrincessInExile extends LeaderUnitCard {
         });
     }
 }
-
-BoKatanKryzePrincessInExile.implemented = true;

--- a/server/game/cards/02_SHD/leaders/BobaFettDaimyo.ts
+++ b/server/game/cards/02_SHD/leaders/BobaFettDaimyo.ts
@@ -41,5 +41,3 @@ export default class BobaFettDaimyo extends LeaderUnitCard {
         });
     }
 }
-
-BobaFettDaimyo.implemented = true;

--- a/server/game/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.ts
+++ b/server/game/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.ts
@@ -47,5 +47,3 @@ export default class CadBaneHeWhoNeedsNoIntroduction extends LeaderUnitCard {
         });
     }
 }
-
-CadBaneHeWhoNeedsNoIntroduction.implemented = true;

--- a/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
+++ b/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
@@ -48,6 +48,4 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
     }
 }
 
-FennecShandHonoringTheDeal.implemented = true;
-
 

--- a/server/game/cards/02_SHD/leaders/FinnThisIsARescue.ts
+++ b/server/game/cards/02_SHD/leaders/FinnThisIsARescue.ts
@@ -46,5 +46,3 @@ export default class FinnThisIsARescue extends LeaderUnitCard {
         });
     }
 }
-
-FinnThisIsARescue.implemented = true;

--- a/server/game/cards/02_SHD/leaders/HanSoloWorthTheRisk.ts
+++ b/server/game/cards/02_SHD/leaders/HanSoloWorthTheRisk.ts
@@ -52,5 +52,3 @@ export default class HanSoloWorthTheRisk extends LeaderUnitCard {
         });
     }
 }
-
-HanSoloWorthTheRisk.implemented = true;

--- a/server/game/cards/02_SHD/leaders/HondoOhnakaThatsGoodBusiness.ts
+++ b/server/game/cards/02_SHD/leaders/HondoOhnakaThatsGoodBusiness.ts
@@ -40,5 +40,3 @@ export default class HondoOhnakaThatsGoodBusiness extends LeaderUnitCard {
         });
     }
 }
-
-HondoOhnakaThatsGoodBusiness.implemented = true;

--- a/server/game/cards/02_SHD/leaders/HunterOutcastSergeant.ts
+++ b/server/game/cards/02_SHD/leaders/HunterOutcastSergeant.ts
@@ -46,5 +46,3 @@ export default class HunterOutcastSergeant extends LeaderUnitCard {
         };
     }
 }
-
-HunterOutcastSergeant.implemented = true;

--- a/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
+++ b/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
@@ -85,5 +85,3 @@ export default class JabbaTheHuttHisHighExaltedness extends LeaderUnitCard {
         });
     }
 }
-
-JabbaTheHuttHisHighExaltedness.implemented = true;

--- a/server/game/cards/02_SHD/leaders/KyloRenRashAndDeadly.ts
+++ b/server/game/cards/02_SHD/leaders/KyloRenRashAndDeadly.ts
@@ -38,5 +38,3 @@ export default class KyloRenRashAndDeadly extends LeaderUnitCard {
         });
     }
 }
-
-KyloRenRashAndDeadly.implemented = true;

--- a/server/game/cards/02_SHD/leaders/QiraIAloneSurvived.ts
+++ b/server/game/cards/02_SHD/leaders/QiraIAloneSurvived.ts
@@ -48,5 +48,3 @@ export default class QiraIAloneSuvived extends LeaderUnitCard {
         });
     }
 }
-
-QiraIAloneSuvived.implemented = true;

--- a/server/game/cards/02_SHD/leaders/ReyMoreThanAScavenger.ts
+++ b/server/game/cards/02_SHD/leaders/ReyMoreThanAScavenger.ts
@@ -31,5 +31,3 @@ export default class ReyMoreThanAScavenger extends LeaderUnitCard {
         });
     }
 }
-
-ReyMoreThanAScavenger.implemented = true;

--- a/server/game/cards/02_SHD/leaders/TheMandalorianSwornToTheCreed.ts
+++ b/server/game/cards/02_SHD/leaders/TheMandalorianSwornToTheCreed.ts
@@ -44,5 +44,3 @@ export default class TheMandalorianSwornToTheCreed extends LeaderUnitCard {
         });
     }
 }
-
-TheMandalorianSwornToTheCreed.implemented = true;

--- a/server/game/cards/02_SHD/units/4-LOMBountyHunterForHire.ts
+++ b/server/game/cards/02_SHD/units/4-LOMBountyHunterForHire.ts
@@ -23,5 +23,3 @@ export default class _4LOMBountyHunterForHire extends NonLeaderUnitCard {
         });
     }
 }
-
-_4LOMBountyHunterForHire.implemented = true;

--- a/server/game/cards/02_SHD/units/ArquitensAssaultCruiser.ts
+++ b/server/game/cards/02_SHD/units/ArquitensAssaultCruiser.ts
@@ -23,5 +23,3 @@ export default class ArquitensAssaultCruiser extends NonLeaderUnitCard {
         });
     }
 }
-
-ArquitensAssaultCruiser.implemented = true;

--- a/server/game/cards/02_SHD/units/BazineNetalSpyForTheFirstOrder.ts
+++ b/server/game/cards/02_SHD/units/BazineNetalSpyForTheFirstOrder.ts
@@ -32,5 +32,3 @@ export default class BazineNetalSpyForTheFirstOrder extends NonLeaderUnitCard {
         });
     }
 }
-
-BazineNetalSpyForTheFirstOrder.implemented = true;

--- a/server/game/cards/02_SHD/units/BountyGuildInitiate.ts
+++ b/server/game/cards/02_SHD/units/BountyGuildInitiate.ts
@@ -25,5 +25,3 @@ export default class BountyGuildInitiate extends NonLeaderUnitCard {
         });
     }
 }
-
-BountyGuildInitiate.implemented = true;

--- a/server/game/cards/02_SHD/units/CartelTurncoat.ts
+++ b/server/game/cards/02_SHD/units/CartelTurncoat.ts
@@ -16,5 +16,3 @@ export default class CartelTurncoat extends NonLeaderUnitCard {
         });
     }
 }
-
-CartelTurncoat.implemented = true;

--- a/server/game/cards/02_SHD/units/CassianAndorRebellionsAreBuiltOnHope.ts
+++ b/server/game/cards/02_SHD/units/CassianAndorRebellionsAreBuiltOnHope.ts
@@ -21,5 +21,3 @@ export default class CassianAndorRebellionsAreBuiltOnHope extends NonLeaderUnitC
         });
     }
 }
-
-CassianAndorRebellionsAreBuiltOnHope.implemented = true;

--- a/server/game/cards/02_SHD/units/ChainCodeCollector.ts
+++ b/server/game/cards/02_SHD/units/ChainCodeCollector.ts
@@ -27,5 +27,3 @@ export default class ChainCodeCollector extends NonLeaderUnitCard {
         });
     }
 }
-
-ChainCodeCollector.implemented = true;

--- a/server/game/cards/02_SHD/units/ClanChallengers.ts
+++ b/server/game/cards/02_SHD/units/ClanChallengers.ts
@@ -18,5 +18,3 @@ export default class ClanChallengers extends NonLeaderUnitCard {
         });
     }
 }
-
-ClanChallengers.implemented = true;

--- a/server/game/cards/02_SHD/units/ClanSaxonGauntlet.ts
+++ b/server/game/cards/02_SHD/units/ClanSaxonGauntlet.ts
@@ -24,5 +24,3 @@ export default class ClanSaxonGauntlet extends NonLeaderUnitCard {
         });
     }
 }
-
-ClanSaxonGauntlet.implemented = true;

--- a/server/game/cards/02_SHD/units/CloneDeserter.ts
+++ b/server/game/cards/02_SHD/units/CloneDeserter.ts
@@ -16,5 +16,3 @@ export default class CloneDeserter extends NonLeaderUnitCard {
         });
     }
 }
-
-CloneDeserter.implemented = true;

--- a/server/game/cards/02_SHD/units/CobbVanthTheMarshal.ts
+++ b/server/game/cards/02_SHD/units/CobbVanthTheMarshal.ts
@@ -31,5 +31,3 @@ export default class CobbVanthTheMarshal extends NonLeaderUnitCard {
         });
     }
 }
-
-CobbVanthTheMarshal.implemented = true;

--- a/server/game/cards/02_SHD/units/ConcordDawnInterceptors.ts
+++ b/server/game/cards/02_SHD/units/ConcordDawnInterceptors.ts
@@ -17,5 +17,3 @@ export default class ConcordDawnInterceptors extends NonLeaderUnitCard {
         });
     }
 }
-
-ConcordDawnInterceptors.implemented = true;

--- a/server/game/cards/02_SHD/units/CovetousRivals.ts
+++ b/server/game/cards/02_SHD/units/CovetousRivals.ts
@@ -25,5 +25,3 @@ export default class CovetousRivals extends NonLeaderUnitCard {
         });
     }
 }
-
-CovetousRivals.implemented = true;

--- a/server/game/cards/02_SHD/units/CriminalMuscle.ts
+++ b/server/game/cards/02_SHD/units/CriminalMuscle.ts
@@ -22,5 +22,3 @@ export default class CriminalMuscle extends NonLeaderUnitCard {
         });
     }
 }
-
-CriminalMuscle.implemented = true;

--- a/server/game/cards/02_SHD/units/CrosshairFollowingOrders.ts
+++ b/server/game/cards/02_SHD/units/CrosshairFollowingOrders.ts
@@ -30,5 +30,3 @@ export default class CrosshairFollowingOrders extends NonLeaderUnitCard {
         });
     }
 }
-
-CrosshairFollowingOrders.implemented = true;

--- a/server/game/cards/02_SHD/units/DengarTheDemolisher.ts
+++ b/server/game/cards/02_SHD/units/DengarTheDemolisher.ts
@@ -25,5 +25,3 @@ export default class DengarTheDemolisher extends NonLeaderUnitCard {
         });
     }
 }
-
-DengarTheDemolisher.implemented = true;

--- a/server/game/cards/02_SHD/units/DiscerningVeteran.ts
+++ b/server/game/cards/02_SHD/units/DiscerningVeteran.ts
@@ -21,5 +21,3 @@ export default class DiscerningVeteran extends NonLeaderUnitCard {
         });
     }
 }
-
-DiscerningVeteran.implemented = true;

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -34,5 +34,3 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
         });
     }
 }
-
-DjBlatantThief.implemented = true;

--- a/server/game/cards/02_SHD/units/DoctorEvazanWantedOnTwelveSystems.ts
+++ b/server/game/cards/02_SHD/units/DoctorEvazanWantedOnTwelveSystems.ts
@@ -18,5 +18,3 @@ export default class DoctorEvazanWantedOnTwelveSystems extends NonLeaderUnitCard
         });
     }
 }
-
-DoctorEvazanWantedOnTwelveSystems.implemented = true;

--- a/server/game/cards/02_SHD/units/DoctorPershingExperimentingWithLife.ts
+++ b/server/game/cards/02_SHD/units/DoctorPershingExperimentingWithLife.ts
@@ -24,5 +24,3 @@ export default class DoctorPershing extends NonLeaderUnitCard {
         });
     }
 }
-
-DoctorPershing.implemented = true;

--- a/server/game/cards/02_SHD/units/EchoRestored.ts
+++ b/server/game/cards/02_SHD/units/EchoRestored.ts
@@ -30,5 +30,3 @@ export default class EchoRestored extends NonLeaderUnitCard {
         });
     }
 }
-
-EchoRestored.implemented = true;

--- a/server/game/cards/02_SHD/units/EmboStoicAndResolute.ts
+++ b/server/game/cards/02_SHD/units/EmboStoicAndResolute.ts
@@ -39,5 +39,3 @@ export default class EmboStoicAndResolute extends NonLeaderUnitCard {
         });
     }
 }
-
-EmboStoicAndResolute.implemented = true;

--- a/server/game/cards/02_SHD/units/EnfysNestMarauder.ts
+++ b/server/game/cards/02_SHD/units/EnfysNestMarauder.ts
@@ -24,5 +24,3 @@ export default class EnfysNestMarauder extends NonLeaderUnitCard {
         });
     }
 }
-
-EnfysNestMarauder.implemented = true;

--- a/server/game/cards/02_SHD/units/EnterprisingLackeys.ts
+++ b/server/game/cards/02_SHD/units/EnterprisingLackeys.ts
@@ -26,5 +26,3 @@ export default class EnterprisingLackeys extends NonLeaderUnitCard {
         });
     }
 }
-
-EnterprisingLackeys.implemented = true;

--- a/server/game/cards/02_SHD/units/FennecShandLoyalSharpshooter.ts
+++ b/server/game/cards/02_SHD/units/FennecShandLoyalSharpshooter.ts
@@ -23,5 +23,3 @@ export default class FennecShandLoyalSharpshooter extends NonLeaderUnitCard {
         });
     }
 }
-
-FennecShandLoyalSharpshooter.implemented = true;

--- a/server/game/cards/02_SHD/units/FinalizerMightOfTheFirstOrder.ts
+++ b/server/game/cards/02_SHD/units/FinalizerMightOfTheFirstOrder.ts
@@ -67,5 +67,3 @@ export default class FinalizerMightOfTheFirstOrder extends NonLeaderUnitCard {
         return new Set(context.events.filter((event) => event.name === EventName.OnCardCaptured).map((event) => event.card));
     }
 }
-
-FinalizerMightOfTheFirstOrder.implemented = true;

--- a/server/game/cards/02_SHD/units/FirstLightHeadquartersOfTheCrimsonDawn.ts
+++ b/server/game/cards/02_SHD/units/FirstLightHeadquartersOfTheCrimsonDawn.ts
@@ -64,5 +64,3 @@ class FirstLightSmuggleAction extends PlayUnitAction {
         );
     }
 }
-
-FirstLightHeadquartersOfTheCrimsonDawn.implemented = true;

--- a/server/game/cards/02_SHD/units/FreetownBackup.ts
+++ b/server/game/cards/02_SHD/units/FreetownBackup.ts
@@ -25,5 +25,3 @@ export default class FreetownBackup extends NonLeaderUnitCard {
         });
     }
 }
-
-FreetownBackup.implemented = true;

--- a/server/game/cards/02_SHD/units/FrontierTrader.ts
+++ b/server/game/cards/02_SHD/units/FrontierTrader.ts
@@ -27,5 +27,3 @@ export default class FrontierTrader extends NonLeaderUnitCard {
         });
     }
 }
-
-FrontierTrader.implemented = true;

--- a/server/game/cards/02_SHD/units/FugitiveWookiee.ts
+++ b/server/game/cards/02_SHD/units/FugitiveWookiee.ts
@@ -20,5 +20,3 @@ export default class FugitiveWookiee extends NonLeaderUnitCard {
         });
     }
 }
-
-FugitiveWookiee.implemented = true;

--- a/server/game/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.ts
+++ b/server/game/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.ts
@@ -31,5 +31,3 @@ export default class GeneralRieekanDefensiveStrategist extends NonLeaderUnitCard
         });
     }
 }
-
-GeneralRieekanDefensiveStrategist.implemented = true;

--- a/server/game/cards/02_SHD/units/GentleGiant.ts
+++ b/server/game/cards/02_SHD/units/GentleGiant.ts
@@ -22,5 +22,3 @@ export default class GentleGiant extends NonLeaderUnitCard {
         });
     }
 }
-
-GentleGiant.implemented = true;

--- a/server/game/cards/02_SHD/units/GideonsLightCruiserDarkTroopersStation.ts
+++ b/server/game/cards/02_SHD/units/GideonsLightCruiserDarkTroopersStation.ts
@@ -31,5 +31,3 @@ export default class GideonsLightCruiserDarkTroopersStation extends NonLeaderUni
         });
     }
 }
-
-GideonsLightCruiserDarkTroopersStation.implemented = true;

--- a/server/game/cards/02_SHD/units/GreySquadronYWing.ts
+++ b/server/game/cards/02_SHD/units/GreySquadronYWing.ts
@@ -23,5 +23,3 @@ export default class GreySquadronYWing extends NonLeaderUnitCard {
         });
     }
 }
-
-GreySquadronYWing.implemented = true;

--- a/server/game/cards/02_SHD/units/GuavianAntagonizer.ts
+++ b/server/game/cards/02_SHD/units/GuavianAntagonizer.ts
@@ -16,5 +16,3 @@ export default class GuavianAntagonizer extends NonLeaderUnitCard {
         });
     }
 }
-
-GuavianAntagonizer.implemented = true;

--- a/server/game/cards/02_SHD/units/HunterOfTheHaxionBrood.ts
+++ b/server/game/cards/02_SHD/units/HunterOfTheHaxionBrood.ts
@@ -18,5 +18,3 @@ export default class HunterOfTheHaxionBrood extends NonLeaderUnitCard {
         });
     }
 }
-
-HunterOfTheHaxionBrood.implemented = true;

--- a/server/game/cards/02_SHD/units/HuntingNexu.ts
+++ b/server/game/cards/02_SHD/units/HuntingNexu.ts
@@ -18,5 +18,3 @@ export default class HuntingNexu extends NonLeaderUnitCard {
         });
     }
 }
-
-HuntingNexu.implemented = true;

--- a/server/game/cards/02_SHD/units/HylobonEnforcer.ts
+++ b/server/game/cards/02_SHD/units/HylobonEnforcer.ts
@@ -16,5 +16,3 @@ export default class HylobonEnforcer extends NonLeaderUnitCard {
         });
     }
 }
-
-HylobonEnforcer.implemented = true;

--- a/server/game/cards/02_SHD/units/IncineratorTrooper.ts
+++ b/server/game/cards/02_SHD/units/IncineratorTrooper.ts
@@ -16,5 +16,3 @@ export default class IncineratorTrooper extends NonLeaderUnitCard {
         });
     }
 }
-
-IncineratorTrooper.implemented = true;

--- a/server/game/cards/02_SHD/units/JabbasRancorPateesa.ts
+++ b/server/game/cards/02_SHD/units/JabbasRancorPateesa.ts
@@ -41,5 +41,3 @@ export default class JabbasRancorPateesa extends NonLeaderUnitCard {
         });
     }
 }
-
-JabbasRancorPateesa.implemented = true;

--- a/server/game/cards/02_SHD/units/JangoFettRenownedBountyHunter.ts
+++ b/server/game/cards/02_SHD/units/JangoFettRenownedBountyHunter.ts
@@ -32,5 +32,3 @@ export default class JangoFettRenownedBountyHunter extends NonLeaderUnitCard {
         });
     }
 }
-
-JangoFettRenownedBountyHunter.implemented = true;

--- a/server/game/cards/02_SHD/units/KetsuOnyoOldFriend.ts
+++ b/server/game/cards/02_SHD/units/KetsuOnyoOldFriend.ts
@@ -28,5 +28,3 @@ export default class KetsuOnyoOldFriend extends NonLeaderUnitCard {
         });
     }
 }
-
-KetsuOnyoOldFriend.implemented = true;

--- a/server/game/cards/02_SHD/units/KihraxzHeavyFighter.ts
+++ b/server/game/cards/02_SHD/units/KihraxzHeavyFighter.ts
@@ -30,5 +30,3 @@ export default class KihraxzHeavyFighter extends NonLeaderUnitCard {
         });
     }
 }
-
-KihraxzHeavyFighter.implemented = true;

--- a/server/game/cards/02_SHD/units/KintanIntimidator.ts
+++ b/server/game/cards/02_SHD/units/KintanIntimidator.ts
@@ -16,5 +16,3 @@ export default class KintanIntimidator extends NonLeaderUnitCard {
         });
     }
 }
-
-KintanIntimidator.implemented = true;

--- a/server/game/cards/02_SHD/units/KoskaReeves.ts
+++ b/server/game/cards/02_SHD/units/KoskaReeves.ts
@@ -25,5 +25,3 @@ export default class KoskaReeves extends NonLeaderUnitCard {
         });
     }
 }
-
-KoskaReeves.implemented = true;

--- a/server/game/cards/02_SHD/units/KraganGorrWarbirdCaptain.ts
+++ b/server/game/cards/02_SHD/units/KraganGorrWarbirdCaptain.ts
@@ -23,5 +23,3 @@ export default class KraganGorrWarbirdCaptain extends NonLeaderUnitCard {
         });
     }
 }
-
-KraganGorrWarbirdCaptain.implemented = true;

--- a/server/game/cards/02_SHD/units/KraytDragon.ts
+++ b/server/game/cards/02_SHD/units/KraytDragon.ts
@@ -27,5 +27,3 @@ export default class KraytDragon extends NonLeaderUnitCard {
         });
     }
 }
-
-KraytDragon.implemented = true;

--- a/server/game/cards/02_SHD/units/KrrsantanMuscleForHire.ts
+++ b/server/game/cards/02_SHD/units/KrrsantanMuscleForHire.ts
@@ -35,5 +35,3 @@ export default class KrrsantanMuscleForHire extends NonLeaderUnitCard {
         });
     }
 }
-
-KrrsantanMuscleForHire.implemented = true;

--- a/server/game/cards/02_SHD/units/KuiilIHaveSpoken.ts
+++ b/server/game/cards/02_SHD/units/KuiilIHaveSpoken.ts
@@ -36,5 +36,3 @@ export default class KuiilIHaveSpoken extends NonLeaderUnitCard {
         return baseAspects.some((aspect) => discardedCardAspects.includes(aspect));
     }
 }
-
-KuiilIHaveSpoken.implemented = true;

--- a/server/game/cards/02_SHD/units/LadyProximaWhiteWormMatriarch.ts
+++ b/server/game/cards/02_SHD/units/LadyProximaWhiteWormMatriarch.ts
@@ -27,5 +27,3 @@ export default class LadyProximaWhiteWormMatriarch extends NonLeaderUnitCard {
         });
     }
 }
-
-LadyProximaWhiteWormMatriarch.implemented = true;

--- a/server/game/cards/02_SHD/units/LomPykeDealerInTruths.ts
+++ b/server/game/cards/02_SHD/units/LomPykeDealerInTruths.ts
@@ -28,5 +28,3 @@ export default class LomPykeDealerInTruths extends NonLeaderUnitCard {
         });
     }
 }
-
-LomPykeDealerInTruths.implemented = true;

--- a/server/game/cards/02_SHD/units/MandalorianWarrior.ts
+++ b/server/game/cards/02_SHD/units/MandalorianWarrior.ts
@@ -22,5 +22,3 @@ export default class MandalorianWarrior extends NonLeaderUnitCard {
         });
     }
 }
-
-MandalorianWarrior.implemented = true;

--- a/server/game/cards/02_SHD/units/MaulShadowCollectiveVisionary.ts
+++ b/server/game/cards/02_SHD/units/MaulShadowCollectiveVisionary.ts
@@ -48,5 +48,3 @@ export default class MaulShadowCollectiveVisionary extends NonLeaderUnitCard {
         });
     }
 }
-
-MaulShadowCollectiveVisionary.implemented = true;

--- a/server/game/cards/02_SHD/units/MazKanataPirateQueen.ts
+++ b/server/game/cards/02_SHD/units/MazKanataPirateQueen.ts
@@ -22,5 +22,3 @@ export default class MazKanataPirateQueen extends NonLeaderUnitCard {
         });
     }
 }
-
-MazKanataPirateQueen.implemented = true;

--- a/server/game/cards/02_SHD/units/MigsMayfeldTriggerman.ts
+++ b/server/game/cards/02_SHD/units/MigsMayfeldTriggerman.ts
@@ -23,5 +23,3 @@ export default class MigsMayfeldTriggerman extends NonLeaderUnitCard {
         });
     }
 }
-
-MigsMayfeldTriggerman.implemented = true;

--- a/server/game/cards/02_SHD/units/MillenniumFalconLandosPride.ts
+++ b/server/game/cards/02_SHD/units/MillenniumFalconLandosPride.ts
@@ -26,5 +26,3 @@ export default class MillenniumFalconLandosPride extends NonLeaderUnitCard {
         });
     }
 }
-
-MillenniumFalconLandosPride.implemented = true;

--- a/server/game/cards/02_SHD/units/OmegaPartOfTheSquad.ts
+++ b/server/game/cards/02_SHD/units/OmegaPartOfTheSquad.ts
@@ -50,5 +50,3 @@ export default class OmegaPartOfTheSquad extends NonLeaderUnitCard {
         );
     }
 }
-
-OmegaPartOfTheSquad.implemented = true;

--- a/server/game/cards/02_SHD/units/OutlandTieVanguard.ts
+++ b/server/game/cards/02_SHD/units/OutlandTieVanguard.ts
@@ -20,5 +20,3 @@ export default class OutlandTieVanguard extends NonLeaderUnitCard {
         });
     }
 }
-
-OutlandTieVanguard.implemented = true;

--- a/server/game/cards/02_SHD/units/OutlawCorona.ts
+++ b/server/game/cards/02_SHD/units/OutlawCorona.ts
@@ -16,5 +16,3 @@ export default class OutlawCorona extends NonLeaderUnitCard {
         });
     }
 }
-
-OutlawCorona.implemented = true;

--- a/server/game/cards/02_SHD/units/PoeDameronQuickToImprovise.ts
+++ b/server/game/cards/02_SHD/units/PoeDameronQuickToImprovise.ts
@@ -45,5 +45,3 @@ export default class PoeDameronQuickToImprovise extends NonLeaderUnitCard {
         });
     }
 }
-
-PoeDameronQuickToImprovise.implemented = true;

--- a/server/game/cards/02_SHD/units/PrincipledOutlaw.ts
+++ b/server/game/cards/02_SHD/units/PrincipledOutlaw.ts
@@ -22,5 +22,3 @@ export default class PrincipledOutlaw extends NonLeaderUnitCard {
         });
     }
 }
-
-PrincipledOutlaw.implemented = true;

--- a/server/game/cards/02_SHD/units/PrivateerCrew.ts
+++ b/server/game/cards/02_SHD/units/PrivateerCrew.ts
@@ -24,5 +24,3 @@ export default class PrivateerCrew extends NonLeaderUnitCard {
         });
     }
 }
-
-PrivateerCrew.implemented = true;

--- a/server/game/cards/02_SHD/units/PrivateerScyk.ts
+++ b/server/game/cards/02_SHD/units/PrivateerScyk.ts
@@ -19,5 +19,3 @@ export default class PrivateerScyk extends NonLeaderUnitCard {
         });
     }
 }
-
-PrivateerScyk.implemented = true;

--- a/server/game/cards/02_SHD/units/ProtectorOfTheThrone.ts
+++ b/server/game/cards/02_SHD/units/ProtectorOfTheThrone.ts
@@ -18,5 +18,3 @@ export default class ProtectorOfTheThrone extends NonLeaderUnitCard {
         });
     }
 }
-
-ProtectorOfTheThrone.implemented = true;

--- a/server/game/cards/02_SHD/units/PunishingOne.ts
+++ b/server/game/cards/02_SHD/units/PunishingOne.ts
@@ -26,5 +26,3 @@ export default class PunishingOne extends NonLeaderUnitCard {
         });
     }
 }
-
-PunishingOne.implemented = true;

--- a/server/game/cards/02_SHD/units/RazorCrest.ts
+++ b/server/game/cards/02_SHD/units/RazorCrest.ts
@@ -23,5 +23,3 @@ export default class RazorCrest extends NonLeaderUnitCard {
         });
     }
 }
-
-RazorCrest.implemented = true;

--- a/server/game/cards/02_SHD/units/ReputableHunter.ts
+++ b/server/game/cards/02_SHD/units/ReputableHunter.ts
@@ -17,5 +17,3 @@ export default class ReputableHunter extends NonLeaderUnitCard {
         });
     }
 }
-
-ReputableHunter.implemented = true;

--- a/server/game/cards/02_SHD/units/RhokaiGunship.ts
+++ b/server/game/cards/02_SHD/units/RhokaiGunship.ts
@@ -18,5 +18,3 @@ export default class RhokaiGunship extends NonLeaderUnitCard {
         });
     }
 }
-
-RhokaiGunship.implemented = true;

--- a/server/game/cards/02_SHD/units/RoseTicoDedicatedToTheCause.ts
+++ b/server/game/cards/02_SHD/units/RoseTicoDedicatedToTheCause.ts
@@ -29,5 +29,3 @@ export default class RoseTicoDedicatedToTheCause extends NonLeaderUnitCard {
         });
     }
 }
-
-RoseTicoDedicatedToTheCause.implemented = true;

--- a/server/game/cards/02_SHD/units/RuthlessAssassin.ts
+++ b/server/game/cards/02_SHD/units/RuthlessAssassin.ts
@@ -21,5 +21,3 @@ export default class RuthlessAssassin extends NonLeaderUnitCard {
         });
     }
 }
-
-RuthlessAssassin.implemented = true;

--- a/server/game/cards/02_SHD/units/SalaciousCrumbObnoxiousPet.ts
+++ b/server/game/cards/02_SHD/units/SalaciousCrumbObnoxiousPet.ts
@@ -33,5 +33,3 @@ export default class SalaciousCrumbObnoxiousPet extends NonLeaderUnitCard {
         });
     }
 }
-
-SalaciousCrumbObnoxiousPet.implemented = true;

--- a/server/game/cards/02_SHD/units/SlaversFreighter.ts
+++ b/server/game/cards/02_SHD/units/SlaversFreighter.ts
@@ -27,5 +27,3 @@ export default class SlaversFreighter extends NonLeaderUnitCard {
         });
     }
 }
-
-SlaversFreighter.implemented = true;

--- a/server/game/cards/02_SHD/units/SmugglersStarfighter.ts
+++ b/server/game/cards/02_SHD/units/SmugglersStarfighter.ts
@@ -27,5 +27,3 @@ export default class SmugglersStarfighter extends NonLeaderUnitCard {
         });
     }
 }
-
-SmugglersStarfighter.implemented = true;

--- a/server/game/cards/02_SHD/units/SugiHiredGuardian.ts
+++ b/server/game/cards/02_SHD/units/SugiHiredGuardian.ts
@@ -18,5 +18,3 @@ export default class SugiHiredGuardian extends NonLeaderUnitCard {
         });
     }
 }
-
-SugiHiredGuardian.implemented = true;

--- a/server/game/cards/02_SHD/units/SupercommandoSquad.ts
+++ b/server/game/cards/02_SHD/units/SupercommandoSquad.ts
@@ -18,5 +18,3 @@ export default class SupercommandoSquad extends NonLeaderUnitCard {
         });
     }
 }
-
-SupercommandoSquad.implemented = true;

--- a/server/game/cards/02_SHD/units/SupremeLeaderSnokeShadowRuler.ts
+++ b/server/game/cards/02_SHD/units/SupremeLeaderSnokeShadowRuler.ts
@@ -19,5 +19,3 @@ export default class SupremeLeaderSnokeShadowRuler extends NonLeaderUnitCard {
         });
     }
 }
-
-SupremeLeaderSnokeShadowRuler.implemented = true;

--- a/server/game/cards/02_SHD/units/SurvivorsGauntlet.ts
+++ b/server/game/cards/02_SHD/units/SurvivorsGauntlet.ts
@@ -39,5 +39,3 @@ export default class SurvivorsGauntlet extends NonLeaderUnitCard {
         });
     }
 }
-
-SurvivorsGauntlet.implemented = true;

--- a/server/game/cards/02_SHD/units/TarffulKashyyykChieftain.ts
+++ b/server/game/cards/02_SHD/units/TarffulKashyyykChieftain.ts
@@ -32,5 +32,3 @@ export default class TarffulKashyyykChieftain extends NonLeaderUnitCard {
         });
     }
 }
-
-TarffulKashyyykChieftain.implemented = true;

--- a/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
+++ b/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
@@ -24,5 +24,3 @@ export default class TechSourceOfInsight extends NonLeaderUnitCard {
         });
     }
 }
-
-TechSourceOfInsight.implemented = true;

--- a/server/game/cards/02_SHD/units/TheArmorerSurvivalIsStrength.ts
+++ b/server/game/cards/02_SHD/units/TheArmorerSurvivalIsStrength.ts
@@ -22,5 +22,3 @@ export default class TheArmorerSurvivalIsStrength extends NonLeaderUnitCard {
         });
     }
 }
-
-TheArmorerSurvivalIsStrength.implemented = true;

--- a/server/game/cards/02_SHD/units/TheClientDictatedByDiscretion.ts
+++ b/server/game/cards/02_SHD/units/TheClientDictatedByDiscretion.ts
@@ -32,5 +32,3 @@ export default class TheClientDictatedByDiscretion extends NonLeaderUnitCard {
         });
     }
 }
-
-TheClientDictatedByDiscretion.implemented = true;

--- a/server/game/cards/02_SHD/units/TheMandalorianWhereverIGoHeGoes.ts
+++ b/server/game/cards/02_SHD/units/TheMandalorianWhereverIGoHeGoes.ts
@@ -23,5 +23,3 @@ export default class TheMandalorianWhereverIGoHeGoes extends NonLeaderUnitCard {
         });
     }
 }
-
-TheMandalorianWhereverIGoHeGoes.implemented = true;

--- a/server/game/cards/02_SHD/units/TheMarauderShuttlingTheBadBatch.ts
+++ b/server/game/cards/02_SHD/units/TheMarauderShuttlingTheBadBatch.ts
@@ -26,5 +26,3 @@ export default class TheMarauderShuttlingTheBadBatch extends NonLeaderUnitCard {
         });
     }
 }
-
-TheMarauderShuttlingTheBadBatch.implemented = true;

--- a/server/game/cards/02_SHD/units/TobiasBeckettITrustNoOne.ts
+++ b/server/game/cards/02_SHD/units/TobiasBeckettITrustNoOne.ts
@@ -25,5 +25,3 @@ export default class TobiasBeckettITrustNoOne extends NonLeaderUnitCard {
         });
     }
 }
-
-TobiasBeckettITrustNoOne.implemented = true;

--- a/server/game/cards/02_SHD/units/ToroCalicanAmbitiousUpstart.ts
+++ b/server/game/cards/02_SHD/units/ToroCalicanAmbitiousUpstart.ts
@@ -29,5 +29,3 @@ export default class ToroCalicanAmbitiousUpstart extends NonLeaderUnitCard {
         });
     }
 }
-
-ToroCalicanAmbitiousUpstart.implemented = true;

--- a/server/game/cards/02_SHD/units/TrandoshanHunters.ts
+++ b/server/game/cards/02_SHD/units/TrandoshanHunters.ts
@@ -21,5 +21,3 @@ export default class TrandoshanHunters extends NonLeaderUnitCard {
         });
     }
 }
-
-TrandoshanHunters.implemented = true;

--- a/server/game/cards/02_SHD/units/ValLoyalToTheEnd.ts
+++ b/server/game/cards/02_SHD/units/ValLoyalToTheEnd.ts
@@ -29,5 +29,3 @@ export default class ValLoyalToTheEnd extends NonLeaderUnitCard {
         });
     }
 }
-
-ValLoyalToTheEnd.implemented = true;

--- a/server/game/cards/02_SHD/units/ValiantAssaultShip.ts
+++ b/server/game/cards/02_SHD/units/ValiantAssaultShip.ts
@@ -23,5 +23,3 @@ export default class ValiantAssaultShip extends NonLeaderUnitCard {
         });
     }
 }
-
-ValiantAssaultShip.implemented = true;

--- a/server/game/cards/02_SHD/units/WantedInsurgents.ts
+++ b/server/game/cards/02_SHD/units/WantedInsurgents.ts
@@ -20,5 +20,3 @@ export default class WantedInsurgents extends NonLeaderUnitCard {
         });
     }
 }
-
-WantedInsurgents.implemented = true;

--- a/server/game/cards/02_SHD/units/WarbirdStowaway.ts
+++ b/server/game/cards/02_SHD/units/WarbirdStowaway.ts
@@ -17,5 +17,3 @@ export default class WarbirdStowaway extends NonLeaderUnitCard {
         });
     }
 }
-
-WarbirdStowaway.implemented = true;

--- a/server/game/cards/02_SHD/units/WildRancor.ts
+++ b/server/game/cards/02_SHD/units/WildRancor.ts
@@ -20,5 +20,3 @@ export default class WildRancor extends NonLeaderUnitCard {
         });
     }
 }
-
-WildRancor.implemented = true;

--- a/server/game/cards/02_SHD/units/WookieeWarrior.ts
+++ b/server/game/cards/02_SHD/units/WookieeWarrior.ts
@@ -21,5 +21,3 @@ export default class WookieeWarrior extends NonLeaderUnitCard {
         });
     }
 }
-
-WookieeWarrior.implemented = true;

--- a/server/game/cards/02_SHD/units/WreckerBoom.ts
+++ b/server/game/cards/02_SHD/units/WreckerBoom.ts
@@ -30,5 +30,3 @@ export default class WreckerBoom extends NonLeaderUnitCard {
         });
     }
 }
-
-WreckerBoom.implemented = true;

--- a/server/game/cards/02_SHD/units/XanaduBloodCadBanesReward.ts
+++ b/server/game/cards/02_SHD/units/XanaduBloodCadBanesReward.ts
@@ -41,5 +41,3 @@ export default class XanaduBloodCadBanesReward extends NonLeaderUnitCard {
         });
     }
 }
-
-XanaduBloodCadBanesReward.implemented = true;

--- a/server/game/cards/02_SHD/units/ZoriiBlissValiantSmuggler.ts
+++ b/server/game/cards/02_SHD/units/ZoriiBlissValiantSmuggler.ts
@@ -29,5 +29,3 @@ export default class ZoriiBlissValiantSmuggler extends NonLeaderUnitCard {
         });
     }
 }
-
-ZoriiBlissValiantSmuggler.implemented = true;

--- a/server/game/cards/02_SHD/units/ZuckussBountyHunterForHire.ts
+++ b/server/game/cards/02_SHD/units/ZuckussBountyHunterForHire.ts
@@ -23,5 +23,3 @@ export default class ZuckussBountyHunterForHire extends NonLeaderUnitCard {
         });
     }
 }
-
-ZuckussBountyHunterForHire.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/ArmedToTheTeeth.ts
+++ b/server/game/cards/02_SHD/upgrades/ArmedToTheTeeth.ts
@@ -25,5 +25,3 @@ export default class ArmedToTheTeeth extends UpgradeCard {
         });
     }
 }
-
-ArmedToTheTeeth.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/BountyHuntersQuarry.ts
+++ b/server/game/cards/02_SHD/upgrades/BountyHuntersQuarry.ts
@@ -30,5 +30,3 @@ export default class BountyHuntersQuarry extends UpgradeCard {
         });
     }
 }
-
-BountyHuntersQuarry.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/BrutalTraditions.ts
+++ b/server/game/cards/02_SHD/upgrades/BrutalTraditions.ts
@@ -27,5 +27,3 @@ export default class BrutalTraditions extends UpgradeCard {
         });
     }
 }
-
-BrutalTraditions.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/DeathMark.ts
+++ b/server/game/cards/02_SHD/upgrades/DeathMark.ts
@@ -20,5 +20,3 @@ export default class DeathMark extends UpgradeCard {
         });
     }
 }
-
-DeathMark.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/EnticingReward.ts
+++ b/server/game/cards/02_SHD/upgrades/EnticingReward.ts
@@ -38,5 +38,3 @@ export default class EnticingReward extends UpgradeCard {
         });
     }
 }
-
-EnticingReward.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/Foundling.ts
+++ b/server/game/cards/02_SHD/upgrades/Foundling.ts
@@ -17,5 +17,3 @@ export default class Foundling extends UpgradeCard {
         });
     }
 }
-
-Foundling.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/FrozenInCarbonite.ts
+++ b/server/game/cards/02_SHD/upgrades/FrozenInCarbonite.ts
@@ -27,5 +27,3 @@ export default class FrozenInCarbonite extends UpgradeCard {
         });
     }
 }
-
-FrozenInCarbonite.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/GuildTarget.ts
+++ b/server/game/cards/02_SHD/upgrades/GuildTarget.ts
@@ -23,5 +23,3 @@ export default class GuildTarget extends UpgradeCard {
         });
     }
 }
-
-GuildTarget.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/HeroicResolve.ts
+++ b/server/game/cards/02_SHD/upgrades/HeroicResolve.ts
@@ -30,5 +30,3 @@ export default class HeroicResolve extends UpgradeCard {
         });
     }
 }
-
-HeroicResolve.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/HotshotDL44Blaster.ts
+++ b/server/game/cards/02_SHD/upgrades/HotshotDL44Blaster.ts
@@ -27,5 +27,3 @@ export default class HotshotDL44Blaster extends UpgradeCard {
         });
     }
 }
-
-HotshotDL44Blaster.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/LegalAuthority.ts
+++ b/server/game/cards/02_SHD/upgrades/LegalAuthority.ts
@@ -29,5 +29,3 @@ export default class LegalAuthority extends UpgradeCard {
         });
     }
 }
-
-LegalAuthority.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/PriceOnYourHead.ts
+++ b/server/game/cards/02_SHD/upgrades/PriceOnYourHead.ts
@@ -20,5 +20,3 @@ export default class PriceOnYourHead extends UpgradeCard {
         });
     }
 }
-
-PriceOnYourHead.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/PublicEnemy.ts
+++ b/server/game/cards/02_SHD/upgrades/PublicEnemy.ts
@@ -24,5 +24,3 @@ export default class PublicEnemy extends UpgradeCard {
         });
     }
 }
-
-PublicEnemy.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/Ruthlessness.ts
+++ b/server/game/cards/02_SHD/upgrades/Ruthlessness.ts
@@ -25,5 +25,3 @@ export default class Ruthlessness extends UpgradeCard {
         });
     }
 }
-
-Ruthlessness.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/TheDarksaber.ts
+++ b/server/game/cards/02_SHD/upgrades/TheDarksaber.ts
@@ -28,5 +28,3 @@ export default class TheDarksaber extends UpgradeCard {
         });
     }
 }
-
-TheDarksaber.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/TheMandaloriansRifle.ts
+++ b/server/game/cards/02_SHD/upgrades/TheMandaloriansRifle.ts
@@ -33,5 +33,3 @@ export default class TheMandaloriansRifle extends UpgradeCard {
         });
     }
 }
-
-TheMandaloriansRifle.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/TopTarget.ts
+++ b/server/game/cards/02_SHD/upgrades/TopTarget.ts
@@ -24,5 +24,3 @@ export default class TopTarget extends UpgradeCard {
         });
     }
 }
-
-TopTarget.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/VambraceFlamethrower.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceFlamethrower.ts
@@ -27,5 +27,3 @@ export default class VambraceFlamethrower extends UpgradeCard {
         });
     }
 }
-
-VambraceFlamethrower.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceGrappleshot.ts
@@ -22,5 +22,3 @@ export default class VambraceGrappleshot extends UpgradeCard {
         });
     }
 }
-
-VambraceGrappleshot.implemented = true;

--- a/server/game/cards/02_SHD/upgrades/Wanted.ts
+++ b/server/game/cards/02_SHD/upgrades/Wanted.ts
@@ -22,5 +22,3 @@ export default class Wanted extends UpgradeCard {
         });
     }
 }
-
-Wanted.implemented = true;

--- a/server/game/cards/03_TWI/bases/PauCity.ts
+++ b/server/game/cards/03_TWI/bases/PauCity.ts
@@ -19,5 +19,3 @@ export default class PauCity extends BaseCard {
         });
     }
 }
-
-PauCity.implemented = true;

--- a/server/game/cards/03_TWI/bases/PetranakiArena.ts
+++ b/server/game/cards/03_TWI/bases/PetranakiArena.ts
@@ -19,5 +19,3 @@ export default class PetranakiArena extends BaseCard {
         });
     }
 }
-
-PetranakiArena.implemented = true;

--- a/server/game/cards/03_TWI/events/BoldResistance.ts
+++ b/server/game/cards/03_TWI/events/BoldResistance.ts
@@ -42,5 +42,3 @@ export default class BoldResistance extends EventCard {
         return true;
     }
 }
-
-BoldResistance.implemented = true;

--- a/server/game/cards/03_TWI/events/BreakingIn.ts
+++ b/server/game/cards/03_TWI/events/BreakingIn.ts
@@ -22,5 +22,3 @@ export default class BreakingIn extends EventCard {
         });
     }
 }
-
-BreakingIn.implemented = true;

--- a/server/game/cards/03_TWI/events/CaughtInTheCrossfire.ts
+++ b/server/game/cards/03_TWI/events/CaughtInTheCrossfire.ts
@@ -41,5 +41,3 @@ export default class CaughtInTheCrossfire extends EventCard {
         });
     }
 }
-
-CaughtInTheCrossfire.implemented = true;

--- a/server/game/cards/03_TWI/events/CornerThePrey.ts
+++ b/server/game/cards/03_TWI/events/CornerThePrey.ts
@@ -22,5 +22,3 @@ export default class CornerThePrey extends EventCard {
         });
     }
 }
-
-CornerThePrey.implemented = true;

--- a/server/game/cards/03_TWI/events/CreativeThinking.ts
+++ b/server/game/cards/03_TWI/events/CreativeThinking.ts
@@ -25,5 +25,3 @@ export default class CreativeThinking extends EventCard {
         });
     }
 }
-
-CreativeThinking.implemented = true;

--- a/server/game/cards/03_TWI/events/DisruptiveBurst.ts
+++ b/server/game/cards/03_TWI/events/DisruptiveBurst.ts
@@ -20,5 +20,3 @@ export default class DisruptiveBurst extends EventCard {
         });
     }
 }
-
-DisruptiveBurst.implemented = true;

--- a/server/game/cards/03_TWI/events/DroidDeployment.ts
+++ b/server/game/cards/03_TWI/events/DroidDeployment.ts
@@ -16,5 +16,3 @@ export default class DroidDeployment extends EventCard {
         });
     }
 }
-
-DroidDeployment.implemented = true;

--- a/server/game/cards/03_TWI/events/DropIn.ts
+++ b/server/game/cards/03_TWI/events/DropIn.ts
@@ -16,5 +16,3 @@ export default class DropIn extends EventCard {
         });
     }
 }
-
-DropIn.implemented = true;

--- a/server/game/cards/03_TWI/events/GrenadeStrike.ts
+++ b/server/game/cards/03_TWI/events/GrenadeStrike.ts
@@ -30,5 +30,3 @@ export default class GrenadeStrike extends EventCard {
         });
     }
 }
-
-GrenadeStrike.implemented = true;

--- a/server/game/cards/03_TWI/events/GuardingTheWay.ts
+++ b/server/game/cards/03_TWI/events/GuardingTheWay.ts
@@ -31,5 +31,3 @@ export default class GuardingTheWay extends EventCard {
         });
     }
 }
-
-GuardingTheWay.implemented = true;

--- a/server/game/cards/03_TWI/events/HelloThere.ts
+++ b/server/game/cards/03_TWI/events/HelloThere.ts
@@ -31,5 +31,3 @@ export default class HelloThere extends EventCard {
         });
     }
 }
-
-HelloThere.implemented = true;

--- a/server/game/cards/03_TWI/events/HeroesOnBothSides.ts
+++ b/server/game/cards/03_TWI/events/HeroesOnBothSides.ts
@@ -46,5 +46,3 @@ export default class HeroesOnBothSides extends EventCard {
         });
     }
 }
-
-HeroesOnBothSides.implemented = true;

--- a/server/game/cards/03_TWI/events/InPursuit.ts
+++ b/server/game/cards/03_TWI/events/InPursuit.ts
@@ -29,5 +29,3 @@ export default class InPursuit extends EventCard {
         });
     }
 }
-
-InPursuit.implemented = true;

--- a/server/game/cards/03_TWI/events/ManufacturedSoldiers.ts
+++ b/server/game/cards/03_TWI/events/ManufacturedSoldiers.ts
@@ -23,5 +23,3 @@ export default class ManufacturedSoldiers extends EventCard {
         });
     }
 }
-
-ManufacturedSoldiers.implemented = true;

--- a/server/game/cards/03_TWI/events/MercilessContest.ts
+++ b/server/game/cards/03_TWI/events/MercilessContest.ts
@@ -32,5 +32,3 @@ export default class MercilessContest extends EventCard {
         });
     }
 }
-
-MercilessContest.implemented = true;

--- a/server/game/cards/03_TWI/events/NowThereAreTwoOfThem.ts
+++ b/server/game/cards/03_TWI/events/NowThereAreTwoOfThem.ts
@@ -32,5 +32,3 @@ export default class NowThereAreTwoOfThem extends EventCard {
         });
     }
 }
-
-NowThereAreTwoOfThem.implemented = true;

--- a/server/game/cards/03_TWI/events/OnTheDoorstep.ts
+++ b/server/game/cards/03_TWI/events/OnTheDoorstep.ts
@@ -16,5 +16,3 @@ export default class OnTheDoorstep extends EventCard {
         });
     }
 }
-
-OnTheDoorstep.implemented = true;

--- a/server/game/cards/03_TWI/events/PetitionTheSenate.ts
+++ b/server/game/cards/03_TWI/events/PetitionTheSenate.ts
@@ -21,5 +21,3 @@ export default class PetitionTheSenate extends EventCard {
         });
     }
 }
-
-PetitionTheSenate.implemented = true;

--- a/server/game/cards/03_TWI/events/PlanetaryInvasion.ts
+++ b/server/game/cards/03_TWI/events/PlanetaryInvasion.ts
@@ -30,5 +30,3 @@ export default class PlanetaryInvasion extends EventCard {
         });
     }
 }
-
-PlanetaryInvasion.implemented = true;

--- a/server/game/cards/03_TWI/events/PrisonerOfWar.ts
+++ b/server/game/cards/03_TWI/events/PrisonerOfWar.ts
@@ -42,5 +42,3 @@ export default class PrisonerOfWar extends EventCard {
         });
     }
 }
-
-PrisonerOfWar.implemented = true;

--- a/server/game/cards/03_TWI/events/PrivateManufacturing.ts
+++ b/server/game/cards/03_TWI/events/PrivateManufacturing.ts
@@ -31,5 +31,3 @@ export default class PrivateManufacturing extends EventCard {
         });
     }
 }
-
-PrivateManufacturing.implemented = true;

--- a/server/game/cards/03_TWI/events/SelfDestruct.ts
+++ b/server/game/cards/03_TWI/events/SelfDestruct.ts
@@ -28,5 +28,3 @@ export default class SelfDestruct extends EventCard {
         });
     }
 }
-
-SelfDestruct.implemented = true;

--- a/server/game/cards/03_TWI/events/StrategicAnalysis.ts
+++ b/server/game/cards/03_TWI/events/StrategicAnalysis.ts
@@ -16,5 +16,3 @@ export default class StrategicAnalysis extends EventCard {
         });
     }
 }
-
-StrategicAnalysis.implemented = true;

--- a/server/game/cards/03_TWI/events/SwordAndShieldManeuver.ts
+++ b/server/game/cards/03_TWI/events/SwordAndShieldManeuver.ts
@@ -26,5 +26,3 @@ export default class SwordAndShieldManeuver extends EventCard {
         });
     }
 }
-
-SwordAndShieldManeuver.implemented = true;

--- a/server/game/cards/03_TWI/events/SynchronizedStrike.ts
+++ b/server/game/cards/03_TWI/events/SynchronizedStrike.ts
@@ -23,5 +23,3 @@ export default class SynchronizedStrike extends EventCard {
         });
     }
 }
-
-SynchronizedStrike.implemented = true;

--- a/server/game/cards/03_TWI/events/TheInvasionOfChristophsis.ts
+++ b/server/game/cards/03_TWI/events/TheInvasionOfChristophsis.ts
@@ -16,5 +16,3 @@ export default class TheInvasionofChristophsis extends EventCard {
         });
     }
 }
-
-TheInvasionofChristophsis.implemented = true;

--- a/server/game/cards/03_TWI/events/UnlimitedPower.ts
+++ b/server/game/cards/03_TWI/events/UnlimitedPower.ts
@@ -48,5 +48,3 @@ export default class UnlimitedPower extends EventCard {
         });
     }
 }
-
-UnlimitedPower.implemented = true;

--- a/server/game/cards/03_TWI/events/UnmaskingTheConspiracy.ts
+++ b/server/game/cards/03_TWI/events/UnmaskingTheConspiracy.ts
@@ -31,5 +31,3 @@ export default class UnmaskingTheConspirancy extends EventCard {
         });
     }
 }
-
-UnmaskingTheConspirancy.implemented = true;

--- a/server/game/cards/03_TWI/events/WartimeProfiteering.ts
+++ b/server/game/cards/03_TWI/events/WartimeProfiteering.ts
@@ -28,5 +28,3 @@ export default class WartimeProfiteering extends EventCard {
         });
     }
 }
-
-WartimeProfiteering.implemented = true;

--- a/server/game/cards/03_TWI/leaders/AsajjVentressUnparalleledAdversary.ts
+++ b/server/game/cards/03_TWI/leaders/AsajjVentressUnparalleledAdversary.ts
@@ -51,5 +51,3 @@ export default class AsajjVentressUnparalleledAdversary extends LeaderUnitCard {
         return this.cardsPlayedThisPhaseWatcher.someCardPlayed((entry) => entry.playedBy === controller && entry.card.isEvent());
     }
 }
-
-AsajjVentressUnparalleledAdversary.implemented = true;

--- a/server/game/cards/03_TWI/leaders/BosskHuntingHisPrey.ts
+++ b/server/game/cards/03_TWI/leaders/BosskHuntingHisPrey.ts
@@ -46,5 +46,3 @@ export default class BosskHuntingHisPrey extends LeaderUnitCard {
         });
     }
 }
-
-BosskHuntingHisPrey.implemented = true;

--- a/server/game/cards/03_TWI/leaders/GeneralGrievousGeneralOfTheDroidArmies.ts
+++ b/server/game/cards/03_TWI/leaders/GeneralGrievousGeneralOfTheDroidArmies.ts
@@ -41,5 +41,3 @@ export default class GeneralGrievousGeneralOfTheDroidArmies extends LeaderUnitCa
         });
     }
 }
-
-GeneralGrievousGeneralOfTheDroidArmies.implemented = true;

--- a/server/game/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.ts
+++ b/server/game/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.ts
@@ -44,5 +44,3 @@ export default class MaceWinduVaapadFormMaster extends LeaderUnitCard {
         });
     }
 }
-
-MaceWinduVaapadFormMaster.implemented = true;

--- a/server/game/cards/03_TWI/leaders/MaulARivalInDarkness.ts
+++ b/server/game/cards/03_TWI/leaders/MaulARivalInDarkness.ts
@@ -30,5 +30,3 @@ export default class MaulARivalInDarkness extends LeaderUnitCard {
         });
     }
 }
-
-MaulARivalInDarkness.implemented = true;

--- a/server/game/cards/03_TWI/leaders/NuteGunrayVindictiveViceroy.ts
+++ b/server/game/cards/03_TWI/leaders/NuteGunrayVindictiveViceroy.ts
@@ -36,5 +36,3 @@ export default class NuteGunrayVindictiveViceroy extends LeaderUnitCard {
         });
     }
 }
-
-NuteGunrayVindictiveViceroy.implemented = true;

--- a/server/game/cards/03_TWI/leaders/PreVizslaPursuingTheThrone.ts
+++ b/server/game/cards/03_TWI/leaders/PreVizslaPursuingTheThrone.ts
@@ -45,5 +45,3 @@ export default class PreVizslaPursuingTheThrone extends LeaderUnitCard {
         });
     }
 }
-
-PreVizslaPursuingTheThrone.implemented = true;

--- a/server/game/cards/03_TWI/leaders/WatTamborTechnoUnionForeman.ts
+++ b/server/game/cards/03_TWI/leaders/WatTamborTechnoUnionForeman.ts
@@ -53,5 +53,3 @@ export default class WatTamborTechnoUnionForeman extends LeaderUnitCard {
         });
     }
 }
-
-WatTamborTechnoUnionForeman.implemented = true;

--- a/server/game/cards/03_TWI/tokens/BattleDroid.ts
+++ b/server/game/cards/03_TWI/tokens/BattleDroid.ts
@@ -8,5 +8,3 @@ export default class BattleDroid extends TokenUnitCard {
         };
     }
 }
-
-BattleDroid.implemented = true;

--- a/server/game/cards/03_TWI/tokens/CloneTrooper.ts
+++ b/server/game/cards/03_TWI/tokens/CloneTrooper.ts
@@ -8,5 +8,3 @@ export default class CloneTrooper extends TokenUnitCard {
         };
     }
 }
-
-CloneTrooper.implemented = true;

--- a/server/game/cards/03_TWI/units/332ndStalwart.ts
+++ b/server/game/cards/03_TWI/units/332ndStalwart.ts
@@ -18,5 +18,3 @@ export default class _332ndStalwart extends NonLeaderUnitCard {
         });
     }
 }
-
-_332ndStalwart.implemented = true;

--- a/server/game/cards/03_TWI/units/41stEliteCorps.ts
+++ b/server/game/cards/03_TWI/units/41stEliteCorps.ts
@@ -18,5 +18,3 @@ export default class _41stEliteCorps extends NonLeaderUnitCard {
         });
     }
 }
-
-_41stEliteCorps.implemented = true;

--- a/server/game/cards/03_TWI/units/501stLiberator.ts
+++ b/server/game/cards/03_TWI/units/501stLiberator.ts
@@ -25,5 +25,3 @@ export default class _501stLiberator extends NonLeaderUnitCard {
         });
     }
 }
-
-_501stLiberator.implemented = true;

--- a/server/game/cards/03_TWI/units/AT-TEVanguard.ts
+++ b/server/game/cards/03_TWI/units/AT-TEVanguard.ts
@@ -16,5 +16,3 @@ export default class AtTeVanguard extends NonLeaderUnitCard {
         });
     }
 }
-
-AtTeVanguard.implemented = true;

--- a/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
+++ b/server/game/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.ts
@@ -31,5 +31,3 @@ export default class AaylaSecuraMasterOfTheBlade extends NonLeaderUnitCard {
         });
     }
 }
-
-AaylaSecuraMasterOfTheBlade.implemented = true;

--- a/server/game/cards/03_TWI/units/AdmiralYularenAdvisingCaution.ts
+++ b/server/game/cards/03_TWI/units/AdmiralYularenAdvisingCaution.ts
@@ -20,5 +20,3 @@ export default class AdmiralYularenAdvisingCaution extends NonLeaderUnitCard {
         });
     }
 }
-
-AdmiralYularenAdvisingCaution.implemented = true;

--- a/server/game/cards/03_TWI/units/AggrievedParliamentarian.ts
+++ b/server/game/cards/03_TWI/units/AggrievedParliamentarian.ts
@@ -21,5 +21,3 @@ export default class AggrievedParliamentarian extends NonLeaderUnitCard {
         });
     }
 }
-
-AggrievedParliamentarian.implemented = true;

--- a/server/game/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.ts
+++ b/server/game/cards/03_TWI/units/AnakinSkywalkerMaverickMentor.ts
@@ -21,5 +21,3 @@ export default class AnakinSkywalkerMaverickMentor extends NonLeaderUnitCard {
         });
     }
 }
-
-AnakinSkywalkerMaverickMentor.implemented = true;

--- a/server/game/cards/03_TWI/units/AsajjVentressCountDookusAssassin.ts
+++ b/server/game/cards/03_TWI/units/AsajjVentressCountDookusAssassin.ts
@@ -36,5 +36,3 @@ export default class AsajjVentressCountDookusAssassin extends NonLeaderUnitCard 
         });
     }
 }
-
-AsajjVentressCountDookusAssassin.implemented = true;

--- a/server/game/cards/03_TWI/units/AurraSingCrackshotSniper.ts
+++ b/server/game/cards/03_TWI/units/AurraSingCrackshotSniper.ts
@@ -23,5 +23,3 @@ export default class AurraSingCrackshotSniper extends NonLeaderUnitCard {
         });
     }
 }
-
-AurraSingCrackshotSniper.implemented = true;

--- a/server/game/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.ts
+++ b/server/game/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.ts
@@ -27,5 +27,3 @@ export default class BoKatanKryzeDeathWatchLieutenant extends NonLeaderUnitCard 
         });
     }
 }
-
-BoKatanKryzeDeathWatchLieutenant.implemented = true;

--- a/server/game/cards/03_TWI/units/CaptainRexLeadByExample.ts
+++ b/server/game/cards/03_TWI/units/CaptainRexLeadByExample.ts
@@ -16,5 +16,3 @@ export default class CaptainRexLeadByExample extends NonLeaderUnitCard {
         });
     }
 }
-
-CaptainRexLeadByExample.implemented = true;

--- a/server/game/cards/03_TWI/units/ChancellorPalpatineWartimeChancellor.ts
+++ b/server/game/cards/03_TWI/units/ChancellorPalpatineWartimeChancellor.ts
@@ -37,5 +37,3 @@ export default class ChancellorPalpatineWartimeChancellor extends NonLeaderUnitC
         });
     }
 }
-
-ChancellorPalpatineWartimeChancellor.implemented = true;

--- a/server/game/cards/03_TWI/units/CloneCommanderCodyCommandingThe212th.ts
+++ b/server/game/cards/03_TWI/units/CloneCommanderCodyCommandingThe212th.ts
@@ -22,5 +22,3 @@ export default class CloneCommanderCodyCommandingThe212th extends NonLeaderUnitC
         });
     }
 }
-
-CloneCommanderCodyCommandingThe212th.implemented = true;

--- a/server/game/cards/03_TWI/units/CloneDiveTrooper.ts
+++ b/server/game/cards/03_TWI/units/CloneDiveTrooper.ts
@@ -21,5 +21,3 @@ export default class CloneDiveTrooper extends NonLeaderUnitCard {
         });
     }
 }
-
-CloneDiveTrooper.implemented = true;

--- a/server/game/cards/03_TWI/units/CloneHeavyGunner.ts
+++ b/server/game/cards/03_TWI/units/CloneHeavyGunner.ts
@@ -18,5 +18,3 @@ export default class CloneHeavyGunner extends NonLeaderUnitCard {
         });
     }
 }
-
-CloneHeavyGunner.implemented = true;

--- a/server/game/cards/03_TWI/units/CompassionateSenator.ts
+++ b/server/game/cards/03_TWI/units/CompassionateSenator.ts
@@ -19,5 +19,3 @@ export default class CompassionateSenator extends NonLeaderUnitCard {
         });
     }
 }
-
-CompassionateSenator.implemented = true;

--- a/server/game/cards/03_TWI/units/ConfederateTriFighter.ts
+++ b/server/game/cards/03_TWI/units/ConfederateTriFighter.ts
@@ -20,5 +20,3 @@ export default class ConfederateTriFighter extends NonLeaderUnitCard {
         });
     }
 }
-
-ConfederateTriFighter.implemented = true;

--- a/server/game/cards/03_TWI/units/CoruscantGuard.ts
+++ b/server/game/cards/03_TWI/units/CoruscantGuard.ts
@@ -18,5 +18,3 @@ export default class CoruscantGuard extends NonLeaderUnitCard {
         });
     }
 }
-
-CoruscantGuard.implemented = true;

--- a/server/game/cards/03_TWI/units/CountDookuFallenJedi.ts
+++ b/server/game/cards/03_TWI/units/CountDookuFallenJedi.ts
@@ -28,5 +28,3 @@ export default class CountDookuFallenJedi extends NonLeaderUnitCard {
         });
     }
 }
-
-CountDookuFallenJedi.implemented = true;

--- a/server/game/cards/03_TWI/units/DaughterOfDathomir.ts
+++ b/server/game/cards/03_TWI/units/DaughterOfDathomir.ts
@@ -18,5 +18,3 @@ export default class DaughterOfDathomir extends NonLeaderUnitCard {
         });
     }
 }
-
-DaughterOfDathomir.implemented = true;

--- a/server/game/cards/03_TWI/units/DevastatingGunship.ts
+++ b/server/game/cards/03_TWI/units/DevastatingGunship.ts
@@ -21,5 +21,3 @@ export default class DevastatingGunship extends NonLeaderUnitCard {
         });
     }
 }
-
-DevastatingGunship.implemented = true;

--- a/server/game/cards/03_TWI/units/DroidCommando.ts
+++ b/server/game/cards/03_TWI/units/DroidCommando.ts
@@ -18,5 +18,3 @@ export default class DroidCommando extends NonLeaderUnitCard {
         });
     }
 }
-
-DroidCommando.implemented = true;

--- a/server/game/cards/03_TWI/units/DuchesssChampion.ts
+++ b/server/game/cards/03_TWI/units/DuchesssChampion.ts
@@ -18,5 +18,3 @@ export default class DuchesssChampion extends NonLeaderUnitCard {
         });
     }
 }
-
-DuchesssChampion.implemented = true;

--- a/server/game/cards/03_TWI/units/EchoValiantArcTrooper.ts
+++ b/server/game/cards/03_TWI/units/EchoValiantArcTrooper.ts
@@ -18,5 +18,3 @@ export default class EchoValiantArcTrooper extends NonLeaderUnitCard {
         });
     }
 }
-
-EchoValiantArcTrooper.implemented = true;

--- a/server/game/cards/03_TWI/units/EnfysNestChampionOfJustice.ts
+++ b/server/game/cards/03_TWI/units/EnfysNestChampionOfJustice.ts
@@ -26,5 +26,3 @@ export default class EnfysNestChampionOfJustice extends NonLeaderUnitCard {
         });
     }
 }
-
-EnfysNestChampionOfJustice.implemented = true;

--- a/server/game/cards/03_TWI/units/FreelanceAssassin.ts
+++ b/server/game/cards/03_TWI/units/FreelanceAssassin.ts
@@ -28,5 +28,3 @@ export default class FreelanceAssassin extends NonLeaderUnitCard {
         });
     }
 }
-
-FreelanceAssassin.implemented = true;

--- a/server/game/cards/03_TWI/units/HeavyPersuaderTank.ts
+++ b/server/game/cards/03_TWI/units/HeavyPersuaderTank.ts
@@ -21,5 +21,3 @@ export default class HeavyPersuaderTank extends NonLeaderUnitCard {
         });
     }
 }
-
-HeavyPersuaderTank.implemented = true;

--- a/server/game/cards/03_TWI/units/HevyStaunchMartyr.ts
+++ b/server/game/cards/03_TWI/units/HevyStaunchMartyr.ts
@@ -26,5 +26,3 @@ export default class HevyStaunchMartyr extends NonLeaderUnitCard {
         });
     }
 }
-
-HevyStaunchMartyr.implemented = true;

--- a/server/game/cards/03_TWI/units/HuyangEnduringInstructor.ts
+++ b/server/game/cards/03_TWI/units/HuyangEnduringInstructor.ts
@@ -24,5 +24,3 @@ export default class HuyangEnduringInstructor extends NonLeaderUnitCard {
         });
     }
 }
-
-HuyangEnduringInstructor.implemented = true;

--- a/server/game/cards/03_TWI/units/IndependentSenator.ts
+++ b/server/game/cards/03_TWI/units/IndependentSenator.ts
@@ -20,5 +20,3 @@ export default class IndependentSenator extends NonLeaderUnitCard {
         });
     }
 }
-
-IndependentSenator.implemented = true;

--- a/server/game/cards/03_TWI/units/JesseHardFightingPatriot.ts
+++ b/server/game/cards/03_TWI/units/JesseHardFightingPatriot.ts
@@ -19,5 +19,3 @@ export default class JesseHardFightingPatriot extends NonLeaderUnitCard {
         });
     }
 }
-
-JesseHardFightingPatriot.implemented = true;

--- a/server/game/cards/03_TWI/units/KashyyykDefender.ts
+++ b/server/game/cards/03_TWI/units/KashyyykDefender.ts
@@ -31,5 +31,3 @@ export default class KashyyykDefender extends NonLeaderUnitCard {
         });
     }
 }
-
-KashyyykDefender.implemented = true;

--- a/server/game/cards/03_TWI/units/KitFistoTheSmilingJedi.ts
+++ b/server/game/cards/03_TWI/units/KitFistoTheSmilingJedi.ts
@@ -26,5 +26,3 @@ export default class KitFistoTheSmilingJedi extends NonLeaderUnitCard {
         });
     }
 }
-
-KitFistoTheSmilingJedi.implemented = true;

--- a/server/game/cards/03_TWI/units/KrakenConfederateTactician.ts
+++ b/server/game/cards/03_TWI/units/KrakenConfederateTactician.ts
@@ -25,5 +25,3 @@ export default class KrakenConfederateTactician extends NonLeaderUnitCard {
         });
     }
 }
-
-KrakenConfederateTactician.implemented = true;

--- a/server/game/cards/03_TWI/units/LowAltitudeGunship.ts
+++ b/server/game/cards/03_TWI/units/LowAltitudeGunship.ts
@@ -23,5 +23,3 @@ export default class LowAltitudeGunship extends NonLeaderUnitCard {
         });
     }
 }
-
-LowAltitudeGunship.implemented = true;

--- a/server/game/cards/03_TWI/units/MagnaguardWingLeader.ts
+++ b/server/game/cards/03_TWI/units/MagnaguardWingLeader.ts
@@ -34,5 +34,3 @@ export default class MagnaguardWingLeader extends NonLeaderUnitCard {
         });
     }
 }
-
-MagnaguardWingLeader.implemented = true;

--- a/server/game/cards/03_TWI/units/MorganElsbethKeeperOfManySecrets.ts
+++ b/server/game/cards/03_TWI/units/MorganElsbethKeeperOfManySecrets.ts
@@ -27,5 +27,3 @@ export default class MorganElsbethKeeperOfManySecrets extends NonLeaderUnitCard 
         });
     }
 }
-
-MorganElsbethKeeperOfManySecrets.implemented = true;

--- a/server/game/cards/03_TWI/units/MultitroopTransport.ts
+++ b/server/game/cards/03_TWI/units/MultitroopTransport.ts
@@ -16,5 +16,3 @@ export default class MultitroopTransport extends NonLeaderUnitCard {
         });
     }
 }
-
-MultitroopTransport.implemented = true;

--- a/server/game/cards/03_TWI/units/ObedientVanguard.ts
+++ b/server/game/cards/03_TWI/units/ObedientVanguard.ts
@@ -24,5 +24,3 @@ export default class ObedientVanguard extends NonLeaderUnitCard {
         });
     }
 }
-
-ObedientVanguard.implemented = true;

--- a/server/game/cards/03_TWI/units/PadawanStarFighter.ts
+++ b/server/game/cards/03_TWI/units/PadawanStarFighter.ts
@@ -18,5 +18,3 @@ export default class PadawanStarFighter extends NonLeaderUnitCard {
         });
     }
 }
-
-PadawanStarFighter.implemented = true;

--- a/server/game/cards/03_TWI/units/PloKoonKohtoyah.ts
+++ b/server/game/cards/03_TWI/units/PloKoonKohtoyah.ts
@@ -18,5 +18,3 @@ export default class PloKoonKohtoyah extends NonLeaderUnitCard {
         });
     }
 }
-
-PloKoonKohtoyah.implemented = true;

--- a/server/game/cards/03_TWI/units/ProvidenceDestroyer.ts
+++ b/server/game/cards/03_TWI/units/ProvidenceDestroyer.ts
@@ -24,5 +24,3 @@ export default class ProvidenceDestroyer extends NonLeaderUnitCard {
         });
     }
 }
-
-ProvidenceDestroyer.implemented = true;

--- a/server/game/cards/03_TWI/units/RecklessTorrent.ts
+++ b/server/game/cards/03_TWI/units/RecklessTorrent.ts
@@ -37,5 +37,3 @@ export default class RecklessTorrent extends NonLeaderUnitCard {
         });
     }
 }
-
-RecklessTorrent.implemented = true;

--- a/server/game/cards/03_TWI/units/RelentlessRocketDroid.ts
+++ b/server/game/cards/03_TWI/units/RelentlessRocketDroid.ts
@@ -18,5 +18,3 @@ export default class RelentlessRocketDroid extends NonLeaderUnitCard {
         });
     }
 }
-
-RelentlessRocketDroid.implemented = true;

--- a/server/game/cards/03_TWI/units/RepublicAttackPod.ts
+++ b/server/game/cards/03_TWI/units/RepublicAttackPod.ts
@@ -17,5 +17,3 @@ export default class RepublicAttackPod extends NonLeaderUnitCard {
         });
     }
 }
-
-RepublicAttackPod.implemented = true;

--- a/server/game/cards/03_TWI/units/RepublicCommando.ts
+++ b/server/game/cards/03_TWI/units/RepublicCommando.ts
@@ -18,5 +18,3 @@ export default class RepublicCommando extends NonLeaderUnitCard {
         });
     }
 }
-
-RepublicCommando.implemented = true;

--- a/server/game/cards/03_TWI/units/RepublicDefenseCarrier.ts
+++ b/server/game/cards/03_TWI/units/RepublicDefenseCarrier.ts
@@ -15,5 +15,3 @@ export default class RepublicDefenseCarrier extends NonLeaderUnitCard {
         });
     }
 }
-
-RepublicDefenseCarrier.implemented = true;

--- a/server/game/cards/03_TWI/units/RuneHaakoSchemingSecond.ts
+++ b/server/game/cards/03_TWI/units/RuneHaakoSchemingSecond.ts
@@ -35,5 +35,3 @@ export default class RuneHaakoSchemingSecond extends NonLeaderUnitCard {
         });
     }
 }
-
-RuneHaakoSchemingSecond.implemented = true;

--- a/server/game/cards/03_TWI/units/SabineWrenYouCanCountOnMe.ts
+++ b/server/game/cards/03_TWI/units/SabineWrenYouCanCountOnMe.ts
@@ -44,5 +44,3 @@ export default class SabineWrenYouCanCountOnMe extends NonLeaderUnitCard {
         });
     }
 }
-
-SabineWrenYouCanCountOnMe.implemented = true;

--- a/server/game/cards/03_TWI/units/SavageOpressMonster.ts
+++ b/server/game/cards/03_TWI/units/SavageOpressMonster.ts
@@ -26,5 +26,3 @@ export default class SavageOpressMonster extends NonLeaderUnitCard {
         });
     }
 }
-
-SavageOpressMonster.implemented = true;

--- a/server/game/cards/03_TWI/units/SawGerreraResistanceIsNotTerrorism.ts
+++ b/server/game/cards/03_TWI/units/SawGerreraResistanceIsNotTerrorism.ts
@@ -24,5 +24,3 @@ export default class SawGerreraResistanceIsNotTerrorism extends NonLeaderUnitCar
         });
     }
 }
-
-SawGerreraResistanceIsNotTerrorism.implemented = true;

--- a/server/game/cards/03_TWI/units/SenatorialCorvette.ts
+++ b/server/game/cards/03_TWI/units/SenatorialCorvette.ts
@@ -19,5 +19,3 @@ export default class SenatorialCorvette extends NonLeaderUnitCard {
         });
     }
 }
-
-SenatorialCorvette.implemented = true;

--- a/server/game/cards/03_TWI/units/SeparatistCommando.ts
+++ b/server/game/cards/03_TWI/units/SeparatistCommando.ts
@@ -18,5 +18,3 @@ export default class SeparatistCommando extends NonLeaderUnitCard {
         });
     }
 }
-
-SeparatistCommando.implemented = true;

--- a/server/game/cards/03_TWI/units/ShaakTiUnityWinsWars.ts
+++ b/server/game/cards/03_TWI/units/ShaakTiUnityWinsWars.ts
@@ -24,5 +24,3 @@ export default class ShaakTiUnityWinsWars extends NonLeaderUnitCard {
         });
     }
 }
-
-ShaakTiUnityWinsWars.implemented = true;

--- a/server/game/cards/03_TWI/units/SoullessOneCustomizedForGrievous.ts
+++ b/server/game/cards/03_TWI/units/SoullessOneCustomizedForGrievous.ts
@@ -29,5 +29,3 @@ export default class SoullessOneCustomizedForGrievous extends NonLeaderUnitCard 
         });
     }
 }
-
-SoullessOneCustomizedForGrievous.implemented = true;

--- a/server/game/cards/03_TWI/units/SubjugatingStarfighter.ts
+++ b/server/game/cards/03_TWI/units/SubjugatingStarfighter.ts
@@ -19,5 +19,3 @@ export default class SubjugatingStarfighter extends NonLeaderUnitCard {
         });
     }
 }
-
-SubjugatingStarfighter.implemented = true;

--- a/server/game/cards/03_TWI/units/TheZilloBeastAwokenFromTheDepths.ts
+++ b/server/game/cards/03_TWI/units/TheZilloBeastAwokenFromTheDepths.ts
@@ -28,5 +28,3 @@ export default class TheZilloBeastAwokenFromTheDepths extends NonLeaderUnitCard 
         });
     }
 }
-
-TheZilloBeastAwokenFromTheDepths.implemented = true;

--- a/server/game/cards/03_TWI/units/TradeFederationShuttle.ts
+++ b/server/game/cards/03_TWI/units/TradeFederationShuttle.ts
@@ -25,5 +25,3 @@ export default class TradeFederationShuttle extends NonLeaderUnitCard {
         });
     }
 }
-
-TradeFederationShuttle.implemented = true;

--- a/server/game/cards/03_TWI/units/VanguardDroidBomber.ts
+++ b/server/game/cards/03_TWI/units/VanguardDroidBomber.ts
@@ -21,5 +21,3 @@ export default class VanguardDroidBomber extends NonLeaderUnitCard {
         });
     }
 }
-
-VanguardDroidBomber.implemented = true;

--- a/server/game/cards/03_TWI/units/VultureInterceptorWing.ts
+++ b/server/game/cards/03_TWI/units/VultureInterceptorWing.ts
@@ -23,5 +23,3 @@ export default class VultureInterceptorWing extends NonLeaderUnitCard {
         });
     }
 }
-
-VultureInterceptorWing.implemented = true;

--- a/server/game/cards/03_TWI/units/ZiroTheHuttColorfulSchemer.ts
+++ b/server/game/cards/03_TWI/units/ZiroTheHuttColorfulSchemer.ts
@@ -28,5 +28,3 @@ export default class ZiroTheHuttColorfulSchemer extends NonLeaderUnitCard {
         });
     }
 }
-
-ZiroTheHuttColorfulSchemer.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/CloneCohort.ts
+++ b/server/game/cards/03_TWI/upgrades/CloneCohort.ts
@@ -22,5 +22,3 @@ export default class CloneCohort extends UpgradeCard {
         });
     }
 }
-
-CloneCohort.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/GrievoussWheelBike.ts
+++ b/server/game/cards/03_TWI/upgrades/GrievoussWheelBike.ts
@@ -22,5 +22,3 @@ export default class GrievoussWheelBike extends UpgradeCard {
         });
     }
 }
-
-GrievoussWheelBike.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/HoldoutBlaster.ts
+++ b/server/game/cards/03_TWI/upgrades/HoldoutBlaster.ts
@@ -28,5 +28,3 @@ export default class HoldoutBlaster extends UpgradeCard {
         });
     }
 }
-
-HoldoutBlaster.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/OldAccessCodes.ts
+++ b/server/game/cards/03_TWI/upgrades/OldAccessCodes.ts
@@ -20,5 +20,3 @@ export default class OldAccessCodes extends UpgradeCard {
         });
     }
 }
-
-OldAccessCodes.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/OnTopOfThings.ts
+++ b/server/game/cards/03_TWI/upgrades/OnTopOfThings.ts
@@ -20,5 +20,3 @@ export default class OnTopOfThings extends UpgradeCard {
         });
     }
 }
-
-OnTopOfThings.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/RogerRoger.ts
+++ b/server/game/cards/03_TWI/upgrades/RogerRoger.ts
@@ -24,5 +24,3 @@ export default class RogerRoger extends UpgradeCard {
         });
     }
 }
-
-RogerRoger.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/SquadSupport.ts
+++ b/server/game/cards/03_TWI/upgrades/SquadSupport.ts
@@ -26,5 +26,3 @@ export default class SquadSupport extends UpgradeCard {
         });
     }
 }
-
-SquadSupport.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/TwiceThePride.ts
+++ b/server/game/cards/03_TWI/upgrades/TwiceThePride.ts
@@ -19,5 +19,3 @@ export default class TwiceThePride extends UpgradeCard {
         });
     }
 }
-
-TwiceThePride.implemented = true;

--- a/server/game/cards/03_TWI/upgrades/UnshakeableWill.ts
+++ b/server/game/cards/03_TWI/upgrades/UnshakeableWill.ts
@@ -13,5 +13,3 @@ export default class UnshakeableWill extends UpgradeCard {
         this.addGainKeywordTargetingAttached({ keyword: KeywordName.Sentinel });
     }
 }
-
-UnshakeableWill.implemented = true;

--- a/server/game/cards/Index.ts
+++ b/server/game/cards/Index.ts
@@ -40,10 +40,6 @@ for (const filepath of allJsFiles(__dirname)) {
         throw Error(`Import card class with duplicate class name: ${card.name}`);
     }
 
-    if (!card.implemented) {
-        console.warn(`Warning: Loading partially implemented card '${cardId.internalName}'`);
-    }
-
     cardsMap.set(cardId.id, card);
     cardClassNames.add(card.name);
 }

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -831,6 +831,7 @@ export class Card extends OngoingEffectSource {
             cost: this.cardData.cost,
             power: this.cardData.power,
             hp: this.cardData.hp,
+            implemented: this.implemented,
             // popupMenuText: this.popupMenuText,
             // showPopup: this.showPopup,
             // tokens: this.tokens,

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -45,6 +45,7 @@ export class Card extends OngoingEffectSource {
     public readonly unique: boolean;
 
     protected override readonly id: string;
+    protected readonly implemented: boolean;
     protected readonly printedKeywords: KeywordInstance[];
     protected readonly printedTraits: Set<Trait>;
     protected readonly printedType: CardType;
@@ -53,7 +54,6 @@ export class Card extends OngoingEffectSource {
     protected constantAbilities: IConstantAbility[] = [];
     protected _controller: Player;
     protected _facedown = true;
-    protected hasImplementationFile: boolean;   // this will be set by the ability setup methods
     protected hiddenForController = true;      // TODO: is this correct handling of hidden / visible card state? not sure how this integrates with the client
     protected hiddenForOpponent = true;
 
@@ -111,7 +111,12 @@ export class Card extends OngoingEffectSource {
         super(owner.game, cardData.title);
 
         this.validateCardData(cardData);
-        this.validateImplementationId(cardData);
+
+        const implementationId = this.getImplementationId();
+        this.implemented = implementationId !== null;
+        if (implementationId) {
+            this.validateImplementationId(implementationId, cardData);
+        }
 
         this.aspects = EnumHelpers.checkConvertToEnum(cardData.aspects, Aspect);
         this.internalName = cardData.internalName;
@@ -220,14 +225,11 @@ export class Card extends OngoingEffectSource {
     /**
      * If this is a subclass implementation of a specific card, validate that it matches the provided card data
      */
-    private validateImplementationId(cardData: any): void {
-        const implementationId = this.getImplementationId();
-        if (implementationId) {
-            if (cardData.id !== implementationId.id || cardData.internalName !== implementationId.internalName) {
-                throw new Error(
-                    `Provided card data { ${cardData.id}, ${cardData.internalName} } does not match the data from the card class: { ${implementationId.id}, ${implementationId.internalName} }. Confirm that you are matching the card data to the right card implementation class.`
-                );
-            }
+    private validateImplementationId(implementationId: { internalName: string; id: string }, cardData: any): void {
+        if (cardData.id !== implementationId.id || cardData.internalName !== implementationId.internalName) {
+            throw new Error(
+                `Provided card data { ${cardData.id}, ${cardData.internalName} } does not match the data from the card class: { ${implementationId.id}, ${implementationId.internalName} }. Confirm that you are matching the card data to the right card implementation class.`
+            );
         }
     }
 

--- a/server/game/core/card/EventCard.ts
+++ b/server/game/core/card/EventCard.ts
@@ -21,7 +21,7 @@ export class EventCard extends EventCardParent {
         super(owner, cardData);
         Contract.assertEqual(this.printedType, CardType.Event);
 
-        Contract.assertFalse(this.hasImplementationFile && !this._eventAbility, 'Event card\'s ability was not initialized');
+        Contract.assertFalse(this.implemented && !this._eventAbility, 'Event card\'s ability was not initialized');
 
         // currently the only constant abilities an event card can have are those that reduce cost, which are always active regardless of zone
         for (const constantAbility of this.constantAbilities) {

--- a/server/game/core/card/LeaderCard.ts
+++ b/server/game/core/card/LeaderCard.ts
@@ -17,7 +17,6 @@ export class LeaderCard extends InPlayCard {
         super(owner, cardData);
         Contract.assertEqual(this.printedType, CardType.Leader);
 
-        this.hasImplementationFile = true;
         this.setupLeaderUnitSide = false;
         this.setupLeaderSideAbilities(this);
     }
@@ -33,9 +32,8 @@ export class LeaderCard extends InPlayCard {
     /**
      * Create card abilities for the leader (non-unit) side by calling subsequent methods with appropriate properties
      */
-    protected setupLeaderSideAbilities(sourceCard: this) {
-        this.hasImplementationFile = false;
-    }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    protected setupLeaderSideAbilities(sourceCard: this) { }
 
     // TODO TYPE REFACTOR: separate out the Leader types from the playable types
     public override getPlayCardActions() {

--- a/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
+++ b/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
@@ -8,11 +8,10 @@ export function WithStandardAbilitySetup<TBaseClass extends CardConstructor>(Bas
         public constructor(...args: any[]) {
             super(...args);
 
-            this.hasImplementationFile = true;
             this.setupCardAbilities(this);
 
             // if an implementation file is provided, enforce that all keywords requiring explicit setup have been set up
-            if (this.hasImplementationFile) {
+            if (this.implemented) {
                 const keywordsMissingImpl = this.printedKeywords.filter((keyword) => !keyword.isFullyImplemented);
                 if (keywordsMissingImpl.length > 0) {
                     const missingKeywordNames = new Set(keywordsMissingImpl.map((keyword) => keyword.name));
@@ -25,8 +24,7 @@ export function WithStandardAbilitySetup<TBaseClass extends CardConstructor>(Bas
         /**
          * Create card abilities by calling subsequent methods with appropriate properties
          */
-        protected setupCardAbilities(sourceCard: this) {
-            this.hasImplementationFile = false;
-        }
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        protected setupCardAbilities(sourceCard: this) { }
     };
 }


### PR DESCRIPTION
Up until now we've been using a static `implemented` property on each card implementation class, but this didn't work well for actually returning the implemented status to the FE. Refactored into a solution that uses an accessible property on Card and remove the static member from existing implementation classes.