### PR TITLE
Flag capture and rescue effects with "not implemented" for the FE testing

### DIFF
--- a/server/game/cards/02_SHD/events/RelentlessPursuit.ts
+++ b/server/game/cards/02_SHD/events/RelentlessPursuit.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class RelentlessPursuit extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '5778949819',

--- a/server/game/cards/02_SHD/events/RuleWithRespect.ts
+++ b/server/game/cards/02_SHD/events/RuleWithRespect.ts
@@ -5,6 +5,8 @@ import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatc
 import { RelativePlayer, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class RuleWithRespect extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     private attacksThisPhaseWatcher: AttacksThisPhaseWatcher;
 
     protected override getImplementationId() {

--- a/server/game/cards/02_SHD/events/TakeCaptive.ts
+++ b/server/game/cards/02_SHD/events/TakeCaptive.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class TakeCaptive extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '3765912000',

--- a/server/game/cards/02_SHD/events/UnexpectedEscape.ts
+++ b/server/game/cards/02_SHD/events/UnexpectedEscape.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { WildcardZoneName, ZoneName } from '../../../core/Constants';
 
 export default class UnexpectedEscape extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '1973545191',

--- a/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
+++ b/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
@@ -4,6 +4,8 @@ import { KeywordName, RelativePlayer, WildcardCardType, WildcardZoneName } from 
 import * as AbilityLimit from '../../../core/ability/AbilityLimit';
 
 export default class JabbaTheHuttHisHighExaltedness extends LeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '0622803599',

--- a/server/game/cards/02_SHD/units/DiscerningVeteran.ts
+++ b/server/game/cards/02_SHD/units/DiscerningVeteran.ts
@@ -3,6 +3,8 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, ZoneName } from '../../../core/Constants';
 
 export default class DiscerningVeteran extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '9765804063',

--- a/server/game/cards/02_SHD/units/EphantMonHeadOfSecurity.ts
+++ b/server/game/cards/02_SHD/units/EphantMonHeadOfSecurity.ts
@@ -5,6 +5,8 @@ import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThis
 import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class EphantMonHeadOfSecurity extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     private attacksThisPhaseWatcher: AttacksThisPhaseWatcher;
 
     protected override getImplementationId() {

--- a/server/game/cards/02_SHD/units/FinalizerMightOfTheFirstOrder.ts
+++ b/server/game/cards/02_SHD/units/FinalizerMightOfTheFirstOrder.ts
@@ -9,6 +9,8 @@ import type { ZoneName } from '../../../core/Constants';
 import { EventName, RelativePlayer, TargetMode, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class FinalizerMightOfTheFirstOrder extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '9752523457',

--- a/server/game/cards/02_SHD/units/L3-37DroidRevolutionary.ts
+++ b/server/game/cards/02_SHD/units/L3-37DroidRevolutionary.ts
@@ -3,6 +3,8 @@ import AbilityHelper from '../../../AbilityHelper';
 import { ZoneName } from '../../../core/Constants';
 
 export default class L337DroidRevolutionary extends NonLeaderUnitCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '9552605383',

--- a/server/game/cards/02_SHD/upgrades/LegalAuthority.ts
+++ b/server/game/cards/02_SHD/upgrades/LegalAuthority.ts
@@ -5,6 +5,8 @@ import type { Card } from '../../../core/card/Card';
 import type Player from '../../../core/Player';
 
 export default class LegalAuthority extends UpgradeCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '8877249477',

--- a/server/game/cards/02_SHD/upgrades/TheMandaloriansRifle.ts
+++ b/server/game/cards/02_SHD/upgrades/TheMandaloriansRifle.ts
@@ -5,6 +5,8 @@ import type { Card } from '../../../core/card/Card';
 import type Player from '../../../core/Player';
 
 export default class TheMandaloriansRifle extends UpgradeCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '0754286363',

--- a/server/game/cards/03_TWI/events/PrisonerOfWar.ts
+++ b/server/game/cards/03_TWI/events/PrisonerOfWar.ts
@@ -3,6 +3,8 @@ import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class PrisonerOfWar extends EventCard {
+    protected override readonly overrideNotImplemented: boolean = true;
+
     protected override getImplementationId() {
         return {
             id: '3799780905',


### PR DESCRIPTION
Since capture isn't implemented in the FE yet, adding the unimplemented flag manually to cards that either capture or rescue