### PR TITLE
Fix bug with Perilous Position

### DIFF
--- a/server/game/cards/03_TWI/units/PerilousPosition.ts
+++ b/server/game/cards/03_TWI/units/PerilousPosition.ts
@@ -13,7 +13,7 @@ export default class PerilousPosition extends UpgradeCard {
         this.addWhenPlayedAbility({
             title: 'Exhaust attached unit.',
             immediateEffect: AbilityHelper.immediateEffects.exhaust((context) => ({
-                target: context.source.parentCard
+                target: context.source.isInPlay() ? context.source.parentCard : null
             }))
         });
     }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -56,9 +56,8 @@ export class UpgradeCard extends UpgradeCardParent {
 
     /** The card that this card is underneath */
     public get parentCard(): UnitCard {
-        if (!this.isInPlay()) {
-            return null;
-        }
+        Contract.assertNotNullLike(this._parentCard);
+        Contract.assertTrue(this.isInPlay());
         return this._parentCard;
     }
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -56,9 +56,9 @@ export class UpgradeCard extends UpgradeCardParent {
 
     /** The card that this card is underneath */
     public get parentCard(): UnitCard {
-        Contract.assertNotNullLike(this._parentCard);
-        Contract.assertTrue(this.isInPlay());
-
+        if (!this.isInPlay()) {
+            return null;
+        }
         return this._parentCard;
     }
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -58,6 +58,7 @@ export class UpgradeCard extends UpgradeCardParent {
     public get parentCard(): UnitCard {
         Contract.assertNotNullLike(this._parentCard);
         Contract.assertTrue(this.isInPlay());
+        
         return this._parentCard;
     }
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -58,7 +58,7 @@ export class UpgradeCard extends UpgradeCardParent {
     public get parentCard(): UnitCard {
         Contract.assertNotNullLike(this._parentCard);
         Contract.assertTrue(this.isInPlay());
-        
+
         return this._parentCard;
     }
 

--- a/test/server/cards/03_TWI/units/PerilousPosition.spec.ts
+++ b/test/server/cards/03_TWI/units/PerilousPosition.spec.ts
@@ -15,5 +15,21 @@ describe('Confederate Courier\'s ability', function () {
             context.player1.clickCard(context.outspokenRepresentative);
             expect(context.outspokenRepresentative.exhausted).toBeTrue();
         });
+
+        it('should defeat unit when played', function () {
+            contextRef.setupTest({
+                phase: 'action',
+                player1: {
+                    hand: ['perilous-position'],
+                    groundArena: ['crafty-smuggler']
+                },
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.perilousPosition);
+            expect(context.player1).toBeAbleToSelectExactly([context.craftySmuggler]);
+            context.player1.clickCard(context.craftySmuggler);
+            expect(context.craftySmuggler).toBeInZone('discard');
+        });
     });
 });


### PR DESCRIPTION
While implementing Bravado, I discovered there was a bug for Perilous Position where if the unit was defeated by the upgrade, an exception would be thrown when the upgrade tried to resolve the exhaust portion of the ability. Since the unit was immediately defeated, when the exhaust resolved the unit and upgrade would both already be in the discard. The simplest solution was to remove the contract checks and let the ability fizzle due to not having a target.