### PR TITLE
first draft of generic deck move system

### DIFF
--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -227,6 +227,7 @@ export enum EventName {
     OnInitiateAbilityEffects = 'onInitiateAbilityEffects',
     OnLeaderDeployed = 'onLeaderDeployed',
     OnLookAtCard = 'onLookAtCard',
+    OnLookMoveDeckCards = 'onLookMoveDeckCards',
     OnLookMoveDeckCardsTopOrBottom = 'onLookMoveDeckCardsTopOrBottom',
     OnPassActionPhasePriority = 'onPassActionPhasePriority',
     OnPhaseCreated = 'onPhaseCreated',

--- a/server/game/gameSystems/LookMoveDeckCardsSystem.ts
+++ b/server/game/gameSystems/LookMoveDeckCardsSystem.ts
@@ -1,0 +1,117 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import type { Card } from '../core/card/Card';
+import type { GameEvent } from '../core/event/GameEvent';
+import type { MoveZoneDestination } from '../core/Constants';
+import { GameStateChangeRequired, ZoneName } from '../core/Constants';
+import { EventName, DeckZoneDestination } from '../core/Constants';
+import { MoveCardSystem } from './MoveCardSystem';
+import * as Contract from '../core/utils/Contract';
+import type { IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTargetSystem';
+import { PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem';
+import type Player from '../core/Player';
+import { DiscardFromDeckSystem } from './DiscardFromDeckSystem';
+
+export interface ILookMoveDeckCardsProperties extends IPlayerTargetSystemProperties {
+    amount: number;
+    destinations: MoveZoneDestination[];
+    promptTitle: string;
+}
+
+export class LookMoveDeckCardsSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, ILookMoveDeckCardsProperties> {
+    public override readonly name = 'lookMoveDeckCardsSystem';
+    protected override readonly eventName = EventName.OnLookMoveDeckCards;
+    public override readonly effectDescription = 'look at the top cards of your deck and move them';
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override eventHandler(event): void { }
+
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext): void {
+        const player = context.player;
+        const { amount, destinations, promptTitle } = this.generatePropertiesFromContext(context);
+        const deckLength = player.drawDeck.length;
+
+        if (deckLength === 0) {
+            return;
+        }
+
+        if (Array.isArray(destinations)) {
+            if (destinations.length === 0) {
+                throw new Error('destinations must have at least one element');
+            }
+        }
+
+        const perCardButtons = destinations.map((destination) => {
+            switch (destination) {
+                case DeckZoneDestination.DeckTop:
+                    return { text: 'Put on top', arg: 'top' };
+                case DeckZoneDestination.DeckBottom:
+                    return { text: 'Put on bottom', arg: 'bottom' };
+                case ZoneName.Discard:
+                    return { text: 'Discard', arg: 'discard' };
+                default:
+                    throw new Error(`LookMoveDeck unsupported destination: ${destination}`);
+            }
+        });
+
+        const actualAmount = Math.min(amount, deckLength);
+        const cards = player.drawDeck.slice(0, actualAmount);
+
+        context.game.promptDisplayCardsWithButtons(player, {
+            activePromptTitle: promptTitle,
+            source: context.source,
+            displayCards: cards,
+            perCardButtons: perCardButtons,
+            onCardButton: (card: Card, arg: string) => {
+                this.pushMoveEvent(arg, card, events, context);
+                return true;
+            }
+        });
+    }
+
+    public override defaultTargets(context: TContext): Player[] {
+        return [context.player];
+    }
+
+    public override canAffect(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
+        let nonAraTarget: Player;
+
+        if (Array.isArray(target)) {
+            if (target.length > 1) {
+                throw new Error('Support for multiple players in LookMoveDeckCardsSystem not implemented yet');
+            }
+
+            Contract.assertTrue(target.length === 1);
+
+            nonAraTarget = target[0];
+        } else {
+            nonAraTarget = target;
+        }
+
+        if (mustChangeGameState !== GameStateChangeRequired.None && nonAraTarget.drawDeck.length === 0) {
+            return false;
+        }
+
+        return super.canAffect(target, context, additionalProperties, mustChangeGameState);
+    }
+
+    // Helper method for pushing the move card event into the events array.
+    private pushMoveEvent(
+        arg: string,
+        card: Card,
+        events: GameEvent[],
+        context: TContext
+    ) {
+        let moveEvent: GameEvent;
+        if (arg === 'discard') {
+            moveEvent = new DiscardFromDeckSystem({
+                amount: 1
+            }).generateEvent(context);
+        } else {
+            moveEvent = new MoveCardSystem({
+                destination: arg === 'bottom' ? DeckZoneDestination.DeckBottom : DeckZoneDestination.DeckTop,
+                target: card
+            }).generateEvent(context);
+        }
+        events.push(moveEvent);
+    }
+}

--- a/server/game/gameSystems/LookMoveDeckCardsTopOrBottomSystem.ts
+++ b/server/game/gameSystems/LookMoveDeckCardsTopOrBottomSystem.ts
@@ -1,29 +1,22 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import type { Card } from '../core/card/Card';
+import { DeckZoneDestination } from '../core/Constants';
 import type { GameEvent } from '../core/event/GameEvent';
-import { GameStateChangeRequired } from '../core/Constants';
-import { EventName, DeckZoneDestination } from '../core/Constants';
 import { LookAtSystem } from './LookAtSystem';
-import { MoveCardSystem } from './MoveCardSystem';
-import * as Contract from '../core/utils/Contract';
-import type { IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTargetSystem';
-import { PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem';
-import type Player from '../core/Player';
+import { LookMoveDeckCardsSystem } from './LookMoveDeckCardsSystem';
 
-export interface ILookMoveDeckCardsTopOrBottomProperties extends IPlayerTargetSystemProperties {
+export interface ILookMoveDeckCardsTopOrBottomProperties {
     amount: number;
 }
 
-export class LookMoveDeckCardsTopOrBottomSystem<TContext extends AbilityContext = AbilityContext> extends PlayerTargetSystem<TContext, ILookMoveDeckCardsTopOrBottomProperties> {
-    public override readonly name = 'lookMoveDeckCardsTopOrBottomSystem';
-    protected override readonly eventName = EventName.OnLookMoveDeckCardsTopOrBottom;
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    public override eventHandler(event): void { }
+export class LookMoveDeckCardsTopOrBottomSystem<TContext extends AbilityContext = AbilityContext> extends LookMoveDeckCardsSystem<TContext> {
+    public constructor(propertiesOrPropertyFactory: ILookMoveDeckCardsTopOrBottomProperties) {
+        const destinations = [DeckZoneDestination.DeckTop, DeckZoneDestination.DeckBottom];
+        const promptTitle = 'Select card to move to the top or bottom of the deck';
+        super({ amount: propertiesOrPropertyFactory.amount, destinations: destinations, promptTitle: promptTitle });
+    }
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext): void {
         const player = context.player;
-        const { amount } = this.generatePropertiesFromContext(context);
         const deckLength = player.drawDeck.length;
 
         if (deckLength === 1) {
@@ -32,73 +25,8 @@ export class LookMoveDeckCardsTopOrBottomSystem<TContext extends AbilityContext 
             }).generateEvent(context);
             events.push(lookAtEvent);
         } else {
-            const actualAmount = Math.min(amount, deckLength);
-            const cards = player.drawDeck.slice(0, actualAmount);
-
-            context.game.promptDisplayCardsWithButtons(player, {
-                activePromptTitle: 'Select card to move to the top or bottom of the deck',
-                source: context.source,
-                displayCards: cards,
-                perCardButtons: [
-                    { text: 'Put on top', arg: 'top' },
-                    { text: 'Put on bottom', arg: 'bottom' }
-                ],
-                onCardButton: (card: Card, arg: string) => {
-                    this.pushMoveEvent(arg, card, events, context);
-                    return true;
-                }
-            });
+            super.queueGenerateEventGameSteps(events, context);
         }
-    }
-
-    public override defaultTargets(context: TContext): Player[] {
-        return [context.player];
-    }
-
-    public override canAffect(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
-        let nonAraTarget: Player;
-
-        if (Array.isArray(target)) {
-            if (target.length > 1) {
-                throw new Error('Support for multiple players in LookMoveDeckCardsTopOrBottomSystem not implemented yet');
-            }
-
-            Contract.assertTrue(target.length === 1);
-
-            nonAraTarget = target[0];
-        } else {
-            nonAraTarget = target;
-        }
-
-        if (mustChangeGameState !== GameStateChangeRequired.None && nonAraTarget.drawDeck.length === 0) {
-            return false;
-        }
-
-        return super.canAffect(target, context, additionalProperties, mustChangeGameState);
-    }
-
-    // Helper method for pushing the move card event into the events array.
-    private pushMoveEvent(
-        arg: string,
-        card: Card,
-        events: GameEvent[],
-        context: TContext
-    ) {
-        let bottom: boolean;
-        if (arg === 'top') {
-            bottom = false;
-        } else if (arg === 'bottom') {
-            bottom = true;
-        } else {
-            Contract.fail(`Unknown arg: ${arg}`);
-        }
-
-        // create a new card event
-        const moveCardEvent = new MoveCardSystem({
-            destination: bottom ? DeckZoneDestination.DeckBottom : DeckZoneDestination.DeckTop,
-            target: card
-        }).generateEvent(context);
-        events.push(moveCardEvent);
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {


### PR DESCRIPTION
I am clearly no there yet but at least unit test of Inferno Four and R2D2 are working.

I am not convinced by the value of the generic method to move card from deck vs having a couple of classes dedicated to the different scenarios we may encounter (top/bottom, top/discard, ...) . But this is very softly opinionated. I'll follow your advice on this @AMMayberry1 .
For example, I am wondering if we can't handle the discard destination in MoveCardSystem and then It should be easier to create a specific class for the Top/Discard case.


I have a problem with 

```
export function lookMoveDeckCardsTopOrBottom<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ILookMoveDeckCardsTopOrBottomProperties, TContext>) {
    return new LookMoveDeckCardsTopOrBottomSystem<TContext>(propertyFactory);
}
```

In gameSystemLibrary. It's not clear how to fix that between the base class and the children class

I have some difficulties creating a generic `getEffectMessage` for all the situations so I decided to not overwrite it in the base class. But maybe I should like in `MoveCardSystem` and implement a complex logic. I was a bit lazzy.


Finally, I am sure to understand how MoveCardSystem ensure we can choose the order of the cards we put on the top or bottom.

