### PR TITLE
Handle route errors and ws async errors

### DIFF
--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -1,3 +1,4 @@
+
 import assert from 'assert';
 
 export enum AssertMode {
@@ -18,7 +19,11 @@ class AssertContractCheckImpl implements IContractCheckImpl {
             debugger;
         }
 
-        assert.fail(`Contract assertion failure: ${message}`);
+        if (process.env.ENVIRONMENT === 'development') {
+            assert.fail(`Contract assertion failure: ${message}`);
+        } else {
+            throw new Error(`Contract assertion failure: ${message}`);
+        }
     }
 }
 

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -110,6 +110,14 @@ export class GameServer {
 
         this.setupAppRoutes(app);
 
+        app.use((err, req, res, next) => {
+            logger.error('Error in API route:', err);
+            res.status(err.status || 500).json({
+                success: false,
+                error: err.message || 'Server error.',
+            });
+        });
+
         server.listen(env.gameNodeSocketIoPort);
         logger.info(`Game server listening on port ${env.gameNodeSocketIoPort}`);
 
@@ -138,15 +146,14 @@ export class GameServer {
     }
 
     private setupAppRoutes(app: express.Application) {
-        app.post('/api/create-lobby', async (req, res) => {
+        app.post('/api/create-lobby', async (req, res, next) => {
             try {
                 await this.processDeckValidation(req.body.deck, SwuGameFormat.Premier, res, async () => {
                     await this.createLobby(req.body.user, req.body.deck, req.body.isPrivate);
                     res.status(200).json({ success: true });
                 });
             } catch (err) {
-                console.error(err);
-                res.status(500).json({ success: false, error: 'Server error.' });
+                next(err);
             }
         });
 
@@ -179,13 +186,17 @@ export class GameServer {
             return res.json(testSetupFilenames);
         });
 
-        app.post('/api/start-test-game', async (req, res) => {
+        app.post('/api/start-test-game', async (req, res, next) => {
             const { filename } = req.body;
-            await this.startTestGame(filename);
-            return res.status(200).json({ success: true });
+            try {
+                await this.startTestGame(filename);
+                return res.status(200).json({ success: true });
+            } catch (err) {
+                next(err);
+            }
         });
 
-        app.post('/api/enter-queue', async (req, res) => {
+        app.post('/api/enter-queue', async (req, res, next) => {
             try {
                 await this.processDeckValidation(req.body.deck, SwuGameFormat.Premier, res, () => {
                     const { user, deck } = req.body;
@@ -196,8 +207,7 @@ export class GameServer {
                     res.status(200).json({ success: true });
                 });
             } catch (err) {
-                console.error(err);
-                res.status(500).json({ success: false, error: 'Server error.' });
+                next(err);
             }
         });
 

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -371,24 +371,14 @@ export class Lobby {
             return;
         }
 
-        await this.runAndCatchErrors(this.game, () => {
-            this.game.stopNonChessClocks();
-            this.game[command](socket.user.id, ...args);
+        this.game.stopNonChessClocks();
+        await this.game[command](socket.user.id, ...args);
 
-            this.game.continue();
+        this.game.continue();
 
-            this.sendGameState(this.game);
-        });
+        this.sendGameState(this.game);
     }
 
-    private async runAndCatchErrors(game: Game, func: () => Promise<void> | void) {
-        try {
-            await func();
-        } catch (e) {
-            this.handleError(game, e);
-            this.sendGameState(game);
-        }
-    }
 
     // TODO: Review this to make sure we're getting the info we need for debugging
     public handleError(game: Game, e: Error) {

--- a/server/socket.js
+++ b/server/socket.js
@@ -28,7 +28,9 @@ class Socket extends EventEmitter {
     }
 
     registerEvent(event, callback) {
-        this.socket.on(event, this.onSocketEvent.bind(this, callback));
+        this.socket.on(event, async (...args) => {
+            await this.onSocketEvent(callback, ...args);
+        });
     }
 
     eventContainsListener(event) {
@@ -52,20 +54,15 @@ class Socket extends EventEmitter {
     }
 
     // Events
-    onSocketEvent(callback, ...args) {
+    async onSocketEvent(callback, ...args) {
         if (!this.user) {
             return;
         }
 
-        const handleError = (err) => logger.info('WebSocket Error:', err);
-
         try {
-            const result = callback(this, ...args);
-            if (result instanceof Promise) {
-                result.catch(handleError);
-            }
+            await callback(this, ...args);
         } catch (err) {
-            handleError(err);
+            logger.info('WebSocket Error:', err);
         }
     }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -57,10 +57,15 @@ class Socket extends EventEmitter {
             return;
         }
 
+        const handleError = (err) => logger.info('WebSocket Error:', err);
+
         try {
-            callback(this, ...args);
+            const result = callback(this, ...args);
+            if (result instanceof Promise) {
+                result.catch(handleError);
+            }
         } catch (err) {
-            logger.info(err);
+            handleError(err);
         }
     }
 


### PR DESCRIPTION
- Adds a simple error handler middleware to api routes
- Adds async error handling for websocket messages
- Switches Contracts failure mode to Throw errors instead of AssertionErrors in production. We can change this to always be thrown errors if we want but I thought it might be useful to maintain the severity of errors when working in local.