### PR TITLE
Correct handling of "active player" in regroup phase

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -22,7 +22,7 @@ const { AbilityContext } = require('./ability/AbilityContext.js');
 const Contract = require('./utils/Contract.js');
 const { cards } = require('../cards/Index.js');
 
-const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName, TokenUnitName } = require('./Constants.js');
+const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName, TokenUnitName, PhaseName } = require('./Constants.js');
 const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
 const { DistributeAmongTargetsPrompt } = require('./gameSteps/prompts/DistributeAmongTargetsPrompt.js');
 const HandlerMenuMultipleSelectionPrompt = require('./gameSteps/prompts/HandlerMenuMultipleSelectionPrompt.js');
@@ -243,6 +243,10 @@ class Game extends EventEmitter {
         return this.getPlayers().sort((a) => (a.hasInitiative() ? -1 : 1));
     }
 
+    getActivePlayer() {
+        return this.currentPhase === PhaseName.Action ? this.actionPhaseActivePlayer : this.initiativePlayer;
+    }
+
     /**
      * Get all players and spectators in the game
      * @returns {{[key: string]: Player | Spectator}} {name1: Player, name2: Player, name3: Spectator}
@@ -281,6 +285,7 @@ class Game extends EventEmitter {
      * Checks who the next legal active player for the action phase should be and updates @member {activePlayer}. If none available, sets it to null.
      */
     rotateActivePlayer() {
+        Contract.assertTrue(this.currentPhase === PhaseName.Action, `rotateActivePlayer can only be called during the action phase, instead called during ${this.currentPhase}`);
         if (!this.actionPhaseActivePlayer.opponent.passedActionPhase) {
             this.createEventAndOpenWindow(
                 EventName.OnPassActionPhasePriority,

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -453,7 +453,7 @@ class Player extends GameObject {
     }
 
     isActivePlayer() {
-        return this.game.actionPhaseActivePlayer === this;
+        return this.game.getActivePlayer() === this;
     }
 
     hasInitiative() {

--- a/server/game/core/gameSteps/ActionWindow.js
+++ b/server/game/core/gameSteps/ActionWindow.js
@@ -11,9 +11,11 @@ class ActionWindow extends UiPrompt {
 
         this.title = title;
         this.windowName = windowName;
-        this.activePlayer = activePlayer ?? this.game.actionPhaseActivePlayer;
         this.activePlayerConsecutiveActions = 0;
         this.opportunityCounter = 0;
+
+        this.activePlayer = activePlayer ?? this.game.actionPhaseActivePlayer;
+        Contract.assertNotNullLike(this.activePlayer);
 
         // whether the previous player passed their action
         this.prevPlayerPassed = prevPlayerPassed;

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -226,17 +226,18 @@ export abstract class TriggerWindowBase extends BaseStep {
     }
 
     private promptForResolvePlayerOrder() {
-        this.game.promptWithHandlerMenu(this.game.actionPhaseActivePlayer, {
+        const activePlayer = this.game.getActivePlayer();
+        this.game.promptWithHandlerMenu(activePlayer, {
             activePromptTitle: 'Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:',
             waitingPromptTitle: 'Waiting for opponent to choose a player to resolve their triggers first',
             choices: ['You', 'Opponent'],
             handlers: [
                 () => {
-                    this.resolvePlayerOrder = [this.game.actionPhaseActivePlayer, this.game.actionPhaseActivePlayer.opponent];
+                    this.resolvePlayerOrder = [activePlayer, activePlayer.opponent];
                     this.promptUnresolvedAbilities();
                 },
                 () => {
-                    this.resolvePlayerOrder = [this.game.actionPhaseActivePlayer.opponent, this.game.actionPhaseActivePlayer];
+                    this.resolvePlayerOrder = [activePlayer.opponent, activePlayer];
                     this.promptUnresolvedAbilities();
                 }
             ]

--- a/test/helpers/CustomMatchers.js
+++ b/test/helpers/CustomMatchers.js
@@ -477,7 +477,7 @@ var customMatchers = {
                 let result = {};
 
                 // use player.player here because the received parameter is a PlayerInteractionWrapper
-                result.pass = player.game.actionPhaseActivePlayer === player.player;
+                result.pass = player.game.getActivePlayer() === player.player;
 
                 if (result.pass) {
                     result.message = `Expected ${player.name} not to be the active player but they were.`;

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -414,6 +414,10 @@ class PlayerInteractionWrapper {
         return this.game.actionPhaseActivePlayer;
     }
 
+    get activePlayer() {
+        return this.game.getActivePlayer();
+    }
+
     get opponent() {
         return this.player.opponent;
     }


### PR DESCRIPTION
SWU rules state that outside of the action phase, the "active player" is whoever has initiative. We were not doing this correctly and causing errors if multiple abilities triggered in the same window in the regroup phase.

Addresses https://github.com/SWU-Karabast/forceteki/issues/662