### PR TITLE
make card data url web safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./node_modules ./node_modules
 ENV GAME_NODE_HOST="localhost"
 ENV GAME_NODE_NAME="test1"
 ENV GAME_NODE_SOCKET_IO_PORT="9500"
-ENV ENVIRONMENT="development"
+ENV ENVIRONMENT="production"
 ENV SECRET="verysecret"
 
 EXPOSE 9500

--- a/server/utils/cardData/RemoteCardDataGetter.ts
+++ b/server/utils/cardData/RemoteCardDataGetter.ts
@@ -24,7 +24,8 @@ export class RemoteCardDataGetter extends CardDataGetter {
     }
 
     protected static getRelativePathFromInternalName(internalName: string) {
-        return `cards/${internalName}.json`;
+        const webSafeInternalName = internalName.replace('#', '%23');
+        return `cards/${webSafeInternalName}.json`;
     }
 
     protected static async fetchFileAsync(remoteDataUrl: string, relativePath: string): Promise<Response> {


### PR DESCRIPTION
replace '#' with '%23' in remote card getter url
Set deocker image environment env to production