### PR TITLE
Better cancel button support

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -88,6 +88,9 @@ class Game extends EventEmitter {
         this.cardDataGetter = details.cardDataGetter;
         this.playableCardTitles = this.cardDataGetter.playableCardTitles;
 
+        /** @type {AbilityResolver | null} */
+        this.currentAbilityResolver = null;
+
         this.initialiseTokens(this.cardDataGetter.tokenData);
 
         /** @type {import('../Interfaces').IClientUIProperties} */

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -235,13 +235,14 @@ class PlayerOrCardAbility {
     /**
      * Prompts the current player to choose each target defined for the ability.
      */
-    resolveTargets(context, passHandler = null) {
+    resolveTargets(context, passHandler = null, canCancel = false) {
         let targetResults = {
             canIgnoreAllCosts:
                 context.stage === Stage.PreTarget ? this.getCosts(context).every((cost) => cost.canIgnoreForTargeting) : false,
             cancelled: false,
             payCostsFirst: false,
-            delayTargeting: null
+            delayTargeting: null,
+            canCancel
         };
         for (let target of this.targetResolvers) {
             context.game.queueSimpleStep(() => target.resolve(context, targetResults, passHandler), `Resolve target '${target.name}' for ${this}`);

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -151,6 +151,9 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
                 buttons.push({ text: 'Pay costs first', arg: 'costsFirst' });
             }
             buttons.push({ text: 'Cancel', arg: 'cancel' });*/
+            if (targetResults.canCancel) {
+                buttons.push({ text: 'Cancel', arg: 'cancel' });
+            }
             if (passPrompt) {
                 buttons.push({ text: passPrompt.buttonText, arg: passPrompt.arg });
                 passPrompt.hasBeenShown = true;

--- a/server/game/core/gameSteps/AbilityResolver.js
+++ b/server/game/core/gameSteps/AbilityResolver.js
@@ -33,6 +33,7 @@ class AbilityResolver extends BaseStepWithPipeline {
         } else {
             this.passButtonText = this.context.ability.isAttackAction() ? 'Pass attack' : 'Pass';
         }
+
         this.passAbilityHandler = (!!this.context.ability.optional || optional) ? {
             buttonText: this.passButtonText,
             arg: 'passAbility',
@@ -85,7 +86,7 @@ class AbilityResolver extends BaseStepWithPipeline {
             // if the opponent is the one choosing whether to pass or not, we don't include the pass handler in the target resolver
             const passAbilityHandler = this.passAbilityHandler?.playerChoosing === this.context.player ? this.passAbilityHandler : null;
 
-            this.targetResults = this.context.ability.resolveTargets(this.context, passAbilityHandler);
+            this.targetResults = this.context.ability.resolveTargets(this.context, passAbilityHandler, true);
         }
     }
 

--- a/server/game/core/gameSteps/AbilityResolver.js
+++ b/server/game/core/gameSteps/AbilityResolver.js
@@ -2,15 +2,12 @@ const { BaseStepWithPipeline } = require('./BaseStepWithPipeline.js');
 const { SimpleStep } = require('./SimpleStep.js');
 const { ZoneName, Stage, CardType, EventName, AbilityType, RelativePlayer } = require('../Constants.js');
 const { GameEvent } = require('../event/GameEvent.js');
-const Contract = require('../utils/Contract.js');
-const { EventWindow } = require('../event/EventWindow.js');
 
 class AbilityResolver extends BaseStepWithPipeline {
-    constructor(game, context, optional = false, canCancel = true) {
+    constructor(game, context, optional = false, canCancel = null) {
         super(game);
 
         this.context = context;
-        this.canCancel = canCancel;
         this.events = [];
         this.targetResults = {};
         this.costResults = this.getCostResults();
@@ -24,6 +21,18 @@ class AbilityResolver extends BaseStepWithPipeline {
          * Otherwise, repeat ability resolution (e.g. if the user clicked "cancel" halfway through)
          */
         this.resolutionComplete = false;
+
+        // if canCancel is not provided, we default to true if there is no previous ability resolver
+        // this prevents us from trying to cancel an "inner" ability while the outer one still resolves
+        // TODO: fix this flow so cancelling is more flexible
+        if (canCancel == null) {
+            this.canCancel = game.currentAbilityResolver == null;
+        } else {
+            this.canCancel = canCancel;
+        }
+
+        this.currentAbilityResolver = game.currentAbilityResolver;
+        game.currentAbilityResolver = this;
 
         // this is used when a triggered ability is marked optional to ensure that a "Pass" button
         // appears at the appropriate times during the prompt flow for that ability
@@ -55,6 +64,7 @@ class AbilityResolver extends BaseStepWithPipeline {
             new SimpleStep(this.game, () => this.resolveEarlyTargets(), 'resolveEarlyTargets'),
             new SimpleStep(this.game, () => this.checkForCancelOrPass(), 'checkForCancelOrPass'),
             new SimpleStep(this.game, () => this.openInitiateAbilityEventWindow(), 'openInitiateAbilityEventWindow'),
+            new SimpleStep(this.game, () => this.resetGameAbilityResolver(), 'resetGameAbilityResolver')
         ]);
     }
 
@@ -86,7 +96,7 @@ class AbilityResolver extends BaseStepWithPipeline {
             // if the opponent is the one choosing whether to pass or not, we don't include the pass handler in the target resolver
             const passAbilityHandler = this.passAbilityHandler?.playerChoosing === this.context.player ? this.passAbilityHandler : null;
 
-            this.targetResults = this.context.ability.resolveTargets(this.context, passAbilityHandler, true);
+            this.targetResults = this.context.ability.resolveTargets(this.context, passAbilityHandler, this.canCancel);
         }
     }
 
@@ -296,6 +306,10 @@ class AbilityResolver extends BaseStepWithPipeline {
         this.context.stage = Stage.Effect;
 
         this.context.ability.executeHandler(this.context);
+    }
+
+    resetGameAbilityResolver() {
+        this.game.currentAbilityResolver = this.currentAbilityResolver;
     }
 
     /** @override */

--- a/test/server/actions/UnitAttack.spec.ts
+++ b/test/server/actions/UnitAttack.spec.ts
@@ -23,6 +23,24 @@ describe('Basic attack', function() {
 
                 context.player1.clickCard(context.wampa);
                 expect(context.player1).toHavePrompt('Choose a target for attack');
+                expect(context.player1).toHaveEnabledPromptButton('Cancel');
+
+                // can target opponent's ground units and base but not space units
+                expect(context.player1).toBeAbleToSelectExactly([context.frontierAtrt, context.enfysNest, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+            });
+
+            it('the player should be able to cancel the attack and then trigger it again', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.wampa);
+                expect(context.player1).toHavePrompt('Choose a target for attack');
+                expect(context.player1).toHaveEnabledPromptButton('Cancel');
+
+                context.player1.clickPrompt('Cancel');
+                expect(context.player1).toBeActivePlayer();
+                context.player1.clickCard(context.wampa);
+                expect(context.player1).toHavePrompt('Choose a target for attack');
 
                 // can target opponent's ground units and base but not space units
                 expect(context.player1).toBeAbleToSelectExactly([context.frontierAtrt, context.enfysNest, context.p2Base]);

--- a/test/server/actions/UnitAttack.spec.ts
+++ b/test/server/actions/UnitAttack.spec.ts
@@ -121,6 +121,31 @@ describe('Basic attack', function() {
                 context.allowTestToEndWithOpenPrompt = true;
             });
         });
+
+        it('When a unit attacks as part of an ability, it should not have a cancel button', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['fleet-lieutenant'],
+                    groundArena: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.fleetLieutenant);
+            expect(context.fleetLieutenant).toBeInZone('groundArena');
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+
+            context.player1.clickCard(context.wampa);
+            expect(context.player1).toBeAbleToSelectExactly([context.p2Base]);
+            expect(context.player1).not.toHaveEnabledPromptButton('Cancel');
+
+            context.player1.clickCard(context.p2Base);
+            expect(context.wampa.exhausted).toBe(true);
+            expect(context.wampa.damage).toBe(0);
+            expect(context.p2Base.damage).toBe(4);
+        });
     });
 });
 

--- a/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
+++ b/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
@@ -21,6 +21,7 @@ describe('Tactical Advantage', function () {
 
                 context.player1.clickCard(context.tacticalAdvantage);
                 expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.wampa]);
+                expect(context.player1).not.toHaveEnabledPromptButton('Cancel');
 
                 context.player1.clickCard(context.pykeSentinel);
                 expect(context.pykeSentinel.getPower()).toBe(4);

--- a/test/server/core/card/Upgrade.spec.ts
+++ b/test/server/core/card/Upgrade.spec.ts
@@ -34,6 +34,32 @@ describe('Upgrade cards', function() {
                 expect(context.wampa.getHp()).toBe(8);
             });
 
+            it('the player should be able to cancel attach target selection and then repeat the action', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.foundling);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.tielnFighter, context.brightHope]);
+                expect(context.player1).toHaveEnabledPromptButton('Cancel');
+
+                // cancel attach
+                context.player1.clickPrompt('Cancel');
+                expect(context.foundling).toBeInZone('hand');
+                expect(context.player1).toBeActivePlayer();
+                expect(context.player1.exhaustedResourceCount).toBe(0);
+
+                // repeat the action and resolve it this time
+                context.player1.clickCard(context.foundling);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.tielnFighter, context.brightHope]);
+                expect(context.player1).toHaveEnabledPromptButton('Cancel');
+                context.player1.clickCard(context.wampa);
+
+                expect(context.wampa.upgrades).toContain(context.academyTraining);
+                expect(context.wampa.upgrades).toContain(context.foundling);
+                expect(context.wampa.upgrades.length).toBe(2);
+                expect(context.wampa.getPower()).toBe(7);
+                expect(context.wampa.getHp()).toBe(8);
+            });
+
             it('its stat bonuses should be correctly applied during combat', function () {
                 const { context } = contextRef;
 


### PR DESCRIPTION
Re-added the Cancel button for certain common and simple scenarios. Basically any ability which uses targeting and is not a "nested" ability (i.e., one ability triggers another) can be safely cancelled.

Will add deeper support in a further PR.