### PR TITLE
Better guard for token generators

### DIFF
--- a/server/game/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.ts
+++ b/server/game/cards/01_SOR/units/LieutenantChildsenDeathStarPrisonWarden.ts
@@ -3,8 +3,6 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Aspect, RelativePlayer, ZoneName, TargetMode } from '../../../core/Constants';
 
 export default class LieutenantChildsenDeathStarPrisonWarden extends NonLeaderUnitCard {
-    protected override readonly overrideNotImplemented: boolean = true;
-
     protected override getImplementationId() {
         return {
             id: '2855740390',

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1269,6 +1269,8 @@ class Game extends EventEmitter {
         for (const [tokenName, cardData] of Object.entries(tokenCardsData)) {
             const tokenConstructor = cards.get(cardData.id);
 
+            Contract.assertNotNullLike(tokenConstructor, `Token card data for ${tokenName} contained unknown id '${cardData.id}'`);
+
             this.tokenFactories[tokenName] = (player) => new tokenConstructor(player, cardData);
         }
     }


### PR DESCRIPTION
Added an exception guard for token generators to let us know if invalid token data is provided. Also removed the unnecessary unimplemented override on Childsen.