### PR TITLE
Expand ViewCardSystem to support new prompt types

### DIFF
--- a/server/game/cards/01_SOR/events/SparkOfRebellion.ts
+++ b/server/game/cards/01_SOR/events/SparkOfRebellion.ts
@@ -13,17 +13,11 @@ export default class SparkOfRebellion extends EventCard {
 
     public override setupCardAbilities() {
         this.setEventAbility({
-            title: 'Look at an opponent\'s hand and discard a card from it.',
-            immediateEffect: AbilityHelper.immediateEffects.sequential([
-                AbilityHelper.immediateEffects.lookAt((context) => ({
-                    target: context.player.opponent.hand,
-                })),
-
-                AbilityHelper.immediateEffects.discardCardsFromOpponentsHand((context) => ({
-                    target: context.player.opponent,
-                    amount: 1
-                })),
-            ])
+            title: 'Look at an opponent\'s hand and discard a card from it',
+            immediateEffect: AbilityHelper.immediateEffects.lookAtAndSelectCard((context) => ({
+                target: context.player.opponent.hand,
+                immediateEffect: AbilityHelper.immediateEffects.discardSpecificCard()
+            }))
         });
     }
 }

--- a/server/game/cards/01_SOR/units/ReinforcementWalker.ts
+++ b/server/game/cards/01_SOR/units/ReinforcementWalker.ts
@@ -1,11 +1,8 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { TargetMode } from '../../../core/Constants';
 
 
 export default class ReinforcementWalker extends NonLeaderUnitCard {
-    protected override readonly overrideNotImplemented: boolean = true;
-
     protected override getImplementationId() {
         return {
             id: '8691800148',
@@ -20,25 +17,22 @@ export default class ReinforcementWalker extends NonLeaderUnitCard {
                 onCardPlayed: (event, context) => event.card === context.source,
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source,
             },
-            immediateEffect: AbilityHelper.immediateEffects.lookAt(
-                (context) => ({ target: context.source.controller.getTopCardOfDeck() })
-            ),
-            ifYouDo: (ifYouDoContext) => {
-                const topCardOfDeck = ifYouDoContext.source.controller.getTopCardOfDeck();
-                return {
-                    title: `Draw "${topCardOfDeck?.title}" or discard it and heal 3 damage from your base.`,
-                    targetResolver: {
-                        mode: TargetMode.Select,
-                        choices: {
-                            ['Draw']: AbilityHelper.immediateEffects.drawSpecificCard(() => ({ target: topCardOfDeck })),
-                            ['Discard']: AbilityHelper.immediateEffects.simultaneous([
+            immediateEffect: AbilityHelper.immediateEffects.lookAtAndChooseOption(
+                (context) => {
+                    const topCardOfDeck = context.player.getTopCardOfDeck();
+
+                    return {
+                        target: topCardOfDeck,
+                        perCardButtons: [
+                            { text: 'Draw', arg: 'draw', immediateEffect: AbilityHelper.immediateEffects.drawSpecificCard(() => ({ target: topCardOfDeck })) },
+                            { text: 'Discard', arg: 'discard', immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                                 AbilityHelper.immediateEffects.discardSpecificCard(() => ({ target: topCardOfDeck })),
-                                AbilityHelper.immediateEffects.heal({ amount: 3, target: ifYouDoContext.source.controller.base })
-                            ])
-                        }
-                    }
-                };
-            }
+                                AbilityHelper.immediateEffects.heal({ amount: 3, target: context.player.base })
+                            ]) }
+                        ]
+                    };
+                }
+            )
         });
     }
 }

--- a/server/game/cards/02_SHD/events/BountyPosting.ts
+++ b/server/game/cards/02_SHD/events/BountyPosting.ts
@@ -1,4 +1,5 @@
 import AbilityHelper from '../../../AbilityHelper';
+import type { CardWithCost } from '../../../core/card/CardTypes';
 import { EventCard } from '../../../core/card/EventCard';
 import { Trait } from '../../../core/Constants';
 
@@ -12,21 +13,21 @@ export default class BountyPosting extends EventCard {
 
     public override setupCardAbilities() {
         this.setEventAbility({
-            title: 'Search your deck for a Bounty upgrade, reveal it, and draw it. (Shuffle your deck.)',
+            title: 'Search your deck for a Bounty upgrade, reveal it, and draw it (shuffle your deck)',
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 cardCondition: (card) => card.isUpgrade() && card.hasSomeTrait(Trait.Bounty),
                 selectedCardsImmediateEffect: AbilityHelper.immediateEffects.drawSpecificCard(),
                 shuffleWhenDone: true
             }),
-            ifYouDo: (context) => ({
-                title: 'Play that upgrade (paying its cost).',
+            ifYouDo: (ifYouDoContext) => ({
+                title: 'Play that upgrade (paying its cost)',
                 optional: true,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
                     condition: () =>
-                        context.targets.length === 1 &&
-                        context.source.controller.readyResourceCount >= context.targets[0].cost,
+                        ifYouDoContext.selectedPromptCards.length === 1 &&
+                        ifYouDoContext.player.readyResourceCount >= (ifYouDoContext.selectedPromptCards[0] as CardWithCost).cost,
                     onTrue: AbilityHelper.immediateEffects.playCardFromHand({
-                        target: context.targets[0]
+                        target: ifYouDoContext.selectedPromptCards[0]
                     }),
                     onFalse: AbilityHelper.immediateEffects.noAction()
                 })
@@ -34,5 +35,3 @@ export default class BountyPosting extends EventCard {
         });
     }
 }
-
-BountyPosting.implemented = true;

--- a/server/game/cards/02_SHD/units/CobbVanthTheMarshal.ts
+++ b/server/game/cards/02_SHD/units/CobbVanthTheMarshal.ts
@@ -22,7 +22,7 @@ export default class CobbVanthTheMarshal extends NonLeaderUnitCard {
                         effect: [
                             OngoingEffectLibrary.canPlayFromDiscard(),
                             OngoingEffectLibrary.forFree({
-                                match: (card) => deckSearchContext.targets.includes(card) // note cost adjusters are attached to player, so have to refilter
+                                match: (card) => deckSearchContext.selectedPromptCards.includes(card) // note cost adjusters are attached to player, so have to refilter
                             })
                         ]
                     })),

--- a/server/game/core/ability/AbilityContext.ts
+++ b/server/game/core/ability/AbilityContext.ts
@@ -24,6 +24,7 @@ export interface IAbilityContextProperties {
     stage?: Stage;
     targetAbility?: any;
     playType?: PlayType;
+    selectedPromptCards?: Card[];
 }
 
 /**
@@ -51,6 +52,7 @@ export class AbilityContext<TSource extends Card = Card> {
     public gameActionsResolutionChain: GameSystem[] = [];
     public playType?: PlayType;
     public cardStateWhenInitiated: any = null;
+    public selectedPromptCards: Card[] = [];
 
     public constructor(properties: IAbilityContextProperties) {
         this.game = properties.game;
@@ -64,6 +66,7 @@ export class AbilityContext<TSource extends Card = Card> {
         this.selects = properties.selects || {};
         this.stage = properties.stage || Stage.Effect;
         this.targetAbility = properties.targetAbility;
+        this.selectedPromptCards = properties.selectedPromptCards || [];
         // const zone = this.player && this.player.playableZones.find(zone => zone.contains(this.source));
 
         this.playType = this.ability?.isPlayCardAbility()
@@ -105,7 +108,8 @@ export class AbilityContext<TSource extends Card = Card> {
             events: this.events,
             stage: this.stage,
             targetAbility: this.targetAbility,
-            playType: this.playType
+            playType: this.playType,
+            selectedPromptCards: this.selectedPromptCards,
         };
     }
 }

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -98,8 +98,9 @@ export interface IDisplayCardsBasicPromptProperties extends IDisplayCardPromptPr
 }
 
 export interface IDisplayCardsWithButtonsPromptProperties extends IDisplayCardPromptPropertiesBase {
-    onCardButton: (card: Card, arg: string) => boolean;
+    onCardButton: (card: Card, arg: string) => void;
     perCardButtons: IButton[];
+    onComplete?: () => void;
 }
 
 export interface ISelectableCard {

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -109,7 +109,7 @@ export interface ISelectableCard {
 
 export interface IDisplayCardsSelectProperties extends IDisplayCardPromptPropertiesBase {
     selectedCardsHandler: (cards: Card[]) => void;
-    validCardCondition: (card: Card) => boolean;
+    validCardCondition?: (card: Card) => boolean;
     canChooseNothing?: boolean;
     maxCards?: number;
     multiSelectCondition?: (card: Card, currentlySelectedCards: Card[]) => boolean;

--- a/server/game/core/gameSteps/prompts/DisplayCardsForSelectionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsForSelectionPrompt.ts
@@ -26,10 +26,12 @@ export class DisplayCardsForSelectionPrompt extends DisplayCardPrompt<IDisplayCa
         this.selectedCardsHandler = properties.selectedCardsHandler;
         this.multiSelectCardCondition = properties.multiSelectCondition || (() => true);
 
+        const validCardCondition = properties.validCardCondition || (() => true);
+
         this.displayCards = properties.displayCards.map((card) => ({
             card,
             // if a card doesn't meet the multi-select condition even when nothing else is selected, we can safely consider it invalid
-            selectionState: properties.validCardCondition(card) && this.multiSelectCardCondition(card, [])
+            selectionState: validCardCondition(card) && this.multiSelectCardCondition(card, [])
                 ? DisplayCardSelectionState.Selectable
                 : DisplayCardSelectionState.Invalid,
         }));

--- a/server/game/core/gameSteps/prompts/DisplayCardsWithButtonsPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DisplayCardsWithButtonsPrompt.ts
@@ -7,7 +7,8 @@ import { DisplayCardSelectionState, type IButton, type IDisplayCardsWithButtonsP
 import { DisplayCardPrompt } from './DisplayCardPrompt';
 
 export class DisplayCardsWithButtonsPrompt extends DisplayCardPrompt<IDisplayCardsWithButtonsPromptProperties> {
-    private readonly onCardButton: (card: Card, arg: string) => boolean;
+    private readonly onCardButton: (card: Card, arg: string) => void;
+    private readonly onComplete: () => void;
     private readonly perCardButtons: Omit<IButton, 'command'>[];
 
     private displayCards: Card[];
@@ -26,6 +27,7 @@ export class DisplayCardsWithButtonsPrompt extends DisplayCardPrompt<IDisplayCar
         }
 
         this.perCardButtons = properties.perCardButtons;
+        this.onComplete = properties.onComplete || (() => undefined);
     }
 
     protected override defaultProperties() {
@@ -66,6 +68,11 @@ export class DisplayCardsWithButtonsPrompt extends DisplayCardPrompt<IDisplayCar
         }
 
         return false;
+    }
+
+    public override complete() {
+        super.complete();
+        this.onComplete();
     }
 
     public override menuCommand(_player: Player, arg: string, _uuid: string): boolean {

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -116,6 +116,7 @@ import type { ICreateXWingProperties } from './CreateXWingSystem';
 import { CreateXWingSystem } from './CreateXWingSystem';
 import type { ICreateTieFighterProperties } from './CreateTieFighterSystem';
 import { CreateTieFighterSystem } from './CreateTieFighterSystem';
+import type { IViewCardWithPerCardButtonsProperties } from './ViewCardSystem';
 import { ViewCardInteractMode } from './ViewCardSystem';
 
 
@@ -243,7 +244,14 @@ export function lookAt<TContext extends AbilityContext = AbilityContext>(propert
         )
     );
 }
-
+export function lookAtAndChooseOption<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IViewCardWithPerCardButtonsProperties, 'interactMode'>, TContext>) {
+    return new LookAtSystem<TContext>(
+        GameSystem.appendToPropertiesOrPropertyFactory<IViewCardWithPerCardButtonsProperties, 'interactMode'>(
+            propertyFactory,
+            { interactMode: ViewCardInteractMode.PerCardButtons }
+        )
+    );
+}
 export function lookMoveDeckCardsTopOrBottom<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ILookMoveDeckCardsTopOrBottomProperties, TContext>) {
     return new LookMoveDeckCardsTopOrBottomSystem<TContext>(propertyFactory);
 }

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -116,6 +116,7 @@ import type { ICreateXWingProperties } from './CreateXWingSystem';
 import { CreateXWingSystem } from './CreateXWingSystem';
 import type { ICreateTieFighterProperties } from './CreateTieFighterSystem';
 import { CreateTieFighterSystem } from './CreateTieFighterSystem';
+import { ViewCardInteractMode } from './ViewCardSystem';
 
 
 type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
@@ -234,8 +235,13 @@ export function giveShield<TContext extends AbilityContext = AbilityContext>(pro
 export function heal<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IHealProperties, TContext>) {
     return new HealSystem<TContext>(propertyFactory);
 }
-export function lookAt<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ILookAtProperties, TContext> = {}) {
-    return new LookAtSystem<TContext>(propertyFactory);
+export function lookAt<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<ILookAtProperties, 'interactMode'>, TContext> = {}) {
+    return new LookAtSystem<TContext>(
+        GameSystem.appendToPropertiesOrPropertyFactory<ILookAtProperties, 'interactMode'>(
+            propertyFactory,
+            { interactMode: ViewCardInteractMode.ViewOnly }
+        )
+    );
 }
 
 export function lookMoveDeckCardsTopOrBottom<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ILookMoveDeckCardsTopOrBottomProperties, TContext>) {
@@ -362,8 +368,13 @@ export function returnToHand<TContext extends AbilityContext = AbilityContext>(p
 /**
  * default chatMessage = false
  */
-export function reveal<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IRevealProperties, TContext> = {}) {
-    return new RevealSystem<TContext>(propertyFactory);
+export function reveal<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IRevealProperties, 'interactMode'>, TContext> = {}) {
+    return new RevealSystem<TContext>(
+        GameSystem.appendToPropertiesOrPropertyFactory<IRevealProperties, 'interactMode'>(
+            propertyFactory,
+            { interactMode: ViewCardInteractMode.ViewOnly }
+        )
+    );
 }
 // export function sacrifice(propertyFactory: PropsFactory<DiscardFromPlayProperties> = {}) {
 //     return new DiscardFromPlayAction(propertyFactory, true);

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -116,7 +116,7 @@ import type { ICreateXWingProperties } from './CreateXWingSystem';
 import { CreateXWingSystem } from './CreateXWingSystem';
 import type { ICreateTieFighterProperties } from './CreateTieFighterSystem';
 import { CreateTieFighterSystem } from './CreateTieFighterSystem';
-import type { IViewCardWithPerCardButtonsProperties } from './ViewCardSystem';
+import type { IViewCardAndSelectSingleProperties, IViewCardWithPerCardButtonsProperties } from './ViewCardSystem';
 import { ViewCardInteractMode } from './ViewCardSystem';
 
 
@@ -249,6 +249,14 @@ export function lookAtAndChooseOption<TContext extends AbilityContext = AbilityC
         GameSystem.appendToPropertiesOrPropertyFactory<IViewCardWithPerCardButtonsProperties, 'interactMode'>(
             propertyFactory,
             { interactMode: ViewCardInteractMode.PerCardButtons }
+        )
+    );
+}
+export function lookAtAndSelectCard<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IViewCardAndSelectSingleProperties, 'interactMode'>, TContext>) {
+    return new LookAtSystem<TContext>(
+        GameSystem.appendToPropertiesOrPropertyFactory<IViewCardAndSelectSingleProperties, 'interactMode'>(
+            propertyFactory,
+            { interactMode: ViewCardInteractMode.SelectSingle }
         )
     );
 }

--- a/server/game/gameSystems/LookAtSystem.ts
+++ b/server/game/gameSystems/LookAtSystem.ts
@@ -2,10 +2,10 @@ import type { AbilityContext } from '../core/ability/AbilityContext';
 import { EventName } from '../core/Constants';
 import type Player from '../core/Player';
 import type { IViewCardProperties } from './ViewCardSystem';
-import { ViewCardSystem } from './ViewCardSystem';
+import { ViewCardInteractMode, ViewCardSystem } from './ViewCardSystem';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ILookAtProperties extends IViewCardProperties {}
+
+export type ILookAtProperties = IViewCardProperties;
 
 export class LookAtSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext, ILookAtProperties> {
     public override readonly name = 'lookAt';
@@ -13,7 +13,9 @@ export class LookAtSystem<TContext extends AbilityContext = AbilityContext> exte
     public override readonly effectDescription = 'look at a card';
 
     protected override defaultProperties: IViewCardProperties = {
+        interactMode: ViewCardInteractMode.ViewOnly,
         message: '{0} sees {1}',
+        useDisplayPrompt: false
     };
 
     public override getMessageArgs(event: any, context: TContext, additionalProperties: any): any[] {

--- a/server/game/gameSystems/LookAtSystem.ts
+++ b/server/game/gameSystems/LookAtSystem.ts
@@ -15,7 +15,7 @@ export class LookAtSystem<TContext extends AbilityContext = AbilityContext> exte
     protected override defaultProperties: IViewCardProperties = {
         interactMode: ViewCardInteractMode.ViewOnly,
         message: '{0} sees {1}',
-        useDisplayPrompt: false
+        useDisplayPrompt: null
     };
 
     public override getMessageArgs(event: any, context: TContext, additionalProperties: any): any[] {
@@ -26,15 +26,11 @@ export class LookAtSystem<TContext extends AbilityContext = AbilityContext> exte
         return messageArgs;
     }
 
-    protected override getChatMessage(properties: IViewCardProperties): string {
-        return properties.useDisplayPrompt ? '{0} looks at a card' : '{0} sees {1}';
+    protected override getChatMessage(useDisplayPrompt: boolean): string {
+        return useDisplayPrompt ? '{0} looks at a card' : '{0} sees {1}';
     }
 
     protected override getPromptedPlayer(properties: ILookAtProperties, context: TContext): Player {
-        if (!properties.useDisplayPrompt) {
-            return null;
-        }
-
         return context.player;
     }
 

--- a/server/game/gameSystems/LookMoveDeckCardsTopOrBottomSystem.ts
+++ b/server/game/gameSystems/LookMoveDeckCardsTopOrBottomSystem.ts
@@ -9,6 +9,7 @@ import * as Contract from '../core/utils/Contract';
 import type { IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTargetSystem';
 import { PlayerTargetSystem } from '../core/gameSystem/PlayerTargetSystem';
 import type Player from '../core/Player';
+import { ViewCardInteractMode } from './ViewCardSystem';
 
 export interface ILookMoveDeckCardsTopOrBottomProperties extends IPlayerTargetSystemProperties {
     amount: number;
@@ -28,7 +29,9 @@ export class LookMoveDeckCardsTopOrBottomSystem<TContext extends AbilityContext 
 
         if (deckLength === 1) {
             const lookAtEvent = new LookAtSystem({
-                target: player.drawDeck[0]
+                target: player.drawDeck[0],
+                interactMode: ViewCardInteractMode.ViewOnly,
+                useDisplayPrompt: true
             }).generateEvent(context);
             events.push(lookAtEvent);
         } else {

--- a/server/game/gameSystems/RevealSystem.ts
+++ b/server/game/gameSystems/RevealSystem.ts
@@ -18,7 +18,7 @@ export class RevealSystem<TContext extends AbilityContext = AbilityContext> exte
     protected override readonly defaultProperties: IRevealProperties = {
         interactMode: ViewCardInteractMode.ViewOnly,
         promptedPlayer: RelativePlayer.Self,
-        useDisplayPrompt: false
+        useDisplayPrompt: null
     };
 
     public override checkEventCondition(event): boolean {
@@ -48,15 +48,11 @@ export class RevealSystem<TContext extends AbilityContext = AbilityContext> exte
         return messageArgs;
     }
 
-    protected override getChatMessage(properties: IViewCardProperties): string | null {
+    protected override getChatMessage(_useDisplayPrompt): string | null {
         return '{0} reveals {1} due to {2}';
     }
 
     protected override getPromptedPlayer(properties: IRevealProperties, context: TContext): Player {
-        if (!properties.useDisplayPrompt) {
-            return null;
-        }
-
         if (!properties.promptedPlayer) {
             return context.player;
         }

--- a/server/game/gameSystems/RevealSystem.ts
+++ b/server/game/gameSystems/RevealSystem.ts
@@ -4,11 +4,11 @@ import { RelativePlayer } from '../core/Constants';
 import { EventName, ZoneName } from '../core/Constants';
 import type Player from '../core/Player';
 import type { IViewCardProperties } from './ViewCardSystem';
-import { ViewCardSystem } from './ViewCardSystem';
+import { ViewCardInteractMode, ViewCardSystem } from './ViewCardSystem';
 
-export interface IRevealProperties extends IViewCardProperties {
+export type IRevealProperties = IViewCardProperties & {
     promptedPlayer?: RelativePlayer;
-}
+};
 
 export class RevealSystem<TContext extends AbilityContext = AbilityContext> extends ViewCardSystem<TContext, IRevealProperties> {
     public override readonly name = 'reveal';
@@ -16,7 +16,9 @@ export class RevealSystem<TContext extends AbilityContext = AbilityContext> exte
     public override readonly costDescription = 'revealing {0}';
 
     protected override readonly defaultProperties: IRevealProperties = {
-        promptedPlayer: RelativePlayer.Self
+        interactMode: ViewCardInteractMode.ViewOnly,
+        promptedPlayer: RelativePlayer.Self,
+        useDisplayPrompt: false
     };
 
     public override checkEventCondition(event): boolean {

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -199,7 +199,7 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
 
     private onSearchComplete(properties: ISearchDeckProperties, context: TContext, event: any, selectedCards: Card[], allCards: Card[]): void {
         event.selectedCards = selectedCards;
-        context.selects['deckSearch'] = Array.from(selectedCards);
+        context.selectedPromptCards = Array.from(selectedCards);
 
         const selectedCardsSet = new Set(selectedCards);
 
@@ -239,16 +239,16 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
         const gameSystem = this.generatePropertiesFromContext(event.context).selectedCardsImmediateEffect;
         if (gameSystem) {
             const selectedArray = Array.from(selectedCards);
-            event.context.targets = selectedArray;
 
             const deckZone = context.player.getZone(ZoneName.Deck) as DeckZone;
             deckZone.moveCardsToSearching(selectedArray, event);
 
+            const events = [];
             gameSystem.setDefaultTargetFn(() => selectedArray);
+            gameSystem.queueGenerateEventGameSteps(events, context);
+
             context.game.queueSimpleStep(() => {
-                if (gameSystem.hasLegalTarget(context)) {
-                    gameSystem.resolve(null, context);
-                }
+                context.game.openEventWindow(events);
             }, 'resolve effect on searched cards');
         }
     }

--- a/server/game/gameSystems/ViewCardSystem.ts
+++ b/server/game/gameSystems/ViewCardSystem.ts
@@ -4,9 +4,17 @@ import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetS
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type Player from '../core/Player';
 import * as Helpers from '../core/utils/Helpers';
+import type { IChoicesInterface } from '../TargetInterfaces';
 
-// TODO: Need some future work to fully implement Thrawn
-export interface IViewCardProperties extends ICardTargetSystemProperties {
+export enum ViewCardInteractMode {
+    ViewOnly = 'viewOnly',
+    SelectSingle = 'selectSingle',
+    PerCardButtons = 'perCardButtons'
+}
+
+interface IViewCardPropertiesBase extends ICardTargetSystemProperties {
+    interactMode: ViewCardInteractMode;
+
     message?: string | ((context) => string);
     messageArgs?: (cards: any) => any[];
 
@@ -20,8 +28,24 @@ export interface IViewCardProperties extends ICardTargetSystemProperties {
     displayTextByCardUuid?: Map<string, string>;
 }
 
+export interface IViewCardOnlyProperties extends IViewCardPropertiesBase {
+    interactMode: ViewCardInteractMode.ViewOnly;
+}
+
+export interface IViewCardAndSelectSingleProperties extends IViewCardPropertiesBase {
+    interactMode: ViewCardInteractMode.SelectSingle;
+}
+
+export interface IViewCardWithPerCardButtonsProperties extends IViewCardPropertiesBase {
+    interactMode: ViewCardInteractMode.PerCardButtons;
+    perCardButtons: IChoicesInterface;
+}
+
+export type IViewCardProperties = IViewCardOnlyProperties | IViewCardAndSelectSingleProperties | IViewCardWithPerCardButtonsProperties;
+
 export abstract class ViewCardSystem<TContext extends AbilityContext = AbilityContext, TProperties extends IViewCardProperties = IViewCardProperties> extends CardTargetSystem<TContext, TProperties> {
     protected override defaultProperties: IViewCardProperties = {
+        interactMode: ViewCardInteractMode.ViewOnly,
         useDisplayPrompt: false
     };
 

--- a/test/server/cards/01_SOR/units/InfernoFourUnforgetting.spec.ts
+++ b/test/server/cards/01_SOR/units/InfernoFourUnforgetting.spec.ts
@@ -73,10 +73,8 @@ describe('Inferno Four - Unforgetting', function() {
             it('while playing should only show card and put it back on top of deck since the deck size is 1', function () {
                 const { context } = contextRef;
                 context.player1.clickCard(context.infernoFour);
-                expect(context.getChatLogs(1)).toContain('Inferno Four sees Foundling');
-                expect(context.player2).toBeActivePlayer();
-                expect(context.p1Base.damage).toEqual(0);
-                expect(context.p2Base.damage).toEqual(0);
+                expect(context.player1).toHaveExactViewableDisplayPromptCards([context.foundling]);
+                context.player1.clickPrompt('Done');
             });
         });
     });

--- a/test/server/cards/01_SOR/units/ReinforcementWalker.spec.ts
+++ b/test/server/cards/01_SOR/units/ReinforcementWalker.spec.ts
@@ -18,35 +18,24 @@ describe('Reinforcement Walker', function() {
                 // Case 1: The player is able to look at the top card of their deck when Reinforcement Walker is played
                 context.player1.clickCard(context.reinforcementWalker);
 
-                expect(context.getChatLogs(1)[0]).toEqual('Reinforcement Walker sees Alliance X-Wing');
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.allianceXwing]);
+                expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.allianceXwing.title);  // confirm that there is no chat message for the cards
 
-                // Case 2: The player can choose to either draw or discard the card
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Draw',
-                    'Discard',
-                ]);
-
-                // Case 3: The user is able to draw the card when they click 'Draw'
-                context.player1.clickPrompt('Draw');
-
+                context.player1.clickDisplayCardPromptButton(context.allianceXwing.uuid, 'draw');
                 expect(context.allianceXwing).toBeInZone('hand');
                 expect(context.player2).toBeActivePlayer();
 
                 context.moveToNextActionPhase();
 
-                // Case 4: The player is able to look at the top card of their deck when Reinforcement Walker attacks
+                // Case 2: The player is able to look at the top card of their deck when Reinforcement Walker attacks
                 context.player1.clickCard(context.reinforcementWalker);
 
-                expect(context.getChatLogs(1)[0]).toEqual('Reinforcement Walker sees Battlefield Marine');
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine]);
+                expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);  // confirm that there is no chat message for the cards
 
-                // Case 5: The player can choose to either draw or discard the card
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Draw',
-                    'Discard',
-                ]);
-
-                // Case 6: The user is able to draw the card when they click 'Draw'
-                context.player1.clickPrompt('Draw');
+                context.player1.clickDisplayCardPromptButton(context.battlefieldMarine.uuid, 'draw');
                 expect(context.battlefieldMarine).toBeInZone('hand');
                 expect(context.player2).toBeActivePlayer();
             });
@@ -70,8 +59,11 @@ describe('Reinforcement Walker', function() {
                     /* Case 1: The user is able to discard the card and heal 3 damage from their base when they play
                     Reinforcement Walker and click 'Discard' */
                     context.player1.clickCard(context.reinforcementWalker);
-                    context.player1.clickPrompt('Discard');
+                    expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.allianceXwing]);
+                    expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);
+                    expect(context.getChatLogs(1)[0]).not.toContain(context.allianceXwing.title);  // confirm that there is no chat message for the cards
 
+                    context.player1.clickDisplayCardPromptButton(context.allianceXwing.uuid, 'discard');
                     expect(context.allianceXwing).toBeInZone('discard');
                     expect(context.p1Base.damage).toEqual(7);
                     expect(context.player2).toBeActivePlayer();
@@ -81,12 +73,11 @@ describe('Reinforcement Walker', function() {
                     /* Case 2: The user is able to discard the card and heal 3 damage from their base when they attack
                     with Reinforcement Walker and click 'Discard' */
                     context.player1.clickCard(context.reinforcementWalker);
-                    expect(context.player1).toHaveExactPromptButtons([
-                        'Draw',
-                        'Discard',
-                    ]);
+                    expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine]);
+                    expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);
+                    expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);  // confirm that there is no chat message for the cards
 
-                    context.player1.clickPrompt('Discard');
+                    context.player1.clickDisplayCardPromptButton(context.battlefieldMarine.uuid, 'discard');
                     expect(context.battlefieldMarine).toBeInZone('discard');
                     expect(context.p1Base.damage).toEqual(4);
                     expect(context.player2).toBeActivePlayer();
@@ -137,7 +128,7 @@ describe('Reinforcement Walker', function() {
 
                 const { context } = contextRef;
 
-                // Case 1: The player can choose to resolve the ability or Ambush first.
+                // The player can choose to resolve the ability or Ambush first.
                 context.player1.clickCard(context.reinforcementWalker);
 
                 expect(context.player1).toHaveExactPromptButtons([
@@ -145,20 +136,17 @@ describe('Reinforcement Walker', function() {
                     'Look at the top card of your deck. Draw it or discard it and heal 3 damage from your base.',
                 ]);
 
-                // Case 2: The ability from on played resolves successfully.
+                // The ability from on played resolves successfully.
                 context.player1.clickPrompt('Look at the top card of your deck. Draw it or discard it and heal 3 damage from your base.');
 
-                expect(context.getChatLogs(1)[0]).toEqual('Reinforcement Walker sees Alliance X-Wing');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Draw',
-                    'Discard',
-                ]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.allianceXwing]);
+                expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.allianceXwing.title);  // confirm that there is no chat message for the cards
 
-                context.player1.clickPrompt('Draw');
-
+                context.player1.clickDisplayCardPromptButton(context.allianceXwing.uuid, 'draw');
                 expect(context.allianceXwing).toBeInZone('hand');
 
-                // Case 3: The on attack ability from Ambush resolved successfully.
+                // The on attack ability from Ambush resolved successfully.
                 expect(context.player1).toHaveExactPromptButtons([
                     'Ambush',
                     'Pass',
@@ -166,14 +154,11 @@ describe('Reinforcement Walker', function() {
 
                 context.player1.clickPrompt('Ambush');
 
-                expect(context.getChatLogs(1)[0]).toEqual('Reinforcement Walker sees Echo Base Defender');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Draw',
-                    'Discard',
-                ]);
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.echoBaseDefender]);
+                expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.echoBaseDefender.title);  // confirm that there is no chat message for the cards
 
-                context.player1.clickPrompt('Draw');
-
+                context.player1.clickDisplayCardPromptButton(context.echoBaseDefender.uuid, 'draw');
                 expect(context.echoBaseDefender).toBeInZone('hand');
                 expect(context.player2).toBeActivePlayer();
             });

--- a/test/server/cards/01_SOR/units/SparkOfRebellion.spec.ts
+++ b/test/server/cards/01_SOR/units/SparkOfRebellion.spec.ts
@@ -16,13 +16,15 @@ describe('Spark Of Rebellion', function () {
 
                 context.player1.clickCard(context.sparkOfRebellion);
 
-                // First check that the lookAt sends ALL the oppoents cards in hand to chat
-                expect(context.getChatLogs(1)).toContain('Spark of Rebellion sees Battlefield Marine, Waylay, Protector, and Inferno Four');
+                // First check that the lookAt sends ALL the opponents cards in hand to chat
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine, context.waylay, context.protector, context.infernoFour]);
+                expect(context.player1).not.toHaveEnabledPromptButton('Done');
+                expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.protector.title);
+                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
 
-                // Now the player can select any card in the opponents hand
-                expect(context.player1).toBeAbleToSelectAllOf([context.battlefieldMarine, context.waylay, context.protector, context.infernoFourUnforgetting]);
-
-                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
                 expect(context.battlefieldMarine).toBeInZone('discard');
 
                 context.player2.passAction();
@@ -33,10 +35,12 @@ describe('Spark Of Rebellion', function () {
                 // Now test only one card to discard
                 context.player1.clickCard(context.sparkOfRebellion);
 
-                expect(context.getChatLogs(1)).toContain('Spark of Rebellion sees Inferno Four');
-                expect(context.player1).toBeAbleToSelectAllOf([context.infernoFourUnforgetting]);
-                context.player1.clickCard(context.infernoFourUnforgetting);
-                expect(context.infernoFourUnforgetting).toBeInZone('discard');
+                expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.infernoFour]);
+                expect(context.player1).not.toHaveEnabledPromptButton('Done');
+                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
+
+                context.player1.clickCardInDisplayCardPrompt(context.infernoFour);
+                expect(context.infernoFour).toBeInZone('discard');
 
                 context.player2.passAction();
 
@@ -45,8 +49,7 @@ describe('Spark Of Rebellion', function () {
 
                 // No choice here so no prompt
                 context.player1.clickCard(context.sparkOfRebellion);
-                // Nothing for lookAt to reveal either -- you get this default message
-                expect(context.getChatLogs(1)).toContain('player1 plays Spark of Rebellion to look at a card');
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/cards/02_SHD/events/BountyPosting.spec.ts
+++ b/test/server/cards/02_SHD/events/BountyPosting.spec.ts
@@ -27,7 +27,7 @@ describe('Bounty Posting', function() {
 
                 context.player1.clickCardInDisplayCardPrompt(context.topTarget);
                 expect(context.topTarget).toBeInZone('hand', context.player1);
-                expect(context.player1).toHavePassAbilityPrompt('Play that upgrade (paying its cost).');
+                expect(context.player1).toHavePassAbilityPrompt('Play that upgrade (paying its cost)');
 
                 expect(context.getChatLogs(4)).toEqual([
                     'player1 plays Bounty Posting to search their deck',
@@ -36,7 +36,7 @@ describe('Bounty Posting', function() {
                     'player1 is shuffling their deck'
                 ]);
 
-                context.player1.clickPrompt('Play that upgrade (paying its cost).');
+                context.player1.clickPrompt('Play that upgrade (paying its cost)');
                 context.player1.clickCard(context.cloneTrooper);
                 expect(context.cloneTrooper).toHaveExactUpgradeNames(['top-target']);
                 expect(preShuffleDeck).not.toEqual(context.player1.deck);

--- a/test/server/cards/02_SHD/units/KylosTieSilencerRuthlesslyEfficient.spec.ts
+++ b/test/server/cards/02_SHD/units/KylosTieSilencerRuthlesslyEfficient.spec.ts
@@ -50,7 +50,7 @@ describe('Kylo\'s TIE Silencer, Ruthless Efficient', function () {
 
             // Player 2 discards Kylo's TIE Silencer from hand using Spark of Rebellion
             context.player2.clickCard(context.sparkOfRebellion);
-            context.player2.clickCard(context.kylosTieSilencer);
+            context.player2.clickCardInDisplayCardPrompt(context.kylosTieSilencer);
             expect(context.kylosTieSilencer).toBeInZone('discard', context.player1);
 
             // Player 1 plays Kylo's TIE Silencer from the discard


### PR DESCRIPTION
Now that we have a framework for how the DisplayCardPrompt stuff will work, expanded the underlying system for lookAt / reveal to be able to handle effects of the form "look at [cards] and do [X]." Since in those cases we want to tie together the view and the action into one prompt, we need to be able to declare this using the appropriate systems.

Ported Reinforcement Walker and Spark of Rebellion onto the new framework as a pilot, will do other cards progressively.