### PR TITLE
Add "not implemented" warning support for piloting cards

### DIFF
--- a/server/utils/cardData/CardDataInterfaces.ts
+++ b/server/utils/cardData/CardDataInterfaces.ts
@@ -21,6 +21,7 @@ export interface ICardDataJson {
     hp?: number;
     power?: number;
     text?: string;
+    pilotText?: string;
     deployBox?: string;
     epicAction?: string;
     unique: boolean;

--- a/server/utils/deck/DeckValidator.ts
+++ b/server/utils/deck/DeckValidator.ts
@@ -58,7 +58,7 @@ export class DeckValidator {
                 type: Card.buildTypeFromPrinted(cardData.types),
                 set: EnumHelpers.checkConvertToEnum(cardData.setId.set, SwuSet)[0],
                 banned: bannedCards.has(cardData.id),
-                implemented: !Card.checkHasNonKeywordAbilityText(cardData.text) || implementedCardIds.has(cardData.id)
+                implemented: !Card.checkHasNonKeywordAbilityText(cardData) || implementedCardIds.has(cardData.id)
             };
 
             this.cardData.set(cardData.id, cardCheckData);


### PR DESCRIPTION
The "not implemented" auto-check wasn't accounting for the new pilot text field. Added that and also automatically marks leaders as requiring implementation.