### PR TITLE
Add option to override "not implemented" status

### DIFF
--- a/server/game/cards/01_SOR/events/DontGetCocky.ts
+++ b/server/game/cards/01_SOR/events/DontGetCocky.ts
@@ -7,6 +7,8 @@ import type { IThenAbilityPropsWithSystems } from '../../../Interfaces';
 import * as Contract from '../../../core/utils/Contract';
 
 export default class DontGetCocky extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '2202839291',

--- a/server/game/cards/01_SOR/events/ItBindsAllThings.ts
+++ b/server/game/cards/01_SOR/events/ItBindsAllThings.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class ItBindsAllThings extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId () {
         return {
             id: '0867878280',

--- a/server/game/cards/01_SOR/events/OverwhelmingBarrage.ts
+++ b/server/game/cards/01_SOR/events/OverwhelmingBarrage.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class OverwhelmingBarrage extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId () {
         return {
             id: '1900571801',

--- a/server/game/cards/01_SOR/events/SparkOfRebellion.ts
+++ b/server/game/cards/01_SOR/events/SparkOfRebellion.ts
@@ -2,6 +2,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 
 export default class SparkOfRebellion extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '2050990622',

--- a/server/game/cards/01_SOR/events/UWingReinforcement.ts
+++ b/server/game/cards/01_SOR/events/UWingReinforcement.ts
@@ -4,6 +4,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import * as Contract from '../../../core/utils/Contract';
 
 export default class UWingReinforcement extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId () {
         return {
             id: '8968669390',

--- a/server/game/cards/01_SOR/events/YoureMyOnlyHope.ts
+++ b/server/game/cards/01_SOR/events/YoureMyOnlyHope.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 
 export default class YoureMyOnlyHope extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '3509161777',

--- a/server/game/cards/01_SOR/units/BodhiRook.ts
+++ b/server/game/cards/01_SOR/units/BodhiRook.ts
@@ -2,6 +2,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 
 export default class BodhiRook extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '7257556541',

--- a/server/game/cards/01_SOR/units/C-3POProtocolDroid.ts
+++ b/server/game/cards/01_SOR/units/C-3POProtocolDroid.ts
@@ -4,6 +4,8 @@ import { TargetMode } from '../../../core/Constants';
 
 
 export default class C3POProtocolDroid extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '8009713136',

--- a/server/game/cards/01_SOR/units/ChimaeraFlagshipOfTheSeventhFleet.ts
+++ b/server/game/cards/01_SOR/units/ChimaeraFlagshipOfTheSeventhFleet.ts
@@ -4,6 +4,8 @@ import { TargetMode } from '../../../core/Constants';
 
 
 export default class ChimaeraFlagshipOfTheSeventhFleet extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '7728042035',

--- a/server/game/cards/01_SOR/units/DarthVaderCommandingTheFirstLegion.ts
+++ b/server/game/cards/01_SOR/units/DarthVaderCommandingTheFirstLegion.ts
@@ -5,6 +5,8 @@ import type { Card } from '../../../core/card/Card';
 import * as Contract from '../../../core/utils/Contract';
 
 export default class DarthVaderCommandingTheFirstLegion extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '8506660490',

--- a/server/game/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.ts
+++ b/server/game/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.ts
@@ -3,6 +3,8 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class EmperorPalpatineMasterOfTheDarkSide extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '9097316363',

--- a/server/game/cards/01_SOR/units/EzraBridger.ts
+++ b/server/game/cards/01_SOR/units/EzraBridger.ts
@@ -4,6 +4,8 @@ import AbilityHelper from '../../../AbilityHelper';
 
 
 export default class EzraBridger extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '9560139036',

--- a/server/game/cards/01_SOR/units/ISBAgent.ts
+++ b/server/game/cards/01_SOR/units/ISBAgent.ts
@@ -3,6 +3,8 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName, RelativePlayer, CardType, WildcardCardType } from '../../../core/Constants';
 
 export default class ISBAgent extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '5154172446',

--- a/server/game/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.ts
+++ b/server/game/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.ts
@@ -3,6 +3,8 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Aspect, RelativePlayer, ZoneName, TargetMode } from '../../../core/Constants';
 
 export default class LieutenantChildsenDeathStarPrisonWarden extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '2855740390',

--- a/server/game/cards/01_SOR/units/RedemptionMedicalFrigate.ts
+++ b/server/game/cards/01_SOR/units/RedemptionMedicalFrigate.ts
@@ -3,6 +3,8 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class RedemptionMedicalFrigate extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '3896582249',

--- a/server/game/cards/01_SOR/units/ReinforcementWalker.ts
+++ b/server/game/cards/01_SOR/units/ReinforcementWalker.ts
@@ -4,6 +4,8 @@ import { TargetMode } from '../../../core/Constants';
 
 
 export default class ReinforcementWalker extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '8691800148',

--- a/server/game/cards/01_SOR/units/ViperProbeDroid.ts
+++ b/server/game/cards/01_SOR/units/ViperProbeDroid.ts
@@ -2,6 +2,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 
 export default class ViperProbeDroid extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '8986035098',

--- a/server/game/cards/02_SHD/events/CalculatedLethality.ts
+++ b/server/game/cards/02_SHD/events/CalculatedLethality.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class CalculatedLethality extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '0302968596',

--- a/server/game/cards/02_SHD/events/MidnightRepairs.ts
+++ b/server/game/cards/02_SHD/events/MidnightRepairs.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class MidnightRepairs extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId () {
         return {
             id: '8818201543',

--- a/server/game/cards/02_SHD/units/BazineNetalSpyForTheFirstOrder.ts
+++ b/server/game/cards/02_SHD/units/BazineNetalSpyForTheFirstOrder.ts
@@ -2,6 +2,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 
 export default class BazineNetalSpyForTheFirstOrder extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '5830140660',

--- a/server/game/cards/02_SHD/units/EmboStoicAndResolute.ts
+++ b/server/game/cards/02_SHD/units/EmboStoicAndResolute.ts
@@ -6,6 +6,8 @@ import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatc
 import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
 
 export default class EmboStoicAndResolute extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {

--- a/server/game/cards/02_SHD/units/RicketyQuadjumper.ts
+++ b/server/game/cards/02_SHD/units/RicketyQuadjumper.ts
@@ -2,6 +2,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 
 export default class RicketyQuadjumper extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '7291903225',

--- a/server/game/cards/02_SHD/upgrades/VambraceFlamethrower.ts
+++ b/server/game/cards/02_SHD/upgrades/VambraceFlamethrower.ts
@@ -4,6 +4,8 @@ import { ZoneName, RelativePlayer, Trait, WildcardCardType } from '../../../core
 import type { Card } from '../../../core/card/Card';
 
 export default class VambraceFlamethrower extends UpgradeCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '6471336466',

--- a/server/game/cards/03_TWI/events/UnmaskingTheConspiracy.ts
+++ b/server/game/cards/03_TWI/events/UnmaskingTheConspiracy.ts
@@ -2,6 +2,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 
 export default class UnmaskingTheConspirancy extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '0959549331',

--- a/server/game/cards/03_TWI/units/KashyyykDefender.ts
+++ b/server/game/cards/03_TWI/units/KashyyykDefender.ts
@@ -3,6 +3,8 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class KashyyykDefender extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '8552292852',

--- a/server/game/cards/03_TWI/upgrades/Foresight.ts
+++ b/server/game/cards/03_TWI/upgrades/Foresight.ts
@@ -3,6 +3,8 @@ import { PhaseName, TargetMode } from '../../../core/Constants';
 import AbilityHelper from '../../../AbilityHelper';
 
 export default class Foresight extends UpgradeCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '3962135775',

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -49,6 +49,7 @@ export class Card extends OngoingEffectSource {
     protected override readonly id: string;
     protected readonly hasNonKeywordAbilityText: boolean;
     protected readonly hasImplementationFile: boolean;
+    protected readonly overrideNotImplemented: boolean = false;
     protected readonly printedKeywords: KeywordInstance[];
     protected readonly printedTraits: Set<Trait>;
     protected readonly printedType: CardType;
@@ -913,7 +914,7 @@ export class Card extends OngoingEffectSource {
             cost: this.cardData.cost,
             power: this.cardData.power,
             hp: this.cardData.hp,
-            implemented: !this.hasNonKeywordAbilityText || this.hasImplementationFile,  // we consider a card "implemented" if it doesn't require any implementation
+            implemented: !this.overrideNotImplemented && (!this.hasNonKeywordAbilityText || this.hasImplementationFile),  // we consider a card "implemented" if it doesn't require any implementation
             // popupMenuText: this.popupMenuText,
             // showPopup: this.showPopup,
             // tokens: this.tokens,

--- a/test/server/cards/01_SOR/units/SparkOfRebellion.spec.ts
+++ b/test/server/cards/01_SOR/units/SparkOfRebellion.spec.ts
@@ -51,5 +51,3 @@ describe('Spark Of Rebellion', function () {
         });
     });
 });
-
-


### PR DESCRIPTION
We have a bunch of cards that are implemented in the BE but are missing critical pieces in the FE in order to be able to function. Added a way to override the "not implemented" status manually so that testers can avoid these cards.

Updated as many cards as I'm aware of to have this marker.