### PR TITLE
Fix in-play id issue for hidden zones

### DIFF
--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -26,7 +26,7 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
             return false;
         }
         const zoneArray = Helpers.asArray(zoneFilter);
-        return zoneArray.length > 0 && zoneArray.every((zone) => EnumHelpers.isHidden(zone, controller));
+        return zoneArray.length > 0 && zoneArray.every((zone) => EnumHelpers.isHiddenFromOpponent(zone, controller));
     }
 
     public constructor(name: string, properties: ICardTargetResolver<AbilityContext>, ability: PlayerOrCardAbility = null) {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -692,7 +692,7 @@ export class Card extends OngoingEffectSource {
      * Subclass methods should override this and call the super method to ensure all statuses are set correctly.
      */
     protected initializeForCurrentZone(prevZone?: ZoneName) {
-        this.hiddenForOpponent = EnumHelpers.isHidden(this.zoneName, RelativePlayer.Self);
+        this.hiddenForOpponent = EnumHelpers.isHiddenFromOpponent(this.zoneName, RelativePlayer.Self);
 
         switch (this.zoneName) {
             case ZoneName.SpaceArena:

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -314,6 +314,11 @@ export class InPlayCard extends PlayableOrDeployableCard {
             }
         } else {
             this.setPendingDefeatEnabled(false);
+
+            // if we're moving from a visible zone (discard, capture) to a hidden zone, increment the in-play id to represent the loss of information (card becomes a new copy)
+            if (EnumHelpers.isHiddenFromOpponent(this.zoneName, RelativePlayer.Self) && !EnumHelpers.isHiddenFromOpponent(prevZone, RelativePlayer.Self)) {
+                this._mostRecentInPlayId += 1;
+            }
         }
     }
 

--- a/server/game/core/utils/EnumHelpers.ts
+++ b/server/game/core/utils/EnumHelpers.ts
@@ -45,11 +45,12 @@ export const isAttackableZone = (zone: ZoneFilter) => {
     }
 };
 
-export const isHidden = (zone: ZoneFilter, controller: RelativePlayer) => {
+export const isHiddenFromOpponent = (zone: ZoneFilter, zoneController: RelativePlayer) => {
     switch (zone) {
         case ZoneName.Hand:
         case ZoneName.Resource:
-            return controller !== RelativePlayer.Opponent;
+            // TODO: switching this to be 'zoneController === RelativePlayer.Self' breaks a lot of tests for some reason
+            return zoneController !== RelativePlayer.Opponent;
         case ZoneName.Deck:
             return true;
         default:


### PR DESCRIPTION
We had an issue where the "in play id" which identifies the current "in play copy" of a card was not being updated correctly. When a card leaves a visible non-arena zone (e.g. discard) and goes to a hidden zone (e.g. hand), it should become a new copy of the card even if it then returns immediately to discard.

This was causing issues in the Admiral Trench case since he was seeing units that were defeated, returned to hand, and discarded again as still the same copy. This change fixes the bug in that branch.