### PR TITLE
Mark "trivial" cards as implemented by default

### DIFF
--- a/server/game/core/card/EventCard.ts
+++ b/server/game/core/card/EventCard.ts
@@ -21,7 +21,7 @@ export class EventCard extends EventCardParent {
         super(owner, cardData);
         Contract.assertEqual(this.printedType, CardType.Event);
 
-        Contract.assertFalse(this.implemented && !this._eventAbility, 'Event card\'s ability was not initialized');
+        Contract.assertFalse(this.hasImplementationFile && !this._eventAbility, 'Event card\'s ability was not initialized');
 
         // currently the only constant abilities an event card can have are those that reduce cost, which are always active regardless of zone
         for (const constantAbility of this.constantAbilities) {

--- a/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
+++ b/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
@@ -11,7 +11,7 @@ export function WithStandardAbilitySetup<TBaseClass extends CardConstructor>(Bas
             this.setupCardAbilities(this);
 
             // if an implementation file is provided, enforce that all keywords requiring explicit setup have been set up
-            if (this.implemented) {
+            if (this.hasImplementationFile) {
                 const keywordsMissingImpl = this.printedKeywords.filter((keyword) => !keyword.isFullyImplemented);
                 if (keywordsMissingImpl.length > 0) {
                     const missingKeywordNames = new Set(keywordsMissingImpl.map((keyword) => keyword.name));


### PR DESCRIPTION
For cards that don't require any explicit implementation, for FE purposes we can consider them "implemented" by default. Added logic to handle the case of these "trivial" cards.