### PR TITLE
Fix bug with bounties on leaders

### DIFF
--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -92,7 +92,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             });
 
             // register listeners for on-defeat keyword abilities
-            game.on(EventName.OnCardDefeated, (event) => {
+            game.on(EventName.OnCardDefeated + ':preResolve', (event) => {
                 const card = event.card as Card;
                 if (card.zoneName !== ZoneName.Resource && card.isUnit()) {
                     card.checkRegisterWhenDefeatedKeywordAbilities(event);

--- a/server/game/core/event/EventWindow.ts
+++ b/server/game/core/event/EventWindow.ts
@@ -191,6 +191,7 @@ export class EventWindow extends BaseStepWithPipeline {
             // need to checkCondition here to ensure the event won't fizzle due to another event's resolution
             event.checkCondition();
             if (event.canResolve) {
+                this.game.emit(event.name + ':preResolve', event);
                 event.executeHandler();
                 this.game.emit(event.name, event);
 

--- a/test/server/core/abilities/keyword/Bounty.spec.ts
+++ b/test/server/core/abilities/keyword/Bounty.spec.ts
@@ -366,6 +366,8 @@ describe('Bounty', function() {
 
             context.player1.clickCard(context.rivalsFall);
             context.player1.clickCard(context.asajjVentress);
+            expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw 2 cards');
+            context.player1.clickPrompt('Collect Bounty: Draw 2 cards');
             expect(context.player1.handSize).toBe(2);
         });
     });

--- a/test/server/core/abilities/keyword/Bounty.spec.ts
+++ b/test/server/core/abilities/keyword/Bounty.spec.ts
@@ -346,5 +346,27 @@ describe('Bounty', function() {
                 expect(context.jangoFett.exhausted).toBe(true);
             });
         });
+
+        it('When a leader with a Bounty ability gained from an effect is defeated, the ability should resolve under the opponent\'s control', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['rivals-fall']
+                },
+                player2: {
+                    leader: {
+                        card: 'asajj-ventress#unparalleled-adversary',
+                        deployed: true,
+                        upgrades: ['death-mark']
+                    }
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.rivalsFall);
+            context.player1.clickCard(context.asajjVentress);
+            expect(context.player1.handSize).toBe(2);
+        });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/SWU-Karabast/forceteki/issues/607

Bounties gained by leaders were not resolving because it was checking if the card was a unit first, and the leader had already moved to the base zone. Added a pre-event emit to be used for this case.