### PR TITLE
Add optional prompt support for "basic" lookat / reveal case

### DIFF
--- a/server/Util.ts
+++ b/server/Util.ts
@@ -28,6 +28,27 @@ export function httpRequest(url: string): Promise<string> {
     });
 }
 
+export function stringArraysEqual(ara1: string[], ara2: string[]): boolean {
+    if ((ara1 == null || ara2 == null) && (ara1 !== ara2)) {
+        return false;
+    }
+
+    if (ara1.length !== ara2.length) {
+        return false;
+    }
+
+    ara1.sort();
+    ara2.sort();
+
+    for (let i = 0; i < ara1.length; i++) {
+        if (ara1[i] !== ara2[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 export function wrapAsync(fn: any): any {
     return function (req, res, next) {
         fn(req, res, next).catch(next);

--- a/server/game/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.ts
+++ b/server/game/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.ts
@@ -19,7 +19,10 @@ export default class LieutenantChildsenDeathStarPrisonWarden extends NonLeaderUn
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
                 cardCondition: (card) => card.hasSomeAspect(Aspect.Vigilance),
-                immediateEffect: AbilityHelper.immediateEffects.reveal(),
+                immediateEffect: AbilityHelper.immediateEffects.reveal({
+                    useDisplayPrompt: true,
+                    promptedPlayer: RelativePlayer.Opponent
+                }),
             },
             ifYouDo: (ifYouDoContext) => ({
                 title: 'For each card revealed this way, give an Experience token to this unit',
@@ -30,5 +33,3 @@ export default class LieutenantChildsenDeathStarPrisonWarden extends NonLeaderUn
         });
     }
 }
-
-LieutenantChildsenDeathStarPrisonWarden.implemented = true;

--- a/server/game/cards/01_SOR/units/ViperProbeDroid.ts
+++ b/server/game/cards/01_SOR/units/ViperProbeDroid.ts
@@ -14,9 +14,8 @@ export default class ViperProbeDroid extends NonLeaderUnitCard {
             title: 'Look at an opponent\'s hand.',
             immediateEffect: AbilityHelper.immediateEffects.lookAt((context) => ({
                 target: context.player.opponent.hand,
+                useDisplayPrompt: true
             }))
         });
     }
 }
-
-ViperProbeDroid.implemented = true;

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -39,6 +39,7 @@ const EnumHelpers = require('./utils/EnumHelpers.js');
 const { SelectCardPrompt } = require('./gameSteps/prompts/SelectCardPrompt.js');
 const { DisplayCardsWithButtonsPrompt } = require('./gameSteps/prompts/DisplayCardsWithButtonsPrompt.js');
 const { DisplayCardsForSelectionPrompt } = require('./gameSteps/prompts/DisplayCardsForSelectionPrompt.js');
+const { DisplayCardsBasicPrompt } = require('./gameSteps/prompts/DisplayCardsBasicPrompt.js');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -668,6 +669,16 @@ class Game extends EventEmitter {
         Contract.assertNotNullLike(player);
 
         this.queueStep(new DisplayCardsForSelectionPrompt(this, player, properties));
+    }
+
+    /**
+     *  @param {Player} player
+     *  @param {import('./gameSteps/PromptInterfaces.js').IDisplayCardsBasicPromptProperties} properties
+     */
+    promptDisplayCardsBasic(player, properties) {
+        Contract.assertNotNullLike(player);
+
+        this.queueStep(new DisplayCardsBasicPrompt(this, player, properties));
     }
 
     /**

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -93,7 +93,7 @@ export interface IDisplayCardPromptPropertiesBase extends IPromptPropertiesBase 
 }
 
 export interface IDisplayCardsBasicPromptProperties extends IDisplayCardPromptPropertiesBase {
-    cardTextByUuid?: Map<string, string>;
+    displayTextByCardUuid?: Map<string, string>;
 }
 
 export interface IDisplayCardsWithButtonsPromptProperties extends IDisplayCardPromptPropertiesBase {

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -88,11 +88,15 @@ export interface ISelectCardPromptProperties extends IPromptPropertiesBase {
 }
 
 export interface IDisplayCardPromptPropertiesBase extends IPromptPropertiesBase {
+    displayCards: Card[];
     source: string | OngoingEffectSource;
 }
 
+export interface IDisplayCardsBasicPromptProperties extends IDisplayCardPromptPropertiesBase {
+    cardTextByUuid?: Map<string, string>;
+}
+
 export interface IDisplayCardsWithButtonsPromptProperties extends IDisplayCardPromptPropertiesBase {
-    displayCards: Card[];
     onCardButton: (card: Card, arg: string) => boolean;
     perCardButtons: IButton[];
 }
@@ -103,7 +107,6 @@ export interface ISelectableCard {
 }
 
 export interface IDisplayCardsSelectProperties extends IDisplayCardPromptPropertiesBase {
-    displayCards: Card[];
     selectedCardsHandler: (cards: Card[]) => void;
     validCardCondition: (card: Card) => boolean;
     canChooseNothing?: boolean;

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -10,7 +10,8 @@ export enum DisplayCardSelectionState {
     Selectable = 'selectable',
     Selected = 'selected',
     Unselectable = 'unselectable',
-    Invalid = 'invalid'
+    Invalid = 'invalid',
+    ViewOnly = 'viewOnly'
 }
 
 export interface IButton {

--- a/server/game/core/gameSteps/prompts/DisplayCardPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardPrompt.ts
@@ -3,7 +3,8 @@ import type Game from '../../Game';
 import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
 import type Player from '../../Player';
 import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
-import type { IDisplayCard, IDisplayCardPromptPropertiesBase } from '../PromptInterfaces';
+import * as Contract from '../../utils/Contract';
+import { DisplayCardSelectionState, type IDisplayCard, type IDisplayCardPromptPropertiesBase } from '../PromptInterfaces';
 import { UiPrompt } from './UiPrompt';
 
 export abstract class DisplayCardPrompt<TProperties extends IDisplayCardPromptPropertiesBase> extends UiPrompt {
@@ -51,11 +52,19 @@ export abstract class DisplayCardPrompt<TProperties extends IDisplayCardPromptPr
     }
 
     public override activePrompt() {
+        const displayCards = this.getDisplayCards();
+
+        const displayCardStates = new Set(displayCards.map((card) => card.selectionState));
+        Contract.assertFalse(
+            displayCardStates.has(DisplayCardSelectionState.ViewOnly) && displayCardStates.size > 1,
+            `Display prompt cannot "ViewOnly" and other selection states together. States found: ${Array.from(displayCardStates).join(', ')}`
+        );
+
         return {
             menuTitle: this.properties.activePromptTitle,
             promptTitle: this.promptTitle,
             promptUuid: this.uuid,
-            displayCards: this.getDisplayCards(),
+            displayCards,
             ...this.activePromptInternal(),
             promptType: PromptType.DisplayCards
         };

--- a/server/game/core/gameSteps/prompts/DisplayCardPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardPrompt.ts
@@ -22,10 +22,10 @@ export abstract class DisplayCardPrompt<TProperties extends IDisplayCardPromptPr
         }
 
         if (!properties.waitingPromptTitle) {
-            properties.waitingPromptTitle = `Waiting for opponent to use ${properties.source.name}`;
+            properties.waitingPromptTitle = this.getDefaultWaitingPromptTitle(properties.source);
         }
         if (!properties.activePromptTitle) {
-            properties.activePromptTitle = `Choose cards for ${properties.source.name} ability`;
+            properties.activePromptTitle = this.getDefaultActivePromptTitle(properties.source);
         }
 
         this.source = properties.source;
@@ -37,6 +37,14 @@ export abstract class DisplayCardPrompt<TProperties extends IDisplayCardPromptPr
     protected abstract activePromptInternal(): Partial<IPlayerPromptStateProperties>;
     protected abstract defaultProperties(): Partial<TProperties>;
     protected abstract getDisplayCards(): IDisplayCard[];
+
+    protected getDefaultWaitingPromptTitle(source: OngoingEffectSource) {
+        return `Waiting for opponent to use ${source.name}`;
+    }
+
+    protected getDefaultActivePromptTitle(source: OngoingEffectSource) {
+        return `Choose cards for ${source.name} ability`;
+    }
 
     public override activeCondition(player) {
         return player === this.choosingPlayer;

--- a/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
@@ -1,6 +1,7 @@
 import * as Util from '../../../../Util';
 import type { Card } from '../../card/Card';
 import type Game from '../../Game';
+import type { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
 import type Player from '../../Player';
 import * as Contract from '../../utils/Contract';
 import type { IDisplayCard, IDisplayCardsBasicPromptProperties } from '../PromptInterfaces';
@@ -31,6 +32,14 @@ export class DisplayCardsBasicPrompt extends DisplayCardPrompt<IDisplayCardsBasi
 
             this.displayTextByCardUuid = properties.displayTextByCardUuid;
         }
+    }
+
+    protected override getDefaultWaitingPromptTitle(source: OngoingEffectSource) {
+        return `Waiting for opponent to finish viewing cards for ${source.name} ability`;
+    }
+
+    protected override getDefaultActivePromptTitle(source: OngoingEffectSource) {
+        return `View cards for ${source.name} ability`;
     }
 
     protected override defaultProperties() {

--- a/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
@@ -1,0 +1,68 @@
+import * as Util from '../../../../Util';
+import type { Card } from '../../card/Card';
+import type Game from '../../Game';
+import type Player from '../../Player';
+import * as Contract from '../../utils/Contract';
+import type { IDisplayCard, IDisplayCardsBasicPromptProperties } from '../PromptInterfaces';
+import { DisplayCardSelectionState, type IButton } from '../PromptInterfaces';
+import { DisplayCardPrompt } from './DisplayCardPrompt';
+
+export class DisplayCardsBasicPrompt extends DisplayCardPrompt<IDisplayCardsBasicPromptProperties> {
+    private readonly doneButton: IButton;
+    private readonly cardTextByUuid: Map<string, string>;
+
+    private displayCards: Card[];
+
+    public constructor(game: Game, choosingPlayer: Player, properties: IDisplayCardsBasicPromptProperties) {
+        Contract.assertTrue(properties.displayCards.length > 0);
+
+        super(game, choosingPlayer, properties);
+
+        this.displayCards = properties.displayCards;
+        this.doneButton = { text: 'Done', arg: 'done' };
+
+        if (properties.cardTextByUuid) {
+            const mapKeys = Array.from(properties.cardTextByUuid.keys());
+            const cardUuids = this.displayCards.map((card) => card.uuid);
+            Contract.assertTrue(
+                Util.stringArraysEqual(mapKeys, cardUuids),
+                `Provided card display text map does not match passed display card uuids\n\tMap keys:${mapKeys.join(', ')}\n\tCard uuids:${cardUuids.join(', ')}`
+            );
+
+            this.cardTextByUuid = properties.cardTextByUuid;
+        }
+    }
+
+    protected override defaultProperties() {
+        return {};
+    }
+
+    public override activePromptInternal() {
+        return {
+            buttons: [this.doneButton],
+        };
+    }
+
+    protected override getDisplayCards(): IDisplayCard[] {
+        return this.displayCards.map((card) => ({
+            cardUuid: card.uuid,
+            setId: card.setId,
+            internalName: card.internalName,
+            selectionState: DisplayCardSelectionState.Invalid,
+            displayText: this.cardTextByUuid?.get(card.uuid),
+        }));
+    }
+
+    public override menuCommand(player: Player, arg: string, uuid: string): boolean {
+        this.checkPlayerAndUuid(player, uuid);
+
+        Contract.assertTrue(arg === 'done', `Unexpected menu command: '${arg}'`);
+
+        this.complete();
+        return true;
+    }
+
+    public override waitingPrompt() {
+        return { menuTitle: this.properties.waitingPromptTitle || 'Waiting for opponent' };
+    }
+}

--- a/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
@@ -57,7 +57,7 @@ export class DisplayCardsBasicPrompt extends DisplayCardPrompt<IDisplayCardsBasi
             cardUuid: card.uuid,
             setId: card.setId,
             internalName: card.internalName,
-            selectionState: DisplayCardSelectionState.Invalid,
+            selectionState: DisplayCardSelectionState.ViewOnly,
             displayText: this.displayTextByCardUuid?.get(card.uuid),
         }));
     }

--- a/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsBasicPrompt.ts
@@ -9,7 +9,7 @@ import { DisplayCardPrompt } from './DisplayCardPrompt';
 
 export class DisplayCardsBasicPrompt extends DisplayCardPrompt<IDisplayCardsBasicPromptProperties> {
     private readonly doneButton: IButton;
-    private readonly cardTextByUuid: Map<string, string>;
+    private readonly displayTextByCardUuid: Map<string, string>;
 
     private displayCards: Card[];
 
@@ -21,15 +21,15 @@ export class DisplayCardsBasicPrompt extends DisplayCardPrompt<IDisplayCardsBasi
         this.displayCards = properties.displayCards;
         this.doneButton = { text: 'Done', arg: 'done' };
 
-        if (properties.cardTextByUuid) {
-            const mapKeys = Array.from(properties.cardTextByUuid.keys());
+        if (properties.displayTextByCardUuid) {
+            const mapKeys = Array.from(properties.displayTextByCardUuid.keys());
             const cardUuids = this.displayCards.map((card) => card.uuid);
             Contract.assertTrue(
                 Util.stringArraysEqual(mapKeys, cardUuids),
                 `Provided card display text map does not match passed display card uuids\n\tMap keys:${mapKeys.join(', ')}\n\tCard uuids:${cardUuids.join(', ')}`
             );
 
-            this.cardTextByUuid = properties.cardTextByUuid;
+            this.displayTextByCardUuid = properties.displayTextByCardUuid;
         }
     }
 
@@ -49,7 +49,7 @@ export class DisplayCardsBasicPrompt extends DisplayCardPrompt<IDisplayCardsBasi
             setId: card.setId,
             internalName: card.internalName,
             selectionState: DisplayCardSelectionState.Invalid,
-            displayText: this.cardTextByUuid?.get(card.uuid),
+            displayText: this.displayTextByCardUuid?.get(card.uuid),
         }));
     }
 

--- a/server/game/gameSystems/LookAtSystem.ts
+++ b/server/game/gameSystems/LookAtSystem.ts
@@ -12,7 +12,6 @@ export class LookAtSystem<TContext extends AbilityContext = AbilityContext> exte
     public override readonly effectDescription = 'look at a card';
 
     protected override defaultProperties: IViewCardProperties = {
-        sendChatMessage: true,
         message: '{0} sees {1}',
         viewType: ViewCardMode.LookAt
     };

--- a/server/game/gameSystems/LookAtSystem.ts
+++ b/server/game/gameSystems/LookAtSystem.ts
@@ -1,34 +1,39 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import { EventName } from '../core/Constants';
-import { GameSystem } from '../core/gameSystem/GameSystem';
+import type Player from '../core/Player';
 import type { IViewCardProperties } from './ViewCardSystem';
-import { ViewCardMode, ViewCardSystem } from './ViewCardSystem';
+import { ViewCardSystem } from './ViewCardSystem';
 
-export type ILookAtProperties = Omit<IViewCardProperties, 'viewType'>;
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ILookAtProperties extends IViewCardProperties {}
 
-export class LookAtSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext> {
+export class LookAtSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext, ILookAtProperties> {
     public override readonly name = 'lookAt';
     public override readonly eventName = EventName.OnLookAtCard;
     public override readonly effectDescription = 'look at a card';
 
     protected override defaultProperties: IViewCardProperties = {
         message: '{0} sees {1}',
-        viewType: ViewCardMode.LookAt
     };
 
-    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
-    public constructor(propertiesOrPropertyFactory: ILookAtProperties | ((context?: AbilityContext) => ILookAtProperties)) {
-        const propsWithViewType = GameSystem.appendToPropertiesOrPropertyFactory<IViewCardProperties, 'viewType'>(propertiesOrPropertyFactory, { viewType: ViewCardMode.LookAt });
-        super(propsWithViewType);
-    }
-
-    // TODO: we need a 'look at' prompt for secretly revealing, currently chat logs go to all players
     public override getMessageArgs(event: any, context: TContext, additionalProperties: any): any[] {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const messageArgs = properties.messageArgs ? properties.messageArgs(event.cards) : [
             context.source, event.cards
         ];
         return messageArgs;
+    }
+
+    protected override getChatMessage(properties: IViewCardProperties): string {
+        return properties.useDisplayPrompt ? '{0} looks at a card' : '{0} sees {1}';
+    }
+
+    protected override getPromptedPlayer(properties: ILookAtProperties, context: TContext): Player {
+        if (!properties.useDisplayPrompt) {
+            return null;
+        }
+
+        return context.player;
     }
 
     public override checkEventCondition(): boolean {

--- a/server/game/gameSystems/RevealSystem.ts
+++ b/server/game/gameSystems/RevealSystem.ts
@@ -1,27 +1,23 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
+import { RelativePlayer } from '../core/Constants';
 import { EventName, ZoneName } from '../core/Constants';
-import { GameSystem } from '../core/gameSystem/GameSystem';
+import type Player from '../core/Player';
 import type { IViewCardProperties } from './ViewCardSystem';
-import { ViewCardMode, ViewCardSystem } from './ViewCardSystem';
+import { ViewCardSystem } from './ViewCardSystem';
 
-export type IRevealProperties = Omit<IViewCardProperties, 'viewType'>;
+export interface IRevealProperties extends IViewCardProperties {
+    promptedPlayer?: RelativePlayer;
+}
 
-export class RevealSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext> {
+export class RevealSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext, IRevealProperties> {
     public override readonly name = 'reveal';
     public override readonly eventName = EventName.OnCardRevealed;
     public override readonly costDescription = 'revealing {0}';
 
-    protected override readonly defaultProperties: IViewCardProperties = {
-        message: '{0} reveals {1} due to {2}',
-        viewType: ViewCardMode.Reveal
+    protected override readonly defaultProperties: IRevealProperties = {
+        promptedPlayer: RelativePlayer.Self
     };
-
-    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
-    public constructor(propertiesOrPropertyFactory: IRevealProperties | ((context?: AbilityContext) => IRevealProperties)) {
-        const propsWithViewType = GameSystem.appendToPropertiesOrPropertyFactory<IViewCardProperties, 'viewType'>(propertiesOrPropertyFactory, { viewType: ViewCardMode.Reveal });
-        super(propsWithViewType);
-    }
 
     public override checkEventCondition(event): boolean {
         for (const card of event.cards) {
@@ -48,6 +44,29 @@ export class RevealSystem<TContext extends AbilityContext = AbilityContext> exte
             event.context.source
         ];
         return messageArgs;
+    }
+
+    protected override getChatMessage(properties: IViewCardProperties): string | null {
+        return '{0} reveals {1} due to {2}';
+    }
+
+    protected override getPromptedPlayer(properties: IRevealProperties, context: TContext): Player {
+        if (!properties.useDisplayPrompt) {
+            return null;
+        }
+
+        if (!properties.promptedPlayer) {
+            return context.player;
+        }
+
+        switch (properties.promptedPlayer) {
+            case RelativePlayer.Opponent:
+                return context.player.opponent;
+            case RelativePlayer.Self:
+                return context.player;
+            default:
+                throw new Error(`Unknown promptedPlayer value: ${properties.promptedPlayer}`);
+        }
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/server/game/gameSystems/RevealSystem.ts
+++ b/server/game/gameSystems/RevealSystem.ts
@@ -13,7 +13,6 @@ export class RevealSystem<TContext extends AbilityContext = AbilityContext> exte
     public override readonly costDescription = 'revealing {0}';
 
     protected override readonly defaultProperties: IViewCardProperties = {
-        sendChatMessage: true,
         message: '{0} reveals {1} due to {2}',
         viewType: ViewCardMode.Reveal
     };

--- a/server/game/gameSystems/ViewCardSystem.ts
+++ b/server/game/gameSystems/ViewCardSystem.ts
@@ -16,6 +16,9 @@ export interface IViewCardProperties extends ICardTargetSystemProperties {
 
     /** Temporary parameter while we are migrating everything to the new display prompt */
     useDisplayPrompt?: boolean;
+
+    /** If we want to display text under any cards, map their uuid(s) to the title text here */
+    displayTextByCardUuid?: Map<string, string>;
 }
 
 export enum ViewCardMode {
@@ -37,6 +40,14 @@ export abstract class ViewCardSystem<TContext extends AbilityContext = AbilityCo
         const context = event.context;
         if (event.sendChatMessage) {
             context.game.addMessage(this.getMessage(event.message, context), ...event.messageArgs);
+        }
+
+        if (event.useDisplayPrompt) {
+            context.game.promptDisplayCardsBasic(context.player, {
+                displayCards: event.cards,
+                source: context.source,
+                displayTextByCardUuid: event.displayTextByCardUuid
+            });
         }
     }
 
@@ -66,6 +77,8 @@ export abstract class ViewCardSystem<TContext extends AbilityContext = AbilityCo
         event.sendChatMessage = !properties.useDisplayPrompt || properties.viewType === ViewCardMode.Reveal;
         event.message = properties.message;
         event.messageArgs = this.getMessageArgs(event, context, additionalProperties);
+        event.useDisplayPrompt = properties.useDisplayPrompt;
+        event.displayTextByCardUuid = properties.displayTextByCardUuid;
     }
 
     public getMessage(message, context: TContext): string {

--- a/test/helpers/CustomMatchers.js
+++ b/test/helpers/CustomMatchers.js
@@ -1,7 +1,6 @@
-/* global describe, beforeEach, jasmine */
+/* global beforeEach, jasmine */
 
-const exp = require('constants');
-const Contract = require('../../server/game/core/utils/Contract.js');
+const { stringArraysEqual } = require('../../server/Util.js');
 const TestSetupError = require('./TestSetupError.js');
 const Util = require('./Util.js');
 
@@ -10,7 +9,6 @@ var customMatchers = {
         return {
             compare: function (actual, expected) {
                 var result = {};
-                var currentPrompt = actual.currentPrompt();
                 result.pass = actual.hasPrompt(expected);
 
                 if (result.pass) {
@@ -745,7 +743,7 @@ var customMatchers = {
 
                 const expectedUpgradeNames = [...upgradeNames];
 
-                result.pass = Util.stringArraysEqual(actualUpgradeNames, expectedUpgradeNames);
+                result.pass = stringArraysEqual(actualUpgradeNames, expectedUpgradeNames);
 
                 if (result.pass) {
                     result.message = `Expected ${card.internalName} not to have this exact set of upgrades but it does: ${expectedUpgradeNames.join(', ')}`;
@@ -771,7 +769,7 @@ var customMatchers = {
 
                 const expectedButtons = [...buttons];
 
-                result.pass = Util.stringArraysEqual(actualButtons, expectedButtons);
+                result.pass = stringArraysEqual(actualButtons, expectedButtons);
 
                 if (result.pass) {
                     result.message = `Expected ${player.name} not to have this exact set of buttons but it does: ${expectedButtons.join(', ')}`;
@@ -796,7 +794,7 @@ var customMatchers = {
 
                 const actualOptions = player.currentPrompt().dropdownListOptions;
 
-                result.pass = Util.stringArraysEqual(actualOptions, expectedOptions);
+                result.pass = stringArraysEqual(actualOptions, expectedOptions);
 
                 if (result.pass) {
                     result.message = `Expected ${player.name} not to have this exact list of options but it does: '${Util.formatDropdownListOptions(expectedOptions)}'`;
@@ -944,7 +942,7 @@ var customMatchers = {
 
                 const actualButtonsInPrompt = player.currentPrompt().perCardButtons.map((button) => button.text);
 
-                result.pass = Util.stringArraysEqual(actualButtonsInPrompt, expectedButtonsInPrompt);
+                result.pass = stringArraysEqual(actualButtonsInPrompt, expectedButtonsInPrompt);
 
                 if (result.pass) {
                     result.message = `Expected ${player.name} not to have this exact set of "per card" buttons but it did: ${expectedButtonsInPrompt.join(', ')}`;

--- a/test/helpers/CustomMatchers.js
+++ b/test/helpers/CustomMatchers.js
@@ -814,23 +814,23 @@ var customMatchers = {
             compare: function (player, expectedCardsInPromptRaw) {
                 const expectedCardsInPromptObject = { selectable: Helpers.asArray(expectedCardsInPromptRaw) };
 
-                return processExpectedCardsInPrompt(player, expectedCardsInPromptObject);
+                return processExpectedCardsInDisplayPrompt(player, expectedCardsInPromptObject);
             }
         };
     },
     toHaveExactViewableDisplayPromptCards: function() {
         return {
             compare: function (player, expectedCardsInPromptRaw) {
-                const expectedCardsInPromptObject = { invalid: Helpers.asArray(expectedCardsInPromptRaw) };
+                const expectedCardsInPromptObject = { viewOnly: Helpers.asArray(expectedCardsInPromptRaw) };
 
-                return processExpectedCardsInPrompt(player, expectedCardsInPromptObject);
+                return processExpectedCardsInDisplayPrompt(player, expectedCardsInPromptObject);
             }
         };
     },
     toHaveExactDisplayPromptCards: function() {
         return {
             compare: function (player, expectedCardsInPromptRaw) {
-                return processExpectedCardsInPrompt(player, expectedCardsInPromptRaw);
+                return processExpectedCardsInDisplayPrompt(player, expectedCardsInPromptRaw);
             }
         };
     },
@@ -875,7 +875,7 @@ function checkConsistentZoneState(card, result) {
     return true;
 }
 
-function processExpectedCardsInPrompt(player, expectedCardsInPromptObject) {
+function processExpectedCardsInDisplayPrompt(player, expectedCardsInPromptObject) {
     let result = {};
 
     if (Array.isArray(expectedCardsInPromptObject)) {

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -111,6 +111,8 @@ declare namespace jasmine {
         toHaveExactPromptButtons<T extends PlayerInteractionWrapper>(this: Matchers<T>, buttons: any[]): boolean;
         toHaveExactDropdownListOptions<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedOptions: any[]): boolean;
         toHaveExactDisplayPromptCards<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedButtonsInPrompt: Card[] | ICardDisplaySelectionState): boolean;
+        toHaveExactSelectableDisplayPromptCards<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedButtonsInPrompt: Card[]): boolean;
+        toHaveExactViewableDisplayPromptCards<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedButtonsInPrompt: Card[]): boolean;
         toHaveExactDisplayPromptPerCardButtons<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedButtonsInPrompt: Card[]): boolean;
     }
 }

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -3,7 +3,7 @@
 
 const Contract = require('../../server/game/core/utils/Contract.js');
 const TestSetupError = require('./TestSetupError.js');
-const { checkNullCard, formatPrompt, getPlayerPromptState, promptStatesEqual, stringArraysEqual } = require('./Util.js');
+const { formatPrompt } = require('./Util.js');
 
 require('./ObjectFormatters.js');
 

--- a/test/helpers/Util.js
+++ b/test/helpers/Util.js
@@ -1,3 +1,4 @@
+const Util = require('../../server/Util.js');
 const TestSetupError = require('./TestSetupError.js');
 
 // card can be a single or an array
@@ -115,30 +116,9 @@ function promptStatesEqual(promptState1, promptState2) {
         return false;
     }
 
-    return stringArraysEqual(promptState1.selectedCards, promptState2.selectedCards) &&
-      stringArraysEqual(promptState1.selectableCards, promptState2.selectableCards) &&
-      stringArraysEqual(promptState1.dropdownListOptions, promptState2.dropdownListOptions);
-}
-
-function stringArraysEqual(ara1, ara2) {
-    if (ara1 == null || ara2 == null) {
-        throw new TestSetupError('Null array passed to stringArraysEqual');
-    }
-
-    if (ara1.length !== ara2.length) {
-        return false;
-    }
-
-    ara1.sort();
-    ara2.sort();
-
-    for (let i = 0; i < ara1.length; i++) {
-        if (ara1[i] !== ara2[i]) {
-            return false;
-        }
-    }
-
-    return true;
+    return Util.stringArraysEqual(promptState1.selectedCards, promptState2.selectedCards) &&
+      Util.stringArraysEqual(promptState1.selectableCards, promptState2.selectableCards) &&
+      Util.stringArraysEqual(promptState1.dropdownListOptions, promptState2.dropdownListOptions);
 }
 
 function formatDropdownListOptions(options) {
@@ -158,7 +138,6 @@ module.exports = {
     formatPrompt,
     getPlayerPromptState,
     promptStatesEqual,
-    stringArraysEqual,
     formatDropdownListOptions,
     formatBothPlayerPrompts,
     isTokenUnit,

--- a/test/scenarios/timingWindows/DefeatTiming.spec.ts
+++ b/test/scenarios/timingWindows/DefeatTiming.spec.ts
@@ -97,6 +97,7 @@ describe('Defeat timing', function() {
 
                 expect(context.lieutenantChildsen).toBeInZone('discard');
                 context.player2.clickPrompt('Reveal up to 4 Vigilance cards from your hand -> Vanquish');
+                context.player1.clickPrompt('Done');
                 expect(context.player1).toBeActivePlayer();
             });
         });

--- a/test/server/cards/01_SOR/units/DarthVaderCommandingTheFirstLegion.spec.ts
+++ b/test/server/cards/01_SOR/units/DarthVaderCommandingTheFirstLegion.spec.ts
@@ -197,7 +197,7 @@ describe('Darth Vader, Commanding the First Legion', function () {
                 .toAllBeInBottomOfDeck(context.player1, 8);
 
             // inferno four's ability should show the next 2 cards
-            expect(context.player1).toHaveExactDisplayPromptCards([context.atst, context.wampa]);
+            expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.atst, context.wampa]);
             expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Put on top', 'Put on bottom']);
             context.player1.clickDisplayCardPromptButton(context.atst.uuid, 'top');
             context.player1.clickDisplayCardPromptButton(context.wampa.uuid, 'bottom');

--- a/test/server/cards/01_SOR/units/InfernoFourUnforgetting.spec.ts
+++ b/test/server/cards/01_SOR/units/InfernoFourUnforgetting.spec.ts
@@ -20,7 +20,7 @@ describe('Inferno Four - Unforgetting', function() {
 
                 // Case 1 on play move the first top card to top and second card to bottom.
                 context.player1.clickCard(context.infernoFour);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.foundling, context.pykeSentinel]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.foundling, context.pykeSentinel]);
                 expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Put on top', 'Put on bottom']);
                 context.player1.clickDisplayCardPromptButton(context.pykeSentinel.uuid, 'top');
                 expect(context.player1.deck).toEqual(preSwapDeck);
@@ -42,7 +42,7 @@ describe('Inferno Four - Unforgetting', function() {
                 // Case 2 on defeat move both cards to the top of the deck
                 context.player2.clickCard(context.tieAdvanced);
                 context.player2.clickCard(context.infernoFour);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.pykeSentinel, context.atst]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.pykeSentinel, context.atst]);
                 expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Put on top', 'Put on bottom']);
                 context.player1.clickDisplayCardPromptButton(context.pykeSentinel.uuid, 'top');
                 expect(context.player1.deck).toEqual(preSwapDeck);

--- a/test/server/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.spec.ts
+++ b/test/server/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.spec.ts
@@ -45,10 +45,9 @@ describe('Lieutenant Childsen', function() {
                     context.player1.clickCard(context.pykeSentinel);
                     context.player1.clickPrompt('Done');
 
-                    expect(context.getChatLogs(2)).toEqual([
-                        'player1 uses Lieutenant Childsen to reveal a card',
-                        'player1 reveals Pyke Sentinel due to Lieutenant Childsen',
-                    ]);
+                    expect(context.player2).toHaveExactViewableDisplayPromptCards([context.pykeSentinel]);
+                    expect(context.getChatLogs(1)[0]).toContain(context.pykeSentinel.title);
+                    context.player2.clickPrompt('Done');
 
                     expect(context.lieutenantChildsen).toHaveExactUpgradeNames(['experience']);
                     expect(context.player2).toBeActivePlayer();
@@ -65,10 +64,12 @@ describe('Lieutenant Childsen', function() {
                     context.player1.clickCardNonChecking(context.systemPatrolCraft);
                     context.player1.clickPrompt('Done');
 
-                    expect(context.getChatLogs(2)).toEqual([
-                        'player1 uses Lieutenant Childsen to reveal 4 cards',
-                        'player1 reveals Cargo Juggernaut, Vanquish, Resilient, Pyke Sentinel due to Lieutenant Childsen',
-                    ]);
+                    expect(context.player2).toHaveExactViewableDisplayPromptCards([context.cargoJuggernaut, context.vanquish, context.resilient, context.pykeSentinel]);
+                    expect(context.getChatLogs(1)[0]).toContain(context.cargoJuggernaut.title);
+                    expect(context.getChatLogs(1)[0]).toContain(context.vanquish.title);
+                    expect(context.getChatLogs(1)[0]).toContain(context.resilient.title);
+                    expect(context.getChatLogs(1)[0]).toContain(context.pykeSentinel.title);
+                    context.player2.clickPrompt('Done');
 
                     expect(context.lieutenantChildsen).toHaveExactUpgradeNames(['experience', 'experience', 'experience', 'experience']);
                     expect(context.player2).toBeActivePlayer();
@@ -110,7 +111,7 @@ describe('Lieutenant Childsen', function() {
 
                     context.player1.clickCard(context.lieutenantChildsen);
 
-                    expect(context.lieutenantChildsen).toHaveExactUpgradeNames([]);
+                    expect(context.lieutenantChildsen.isUpgraded()).toBeFalse();
                     expect(context.player2).toBeActivePlayer();
                 });
             });

--- a/test/server/cards/01_SOR/units/R2D2IgnoringProtocol.spec.ts
+++ b/test/server/cards/01_SOR/units/R2D2IgnoringProtocol.spec.ts
@@ -20,7 +20,7 @@ describe('R2D2 - Ignoring Protocol', function() {
 
                 // Case 1 on play move top card to bottom
                 context.player1.clickCard(context.r2d2);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.foundling]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.foundling]);
                 expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Put on top', 'Put on bottom']);
                 context.player1.clickDisplayCardPromptButton(context.foundling.uuid, 'bottom');
 
@@ -38,7 +38,7 @@ describe('R2D2 - Ignoring Protocol', function() {
                 // Case 2 on attack move to top
                 context.player1.clickCard(context.r2d2);
                 context.player1.clickCard(context.battlefieldMarine);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.pykeSentinel]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.pykeSentinel]);
                 expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Put on top', 'Put on bottom']);
                 context.player1.clickDisplayCardPromptButton(context.pykeSentinel.uuid, 'top');
 

--- a/test/server/cards/01_SOR/units/ViperProbeDroid.spec.ts
+++ b/test/server/cards/01_SOR/units/ViperProbeDroid.spec.ts
@@ -19,7 +19,9 @@ describe('Viper Probe Droid', function() {
 
                 context.player1.clickCard(context.viperProbeDroid);
                 expect(context.viperProbeDroid.zoneName).toBe('groundArena');
-                expect(context.getChatLogs(1)).toContain('Viper Probe Droid sees Wampa, Battlefield Marine, and Pyke Sentinel');
+                expect(context.player1).toHaveExactViewableDisplayPromptCards([context.wampa, context.battlefieldMarine, context.pykeSentinel]);
+                expect(context.getChatLogs(1)[0]).not.toContain('Wampa');  // confirm that there is no chat message for the cards
+                context.player1.clickPrompt('Done');
                 expect(context.player2).toBeActivePlayer();
             });
 

--- a/test/server/cards/01_SOR/units/ViperProbeDroid.spec.ts
+++ b/test/server/cards/01_SOR/units/ViperProbeDroid.spec.ts
@@ -20,7 +20,7 @@ describe('Viper Probe Droid', function() {
                 context.player1.clickCard(context.viperProbeDroid);
                 expect(context.viperProbeDroid.zoneName).toBe('groundArena');
                 expect(context.player1).toHaveExactViewableDisplayPromptCards([context.wampa, context.battlefieldMarine, context.pykeSentinel]);
-                expect(context.getChatLogs(1)[0]).not.toContain('Wampa');  // confirm that there is no chat message for the cards
+                expect(context.getChatLogs(1)[0]).not.toContain(context.wampa.title);  // confirm that there is no chat message for the cards
                 context.player1.clickPrompt('Done');
                 expect(context.player2).toBeActivePlayer();
             });

--- a/test/server/cards/02_SHD/units/CobbVanthTheMarshal.spec.ts
+++ b/test/server/cards/02_SHD/units/CobbVanthTheMarshal.spec.ts
@@ -76,7 +76,7 @@ describe('Cobb Vanth, The Marshal', function() {
 
                 context.player2.clickCard(context.wampa);
                 context.player2.clickCard(context.cobbVanth);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.battlefieldMarine]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine]);
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
                 context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
@@ -108,7 +108,7 @@ describe('Cobb Vanth, The Marshal', function() {
 
                 context.player2.clickCard(context.wampa);
                 context.player2.clickCard(context.cobbVanth);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.battlefieldMarine]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine]);
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
                 context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
@@ -160,7 +160,7 @@ describe('Cobb Vanth, The Marshal', function() {
 
                 context.player2.clickCard(context.wampa);
                 context.player2.clickCard(context.cobbVanth);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.battlefieldMarine]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine]);
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
                 context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);

--- a/test/server/cards/03_TWI/events/WartimeProfiteering.spec.ts
+++ b/test/server/cards/03_TWI/events/WartimeProfiteering.spec.ts
@@ -33,7 +33,7 @@ describe('Wartime Profiteering', function () {
 
                 // show 2 cards and select 1
                 context.player1.clickCard(context.wartimeProfiteering);
-                expect(context.player1).toHaveExactDisplayPromptCards([context.atst, context.yoda]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.atst, context.yoda]);
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
                 context.player1.clickCardInDisplayCardPrompt(context.yoda);


### PR DESCRIPTION
Beginning the process of refactoring for every lookat / reveal effect to use the display prompt instead of relying on text messages. Since there are a lot of cards that need to be updated and many of them are special cases, we are adding an optional property that enables the prompt in the `lookAt()` and `reveal()` functions. This will be removed once all cards are ported over.

Converted VPD and Childsen to use the new prompt system.