### PR TITLE
Add `context.ongoingEffect`

### DIFF
--- a/server/game/core/ability/AbilityContext.ts
+++ b/server/game/core/ability/AbilityContext.ts
@@ -7,12 +7,14 @@ import type { GameSystem } from '../gameSystem/GameSystem';
 import type Player from '../Player';
 import type { Card } from '../card/Card';
 import type { TriggeredAbilityContext } from './TriggeredAbilityContext';
+import type { IOngoingEffectProps } from '../../Interfaces';
 
 export interface IAbilityContextProperties {
     game: Game;
     source?: any;
     player?: Player;
     ability?: PlayerOrCardAbility;
+    ongoingEffect?: IOngoingEffectProps;
     costs?: any;
     costAspects?: Aspect[];
     targets?: any;
@@ -33,7 +35,8 @@ export class AbilityContext<TSource extends Card = Card> {
     public game: Game;
     public source: TSource;
     public player: Player;
-    public ability: PlayerOrCardAbility;
+    public ability?: PlayerOrCardAbility;
+    public ongoingEffect?: IOngoingEffectProps;
     public costs: any;
     public costAspects: Aspect[];
     public targets: any;
@@ -53,9 +56,10 @@ export class AbilityContext<TSource extends Card = Card> {
         this.game = properties.game;
         this.source = properties.source || new OngoingEffectSource(this.game);
         this.player = properties.player;
-        this.ability = properties.ability || null;
+        this.ability = properties.ability;
         this.costs = properties.costs || {};
         this.costAspects = properties.costAspects || [];
+        this.ongoingEffect = properties.ongoingEffect;
         this.targets = properties.targets || {};
         this.selects = properties.selects || {};
         this.stage = properties.stage || Stage.Effect;
@@ -93,6 +97,7 @@ export class AbilityContext<TSource extends Card = Card> {
             source: this.source,
             player: this.player,
             ability: this.ability,
+            ongoingEffect: this.ongoingEffect,
             costs: Object.assign({}, this.costs),
             costAspects: this.costAspects,
             targets: Object.assign({}, this.targets),

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -1,6 +1,5 @@
 import type { IOngoingEffectProps, WhenType } from '../../Interfaces';
 import type { AbilityContext } from '../ability/AbilityContext';
-import type PlayerOrCardAbility from '../ability/PlayerOrCardAbility';
 import type { Card } from '../card/Card';
 import type { ZoneFilter } from '../Constants';
 import { Duration, WildcardZoneName, EffectName } from '../Constants';
@@ -46,8 +45,7 @@ export abstract class OngoingEffect {
     public condition: (context?: AbilityContext) => boolean;
     public sourceZoneFilter: ZoneFilter | ZoneFilter[];
     public impl: OngoingEffectImpl<any>;
-    // ISSUE: refreshContext sets ability to IOngoingEffectProps, but the listed type for context is PlayerOrCardAbility. Why is there a mismatch? Are we just overriding it in the context of OngoingEffects and everywhere else it acts as PlayerOrCardAbility?
-    public ability?: IOngoingEffectProps;
+    public ongoingEffect?: IOngoingEffectProps;
     public targets: (Player | Card)[];
     public context: AbilityContext;
 
@@ -65,7 +63,7 @@ export abstract class OngoingEffect {
         this.condition = properties.condition || (() => true);
         this.sourceZoneFilter = properties.sourceZoneFilter || WildcardZoneName.AnyArena;
         this.impl = effectImpl;
-        this.ability = properties;
+        this.ongoingEffect = properties;
         this.targets = [];
         this.refreshContext();
 
@@ -78,7 +76,7 @@ export abstract class OngoingEffect {
         this.context.source = this.source;
         // The process of creating the OngoingEffect tacks on additional properties that are ability related,
         //  so this is *probably* fine, but definitely a sign it needs a refactor at some point.
-        this.context.ability = this.ability as PlayerOrCardAbility;
+        this.context.ongoingEffect = this.ongoingEffect;
         this.impl.setContext(this.context);
     }
 

--- a/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
+++ b/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
@@ -23,9 +23,9 @@ export class GainAbility extends OngoingEffectValueWrapper<IAbilityPropsWithType
     public override setContext(context) {
         Contract.assertNotNullLike(context.source);
 
-        if (context.ability?.abilityIdentifier) {
-            this.abilityIdentifier = `gained_from_${context.ability.abilityIdentifier}`;
-        } else if (context.ability?.isLastingEffect) {
+        if (context.ongoingEffect?.abilityIdentifier) {
+            this.abilityIdentifier = `gained_from_${context.ongoingEffect.abilityIdentifier}`;
+        } else if (context.ongoingEffect?.isLastingEffect) {
             // TODO: currently all gained ability identifiers are the same, find a way to make these unique in case a card gains two
             this.abilityIdentifier = 'gained_from_lasting_effect';
         } else if (!this.abilityIdentifier) {


### PR DESCRIPTION
In certain cases an ongoing effect was being activated as if it were an ability. In these cases, we were shoehorning the effect definition into `context.ability` to make everything work.

That has started causing some issues so we've added `context.ongoingEffect` as an alternative to handle those cases.