### PR TITLE
SubStep Check Fixes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,10 +33,9 @@ export default tseslint.config(
                 ...globals.jasmine,
             },
 
-            ecmaVersion: 2020,
+            ecmaVersion: 2022,
             sourceType: "commonjs",
         },
-
         rules: {
             "jasmine/no-spec-dupes": 0,
             "jasmine/no-suite-dupes": 0,

--- a/server/game/abilities/keyword/BountyAbility.ts
+++ b/server/game/abilities/keyword/BountyAbility.ts
@@ -1,7 +1,7 @@
 import TriggeredAbility from '../../core/ability/TriggeredAbility';
 import type { Card } from '../../core/card/Card';
 import type { IUnitCard } from '../../core/card/propertyMixins/UnitProperties';
-import { EventName, KeywordName, RelativePlayer, WildcardZoneName } from '../../core/Constants';
+import { EventName, KeywordName, RelativePlayer, SubStepCheck, WildcardZoneName } from '../../core/Constants';
 import { GameEvent } from '../../core/event/GameEvent';
 import type Game from '../../core/Game';
 import * as Contract from '../../core/utils/Contract';
@@ -52,7 +52,7 @@ export class BountyAbility extends TriggeredAbility {
     }
 
     // Bounty abilities always have some game effect because we always do "collecting the bounty" / emitting the onBountyCollected event
-    public override hasAnyLegalEffects(context, includeSubSteps = false) {
+    public override hasAnyLegalEffects(context, includeSubSteps = SubStepCheck.None) {
         return true;
     }
 

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -468,3 +468,10 @@ export enum PromptType {
     DisplayCards = 'displayCards',
     DistributeAmongTargets = 'distributeAmongTargets',
 }
+
+export enum SubStepCheck { 
+    None = 'none',
+    /** ifYouDoNot is a special case which needs to ignore SubStep checks, but then and ifYouDo will do this check. */
+    ThenIfYouDo = 'thenIfYouDo',
+    All = 'all'
+}

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -469,7 +469,7 @@ export enum PromptType {
     DistributeAmongTargets = 'distributeAmongTargets',
 }
 
-export enum SubStepCheck { 
+export enum SubStepCheck {
     None = 'none',
     /** ifYouDoNot is a special case which needs to ignore SubStep checks, but then and ifYouDo will do this check. */
     ThenIfYouDo = 'thenIfYouDo',

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -41,6 +41,8 @@ const { WildcardCardType } = require('./Constants');
 const { validateGameConfiguration, validateGameOptions } = require('./GameInterfaces.js');
 
 class Game extends EventEmitter {
+    #debug;
+
     /**
      * @param {import('./GameInterfaces.js').GameConfiguration} details
      * @param {import('./GameInterfaces.js').GameOptions} options
@@ -67,7 +69,8 @@ class Game extends EventEmitter {
         this.playStarted = false;
         this.createdAt = new Date();
         this.currentActionWindow = null;
-        this.debug = { pipeline: false }
+        // Debug flags, intended only for manual testing, and should always be false. Use the debug methods to temporarily flag these on.
+        this.#debug = { pipeline: false }
 
         /** @type { EventWindow } */
         this.currentEventWindow = null;
@@ -1450,6 +1453,41 @@ class Game extends EventEmitter {
             };
         }
         return {};
+    }
+
+    // TODO: Make a debug object type.
+    /**
+     * Should only be used for manual testing inside of unit tests, *never* committing any usage into main.
+     * @param {{ pipeline: boolean; }} settings
+     * @param {() => void} fcn
+     */
+    debug(settings, fcn) {
+        const currDebug = this.#debug;
+        this.#debug = settings;
+        try {
+            fcn();
+        }
+        finally {
+            this.#debug = currDebug;
+        }
+    }
+
+    /**
+     * Should only be used for manual testing inside of unit tests, *never* committing any usage into main.
+     * @param {() => void} fcn
+     */
+    debugPipeline(fcn) {
+        this.#debug.pipeline = true;
+        try {
+            fcn();
+        }
+        finally {
+            this.#debug.pipeline = false;
+        }
+    }
+
+    get isDebugPipeline() {
+        return this.#debug.pipeline;
     }
 
     // return this.getSummary(notInactivePlayerName);

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -67,6 +67,7 @@ class Game extends EventEmitter {
         this.playStarted = false;
         this.createdAt = new Date();
         this.currentActionWindow = null;
+        this.debug = { pipeline: false }
 
         /** @type { EventWindow } */
         this.currentEventWindow = null;
@@ -1264,7 +1265,7 @@ class Game extends EventEmitter {
     }
 
     continue() {
-        this.pipeline.continue();
+        this.pipeline.continue(this);
     }
 
     /**

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -70,7 +70,7 @@ class Game extends EventEmitter {
         this.createdAt = new Date();
         this.currentActionWindow = null;
         // Debug flags, intended only for manual testing, and should always be false. Use the debug methods to temporarily flag these on.
-        this.#debug = { pipeline: false }
+        this.#debug = { pipeline: false };
 
         /** @type { EventWindow } */
         this.currentEventWindow = null;
@@ -1466,8 +1466,7 @@ class Game extends EventEmitter {
         this.#debug = settings;
         try {
             fcn();
-        }
-        finally {
+        } finally {
             this.#debug = currDebug;
         }
     }
@@ -1480,8 +1479,7 @@ class Game extends EventEmitter {
         this.#debug.pipeline = true;
         try {
             fcn();
-        }
-        finally {
+        } finally {
             this.#debug.pipeline = false;
         }
     }

--- a/server/game/core/GamePipeline.ts
+++ b/server/game/core/GamePipeline.ts
@@ -1,3 +1,4 @@
+import Game from './Game';
 import type Player from './Player';
 import type { Card } from './card/Card';
 import type { IStep } from './gameSteps/IStep';
@@ -25,7 +26,7 @@ export class GamePipeline {
      * Resolve all steps in the pipeline (including any new ones added during resolution)
      * @returns {boolean} True if the pipeline has completed, false if it has been paused with steps still queued
      */
-    public continue() {
+    public continue(game: Game) {
         this.queueNewStepsIntoPipeline();
 
         while (this.pipeline.length > 0) {
@@ -33,6 +34,9 @@ export class GamePipeline {
 
             // Explicitly check for a return of false - if no return values is
             // defined then just continue to the next step.
+            if(game.debug.pipeline) {
+                console.log(currentStep.getDebugInfo());
+            }
             if (currentStep.continue() === false) {
                 if (this.stepsQueuedDuringCurrentStep.length === 0) {
                     return false;

--- a/server/game/core/GamePipeline.ts
+++ b/server/game/core/GamePipeline.ts
@@ -1,4 +1,4 @@
-import Game from './Game';
+import type Game from './Game';
 import type Player from './Player';
 import type { Card } from './card/Card';
 import type { IStep } from './gameSteps/IStep';
@@ -32,11 +32,12 @@ export class GamePipeline {
         while (this.pipeline.length > 0) {
             const currentStep = this.getCurrentStep();
 
-            if(game.isDebugPipeline) {
-                // Intended to be used when manually testing a single unit test. 
-                // Can be used to determine when a pipeline has an unexpected branch. 
+            if (game.isDebugPipeline) {
+                // Intended to be used when manually testing a single unit test.
+                // Can be used to determine when a pipeline has an unexpected branch.
                 console.log(currentStep.getDebugInfo());
             }
+
             // Explicitly check for a return of false - if no return values is
             // defined then just continue to the next step.
             if (currentStep.continue() === false) {

--- a/server/game/core/GamePipeline.ts
+++ b/server/game/core/GamePipeline.ts
@@ -32,11 +32,13 @@ export class GamePipeline {
         while (this.pipeline.length > 0) {
             const currentStep = this.getCurrentStep();
 
-            // Explicitly check for a return of false - if no return values is
-            // defined then just continue to the next step.
-            if(game.debug.pipeline) {
+            if(game.isDebugPipeline) {
+                // Intended to be used when manually testing a single unit test. 
+                // Can be used to determine when a pipeline has an unexpected branch. 
                 console.log(currentStep.getDebugInfo());
             }
+            // Explicitly check for a return of false - if no return values is
+            // defined then just continue to the next step.
             if (currentStep.continue() === false) {
                 if (this.stepsQueuedDuringCurrentStep.length === 0) {
                     return false;

--- a/server/game/core/ability/CardAbilityStep.js
+++ b/server/game/core/ability/CardAbilityStep.js
@@ -1,6 +1,6 @@
 const { AbilityContext } = require('./AbilityContext.js');
 const PlayerOrCardAbility = require('./PlayerOrCardAbility.js');
-const { Stage, AbilityType, RelativePlayer, WildcardRelativePlayer } = require('../Constants.js');
+const { Stage, AbilityType, RelativePlayer, WildcardRelativePlayer, SubStepCheck } = require('../Constants.js');
 const AttackHelper = require('../attack/AttackHelpers.js');
 const Helpers = require('../utils/Helpers.js');
 const Contract = require('../utils/Contract.js');
@@ -34,7 +34,7 @@ class CardAbilityStep extends PlayerOrCardAbility {
     }
 
     /** @override */
-    hasAnyLegalEffects(context, includeSubSteps = false) {
+    hasAnyLegalEffects(context, includeSubSteps = SubStepCheck.None) {
         if (this.immediateEffect && this.checkGameActionsForPotential(context)) {
             return true;
         }
@@ -43,7 +43,7 @@ class CardAbilityStep extends PlayerOrCardAbility {
             return true;
         }
 
-        if (includeSubSteps) {
+        if (includeSubSteps == SubStepCheck.All || (includeSubSteps == SubStepCheck.ThenIfYouDo && (this.properties.then || this.properties.ifYouDo))) {
             const subAbilityStepContext = this.getSubAbilityStepContext(context);
             return subAbilityStepContext && subAbilityStepContext.ability.hasAnyLegalEffects(subAbilityStepContext);
         }

--- a/server/game/core/ability/CardAbilityStep.js
+++ b/server/game/core/ability/CardAbilityStep.js
@@ -43,7 +43,7 @@ class CardAbilityStep extends PlayerOrCardAbility {
             return true;
         }
 
-        if (includeSubSteps == SubStepCheck.All || (includeSubSteps == SubStepCheck.ThenIfYouDo && (this.properties.then || this.properties.ifYouDo))) {
+        if (includeSubSteps === SubStepCheck.All || (includeSubSteps === SubStepCheck.ThenIfYouDo && (this.properties.then || this.properties.ifYouDo))) {
             const subAbilityStepContext = this.getSubAbilityStepContext(context);
             return subAbilityStepContext && subAbilityStepContext.ability.hasAnyLegalEffects(subAbilityStepContext);
         }

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -160,7 +160,7 @@ class PlayerOrCardAbility {
             }
         }
 
-        if (!ignoredRequirements.includes('gameStateChange') && !this.hasAnyLegalEffects(context)) {
+        if (!ignoredRequirements.includes('gameStateChange') && !this.hasAnyLegalEffects(context, true)) {
             return 'gameStateChange';
         }
 

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -1,6 +1,6 @@
 const { CardTargetResolver } = require('./abilityTargets/CardTargetResolver.js');
 const { SelectTargetResolver } = require('./abilityTargets/SelectTargetResolver.js');
-const { Stage, TargetMode, AbilityType, RelativePlayer } = require('../Constants.js');
+const { Stage, TargetMode, AbilityType, RelativePlayer, SubStepCheck } = require('../Constants.js');
 const { GameEvent } = require('../event/GameEvent.js');
 const Contract = require('../utils/Contract.js');
 const { v4: uuidv4 } = require('uuid');
@@ -160,14 +160,14 @@ class PlayerOrCardAbility {
             }
         }
 
-        if (!ignoredRequirements.includes('gameStateChange') && !this.hasAnyLegalEffects(context, true)) {
+        if (!ignoredRequirements.includes('gameStateChange') && !this.hasAnyLegalEffects(context, SubStepCheck.ThenIfYouDo)) {
             return 'gameStateChange';
         }
 
         return '';
     }
 
-    hasAnyLegalEffects(context, includeSubSteps = false) {
+    hasAnyLegalEffects(context, includeSubSteps = SubStepCheck.None) {
         return true;
     }
 

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -9,6 +9,7 @@ import type { TriggeredAbilityWindow } from '../gameSteps/abilityWindow/Triggere
 import * as Contract from '../utils/Contract';
 import type { ITriggeredAbilityTargetResolver } from '../../TargetInterfaces';
 import type { ICardWithTriggeredAbilities } from '../card/propertyMixins/TriggeredAbilityRegistration';
+import CardAbilityStep from './CardAbilityStep';
 
 interface IEventRegistration {
     name: string;

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -9,7 +9,6 @@ import type { TriggeredAbilityWindow } from '../gameSteps/abilityWindow/Triggere
 import * as Contract from '../utils/Contract';
 import type { ITriggeredAbilityTargetResolver } from '../../TargetInterfaces';
 import type { ICardWithTriggeredAbilities } from '../card/propertyMixins/TriggeredAbilityRegistration';
-import CardAbilityStep from './CardAbilityStep';
 
 interface IEventRegistration {
     name: string;

--- a/server/game/core/gameSteps/BaseStepWithPipeline.ts
+++ b/server/game/core/gameSteps/BaseStepWithPipeline.ts
@@ -10,7 +10,7 @@ export abstract class BaseStepWithPipeline extends BaseStep implements IStep {
 
     public override continue() {
         try {
-            return this.pipeline.continue();
+            return this.pipeline.continue(this.game);
         } catch (e) {
             this.game.reportError(e);
             return true;

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -1,7 +1,7 @@
 import type Player from '../../Player';
 import type { GameEvent } from '../../event/GameEvent';
 import type { EventWindow } from '../../event/EventWindow';
-import { AbilityType } from '../../Constants';
+import { AbilityType, SubStepCheck } from '../../Constants';
 import * as Contract from '../../utils/Contract';
 import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import type TriggeredAbility from '../../ability/TriggeredAbility';
@@ -305,7 +305,7 @@ export abstract class TriggerWindowBase extends BaseStep {
     }
 
     private canAnyAbilitiesResolve(triggeredAbilities: TriggeredAbilityContext[]) {
-        return triggeredAbilities?.some((triggeredAbilityContext) => triggeredAbilityContext.ability.hasAnyLegalEffects(triggeredAbilityContext, true));
+        return triggeredAbilities?.some((triggeredAbilityContext) => triggeredAbilityContext.ability.hasAnyLegalEffects(triggeredAbilityContext, SubStepCheck.All));
     }
 
     public abstract override toString(): string;

--- a/test/server/cards/02_SHD/units/QiraPlayingHerPart.spec.ts
+++ b/test/server/cards/02_SHD/units/QiraPlayingHerPart.spec.ts
@@ -21,11 +21,7 @@ describe('Qi\'ra, Playing Her Part', function () {
             const marine2 = context.player2.findCardByName('battlefield-marine');
 
             // play qira and increase cost of Battlefield Marine
-            //console.log();
-            //console.log('Hand Check');
-            //context.game.debug.pipeline = true;
             context.player1.clickCard(context.qira);
-            context.game.debug.pipeline = false;
 
             // Cards are not revealed in chat
             expect(context.getChatLogs(1)[0]).not.toContain(marine2.title);
@@ -108,7 +104,7 @@ describe('Qi\'ra, Playing Her Part', function () {
             expect(context.player2.exhaustedResourceCount).toBe(9); // 7 from vanquish with penaly aspect + 2 from marine
         });
 
-        it('when the opponents hand is empty, should skip viewing the opponents hand, name a card, and increase that card\'s cost to play.', async function () {
+        it('when the opponents hand is empty, skip straight to naming a card.', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -125,16 +121,7 @@ describe('Qi\'ra, Playing Her Part', function () {
 
             const { context } = contextRef;
 
-            //const marine1 = context.player1.findCardByName('battlefield-marine');
-            //const marine2 = context.player2.findCardByName('battlefield-marine');
-
-            // play qira and increase cost of Battlefield Marine
-            
-            //console.log();
-            //console.log('No Hand Check');
-            //context.game.debug.pipeline = true;
             context.player1.clickCard(context.qira);
-            context.game.debug.pipeline = false;
 
             expect(context.player1).toHaveExactDropdownListOptions(context.getPlayableCardTitles());
             context.player1.chooseListOption('Battlefield Marine');

--- a/test/server/cards/02_SHD/units/QiraPlayingHerPart.spec.ts
+++ b/test/server/cards/02_SHD/units/QiraPlayingHerPart.spec.ts
@@ -1,6 +1,6 @@
 describe('Qi\'ra, Playing Her Part', function () {
     integration(function (contextRef) {
-        it('should draw a card', async function () {
+        it('should view the opponents hand, name a card, and increase that card\'s cost to play.', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -21,7 +21,11 @@ describe('Qi\'ra, Playing Her Part', function () {
             const marine2 = context.player2.findCardByName('battlefield-marine');
 
             // play qira and increase cost of Battlefield Marine
+            //console.log();
+            //console.log('Hand Check');
+            //context.game.debug.pipeline = true;
             context.player1.clickCard(context.qira);
+            context.game.debug.pipeline = false;
 
             // Cards are not revealed in chat
             expect(context.getChatLogs(1)[0]).not.toContain(marine2.title);
@@ -101,6 +105,38 @@ describe('Qi\'ra, Playing Her Part', function () {
             // player 2 marine should cost 2 as qira was defeated
             context.player2.clickCard(marine2);
             expect(context.player2.exhaustedResourceCount).toBe(9); // 7 from vanquish with penaly aspect + 2 from marine
+        });
+
+        it('when the opponents hand is empty, should skip viewing the opponents hand, name a card, and increase that card\'s cost to play.', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['qira#playing-her-part', 'battlefield-marine'],
+                    leader: 'padme-amidala#serving-the-republic',
+                    base: 'jabbas-palace'
+                },
+                player2: {
+                    hand: [],
+                    leader: 'leia-organa#alliance-general',
+                    base: 'level-1313'
+                }
+            });
+
+            const { context } = contextRef;
+
+            //const marine1 = context.player1.findCardByName('battlefield-marine');
+            //const marine2 = context.player2.findCardByName('battlefield-marine');
+
+            // play qira and increase cost of Battlefield Marine
+            
+            //console.log();
+            //console.log('No Hand Check');
+            //context.game.debug.pipeline = true;
+            context.player1.clickCard(context.qira);
+            context.game.debug.pipeline = false;
+
+            expect(context.player1).toHaveExactDropdownListOptions(context.getPlayableCardTitles());
+            context.player1.chooseListOption('Battlefield Marine');
         });
     });
 });


### PR DESCRIPTION
Fix for Qira Playing Her Part (and any Then usage). meetRequirements now only checks substeps for then/ifYouDo.

Additionally, I added some limited "debug" flags to the Game class and flag checks inside of the GamePipeline, intended for manual usage only. Essentially this allowed me to take a side-by-side comparison of the pipeline steps with and w/o a hand of cards (WinMerge for the win) to see where it diverged.

LMK if you'd prefer to remove the debug, I added some safety's but might still be good to keep it out unless we could enforce the flags at build time, IE ignore debug calls entirely unless we are running a single unit test.

<img width="259" alt="image" src="https://github.com/user-attachments/assets/4ecb3088-834e-4012-9a82-f14d09f51da5" />

The above example would enable the flag to write out each pipeline step, then disable it again, so it's scoped to specific actions. Also prevents people from leaving a debug flag active accidentally.