### PR TITLE
Improve button text for common prompts

### DIFF
--- a/server/game/core/gameSteps/AbilityResolver.js
+++ b/server/game/core/gameSteps/AbilityResolver.js
@@ -231,7 +231,7 @@ class AbilityResolver extends BaseStepWithPipeline {
             this.passAbilityHandler.hasBeenShown = true;
             this.game.promptWithHandlerMenu(this.passAbilityHandler.playerChoosing, {
                 activePromptTitle: `Trigger the ability '${this.getAbilityPromptTitle(this.context)}' or pass`,
-                choices: [this.getAbilityPromptTitle(this.context), this.passAbilityHandler.buttonText],
+                choices: ['Trigger', this.passAbilityHandler.buttonText],
                 handlers: [
                     () => {},
                     () => {

--- a/server/game/core/gameSteps/phases/SetupPhase.ts
+++ b/server/game/core/gameSteps/phases/SetupPhase.ts
@@ -27,9 +27,9 @@ export class SetupPhase extends Phase {
 
         this.game.promptWithHandlerMenu(firstPlayer, {
             promptType: PromptType.Initiative,
-            activePromptTitle: 'You won the flip. Do you want to start with initiative:',
+            activePromptTitle: 'You won the flip. Choose the player to start with initiative:',
             source: 'Choose Initiative Player',
-            choices: ['Yes', 'No'],
+            choices: ['Yourself', 'Opponent'],
             handlers: [
                 () => {
                     this.game.initiativePlayer = firstPlayer;

--- a/server/game/core/gameSteps/prompts/MulliganPrompt.ts
+++ b/server/game/core/gameSteps/prompts/MulliganPrompt.ts
@@ -21,8 +21,8 @@ export class MulliganPrompt extends AllPlayerPrompt {
 
     public override activePrompt(): IPlayerPromptStateProperties {
         return {
-            menuTitle: 'Do you want to mulligan your hand?',
-            buttons: [{ text: 'Yes', arg: 'yes' }, { text: 'No', arg: 'no' }],
+            menuTitle: 'Choose whether to mulligan or keep your hand',
+            buttons: [{ text: 'Mulligan', arg: 'mulligan' }, { text: 'Keep', arg: 'keep' }],
             promptTitle: 'Mulligan Step',
             promptUuid: this.uuid
         };
@@ -42,7 +42,7 @@ export class MulliganPrompt extends AllPlayerPrompt {
     }
 
     public override menuCommand(player, arg): boolean {
-        if (arg === 'yes') {
+        if (arg === 'mulligan') {
             if (this.completionCondition(player)) {
                 return false;
             }
@@ -50,7 +50,7 @@ export class MulliganPrompt extends AllPlayerPrompt {
             this.playersDone[player.name] = true;
             this.playerMulligan[player.name] = true;
             return true;
-        } else if (arg === 'no') {
+        } else if (arg === 'keep') {
             this.game.addMessage('{0} has not mulliganed', player);
             this.playersDone[player.name] = true;
             return true;

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -85,7 +85,7 @@ class GameFlowWrapper {
      */
     keepStartingHand() {
         this.guardCurrentPhase('setup');
-        this.allPlayersInInitiativeOrder().forEach((player) => player.clickPrompt('No'));
+        this.allPlayersInInitiativeOrder().forEach((player) => player.clickPrompt('Keep'));
     }
 
 
@@ -190,11 +190,11 @@ class GameFlowWrapper {
     }
 
     selectInitiativePlayer(player) {
-        var promptedPlayer = this.getPromptedPlayer('You won the flip. Do you want to start with initiative:');
+        var promptedPlayer = this.getPromptedPlayer('You won the flip. Choose the player to start with initiative:');
         if (player === promptedPlayer) {
-            promptedPlayer.clickPrompt('Yes');
+            promptedPlayer.clickPrompt('Yourself');
         } else {
-            promptedPlayer.clickPrompt('No');
+            promptedPlayer.clickPrompt('Opponent');
         }
     }
 

--- a/test/scenarios/ability/MultiplePlay.spec.ts
+++ b/test/scenarios/ability/MultiplePlay.spec.ts
@@ -34,7 +34,7 @@ describe('Abilities', function() {
 
                 context.player1.clickCard(context.ruggedSurvivors);
                 context.player1.clickCard(context.p2Base);
-                context.player1.clickPrompt('Draw a card if you control a leader unit');
+                context.player1.clickPrompt('Trigger');
 
                 // check board state
                 expect(context.player1.hand.length).toBe(1);

--- a/test/scenarios/timingWindows/DefeatTiming.spec.ts
+++ b/test/scenarios/timingWindows/DefeatTiming.spec.ts
@@ -146,7 +146,7 @@ describe('Defeat timing', function() {
                 context.player1.clickPrompt('Draw a card');
                 // may ability prompts the player whether or not to actually use it before it fully resolves
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'When an opponent\'s unit is defeated, heal 1 from base']);
                 context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
                 // last trigger is chosen automatically
@@ -160,7 +160,7 @@ describe('Defeat timing', function() {
                 context.player2.clickPrompt('You');
                 context.player2.clickPrompt('Done');
                 expect(context.player2).toHavePassAbilityPrompt('Put Superlaser Technician into play as a resource and ready it');
-                context.player2.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+                context.player2.clickPrompt('Trigger');
 
                 // triggers all done, action is finally over
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
+++ b/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
@@ -30,7 +30,7 @@ describe('Energy Conversion Lab', function() {
                 expect(context.player1.exhaustedResourceCount).toBe(2);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.rebelPathfinder.exhausted).toBe(true);
                 expect(context.rebelPathfinder.damage).toBe(1);
                 expect(context.isbAgent.damage).toBe(2);

--- a/test/server/cards/01_SOR/events/HeroicSacrifice.spec.ts
+++ b/test/server/cards/01_SOR/events/HeroicSacrifice.spec.ts
@@ -96,7 +96,7 @@ describe('Heroic Sacrifice', function() {
                 context.player1.clickPrompt(flamethrowerPrompt);
 
                 expect(context.player1).toHavePassAbilityPrompt(flamethrowerPrompt);
-                context.player1.clickPrompt(flamethrowerPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.sundariPeacekeeper, context.atst, context.craftySmuggler]);
                 context.player1.setDistributeDamagePromptState(new Map([

--- a/test/server/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.spec.ts
+++ b/test/server/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.spec.ts
@@ -193,7 +193,7 @@ describe('Leia Organa, Alliance General', function() {
                 expect(context.leiaOrgana.exhausted).toBe(true);
                 expect(context.p2Base.damage).toBe(7);
 
-                expect(context.player1).toHaveEnabledPromptButton('Attack with another Rebel unit');
+                expect(context.player1).toHaveEnabledPromptButton('Trigger');
                 expect(context.player1).toHaveEnabledPromptButton('Pass');
                 context.player1.clickPrompt('Pass');
 

--- a/test/server/cards/01_SOR/tokens/TokenUnits.spec.ts
+++ b/test/server/cards/01_SOR/tokens/TokenUnits.spec.ts
@@ -80,7 +80,7 @@ describe('Token units', function() {
 
                 // confirm that Battle Droid defeat event registered correctly and triggered Krell ability
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
 
                 // CASE 2: defeat due to direct defeat effect
                 context.player1.clickCard(context.vanquish);
@@ -90,7 +90,7 @@ describe('Token units', function() {
 
                 // confirm that Battle Droid defeat event registered correctly and triggered Krell ability
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
 
                 // CASE 3: defeat to -hp effect
                 context.player2.clickCard(context.supremeLeaderSnoke);
@@ -98,7 +98,7 @@ describe('Token units', function() {
 
                 // confirm that Battle Droid defeat event registered correctly and triggered Krell ability
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
             });
 
             it('should be moved outside the game if they would be moved out of the arena, but not register as defeated', async function () {

--- a/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
+++ b/test/server/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.spec.ts
@@ -26,8 +26,8 @@ describe('Admiral Piett, Captain of the Executor\'s Folly', function() {
 
                 // CASE 1: friendly non-leader unit cost >= 6, gains Ambush
                 context.player1.clickCard(context.relentless);
-                expect(context.player1).toHaveExactPromptButtons(['Ambush', 'Pass']);
-                context.player1.clickPrompt('Ambush');
+                expect(context.player1).toHaveExactPromptButtons(['Trigger', 'Pass']);
+                context.player1.clickPrompt('Trigger');
                 expect(context.relentless.exhausted).toBeTrue();
                 expect(context.relentless.damage).toBe(6);
                 expect(context.redemption.damage).toBe(8);

--- a/test/server/cards/01_SOR/units/AgentKallusSeekingTheRebels.spec.ts
+++ b/test/server/cards/01_SOR/units/AgentKallusSeekingTheRebels.spec.ts
@@ -54,7 +54,7 @@ describe('Agent Kallus, Seeking the Rebels', function() {
                 context.player2.clickCard(context.agentKallus);
                 expect(context.generalVeers).toBeInZone('discard');
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(round1HandSize + 1);
 
                 reset(false);
@@ -74,7 +74,7 @@ describe('Agent Kallus, Seeking the Rebels', function() {
                 context.player1.clickCard(context.wampa);
                 expect(context.generalTagge).toBeInZone('discard');
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(round2HandSize + 1);
 
                 reset();

--- a/test/server/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.spec.ts
+++ b/test/server/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.spec.ts
@@ -25,7 +25,7 @@ describe('Black One', function() {
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player1).toHavePassAbilityPrompt('Discard your hand');
-                context.player1.clickPrompt('Discard your hand');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(3);
                 expect(context.confiscate).toBeInZone('hand', context.player1);
@@ -38,7 +38,7 @@ describe('Black One', function() {
 
                 // Player 1 actives When Defeated, drawing cards
                 expect(context.player1).toHavePassAbilityPrompt('Discard your hand');
-                context.player1.clickPrompt('Discard your hand');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(3);
                 expect(context.confiscate).toBeInZone('discard', context.player1);
@@ -52,7 +52,7 @@ describe('Black One', function() {
                 expect(context.player1).toBeActivePlayer();
                 context.player1.moveCard(context.blackOne, 'hand');
                 context.player1.clickCard(context.blackOne);
-                context.player1.clickPrompt('Discard your hand');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(1);
                 expect(context.cartelSpacer).toBeInZone('discard', context.player1);
@@ -66,7 +66,7 @@ describe('Black One', function() {
                 context.player2.clickCard(context.rivalsFall);
 
                 // Player 1 actives When Defeated, drawing cards
-                context.player1.clickPrompt('Discard your hand');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.atst).toBeInZone('discard', context.player1);

--- a/test/server/cards/01_SOR/units/BlizzardAssaultAtat.spec.ts
+++ b/test/server/cards/01_SOR/units/BlizzardAssaultAtat.spec.ts
@@ -78,7 +78,7 @@ describe('Blizzard Assault AT-AT', function() {
                 expect(context.blizzardAssaultAtat).toBeInZone('discard');
 
                 expect(context.player1).toHavePassAbilityPrompt('Deal the excess damage from the attack to an enemy ground unit');
-                context.player1.clickPrompt('Deal the excess damage from the attack to an enemy ground unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.chewbacca.damage).toBe(1);
                 expect(context.player2).toBeActivePlayer();
             });

--- a/test/server/cards/01_SOR/units/EscortSkiff.spec.ts
+++ b/test/server/cards/01_SOR/units/EscortSkiff.spec.ts
@@ -21,10 +21,10 @@ describe('Escort Skiff', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.escortSkiff);
-                expect(context.player1).toHaveExactPromptButtons(['Ambush', 'Pass']);
+                expect(context.player1).toHaveExactPromptButtons(['Trigger', 'Pass']);
 
                 // ambush grogu
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.escortSkiff.exhausted).toBeTrue();
                 expect(context.escortSkiff.damage).toBe(0);
                 expect(context.grogu.damage).toBe(4);

--- a/test/server/cards/01_SOR/units/FifthBrotherFearHunter.spec.ts
+++ b/test/server/cards/01_SOR/units/FifthBrotherFearHunter.spec.ts
@@ -40,7 +40,7 @@ describe('Fifth Brother, Fear Hunter', function() {
                 context.player1.clickCard(context.p2Base);
 
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.rebelPathfinder]);
                 context.player1.clickCard(context.wampa);
 
@@ -62,7 +62,7 @@ describe('Fifth Brother, Fear Hunter', function() {
                 context.player1.clickCard(context.p2Base);
 
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.rebelPathfinder]);
                 context.player1.clickCard(context.wampa);
 

--- a/test/server/cards/01_SOR/units/FrontierATRT.spec.ts
+++ b/test/server/cards/01_SOR/units/FrontierATRT.spec.ts
@@ -21,10 +21,10 @@ describe('Frontier AT-RT', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.frontierAtrt);
-                expect(context.player1).toHaveExactPromptButtons(['Ambush', 'Pass']);
+                expect(context.player1).toHaveExactPromptButtons(['Trigger', 'Pass']);
 
                 // ambush grogu
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.frontierAtrt.exhausted).toBeTrue();
                 expect(context.frontierAtrt.damage).toBe(0);
                 expect(context.grogu.damage).toBe(3);

--- a/test/server/cards/01_SOR/units/GeneralKrellHeartlessTactician.spec.ts
+++ b/test/server/cards/01_SOR/units/GeneralKrellHeartlessTactician.spec.ts
@@ -26,7 +26,7 @@ describe('General Krell, Heartless Tactician', function() {
                 context.player1.clickCard(context.syndicateLackeys);
                 context.player1.clickCard(context.wampa);
                 expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.syndicateLackeys).toBeInZone('discard');
                 expect(context.player1.handSize).toBe(startingHandSize + 1);
 
@@ -35,7 +35,7 @@ describe('General Krell, Heartless Tactician', function() {
                 context.player1.clickCard(context.leiaOrgana);
                 context.player1.clickCard(context.atatSuppressor);
                 expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.leiaOrgana).toBeInZone('base');
                 expect(context.player1.handSize).toBe(startingHandSize + 2);
 
@@ -47,7 +47,7 @@ describe('General Krell, Heartless Tactician', function() {
                 context.player1.clickCard(context.battlefieldMarine);
                 context.player1.clickCard(context.atatSuppressor);
                 expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine).toBeInZone('discard');
                 expect(context.player1.handSize).toBe(startingHandSize + 2);   // hand size goes down by 1 from playing the marine
 
@@ -93,7 +93,7 @@ describe('General Krell, Heartless Tactician', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(startingHandSize + 1);
             });
@@ -132,7 +132,7 @@ describe('General Krell, Heartless Tactician', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player2).toBeActivePlayer();
 
                 // its the same as the starting hand since we play 1 card
@@ -148,7 +148,7 @@ describe('General Krell, Heartless Tactician', function() {
                 context.player1.clickCard(context.atst);
 
                 expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                context.player1.clickPrompt('Draw a card');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(startingHandSize + 1);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/01_SOR/units/GreedoSlowOnTheDraw.spec.ts
+++ b/test/server/cards/01_SOR/units/GreedoSlowOnTheDraw.spec.ts
@@ -25,7 +25,7 @@ describe('Greedo, Slow on the Draw', function () {
 
                 // player2 should have prompt or pass
                 expect(context.player2).toHavePassAbilityPrompt(prompt);
-                context.player2.clickPrompt(prompt);
+                context.player2.clickPrompt('Trigger');
 
                 // top card is an upgrade, deal 2 damage to a ground unit
                 expect(context.protector).toBeInZone('discard');
@@ -57,7 +57,7 @@ describe('Greedo, Slow on the Draw', function () {
 
                 // player2 should have prompt or pass
                 expect(context.player2).toHavePassAbilityPrompt(prompt);
-                context.player2.clickPrompt(prompt);
+                context.player2.clickPrompt('Trigger');
 
                 // top card is a unit, nothing happen
                 expect(context.isbAgent).toBeInZone('discard');

--- a/test/server/cards/01_SOR/units/GuerillaAttackPod.spec.ts
+++ b/test/server/cards/01_SOR/units/GuerillaAttackPod.spec.ts
@@ -64,7 +64,7 @@ describe('Guerilla Attack Pod', function () {
                 context.player1.clickPrompt('Play a unit that costs 6 or less from your hand. Give it ambush for this phase -> Guerilla Attack Pod');
                 context.player1.clickPrompt('Ambush');
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.guerillaAttackPod.damage).toBe(3);
                 expect(context.ruggedSurvivors.damage).toBe(4);
                 expect(context.guerillaAttackPod.exhausted).toBe(false);

--- a/test/server/cards/01_SOR/units/HanSoloReluctantHero.spec.ts
+++ b/test/server/cards/01_SOR/units/HanSoloReluctantHero.spec.ts
@@ -24,7 +24,7 @@ describe('Han Solo Reluctant Hero', function() {
                 };
                 // Case 1 attack action shouldn't deal damage to the shielded wampa and should deal 4 damage to Han Solo
                 context.player1.clickCard(context.hanSolo);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.wampa);
 
                 // check board state

--- a/test/server/cards/01_SOR/units/KananJarrusRevealedJedi.spec.ts
+++ b/test/server/cards/01_SOR/units/KananJarrusRevealedJedi.spec.ts
@@ -25,7 +25,7 @@ describe('Kanan Jarrus, Revealed Jedi', function() {
 
                 context.player1.clickCard(context.kananJarrus);
                 expect(context.player1).toHavePassAbilityPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
-                context.player1.clickPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player2.base.damage).toBe(4);
 
                 // Check mill and heal
@@ -59,7 +59,7 @@ describe('Kanan Jarrus, Revealed Jedi', function() {
 
                 context.player1.clickCard(context.kananJarrus);
                 expect(context.player1).toHavePassAbilityPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
-                context.player1.clickPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player2.base.damage).toBe(4);
 
                 // Check mill and heal
@@ -98,7 +98,7 @@ describe('Kanan Jarrus, Revealed Jedi', function() {
 
                 context.player1.clickCard(context.kananJarrus);
                 expect(context.player1).toHavePassAbilityPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
-                context.player1.clickPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
+                context.player1.clickPrompt('Trigger');
 
                 // Check mill and heal
                 expect(context.player2.deck.length).toBe(0);

--- a/test/server/cards/01_SOR/units/MaceWinduPartyCrasher.spec.ts
+++ b/test/server/cards/01_SOR/units/MaceWinduPartyCrasher.spec.ts
@@ -26,7 +26,7 @@ describe('Mace Windu, Party Crasher', function() {
 
                 // CASE 1: Mace ambush kills a unit
                 context.player1.clickCard(context.maceWindu);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.wampa);
                 expect(context.wampa).toBeInZone('discard');
                 expect(context.maceWindu.damage).toBe(4);

--- a/test/server/cards/01_SOR/units/MiningGuildTieFighter.spec.ts
+++ b/test/server/cards/01_SOR/units/MiningGuildTieFighter.spec.ts
@@ -18,7 +18,7 @@ describe('Mining Guild TIE Fighter', function() {
                 expect(context.player1).toHavePassAbilityPrompt('Pay 2 resources to draw');
 
                 // pay 2 resources to draw
-                context.player1.clickPrompt('Pay 2 resources to draw');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.hand.length).toBe(1);
                 expect(context.player1.exhaustedResourceCount).toBe(2);
 

--- a/test/server/cards/01_SOR/units/ReinforcementWalker.spec.ts
+++ b/test/server/cards/01_SOR/units/ReinforcementWalker.spec.ts
@@ -148,11 +148,11 @@ describe('Reinforcement Walker', function() {
 
                 // The on attack ability from Ambush resolved successfully.
                 expect(context.player1).toHaveExactPromptButtons([
-                    'Ambush',
+                    'Trigger',
                     'Pass',
                 ]);
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.echoBaseDefender]);
                 expect(context.player1).toHaveExactDisplayPromptPerCardButtons(['Draw', 'Discard']);

--- a/test/server/cards/01_SOR/units/RogueSquadronSkirmisher.spec.ts
+++ b/test/server/cards/01_SOR/units/RogueSquadronSkirmisher.spec.ts
@@ -31,10 +31,10 @@ describe('Rogue Squadron Skirmisher', function () {
 
                 // chooses to trigger the ambush
                 expect(context.player1).toHaveExactPromptButtons([
-                    'Ambush',
+                    'Trigger',
                     'Pass',
                 ]);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 // solves ambush damages
                 expect(context.rogueSquadronSkirmisher.exhausted).toBeTrue();
@@ -83,7 +83,7 @@ describe('Rogue Squadron Skirmisher', function () {
                 expect(context.player1.handSize).toBe(0);
 
                 expect(context.player1).toHaveExactPromptButtons([
-                    'Ambush',
+                    'Trigger',
                     'Pass',
                 ]);
                 context.player1.clickPrompt('Pass');

--- a/test/server/cards/01_SOR/units/RuggedSurvivors.spec.ts
+++ b/test/server/cards/01_SOR/units/RuggedSurvivors.spec.ts
@@ -19,7 +19,7 @@ describe('Rugged Survivors', function () {
 
                 context.player1.clickCard(context.ruggedSurvivors);
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card if you control a leader unit');
-                context.player1.clickPrompt('Draw a card if you control a leader unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.hand.length).toBe(1);
                 expect(context.player2.hand.length).toBe(0);

--- a/test/server/cards/01_SOR/units/Snowspeeder.spec.ts
+++ b/test/server/cards/01_SOR/units/Snowspeeder.spec.ts
@@ -22,7 +22,7 @@ describe('Snowspeeder', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.snowspeeder);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.occupierSiegeTank]);
 
                 context.player1.clickCard(context.atst);

--- a/test/server/cards/01_SOR/units/SuperlaserTechnician.spec.ts
+++ b/test/server/cards/01_SOR/units/SuperlaserTechnician.spec.ts
@@ -21,7 +21,7 @@ describe('Superlaser Technician', function() {
 
                 const readyResourcesBeforeTrigger = context.player1.readyResourceCount;
                 expect(context.player1).toHavePassAbilityPrompt('Put Superlaser Technician into play as a resource and ready it');
-                context.player1.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.readyResourceCount).toBe(readyResourcesBeforeTrigger + 1);
                 expect(context.superlaserTechnician).toBeInZone('resource');

--- a/test/server/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.spec.ts
+++ b/test/server/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.spec.ts
@@ -23,8 +23,8 @@ describe('Wedge Antilles, Star of the Rebellion', function() {
 
                 // Case 1: It should give Ambush and +1/+1 to a friendly Vehicle unit.
                 context.player1.clickCard(context.allianceXwing);
-                expect(context.player1).toHaveExactPromptButtons(['Ambush', 'Pass']);
-                context.player1.clickPrompt('Ambush');
+                expect(context.player1).toHaveExactPromptButtons(['Trigger', 'Pass']);
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.allianceXwing.exhausted).toBeTrue();
                 expect(context.allianceXwing.getPower()).toBe(3);

--- a/test/server/cards/01_SOR/units/ZebOrreliosHeadstrongWarrior.spec.ts
+++ b/test/server/cards/01_SOR/units/ZebOrreliosHeadstrongWarrior.spec.ts
@@ -26,7 +26,7 @@ describe('Zeb Orrelios, Headstrong Warrior', function () {
                 // kill superlaser technician, should deal 4 to a ground unit
                 context.player1.clickCard(context.zebOrrelios);
                 context.player1.clickCard(context.superlaserTechnician);
-                context.player2.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+                context.player2.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.zebOrrelios, context.swoopRacer, context.consularSecurityForce, context.steadfastBattalion]);
                 expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickCard(context.consularSecurityForce);
@@ -73,7 +73,7 @@ describe('Zeb Orrelios, Headstrong Warrior', function () {
                 context.player1.clickCard(context.zebOrrelios);
                 context.player1.clickCard(context.battlefieldMarine);
 
-                context.player1.clickPrompt('Deal 3 damage divided as you choose among enemy ground units');
+                context.player1.clickPrompt('Trigger');
 
                 // kill battlefield marine with flamethrower, zeb should deal 4 damage to another unit
                 context.player1.setDistributeDamagePromptState(new Map([

--- a/test/server/cards/01_SOR/upgrades/SnapshotReflexes.spec.ts
+++ b/test/server/cards/01_SOR/upgrades/SnapshotReflexes.spec.ts
@@ -22,7 +22,7 @@ describe('Snapshot Reflexes', function() {
 
                 expect(context.player1).toHavePassAbilityPrompt('Attack with attached unit');
 
-                context.player1.clickPrompt('Attack with attached unit');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.specforceSoldier);
 
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['snapshot-reflexes']);

--- a/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
+++ b/test/server/cards/02_SHD/events/ANewAdventure.spec.ts
@@ -28,7 +28,7 @@ describe('A New Adventure', function() {
                 expect(context.patrollingVwing).toBeInZone('hand');
                 expect(context.player2).toHavePassAbilityPrompt('Play Patrolling V-Wing for free');
 
-                context.player2.clickPrompt('Play Patrolling V-Wing for free');
+                context.player2.clickPrompt('Trigger');
                 expect(context.patrollingVwing).toBeInZone('spaceArena');
                 expect(context.player2.exhaustedResourceCount).toBe(0);
                 expect(context.player2.handSize).toBe(1);   // from V-Wing ability
@@ -44,7 +44,7 @@ describe('A New Adventure', function() {
                 expect(context.salaciousCrumb).toBeInZone('hand');
                 expect(context.player1).toHavePassAbilityPrompt('Play Salacious Crumb for free');
 
-                context.player1.clickPrompt('Play Salacious Crumb for free');
+                context.player1.clickPrompt('Trigger');
                 expect(context.salaciousCrumb).toBeInZone('groundArena');
                 expect(context.player1.exhaustedResourceCount).toBe(2); // just the cost of A New Adventure
                 expect(context.p1Base.damage).toBe(1);   // from Crumb ability
@@ -79,7 +79,7 @@ describe('A New Adventure', function() {
             expect(context.salaciousCrumb).toBeInZone('hand', context.player1);
             expect(context.player1).toHavePassAbilityPrompt('Play Salacious Crumb for free');
 
-            context.player1.clickPrompt('Play Salacious Crumb for free');
+            context.player1.clickPrompt('Trigger');
             expect(context.salaciousCrumb).toBeInZone('groundArena');
             expect(context.player1.exhaustedResourceCount).toBe(2); // just the cost of A New Adventure
             expect(context.p1Base.damage).toBe(1);   // from Crumb ability

--- a/test/server/cards/02_SHD/events/BountyPosting.spec.ts
+++ b/test/server/cards/02_SHD/events/BountyPosting.spec.ts
@@ -36,7 +36,7 @@ describe('Bounty Posting', function() {
                     'player1 is shuffling their deck'
                 ]);
 
-                context.player1.clickPrompt('Play that upgrade (paying its cost)');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.cloneTrooper);
                 expect(context.cloneTrooper).toHaveExactUpgradeNames(['top-target']);
                 expect(preShuffleDeck).not.toEqual(context.player1.deck);

--- a/test/server/cards/02_SHD/events/EndlessLegions.spec.ts
+++ b/test/server/cards/02_SHD/events/EndlessLegions.spec.ts
@@ -138,7 +138,7 @@ describe('Endless Legions', function() {
             expect(context.player1.findCardsByName('clone-trooper').every((cloneTrooper) => cloneTrooper.damage === 1)).toBeTrue();
 
             // Player 1 triggers Wrecker's ambush
-            context.player1.clickPrompt('Ambush');
+            context.player1.clickPrompt('Trigger');
             context.player1.clickCard(context.gor);
 
             // Player 1 plays Arquitens Assault Cruiser for free
@@ -147,7 +147,7 @@ describe('Endless Legions', function() {
             ]);
 
             context.player1.clickCard(context.arquitensAssaultCruiser);
-            context.player1.clickPrompt('Ambush');
+            context.player1.clickPrompt('Trigger');
             context.player1.clickCard(context.tieAdvanced);
 
             expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/02_SHD/events/TimelyIntervention.spec.ts
+++ b/test/server/cards/02_SHD/events/TimelyIntervention.spec.ts
@@ -30,7 +30,7 @@ describe('Timely Intervention', function () {
                 expect(context.player1.exhaustedResourceCount).toBe(3);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.rebelPathfinder.exhausted).toBe(true);
                 expect(context.rebelPathfinder.damage).toBe(1);
                 expect(context.isbAgent.damage).toBe(2);
@@ -67,7 +67,7 @@ describe('Timely Intervention', function () {
                 expect(context.player1.exhaustedResourceCount).toBe(4);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.rebelPathfinder.exhausted).toBe(true);
                 expect(context.rebelPathfinder.damage).toBe(1);
                 expect(context.isbAgent.damage).toBe(2);

--- a/test/server/cards/02_SHD/leaders/BobaFettDaimyo.spec.ts
+++ b/test/server/cards/02_SHD/leaders/BobaFettDaimyo.spec.ts
@@ -25,7 +25,7 @@ describe('Boba Fett, Daimyo', function () {
 
                 context.player1.clickCard(context.greenSquadronAwing);
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
-                context.player1.clickPrompt('Exhaust this leader');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.wildernessFighter, context.greenSquadronAwing]);
 
                 // give +1/+0 to battlefield marine, boba should be exhausted
@@ -58,7 +58,7 @@ describe('Boba Fett, Daimyo', function () {
                 // play a unit with keyword, boba is not exhausted, should be able to give +1/+0 to a friendly unit
                 context.player1.clickCard(context.cantinaBraggart);
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
-                context.player1.clickPrompt('Exhaust this leader');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.wildernessFighter, context.greenSquadronAwing, context.cantinaBraggart]);
                 expect(context.player1).not.toHavePassAbilityButton();
 
@@ -93,7 +93,7 @@ describe('Boba Fett, Daimyo', function () {
                 context.player1.clickCard(context.allianceXwing);
                 // boba triggers as red three give raid 1 to alliance x-wing
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
-                context.player1.clickPrompt('Exhaust this leader');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.redThree, context.allianceXwing]);
 
                 // give +1/+0 to battlefield marine, boba should be exhausted

--- a/test/server/cards/02_SHD/leaders/BosskHuntingHisPrey.spec.ts
+++ b/test/server/cards/02_SHD/leaders/BosskHuntingHisPrey.spec.ts
@@ -25,7 +25,7 @@ describe('Bossk, Hunting his Prey', function () {
 
             // resolve optional +1/+0
             expect(context.player1).toHavePassAbilityPrompt('Give it +1/+0 for this phase');
-            context.player1.clickPrompt('Give it +1/+0 for this phase');
+            context.player1.clickPrompt('Trigger');
             expect(context.cloneTrooper.getPower()).toBe(3);
             expect(context.cloneTrooper.getHp()).toBe(2);
 
@@ -109,12 +109,12 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickCard(context.hylobonEnforcer);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(1);
                 expect(context.player2.handSize).toBe(1);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(2);
                 expect(context.player2.handSize).toBe(1);
 
@@ -124,7 +124,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player2.clickCard(context.guavianAntagonizer);
                 context.player2.clickCard(context.bossk);
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(3);
                 expect(context.player2.handSize).toBe(1);
 
@@ -140,7 +140,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.cloneDeserter);
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
                 expect(context.player2.handSize).toBe(p2HandSizePhase2);   // played Vanquish then drew a card
                 expect(context.player1).toBeActivePlayer();
 
@@ -154,7 +154,7 @@ describe('Bossk, Hunting his Prey', function () {
                 expect(context.p2Base.damage).toBe(3);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 expect(context.player1).not.toHavePassAbilityButton();
                 context.player1.clickCard(context.p2Base);
@@ -220,9 +220,9 @@ describe('Bossk, Hunting his Prey', function () {
 
                 // trigger the bounty twice
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: The next unit you play this phase costs 1 resource less');
-                context.player1.clickPrompt('Collect Bounty: The next unit you play this phase costs 1 resource less');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
 
                 // play a 3-cost unit with a 2-cost discount
                 context.player2.passAction();
@@ -261,14 +261,14 @@ describe('Bossk, Hunting his Prey', function () {
                 expect(context.p2Base.damage).toBe(2);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);
                 expect(context.p2Base.damage).toBe(4);
 
                 // resolve the Clone Deserter bounty, Bossk ability is already used and can't trigger
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(1);
 
                 expect(context.player2).toBeActivePlayer();
@@ -295,11 +295,11 @@ describe('Bossk, Hunting his Prey', function () {
 
                 // resolve the Clone Deserter bounty, Bossk ability is already used and can't trigger
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(1);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(2);
 
                 expect(context.player2).toBeActivePlayer();
@@ -331,12 +331,12 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickCard(context.cloneTrooper);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Put the top card of your deck into play as a resource');
-                context.player1.clickPrompt('Collect Bounty: Put the top card of your deck into play as a resource');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.resources.length).toBe(5);
                 expect(context.atst).toBeInZone('resource');
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.resources.length).toBe(6);
                 expect(context.waylay).toBeInZone('resource');
             });
@@ -350,12 +350,12 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickCard(context.cloneTrooper);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Put the top card of your deck into play as a resource');
-                context.player1.clickPrompt('Collect Bounty: Put the top card of your deck into play as a resource');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.resources.length).toBe(4);
 
                 // Bossk ability triggers since we chose to resolve the Bounty (even though the resolution didn't change game state)
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.resources.length).toBe(4);
 
                 // trigger a second Bounty to confirm that Bossk's ability limit did trigger and is used up for the phase
@@ -392,7 +392,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickCard(context.bossk);
                 context.player1.clickCard(context.cloneTrooper);
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine, context.snowtrooperLieutenant, context.sabineWren],
                     invalid: [context.waylay, context.protector]
@@ -406,7 +406,7 @@ describe('Bossk, Hunting his Prey', function () {
 
                 // second Bounty trigger, play a unit that has a "when played" which triggers an attack
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.infernoFour, context.sabineWren, context.snowtrooperLieutenant],
                     invalid: [context.waylay, context.protector]
@@ -426,7 +426,7 @@ describe('Bossk, Hunting his Prey', function () {
 
                 // resolve the Clone Deserter bounty
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(1);
             });
 
@@ -438,7 +438,7 @@ describe('Bossk, Hunting his Prey', function () {
                 context.player1.clickCard(context.bossk);
                 context.player1.clickCard(context.cloneTrooper);
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine, context.snowtrooperLieutenant, context.sabineWren],
                     invalid: [context.waylay, context.protector]
@@ -461,12 +461,12 @@ describe('Bossk, Hunting his Prey', function () {
 
                 // resolve the Clone Deserter bounty
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(1);
 
                 // activate Bossk ability here to re-collect the Clone Deserter bounty, using up the per-round limit so we can't activate BHQ's Bounty again
                 expect(context.player1).toHavePassAbilityPrompt('Collect the Bounty again');
-                context.player1.clickPrompt('Collect the Bounty again');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1.handSize).toBe(2);
 
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.spec.ts
+++ b/test/server/cards/02_SHD/leaders/CadBaneHeWhoNeedsNoIntroduction.spec.ts
@@ -29,7 +29,7 @@ describe('Cad Bane, He Who Needs No Introduction', function () {
             // CASE 3: controller plays an Underworld card, ability triggers
             context.player1.clickCard(context.pykeSentinel);
             expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
-            context.player1.clickPrompt('Exhaust this leader');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.cadBane.exhausted).toBeTrue();
             expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.tieAdvanced, context.cantinaBraggart]);
@@ -69,7 +69,7 @@ describe('Cad Bane, He Who Needs No Introduction', function () {
             // CASE 3: controller plays an Underworld card, ability triggers
             context.player1.clickCard(context.pykeSentinel);
             expect(context.player1).toHavePassAbilityPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
-            context.player1.clickPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.tieAdvanced, context.cantinaBraggart]);
             expect(context.player2).not.toHavePassAbilityButton();
@@ -87,7 +87,7 @@ describe('Cad Bane, He Who Needs No Introduction', function () {
             context.player2.passAction();
             context.player1.clickCard(context.outlawCorona);
             expect(context.player1).toHavePassAbilityPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
-            context.player1.clickPrompt('The opponent chooses a unit they control. Deal 2 damage to it.');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.tieAdvanced, context.cantinaBraggart]);
             expect(context.player2).not.toHavePassAbilityButton();

--- a/test/server/cards/02_SHD/leaders/FennecShandHonoringTheDeal.spec.ts
+++ b/test/server/cards/02_SHD/leaders/FennecShandHonoringTheDeal.spec.ts
@@ -31,7 +31,7 @@ describe('Fennec Shand, Honoring the Deal', function () {
                 expect(context.player1.exhaustedResourceCount).toBe(3);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.rebelPathfinder.exhausted).toBeTrue();
                 expect(context.rebelPathfinder.damage).toBe(1);
                 expect(context.isbAgent.damage).toBe(2);
@@ -72,7 +72,7 @@ describe('Fennec Shand, Honoring the Deal', function () {
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
                 // ambush isb agent
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.isbAgent);
                 expect(context.fennecShand.exhausted).toBeFalse();
                 expect(context.rebelPathfinder.exhausted).toBeTrue();
@@ -98,7 +98,7 @@ describe('Fennec Shand, Honoring the Deal', function () {
                 expect(context.player1.exhaustedResourceCount).toBe(6); // no extra cost
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.battlefieldMarine);
                 expect(context.moddedCohort.exhausted).toBeTrue();
                 expect(context.moddedCohort.damage).toBe(3);

--- a/test/server/cards/02_SHD/leaders/HondoOhnakaThatsGoodBusiness.spec.ts
+++ b/test/server/cards/02_SHD/leaders/HondoOhnakaThatsGoodBusiness.spec.ts
@@ -44,7 +44,7 @@ describe('Hondo Ohnaka, That\'s Good Business', function () {
                 // play a second unit from smuggle
                 context.player1.clickCard(context.warbirdStowaway);
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
-                context.player1.clickPrompt('Exhaust this leader');
+                context.player1.clickPrompt('Trigger');
 
                 // give experience token to warbird stowaway
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.privateerCrew, context.greenSquadronAwing, context.warbirdStowaway, context.freetownBackup, context.allianceXwing]);

--- a/test/server/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.spec.ts
+++ b/test/server/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.spec.ts
@@ -34,7 +34,7 @@ describe('Jabba the Hutt, His High Exaltedness', function () {
 
                 // collect bounty
                 expect(context.player1).toHavePassAbilityPrompt(bountyPrompt);
-                context.player1.clickPrompt(bountyPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 context.player2.passAction();
 
@@ -65,7 +65,7 @@ describe('Jabba the Hutt, His High Exaltedness', function () {
 
                 // collect bounty
                 expect(context.player1).toHavePassAbilityPrompt(bountyPrompt);
-                context.player1.clickPrompt(bountyPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 context.moveToNextActionPhase();
 
@@ -165,7 +165,7 @@ describe('Jabba the Hutt, His High Exaltedness', function () {
 
                 // collect bounty
                 expect(context.player1).toHavePassAbilityPrompt(bountyPrompt);
-                context.player1.clickPrompt(bountyPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 context.player2.passAction();
 
@@ -196,7 +196,7 @@ describe('Jabba the Hutt, His High Exaltedness', function () {
                 context.player1.clickCard(context.wampa);
                 context.player1.clickCard(context.battlefieldMarine);
                 expect(context.player1).toHavePassAbilityPrompt(bountyPrompt);
-                context.player1.clickPrompt(bountyPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 context.moveToNextActionPhase();
 

--- a/test/server/cards/02_SHD/leaders/TheMandalorianSwornToTheCreed.spec.ts
+++ b/test/server/cards/02_SHD/leaders/TheMandalorianSwornToTheCreed.spec.ts
@@ -38,7 +38,7 @@ describe('The Mandalorian, Sworn To The Creed', function () {
                 // play an upgrade from hand and pass
                 context.player1.clickCard(context.academyTraining);
                 context.player1.clickCard(context.wampa);
-                expect(context.player1).toHaveExactPromptButtons(['Pass', 'Exhaust this leader']);
+                expect(context.player1).toHaveExactPromptButtons(['Pass', 'Trigger']);
                 context.player1.clickPrompt('Pass');
                 expect(context.theMandalorian.exhausted).toBeFalse();
 
@@ -49,7 +49,7 @@ describe('The Mandalorian, Sworn To The Creed', function () {
                 // play an upgrade from smuggle, exhaust an enemy unit
                 context.player1.clickCard(context.armedToTheTeeth);
                 context.player1.clickCard(context.wampa);
-                context.player1.clickPrompt('Exhaust this leader');
+                context.player1.clickPrompt('Trigger');
 
                 // exhaust battlefield marine
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.greenSquadronAwing, context.consularSecurityForce]);

--- a/test/server/cards/02_SHD/units/4-LOMBountyHunterForHire.spec.ts
+++ b/test/server/cards/02_SHD/units/4-LOMBountyHunterForHire.spec.ts
@@ -20,7 +20,7 @@ describe('4-LOM, Bounty Hunter for Hire', function () {
                 context.player1.clickCard(context.zuckuss);
 
                 // should have ambush from 4-lom
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 // should have saboteur from himself
                 expect(context.player1).toBeAbleToSelectExactly([context.bendu, context.consularSecurityForce]);

--- a/test/server/cards/02_SHD/units/ArquitensAssaultCruiser.spec.ts
+++ b/test/server/cards/02_SHD/units/ArquitensAssaultCruiser.spec.ts
@@ -32,7 +32,7 @@ describe('Arquitens Assault Cruiser', function() {
 
                 // CASE 1: Arquitens ambush kills a unit
                 context.player1.clickCard(context.arquitensAssaultCruiser);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.tielnFighter);
                 expect(context.tielnFighter).toBeInZone('resource', context.player1);
                 expect(context.tielnFighter.exhausted).toBeTrue();

--- a/test/server/cards/02_SHD/units/CartelTurncoat.spec.ts
+++ b/test/server/cards/02_SHD/units/CartelTurncoat.spec.ts
@@ -18,7 +18,7 @@ describe('Cartel Turncoat', function() {
                 context.player1.clickCard(context.razorCrest);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);

--- a/test/server/cards/02_SHD/units/ChainCodeCollector.spec.ts
+++ b/test/server/cards/02_SHD/units/ChainCodeCollector.spec.ts
@@ -18,7 +18,7 @@ describe('Chain Code Collector', function () {
 
                 // ambush gideon hask
                 context.player1.clickCard(context.chainCodeCollector);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.gideonHask);
 
                 // chain code collector take only 1 damage (gideon gets -4/-0)

--- a/test/server/cards/02_SHD/units/CloneDeserter.spec.ts
+++ b/test/server/cards/02_SHD/units/CloneDeserter.spec.ts
@@ -21,7 +21,7 @@ describe('Clone Deserter', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);

--- a/test/server/cards/02_SHD/units/CoruscantDissident.spec.ts
+++ b/test/server/cards/02_SHD/units/CoruscantDissident.spec.ts
@@ -19,7 +19,7 @@ describe('Coruscant Dissident', function() {
 
             context.player1.clickCard(context.coruscantDissident);
             expect(context.player1).toHavePassAbilityPrompt('Ready a resource');
-            context.player1.clickPrompt('Ready a resource');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.exhaustedResourceCount).toBe(1);
         });
     });

--- a/test/server/cards/02_SHD/units/DengarTheDemolisher.spec.ts
+++ b/test/server/cards/02_SHD/units/DengarTheDemolisher.spec.ts
@@ -23,7 +23,7 @@ describe('Dengar, The Demolisher', function () {
                 context.player1.clickCard(context.battlefieldMarine);
 
                 expect(context.player1).toHaveEnabledPromptButtons(['Deal 1 damage to the upgraded unit', 'Pass']);
-                context.player1.clickPrompt('Deal 1 damage to the upgraded unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.damage).toBe(1);
 
                 // enemy play an upgrade, nothing happen

--- a/test/server/cards/02_SHD/units/EchoRestored.spec.ts
+++ b/test/server/cards/02_SHD/units/EchoRestored.spec.ts
@@ -39,7 +39,7 @@ describe('Echo, Restored', function () {
 
                 // discard a card
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
 
                 // can discard any cards
                 expect(context.player1).toBeAbleToSelectExactly([handLuke, handBattlefieldMarine, handWampa, context.atst]);
@@ -59,7 +59,7 @@ describe('Echo, Restored', function () {
 
                 // play echo
                 context.player1.clickCard(context.echo);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(handLuke);
 
                 // luke was discarded, leader luke should have 2 experiences tokens
@@ -76,7 +76,7 @@ describe('Echo, Restored', function () {
 
                 // play echo
                 context.player1.clickCard(context.echo);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(handWampa);
 
                 // 2 units with the same title, can choose between them

--- a/test/server/cards/02_SHD/units/EmboStoicAndResolute.spec.ts
+++ b/test/server/cards/02_SHD/units/EmboStoicAndResolute.spec.ts
@@ -48,7 +48,7 @@ describe('Embo, Stoic and Resolute', function () {
                 // defender is defeated but not in discard
                 context.player1.clickCard(context.embo);
                 context.player1.clickCard(context.superlaserTechnician);
-                context.player2.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+                context.player2.clickPrompt('Trigger');
                 expect(context.player1).toBeAbleToSelectExactly([context.embo, context.escortSkiff, context.consularSecurityForce, context.swoopRacer, context.greenSquadronAwing]);
                 expect(context.player1).toHaveChooseNoTargetButton();
                 context.player1.setDistributeHealingPromptState(new Map([
@@ -87,7 +87,7 @@ describe('Embo, Stoic and Resolute', function () {
                 context.player1.clickCard(context.embo);
                 context.player1.clickCard(context.battlefieldMarine);
 
-                context.player1.clickPrompt('Deal 3 damage divided as you choose among enemy ground units');
+                context.player1.clickPrompt('Trigger');
 
                 // kill battlefield marine with flamethrower, embo should heal up to 2 damage
                 context.player1.setDistributeDamagePromptState(new Map([

--- a/test/server/cards/02_SHD/units/EnfysNestMarauder.spec.ts
+++ b/test/server/cards/02_SHD/units/EnfysNestMarauder.spec.ts
@@ -33,7 +33,7 @@ describe('Enfys Nest, Marauder', function () {
 
                 // Case 1: Enfys applies its ability to itself
                 context.player1.clickCard(context.enfysNest);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.atst);
 
                 expect(context.enfysNest.damage).toBe(3);
@@ -44,7 +44,7 @@ describe('Enfys Nest, Marauder', function () {
                 // Case 2: Ability applies to a played unit with printed ambush
                 reset();
                 context.player1.clickCard(context.syndicateLackeys);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.atst);
 
                 expect(context.syndicateLackeys.damage).toBe(3);
@@ -64,7 +64,7 @@ describe('Enfys Nest, Marauder', function () {
                 context.player1.clickCard(context.energyConversionLab);
                 expect(context.player1).toHavePassSingleTargetPrompt('Play a unit that costs 6 or less from your hand. Give it ambush for this phase', context.liberatedSlaves);
                 context.player1.clickPrompt('Play a unit that costs 6 or less from your hand. Give it ambush for this phase -> Liberated Slaves');
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.atst);
 
                 expect(context.liberatedSlaves.damage).toBe(3);
@@ -73,7 +73,7 @@ describe('Enfys Nest, Marauder', function () {
                 // Case 5: Ability does not apply to opponent's unit attacking with ambush(or to that defender)
                 context.liberatedSlaves.damage = 0;
                 context.player2.clickCard(context._4lom);
-                context.player2.clickPrompt('Ambush');
+                context.player2.clickPrompt('Trigger');
                 context.player2.clickCard(context.liberatedSlaves);
 
                 expect(context._4lom.damage).toBe(3);

--- a/test/server/cards/02_SHD/units/FrontierTrader.spec.ts
+++ b/test/server/cards/02_SHD/units/FrontierTrader.spec.ts
@@ -41,7 +41,7 @@ describe('Frontier Trader', function() {
                 ]);
                 context.player1.clickCard(context.collectionsStarhopper);
                 expect(context.player1).toHavePassAbilityPrompt('Put the top card of your deck into play as a resource.');
-                context.player1.clickPrompt('Put the top card of your deck into play as a resource.');
+                context.player1.clickPrompt('Trigger');
                 expect(context.collectionsStarhopper).toBeInZone(ZoneName.Hand);
                 expect(context.wampa).toBeInZone(ZoneName.Resource);
             });

--- a/test/server/cards/02_SHD/units/GreySquadronYWing.spec.ts
+++ b/test/server/cards/02_SHD/units/GreySquadronYWing.spec.ts
@@ -25,7 +25,7 @@ describe('Grey squadron Y-Wing', function() {
                 context.player2.clickCard(context.p2Base);
                 expect(context.player1).toHavePassAbilityPrompt('Deal 2 damage to Administrator\'s Tower');
 
-                context.player1.clickPrompt('Deal 2 damage to Administrator\'s Tower');
+                context.player1.clickPrompt('Trigger');
                 expect(context.p2Base.damage).toEqual(2);
             });
         });

--- a/test/server/cards/02_SHD/units/GuavianAntagonizer.spec.ts
+++ b/test/server/cards/02_SHD/units/GuavianAntagonizer.spec.ts
@@ -18,7 +18,7 @@ describe('Guavian Antagonizer', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);

--- a/test/server/cards/02_SHD/units/HylobonEnforcer.spec.ts
+++ b/test/server/cards/02_SHD/units/HylobonEnforcer.spec.ts
@@ -18,7 +18,7 @@ describe('Hylobon Enforcer', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);
@@ -43,7 +43,7 @@ describe('Hylobon Enforcer', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(0);

--- a/test/server/cards/02_SHD/units/KraytDragon.spec.ts
+++ b/test/server/cards/02_SHD/units/KraytDragon.spec.ts
@@ -62,7 +62,7 @@ describe('Krayt Dragon', function () {
                 context.player1.passAction();
                 context.player2.clickCard(context.superlaserBlast);
                 expect(context.player1).toHavePassAbilityPrompt('Deal damage equal to that card’s cost to their base or a ground unit they control');
-                context.player1.clickPrompt('Deal damage equal to that card’s cost to their base or a ground unit they control');
+                context.player1.clickPrompt('Trigger');
                 expect(context.p2Base.damage).toBe(8);
             });
             // TODO test u-wing, vader or endless legion when implemented

--- a/test/server/cards/02_SHD/units/KrrsantanMuscleForHire.spec.ts
+++ b/test/server/cards/02_SHD/units/KrrsantanMuscleForHire.spec.ts
@@ -15,7 +15,7 @@ describe('Krrsantan, Muscle For Hire', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.krrsantan);
-                context.player1.clickPrompt('Ready this unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.player2).toBeActivePlayer();
                 expect(context.krrsantan.exhausted).toBeFalse();
             });

--- a/test/server/cards/02_SHD/units/KylosTieSilencerRuthlesslyEfficient.spec.ts
+++ b/test/server/cards/02_SHD/units/KylosTieSilencerRuthlesslyEfficient.spec.ts
@@ -23,7 +23,7 @@ describe('Kylo\'s TIE Silencer, Ruthless Efficient', function () {
             context.player2.clickCard(context.kananJarrus);
             context.player2.clickCard(context.p1Base);
             context.player2.clickPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
-            context.player2.clickPrompt('Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.');
+            context.player2.clickPrompt('Trigger');
             expect(context.kylosTieSilencer).toBeInZone('discard', context.player1);
             expect(context.player1.currentActionTargets).toContain(context.kylosTieSilencer);
 

--- a/test/server/cards/02_SHD/units/LomPykeDealerInTruths.spec.ts
+++ b/test/server/cards/02_SHD/units/LomPykeDealerInTruths.spec.ts
@@ -140,7 +140,7 @@ describe('Lom Pyke, Dealer in Truths', function() {
                 context.player1.clickCard(context.lomPyke);
                 context.player1.clickCard(context.p2Base);
                 expect(context.player1).toHavePassAbilityPrompt('Give a Shield token to an enemy unit');
-                context.player1.clickPrompt('Give a Shield token to an enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.p2Base.damage).toBe(4);
                 expect(context.lomPyke).toHaveExactUpgradeNames(['shield']);

--- a/test/server/cards/02_SHD/units/LurkingTIEPhantom.spec.ts
+++ b/test/server/cards/02_SHD/units/LurkingTIEPhantom.spec.ts
@@ -123,7 +123,7 @@ describe('Lurking TIE Phantom', function() {
 
             // Case 13: Can not be damaged by opponent ability even if you pick
             context.player1.clickCard(context.mercenaryGunship);
-            context.player1.clickPrompt('Exhaust this leader');
+            context.player1.clickPrompt('Trigger');
             expect(context.player2).toBeAbleToSelectExactly([context.lurkingTiePhantom, context.battlefieldMarine, context.countDooku, context.devastator]);
             context.player2.clickCard(context.lurkingTiePhantom);
             expect(context.lurkingTiePhantom).toBeInZone('spaceArena');

--- a/test/server/cards/02_SHD/units/MaulShadowCollectiveVisionary.spec.ts
+++ b/test/server/cards/02_SHD/units/MaulShadowCollectiveVisionary.spec.ts
@@ -236,7 +236,7 @@ describe('Maul, Shadow Collective Visionary', function() {
 
                 // Resolve Jango's ability
                 expect(context.player2).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
-                context.player2.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.mercenaryCompany.exhausted).toBeTrue();
                 expect(context.mercenaryCompany.damage).toBe(4);
@@ -263,7 +263,7 @@ describe('Maul, Shadow Collective Visionary', function() {
                 context.player1.clickPrompt('Heal 1 damage from your base'); // select yularen's heal on base
 
                 // Select opponents Yularen to be ambushed
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(p2Yularen);
 
                 expect(p2Yularen).toBeInZone('discard');

--- a/test/server/cards/02_SHD/units/MillenniumFalconLandosPride.spec.ts
+++ b/test/server/cards/02_SHD/units/MillenniumFalconLandosPride.spec.ts
@@ -17,7 +17,7 @@ describe('Millennium Falcon, Landos Pride', function() {
             // CASE 1: Falcon gets Ambush when played from hand
             context.player1.clickCard(context.millenniumFalcon);
             expect(context.player1).toHavePassAbilityPrompt('Ambush');
-            context.player1.clickPrompt('Ambush');
+            context.player1.clickPrompt('Trigger');
 
             context.player1.clickCard(context.survivorsGauntlet);
             expect(context.survivorsGauntlet.damage).toBe(5);

--- a/test/server/cards/02_SHD/units/OutlawCorona.spec.ts
+++ b/test/server/cards/02_SHD/units/OutlawCorona.spec.ts
@@ -22,7 +22,7 @@ describe('Outlaw Corona', function() {
                 context.player1.clickCard(context.fettsFirespray);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Put the top card of your deck into play as a resource.');
-                context.player2.clickPrompt('Collect Bounty: Put the top card of your deck into play as a resource.');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player2.resources.length).toBe(startingResources + 1);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/02_SHD/units/PunishingOne.spec.ts
+++ b/test/server/cards/02_SHD/units/PunishingOne.spec.ts
@@ -31,7 +31,7 @@ describe('Punishing One', function() {
                 context.player1.clickCard(context.vanquish);
                 context.player1.clickCard(context.wampa);
                 expect(context.wampa).toBeInZone('discard');
-                context.player1.clickPrompt('Ready this unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.punishingOne.exhausted).toBe(false);
 
 
@@ -41,7 +41,7 @@ describe('Punishing One', function() {
                 // CASE 2: Punishing One readies after defeating a unit with an upgrade
                 context.player1.clickCard(context.punishingOne);
                 context.player1.clickCard(context.privateerScyk);
-                context.player1.clickPrompt('Ready this unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.punishingOne.exhausted).toBe(false);
 
                 reset(false);
@@ -58,7 +58,7 @@ describe('Punishing One', function() {
                 // CASE 4: Punishing One should only ready once after defeating 2 units with upgrades
                 context.player1.clickCard(context.punishingOne);
                 context.player1.clickCard(context.outlandTieVanguard);
-                context.player1.clickPrompt('Ready this unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.punishingOne.exhausted).toBe(false);
                 reset();
                 context.player1.clickCard(context.punishingOne);

--- a/test/server/cards/02_SHD/units/RicketyQuadjumper.spec.ts
+++ b/test/server/cards/02_SHD/units/RicketyQuadjumper.spec.ts
@@ -21,7 +21,7 @@ describe('RicketyQuadjumper', function () {
 
                 // player1 should have prompt or pass
                 expect(context.player1).toHavePassAbilityPrompt('Reveal a card');
-                context.player1.clickPrompt('Reveal a card');
+                context.player1.clickPrompt('Trigger');
 
                 // top card is an upgrade, give exp to another unit
                 expect(context.protector).toBeInZone('deck');
@@ -54,7 +54,7 @@ describe('RicketyQuadjumper', function () {
                 context.player1.clickCard(context.p2Base);
                 // player1 should have prompt or pass
                 expect(context.player1).toHavePassAbilityPrompt('Reveal a card');
-                context.player1.clickPrompt('Reveal a card');
+                context.player1.clickPrompt('Trigger');
 
                 // top card is a unit, nothing happen
                 expect(context.isbAgent).toBeInZone('deck');

--- a/test/server/cards/02_SHD/units/RoseTicoDedicatedToTheCause.spec.ts
+++ b/test/server/cards/02_SHD/units/RoseTicoDedicatedToTheCause.spec.ts
@@ -30,7 +30,7 @@ describe('Rose Tico, Dedicated to the Cause', function () {
                 context.player1.clickCard(context.p2Base);
 
                 // add shield on enemy unit with lom pyke
-                context.player1.clickPrompt('Give a Shield token to an enemy unit');
+                context.player1.clickPrompt('Trigger');
                 // atst is automatically choose
                 context.player1.clickCard(context.greenSquadronAwing);
 

--- a/test/server/cards/02_SHD/units/StolenLandspeeder.spec.ts
+++ b/test/server/cards/02_SHD/units/StolenLandspeeder.spec.ts
@@ -29,7 +29,7 @@ describe('Stolen Landspeeder', function () {
 
             // and collects the bounty
             expect(context.player1).toHavePassAbilityPrompt(bountyPrompt);
-            context.player1.clickPrompt(bountyPrompt);
+            context.player1.clickPrompt('Trigger');
 
             expect(context.stolenLandspeeder).toBeInZone('groundArena', context.player1);
             expect(context.stolenLandspeeder).toHaveExactUpgradeNames(['experience']);
@@ -40,7 +40,7 @@ describe('Stolen Landspeeder', function () {
 
             // and collects the bounty
             expect(context.player2).toHavePassAbilityPrompt(bountyPrompt);
-            context.player2.clickPrompt(bountyPrompt);
+            context.player2.clickPrompt('Trigger');
 
             // which does nothing
             expect(context.stolenLandspeeder).toBeInZone('discard', context.player1);

--- a/test/server/cards/02_SHD/units/SynaraSanLoyalToKragan.spec.ts
+++ b/test/server/cards/02_SHD/units/SynaraSanLoyalToKragan.spec.ts
@@ -19,7 +19,7 @@ describe('Synara San, Loyal to Kragan', function() {
                 context.player2.clickCard(context.synaraSan);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Deal 5 damage to a base');
-                context.player2.clickPrompt('Collect Bounty: Deal 5 damage to a base');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player2).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player2.clickCard(context.p1Base);
@@ -45,7 +45,7 @@ describe('Synara San, Loyal to Kragan', function() {
                 context.player1.clickCard(context.atst);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Deal 5 damage to a base');
-                context.player2.clickPrompt('Collect Bounty: Deal 5 damage to a base');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player2).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player2.clickCard(context.p1Base);

--- a/test/server/cards/02_SHD/units/ToroCalicanAmbitiousUpstart.spec.ts
+++ b/test/server/cards/02_SHD/units/ToroCalicanAmbitiousUpstart.spec.ts
@@ -56,7 +56,7 @@ describe('Toro Calican, Ambitious Upstart', function() {
                 // CASE 5: play friendly Bounty Hunter, ability triggers
                 context.player1.clickCard(context.ketsuOnyo);
                 expect(context.player1).toHavePassAbilityPrompt('Deal 1 damage to the played Bounty Hunter unit');
-                context.player1.clickPrompt('Deal 1 damage to the played Bounty Hunter unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.ketsuOnyo.damage).toBe(1);
                 expect(context.toroCalican.exhausted).toBeFalse();
 
@@ -76,7 +76,7 @@ describe('Toro Calican, Ambitious Upstart', function() {
                 // ability triggers and can be activated even though Toro is not exhausted
                 context.player1.clickCard(context.embo);
                 expect(context.player1).toHavePassAbilityPrompt('Deal 1 damage to the played Bounty Hunter unit');
-                context.player1.clickPrompt('Deal 1 damage to the played Bounty Hunter unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.embo.damage).toBe(1);
                 expect(context.toroCalican.exhausted).toBeFalse();
 
@@ -86,7 +86,7 @@ describe('Toro Calican, Ambitious Upstart', function() {
                 // CASE 8: shield replacement effect should activate "if you do" ability
                 context.player1.clickCard(context.hunterOfTheHaxionBrood);
                 context.player1.clickPrompt('Shielded');
-                context.player1.clickPrompt('Deal 1 damage to the played Bounty Hunter unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.hunterOfTheHaxionBrood.isUpgraded()).toBeFalse();
                 expect(context.hunterOfTheHaxionBrood.damage).toBe(0);

--- a/test/server/cards/02_SHD/units/UnlicensedHeadhunter.spec.ts
+++ b/test/server/cards/02_SHD/units/UnlicensedHeadhunter.spec.ts
@@ -20,7 +20,7 @@ describe('Unlicensed Headhunter', function() {
                 context.player2.clickCard(context.unlicensedHeadhunter);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Heal 5 damage from your base');
-                context.player2.clickPrompt('Collect Bounty: Heal 5 damage from your base');
+                context.player2.clickPrompt('Trigger');
                 expect(context.p2Base.damage).toBe(1);
             });
 
@@ -42,7 +42,7 @@ describe('Unlicensed Headhunter', function() {
                 context.player1.clickCard(context.survivorsGauntlet);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Heal 5 damage from your base');
-                context.player2.clickPrompt('Collect Bounty: Heal 5 damage from your base');
+                context.player2.clickPrompt('Trigger');
                 expect(context.p2Base.damage).toBe(1);
             });
 

--- a/test/server/cards/02_SHD/units/ZuckussBountyHunterForHire.spec.ts
+++ b/test/server/cards/02_SHD/units/ZuckussBountyHunterForHire.spec.ts
@@ -23,7 +23,7 @@ describe('Zuckuss, Bounty Hunter for Hire', function() {
                 context.player1.clickCard(context._4lom);
 
                 // ambush from himself
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 // should have saboteur from zuckuss
                 expect(context.player1).toBeAbleToSelectExactly([context.bendu, context.vigilantHonorGuards]);
@@ -60,7 +60,7 @@ describe('Zuckuss, Bounty Hunter for Hire', function() {
 
                 context.player1.passAction();
                 context.player2.clickCard(context._4lom);
-                context.player2.clickPrompt('Ambush');
+                context.player2.clickPrompt('Trigger');
                 // pyke sentinel is automatically choose
 
                 expect(context.player1).toBeActivePlayer();

--- a/test/server/cards/02_SHD/upgrades/BountyHuntersQuarry.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/BountyHuntersQuarry.spec.ts
@@ -26,7 +26,7 @@ describe('Bounty hunter\'s quarry', function () {
 
                 // use bounty
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.battlefieldMarine, context.infernoFour, context.sabineWren],
                     invalid: [context.waylay, context.protector]
@@ -54,7 +54,7 @@ describe('Bounty hunter\'s quarry', function () {
 
                 // use bounty
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.sabineWren, context.infernoFour, context.superlaserTechnician, context.echoBaseDefender, context.swoopRacer],
                     invalid: [context.devotion, context.waylay, context.protector, context.consularSecurityForce, context.resupply]

--- a/test/server/cards/02_SHD/upgrades/DeathMark.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/DeathMark.spec.ts
@@ -19,7 +19,7 @@ describe('Death Mark', function() {
 
                 const prompt = 'Collect Bounty: Draw 2 cards';
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(2);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/02_SHD/upgrades/EnticingReward.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/EnticingReward.spec.ts
@@ -24,7 +24,7 @@ describe('Enticing Reward', function () {
 
                 // use bounty
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
 
                 // choose up to 2 non-units cards
                 expect(context.player1).toHaveExactDisplayPromptCards({
@@ -97,7 +97,7 @@ describe('Enticing Reward', function () {
 
                 // use bounty
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
 
                 // choose up to 2 non-units cards
                 expect(context.player1).toHaveExactDisplayPromptCards({

--- a/test/server/cards/02_SHD/upgrades/PriceOnYourHead.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/PriceOnYourHead.spec.ts
@@ -21,7 +21,7 @@ describe('Price on your Head', function() {
                 context.player1.clickCard(context.restoredArc170);
 
                 expect(context.player1).toHavePassAbilityPrompt(prompt);
-                context.player1.clickPrompt(prompt);
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.resources.length).toBe(startingResources + 1);
                 expect(context.player2).toBeActivePlayer();
@@ -46,7 +46,7 @@ describe('Price on your Head', function() {
 
                 // bounty trigger still appears even though there's no effect, b/c the player still needs to decide whether to "collect the bounty"
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Put the top card of your deck into play as a resource');
-                context.player1.clickPrompt('Collect Bounty: Put the top card of your deck into play as a resource');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player2).toBeActivePlayer();
             });

--- a/test/server/cards/02_SHD/upgrades/RichReward.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/RichReward.spec.ts
@@ -88,7 +88,7 @@ describe('Rich Reward', function() {
                 expect(context.player1).toHaveExactPromptButtons(['You', 'Opponent']);
                 context.player1.clickPrompt('You');
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Give an Experience token to each of up to 2 units');
-                context.player1.clickPrompt('Collect Bounty: Give an Experience token to each of up to 2 units');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player2).toBeActivePlayer();
             });

--- a/test/server/cards/02_SHD/upgrades/VambraceFlamethrower.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/VambraceFlamethrower.spec.ts
@@ -23,7 +23,7 @@ describe('Vambrace Flamethrower', function () {
                 context.player1.clickCard(context.p2Base);
 
                 expect(context.player1).toHavePassAbilityPrompt(flamethrowerPrompt);
-                context.player1.clickPrompt(flamethrowerPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.specforceSoldier]);
                 context.player1.setDistributeDamagePromptState(new Map([
@@ -59,7 +59,7 @@ describe('Vambrace Flamethrower', function () {
                 context.player1.clickCard(context.p2Base);
 
                 expect(context.player1).toHavePassAbilityPrompt(flamethrowerPrompt);
-                context.player1.clickPrompt(flamethrowerPrompt);
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.specforceSoldier]);
                 context.player1.setDistributeDamagePromptState(new Map([

--- a/test/server/cards/03_TWI/events/CornerThePrey.spec.ts
+++ b/test/server/cards/03_TWI/events/CornerThePrey.spec.ts
@@ -23,7 +23,7 @@ describe('Corner The Prey', function () {
 
                 // The Consular Security Force should have +2 power for this attack
                 expect(context.consularSecurityForce.getPower()).toBe(6);
-                context.player1.clickPrompt('Deal 3 damage divided as you choose among enemy ground units');
+                context.player1.clickPrompt('Trigger');
 
                 // Deal 3 damage to Chewbacca before the attack resolution
                 // They should not increase the power of the Consular Security Force for this attack

--- a/test/server/cards/03_TWI/events/PoliticalPressure.spec.ts
+++ b/test/server/cards/03_TWI/events/PoliticalPressure.spec.ts
@@ -23,7 +23,7 @@ describe('Political Pressure', function() {
                 context.player1.clickCard(context.politicalPressure);
 
                 expect(context.player2).toHaveEnabledPromptButtons(['Discard a random card from your hand', 'Opponent creates 2 Battle Droid Tokens']);
-                context.player2.clickPrompt('Discard a random card from your hand');
+                context.player2.clickPrompt('Trigger');
                 expect(context.player2.getCardsInZone('discard').length).toBe(1);
                 expect(context.player1.getCardsInZone('groundArena').length).toBe(0); // No Battle Droids tokens are created
                 expect(context.player2.hand.length).toBe(2);
@@ -58,7 +58,7 @@ describe('Political Pressure', function() {
 
                 // TODO: this probably shouldn't show a prompt at all since the discard effect won't fire, likely our resolution checks need some additional work around the optional: true case
                 expect(context.player2).toHaveEnabledPromptButtons(['Discard a random card from your hand', 'Opponent creates 2 Battle Droid Tokens']);
-                context.player2.clickPrompt('Discard a random card from your hand');
+                context.player2.clickPrompt('Trigger');
                 expect(context.player2.getCardsInZone('discard').length).toBe(0);
                 expect(context.player1.getCardsInZone('groundArena').length).toBe(2); // Battle Droids tokens are created
             });

--- a/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
@@ -47,7 +47,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
 
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.mandalorianWarrior.exhausted).toBeTrue();
 
@@ -61,7 +61,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
 
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
 
@@ -76,7 +76,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
 
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
 
@@ -112,7 +112,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 // Resolve for Fleet Lieutenant
                 context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
+                context.player1.clickPrompt('Trigger');
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
                 expect(context.jangoFett.exhausted).toBeTrue();
 
@@ -125,7 +125,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 context.player1.clickCard(context.isbAgent);
                 context.player1.clickCard(context.volunteerSoldier);
-                context.player1.clickPrompt('Deal 3 damage divided as you choose among enemy ground units');
+                context.player1.clickPrompt('Trigger');
                 context.player1.setDistributeDamagePromptState(new Map([
                     [context.battlefieldMarine, 2],
                     [context.fleetLieutenant, 1],
@@ -140,7 +140,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Resolve for Battlefield Marine
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
 
                 // CASE 6: Trigger Jango's ability when a unit is defeated at the end of the phase
@@ -166,7 +166,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
 
                 // Use Jango's ability to exhaust Mandalorian Warrior
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.mandalorianWarrior.exhausted).toBeTrue();
 
                 // CASE 7: Trigger Jango's ability when a stolen unit attacks
@@ -186,7 +186,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Use Jango's ability to exhaust Consular Security Force
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.consularSecurityForce.exhausted).toBeTrue();
             });
 
@@ -260,7 +260,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 // Use Jango's ability to exhaust Battlefield Marine
                 context.player1.clickCard(context.battlefieldMarine);
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
                 expect(context.jangoFett.exhausted).toBeTrue();
 
@@ -328,7 +328,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
                 expect(context.jangoFett.exhausted).toBeTrue();
@@ -385,7 +385,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit');
 
-                context.player1.clickPrompt('Exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.mandalorianWarrior.exhausted).toBeTrue();
 
@@ -399,7 +399,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit');
 
-                context.player1.clickPrompt('Exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
 
@@ -413,7 +413,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 context.player1.clickCard(context.fleetLieutenant);
 
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
 
@@ -444,7 +444,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Exhaust Volunteer Soldier
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
+                context.player1.clickPrompt('Trigger');
                 expect(context.volunteerSoldier.exhausted).toBeTrue();
 
                 // Choose resolution order again
@@ -458,12 +458,12 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Exhaust Fleet Lieutenant
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
+                context.player1.clickPrompt('Trigger');
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
 
                 // Exhaust Battlefield Marine
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
 
                 // CASE 5: Trigger Jango's ability from an upgrade's granted ability
@@ -474,7 +474,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 // Attack and distribute damage with Vambrace Flamethrower
                 context.player1.clickCard(context.isbAgent);
                 context.player1.clickCard(context.volunteerSoldier);
-                context.player1.clickPrompt('Deal 3 damage divided as you choose among enemy ground units');
+                context.player1.clickPrompt('Trigger');
                 context.player1.setDistributeDamagePromptState(new Map([
                     [context.battlefieldMarine, 2],
                     [context.fleetLieutenant, 1],
@@ -485,15 +485,15 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Exhaust Fleet Lieutenant
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
+                context.player1.clickPrompt('Trigger');
 
                 // Exhaust for Battlefield Marine
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
 
                 // Exhaust Volunteer Soldier
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
@@ -516,7 +516,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Use Jango's ability to exhaust Consular Security Force
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.consularSecurityForce.exhausted).toBeTrue();
 
                 // CASE 11: Trigger Jango's ability with indirect damage
@@ -545,7 +545,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Exhaust Volunteer Soldier
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
+                context.player1.clickPrompt('Trigger');
                 expect(context.volunteerSoldier.exhausted).toBeTrue();
 
                 // Choose resolution order again
@@ -559,12 +559,12 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // Exhaust Battlefield Marine
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
 
                 // Exhaust Fleet Lieutenant
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
+                context.player1.clickPrompt('Trigger');
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
             });
         });

--- a/test/server/cards/03_TWI/leaders/QuinlanVosStickingTheLanding.spec.ts
+++ b/test/server/cards/03_TWI/leaders/QuinlanVosStickingTheLanding.spec.ts
@@ -28,7 +28,7 @@ describe('Quinlan Vos, Sticking the Landing', function () {
 
             // can pass this trigger
             expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
-            context.player1.clickPrompt('Exhaust this leader');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player1).toBeAbleToSelectExactly([context.craftySmuggler, context.greenSquadronAwing]);
             context.player1.clickCard(context.greenSquadronAwing);

--- a/test/server/cards/03_TWI/leaders/YodaSensingDarkness.spec.ts
+++ b/test/server/cards/03_TWI/leaders/YodaSensingDarkness.spec.ts
@@ -191,7 +191,7 @@ describe('Yoda, Sensing Darkness', function () {
 
                 // Should be able to pass
                 expect(context.player1).toHavePassAbilityPrompt('You may discard the top card from your deck. If you do, defeat an enemy non-leader unit with cost equal to or less than the cost of the discarded card.');
-                context.player1.clickPrompt('You may discard the top card from your deck. If you do, defeat an enemy non-leader unit with cost equal to or less than the cost of the discarded card.');
+                context.player1.clickPrompt('Trigger');
                 expect(context.entrenched).toBeInZone('discard');
                 expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.battlefieldMarine]);
                 context.player1.clickCard(context.pykeSentinel);

--- a/test/server/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.spec.ts
+++ b/test/server/cards/03_TWI/units/AaylaSecuraMasterOfTheBlade.spec.ts
@@ -85,7 +85,7 @@ describe('Aayla Secura, Master of the Blade', function() {
                 // Player 1 ambushes Aayla back into play, activating Coordinate and preventing combat damage
                 context.player1.clickCard(context.timelyIntervention);
                 context.player1.clickCard(context.aaylaSecura);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.consularSecurityForce);
 
                 expect(context.aaylaSecura.damage).toBe(0);

--- a/test/server/cards/03_TWI/units/CadBaneHostageTaker.spec.ts
+++ b/test/server/cards/03_TWI/units/CadBaneHostageTaker.spec.ts
@@ -59,7 +59,7 @@ describe('Cad Bane, Hostage Taker', function() {
             // Player 2 rescues the Wampa and Player 1 draws 2 cards
             expect(context.player1.handSize).toBe(0);
             expect(context.player2).toHavePassAbilityPrompt('Rescue a card you own captured by Cad Bane and the opponent draws 2 cards');
-            context.player2.clickPrompt('Rescue a card you own captured by Cad Bane and the opponent draws 2 cards');
+            context.player2.clickPrompt('Trigger');
 
             // Player 2 can't rescue the Battlefield Marine because they don't own it
             expect(context.player2).toBeAbleToSelectExactly([context.wampa, context.wingLeader]);

--- a/test/server/cards/03_TWI/units/CoruscantGuard.spec.ts
+++ b/test/server/cards/03_TWI/units/CoruscantGuard.spec.ts
@@ -20,7 +20,7 @@ describe('Coruscant Guard', function() {
 
             context.player1.clickCard(context.coruscantGuard);
             expect(context.player1).toHavePassAbilityPrompt('Ambush');
-            context.player1.clickPrompt('Ambush');
+            context.player1.clickPrompt('Trigger');
             expect(context.coruscantGuard.damage).toBe(1);
             expect(context.hylobonEnforcer.damage).toBe(3);
         });

--- a/test/server/cards/03_TWI/units/DroidCommando.spec.ts
+++ b/test/server/cards/03_TWI/units/DroidCommando.spec.ts
@@ -21,7 +21,7 @@ describe('Droid Commando', function () {
                 context.player1.clickCard(context.droidCommando);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.consularSecurityForce.damage).toBe(4);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/03_TWI/units/FreelanceAssassin.spec.ts
+++ b/test/server/cards/03_TWI/units/FreelanceAssassin.spec.ts
@@ -20,7 +20,7 @@ describe('Freelance Assassin', function () {
 
                 // have a prompt to pay 2 resources
                 expect(context.player1).toHavePassAbilityPrompt('Pay 2 resources');
-                context.player1.clickPrompt('Pay 2 resources');
+                context.player1.clickPrompt('Trigger');
 
                 // deal 2 damage to a unit
                 expect(context.player1).toBeAbleToSelectExactly([context.freelanceAssassin, context.restoredArc170, context.battlefieldMarine]);

--- a/test/server/cards/03_TWI/units/KiAdiMundiComposedAndConfident.spec.ts
+++ b/test/server/cards/03_TWI/units/KiAdiMundiComposedAndConfident.spec.ts
@@ -23,7 +23,7 @@ describe('Ki Adi Mundi, Composed and Confident', function() {
                 context.player2.clickCard(context.atst); // Opponent plays second card, ability triggers
 
                 expect(context.player1).toHavePassAbilityPrompt('Draw 2 cards');
-                context.player1.clickPrompt('Draw 2 cards');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(3);
                 expect(context.battlefieldMarine).toBeInZone('hand');
@@ -58,7 +58,7 @@ describe('Ki Adi Mundi, Composed and Confident', function() {
                 context.player2.clickCard(context.wampa);
 
                 expect(context.player1).toHavePassAbilityPrompt('Draw 2 cards');
-                context.player1.clickPrompt('Draw 2 cards');
+                context.player1.clickPrompt('Trigger');
                 expect(context.consularSecurityForce).toBeInZone('hand');
                 expect(context.kashyyykDefender).toBeInZone('hand');
             });

--- a/test/server/cards/03_TWI/units/MasAmeddaViceChair.spec.ts
+++ b/test/server/cards/03_TWI/units/MasAmeddaViceChair.spec.ts
@@ -22,10 +22,10 @@ describe('Mas Amedda, Vice Chair', function() {
 
                 context.player1.clickCard(context.frontierAtrt);
                 expect(context.player1).toHavePrompt('Trigger the ability \'Exhaust this unit\' or pass');
-                expect(context.player1).toHaveEnabledPromptButton('Exhaust this unit');
+                expect(context.player1).toHaveEnabledPromptButton('Trigger');
                 expect(context.player1).toHaveEnabledPromptButton('Pass');
 
-                context.player1.clickPrompt('Exhaust this unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.systemPatrolCraft, context.clanWrenRescuer, context.concordDawnInterceptors],
@@ -50,10 +50,10 @@ describe('Mas Amedda, Vice Chair', function() {
 
                 context.player1.clickCard(context.frontierAtrt);
                 expect(context.player1).toHavePrompt('Trigger the ability \'Exhaust this unit\' or pass');
-                expect(context.player1).toHaveEnabledPromptButton('Exhaust this unit');
+                expect(context.player1).toHaveEnabledPromptButton('Trigger');
                 expect(context.player1).toHaveEnabledPromptButton('Pass');
 
-                context.player1.clickPrompt('Exhaust this unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.systemPatrolCraft, context.clanWrenRescuer, context.concordDawnInterceptors],
@@ -72,7 +72,7 @@ describe('Mas Amedda, Vice Chair', function() {
 
                 context.player1.clickCard(context.frontierAtrt);
                 expect(context.player1).toHavePrompt('Trigger the ability \'Exhaust this unit\' or pass');
-                expect(context.player1).toHaveEnabledPromptButton('Exhaust this unit');
+                expect(context.player1).toHaveEnabledPromptButton('Trigger');
                 expect(context.player1).toHaveEnabledPromptButton('Pass');
 
                 context.player1.clickPrompt('Pass');
@@ -88,10 +88,10 @@ describe('Mas Amedda, Vice Chair', function() {
 
                 context.player2.clickCard(context.superlaserTechnician);
                 expect(context.player2).toHavePrompt('Trigger the ability \'Exhaust this unit\' or pass');
-                expect(context.player2).toHaveEnabledPromptButton('Exhaust this unit');
+                expect(context.player2).toHaveEnabledPromptButton('Trigger');
                 expect(context.player2).toHaveEnabledPromptButton('Pass');
 
-                context.player2.clickPrompt('Exhaust this unit');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player2).toHaveExactDisplayPromptCards({
                     invalid: [context.priceOnYourHead, context.mercilessContest, context.overwhelmingBarrage, context.publicEnemy]

--- a/test/server/cards/03_TWI/units/ObiWansAetherspriteThisIsWhyIHateFlying.spec.ts
+++ b/test/server/cards/03_TWI/units/ObiWansAetherspriteThisIsWhyIHateFlying.spec.ts
@@ -18,7 +18,7 @@ describe('Obi Wan\'s Aethersprite, This Is Why I Hate Flying', function () {
             // When played ability
             context.player1.clickCard(context.obiwansAetherspriteThisIsWhyIHateFlying);
             expect(context.player1).toHavePassAbilityPrompt('Deal 1 damage to this unit');
-            context.player1.clickPrompt('Deal 1 damage to this unit');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.tielnFighter, context.corellianFreighter]);
             context.player1.clickCard(context.greenSquadronAwing);
 
@@ -32,7 +32,7 @@ describe('Obi Wan\'s Aethersprite, This Is Why I Hate Flying', function () {
             context.player1.clickCard(context.p2Base);
 
             expect(context.player1).toHavePassAbilityPrompt('Deal 1 damage to this unit');
-            context.player1.clickPrompt('Deal 1 damage to this unit');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing, context.tielnFighter, context.corellianFreighter]);
             context.player1.clickCard(context.corellianFreighter);
 

--- a/test/server/cards/03_TWI/units/PloKoonKohtoyah.spec.ts
+++ b/test/server/cards/03_TWI/units/PloKoonKohtoyah.spec.ts
@@ -19,7 +19,7 @@ describe('Plo Koon Kohtoyah', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.ploKoon);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.consularSecurityForce);
                 expect(context.consularSecurityForce.damage).toBe(6);
                 expect(context.ploKoon.damage).toBe(3);
@@ -48,7 +48,7 @@ describe('Plo Koon Kohtoyah', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.ploKoon);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 expect(context.wampa.damage).toBe(3);
                 expect(context.ploKoon.damage).toBe(4);
             });

--- a/test/server/cards/03_TWI/units/PoggleTheLesserArchdukeOfTheStalgasinHive.spec.ts
+++ b/test/server/cards/03_TWI/units/PoggleTheLesserArchdukeOfTheStalgasinHive.spec.ts
@@ -18,7 +18,7 @@ describe('Poggle The Lesser, Archduke of the Stalgasin Hive', function() {
             // Player plays a unit, exhaust Poggle and create a Battle Droid token
             context.player1.clickCard(context.battlefieldMarine);
             expect(context.player1).toHavePassAbilityPrompt('Exhaust this unit');
-            context.player1.clickPrompt('Exhaust this unit');
+            context.player1.clickPrompt('Trigger');
 
             let battleDroids = context.player1.findCardsByName('battle-droid');
             expect(battleDroids.length).toBe(1);

--- a/test/server/cards/03_TWI/units/SabineWrenYouCanCountOnMe.spec.ts
+++ b/test/server/cards/03_TWI/units/SabineWrenYouCanCountOnMe.spec.ts
@@ -21,7 +21,7 @@ describe('Sabine Wren, You Can Count On Me', function () {
 
             // can discard the top card of deck
             expect(context.player1).toHavePassAbilityPrompt('Discard the top card from your deck');
-            context.player1.clickPrompt('Discard the top card from your deck');
+            context.player1.clickPrompt('Trigger');
 
             // specforce soldier does not share an aspect with echo base, can select an enemy ground unit
             expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.consularSecurityForce]);
@@ -37,7 +37,7 @@ describe('Sabine Wren, You Can Count On Me', function () {
             // aspect match the base, nothing happen
             context.player1.clickCard(context.sabineWren);
             context.player1.clickCard(context.p2Base);
-            context.player1.clickPrompt('Discard the top card from your deck');
+            context.player1.clickPrompt('Trigger');
             expect(context.player2).toBeActivePlayer();
 
             // sabine wren can't be attacked

--- a/test/server/cards/03_TWI/units/SanHillChairmanOfTheBankingClan.spec.ts
+++ b/test/server/cards/03_TWI/units/SanHillChairmanOfTheBankingClan.spec.ts
@@ -21,7 +21,7 @@ describe('San Hill, Chairman of the Banking Clan', function () {
 
                 // Syndicate Lackeys should be defeated by attacking Wampa
                 context.player1.clickCard(context.syndicateLackeys);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player1.readyResourceCount).toBe(5);

--- a/test/server/cards/03_TWI/units/SteelaGerreraBelovedTactician.spec.ts
+++ b/test/server/cards/03_TWI/units/SteelaGerreraBelovedTactician.spec.ts
@@ -28,7 +28,7 @@ describe('Steela Gerrera, Beloved Tactician', function () {
 
             // deal 2 damage to our base to search the top 8 card of deck for a tactic card
             expect(context.player1).toHavePassAbilityPrompt('Deal 2 damage to your base');
-            context.player1.clickPrompt('Deal 2 damage to your base');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player1).toHaveExactDisplayPromptCards({
                 selectable: [context.takedown, context.superlaserBlast, context.strikeTrue],

--- a/test/server/cards/03_TWI/units/ZiroTheHuttColorfulSchemer.spec.ts
+++ b/test/server/cards/03_TWI/units/ZiroTheHuttColorfulSchemer.spec.ts
@@ -33,7 +33,7 @@ describe('Ziro the Hutt, Colorful Schemer', function () {
 
                 // should exhaust an enemy resource
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust an enemy resource');
-                context.player1.clickPrompt('Exhaust an enemy resource');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player2.exhaustedResourceCount).toBe(1);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/03_TWI/upgrades/Foresight.spec.ts
+++ b/test/server/cards/03_TWI/upgrades/Foresight.spec.ts
@@ -23,7 +23,7 @@ describe('Foresight', function () {
 
             // top card is millennium falcon, can reveal and draw
             expect(context.player1).toHavePassAbilityPrompt('Reveal and draw the top card of deck');
-            context.player1.clickPrompt('Reveal and draw the top card of deck');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.hand.length).toBe(3);
 
             // move to action phase

--- a/test/server/cards/03_TWI/upgrades/HoldoutBlaster.spec.ts
+++ b/test/server/cards/03_TWI/upgrades/HoldoutBlaster.spec.ts
@@ -28,7 +28,7 @@ describe('Hold-out Blaster', function() {
 
             // Resolve Jango's ability
             expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
-            context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.r2d2IgnoringProtocol.damage).toBe(1);
             expect(context.r2d2IgnoringProtocol.exhausted).toBeTrue();

--- a/test/server/cards/04_JTL/events/NoGloryOnlyResults.spec.ts
+++ b/test/server/cards/04_JTL/events/NoGloryOnlyResults.spec.ts
@@ -22,7 +22,7 @@ describe('No Glory, Only Results', function() {
 
             // Choose Superlaser Technician and defeat it
             context.player1.clickCard(context.superlaserTechnician);
-            context.player1.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+            context.player1.clickPrompt('Trigger');
             expect(context.superlaserTechnician).toBeInZone('resource', context.player1);
 
             // Player 2 passes
@@ -88,7 +88,7 @@ describe('No Glory, Only Results', function() {
 
             // Choose Supreme Leader Snoke and defeat it
             context.player1.clickCard(context.supremeLeaderSnoke);
-            context.player2.clickPrompt('Put Superlaser Technician into play as a resource and ready it');
+            context.player2.clickPrompt('Trigger');
             expect(context.supremeLeaderSnoke).toBeInZone('discard');
             expect(context.blackSunStarfighter).toBeInZone('discard');
             expect(context.superlaserTechnician).toBeInZone('resource');

--- a/test/server/cards/04_JTL/units/BlackSquadronScoutWing.spec.ts
+++ b/test/server/cards/04_JTL/units/BlackSquadronScoutWing.spec.ts
@@ -19,7 +19,7 @@ describe('Black Squadron Scout Wing', function() {
 
             expect(context.player1).toHavePassAbilityPrompt('Attack with this unit. It gets +1/+0 for this attack.');
 
-            context.player1.clickPrompt('Attack with this unit. It gets +1/+0 for this attack.');
+            context.player1.clickPrompt('Trigger');
             context.player1.clickCard(context.p2Base);
 
             // Player 2's base should have 7 damage (4 from Black Squadron Scout Wing + 2 from Academy Training + 1 from card text)

--- a/test/server/cards/04_JTL/units/ChamSyndullaRallyingRyloth.spec.ts
+++ b/test/server/cards/04_JTL/units/ChamSyndullaRallyingRyloth.spec.ts
@@ -18,7 +18,7 @@ describe('Cham Syndulla, Rallying Ryloth', function () {
             context.player1.clickCard(context.chamSyndulla);
 
             expect(context.player1).toHavePassAbilityPrompt('Put the top card of your deck into play as a resource');
-            context.player1.clickPrompt('Put the top card of your deck into play as a resource');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.battlefieldMarine).toBeInZone('resource');

--- a/test/server/cards/04_JTL/units/LandingShuttle.spec.ts
+++ b/test/server/cards/04_JTL/units/LandingShuttle.spec.ts
@@ -21,7 +21,7 @@ describe('Landing Shuttle', function() {
 
             expect(context.player1).toHavePassAbilityPrompt('Draw a card');
 
-            context.player1.clickPrompt('Draw a card');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player1.hand.length).toBe(startingHandSize + 1);
             expect(context.player1.deck.length).toBe(startingDeckSize - 1);

--- a/test/server/cards/04_JTL/units/MistHunterTheFindsmansPursuit.spec.ts
+++ b/test/server/cards/04_JTL/units/MistHunterTheFindsmansPursuit.spec.ts
@@ -31,7 +31,7 @@ describe('Mist Hunter The Findsmans Pursuit', function() {
             context.player1.clickCard(context.mistHunter);
             context.player1.clickCard(context.p2Base);
             expect(context.player1).toHavePassAbilityButton();
-            context.player1.clickPrompt('Draw a card');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.handSize).toBe(4);
 
 
@@ -42,7 +42,7 @@ describe('Mist Hunter The Findsmans Pursuit', function() {
             context.player2.passAction();
             context.player1.clickCard(context.mistHunter);
             context.player1.clickCard(context.p2Base);
-            context.player1.clickPrompt('Draw a card');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.handSize).toBe(6);
 
             context.moveToNextActionPhase();  // adds two cards to hand

--- a/test/server/cards/04_JTL/units/RedSquadronXWing.spec.ts
+++ b/test/server/cards/04_JTL/units/RedSquadronXWing.spec.ts
@@ -19,7 +19,7 @@ describe('Red Squadron X-Wing', function() {
             // Play Red Squadron X-Wing and deal 1 damage to itself to draw a card
             context.player1.clickCard(context.redSquadronXwing);
             expect(context.player1).toHavePassAbilityPrompt('Deal 2 damage to this unit');
-            context.player1.clickPrompt('Deal 2 damage to this unit');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.redSquadronXwing.damage).toBe(2);

--- a/test/server/cards/04_JTL/units/ResupplyCarrier.spec.ts
+++ b/test/server/cards/04_JTL/units/ResupplyCarrier.spec.ts
@@ -17,7 +17,7 @@ describe('Resupply Carrier', function() {
 
             expect(context.player1).toHavePassAbilityPrompt('Put the top card of your deck into play as a resource');
 
-            context.player1.clickPrompt('Put the top card of your deck into play as a resource');
+            context.player1.clickPrompt('Trigger');
 
             expect(context.player1.resources.length).toBe(startingResources + 1);
             expect(context.player1.deck.length).toBe(startingDeckSize - 1);

--- a/test/server/core/abilities/keyword/Ambush.spec.ts
+++ b/test/server/core/abilities/keyword/Ambush.spec.ts
@@ -24,7 +24,7 @@ describe('Ambush keyword', function() {
 
                 context.player1.clickCard(context.syndicateLackeys);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce, context.snowspeeder]);
 
@@ -60,7 +60,7 @@ describe('Ambush keyword', function() {
 
                 context.player1.clickCard(context.syndicateLackeys);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.syndicateLackeys.exhausted).toBe(true);
                 expect(context.p2Base.damage).toBe(0);
@@ -122,7 +122,7 @@ describe('Ambush keyword', function() {
 
                 context.player1.clickCard(context.syndicateLackeys);
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce, context.snowspeeder]);
 

--- a/test/server/core/abilities/keyword/Bounty.spec.ts
+++ b/test/server/core/abilities/keyword/Bounty.spec.ts
@@ -21,7 +21,7 @@ describe('Bounty', function() {
                 context.player1.clickCard(context.wampa);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);
@@ -74,7 +74,7 @@ describe('Bounty', function() {
                 context.player1.clickCard(context.vanquish);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);
@@ -104,7 +104,7 @@ describe('Bounty', function() {
                 expect(context.hylobonEnforcer).toBeCapturedBy(context.discerningVeteran);
 
                 expect(context.player2).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player2.clickPrompt('Collect Bounty: Draw a card');
+                context.player2.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(0);
                 expect(context.player2.handSize).toBe(1);
@@ -232,7 +232,7 @@ describe('Bounty', function() {
                 context.player1.clickCard(context.hylobonEnforcer);
 
                 expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw a card');
-                context.player1.clickPrompt('Collect Bounty: Draw a card');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1.handSize).toBe(1);
                 expect(context.player2.handSize).toBe(0);
@@ -296,7 +296,7 @@ describe('Bounty', function() {
 
                 // Jango triggers
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.consularSecurityForce.exhausted).toBe(true);
                 expect(context.jangoFett.exhausted).toBe(true);
@@ -340,7 +340,7 @@ describe('Bounty', function() {
 
                 // Jango triggers
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit');
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit');
+                context.player1.clickPrompt('Trigger');
 
                 expect(context.consularSecurityForce.exhausted).toBe(true);
                 expect(context.jangoFett.exhausted).toBe(true);
@@ -367,7 +367,7 @@ describe('Bounty', function() {
             context.player1.clickCard(context.rivalsFall);
             context.player1.clickCard(context.asajjVentress);
             expect(context.player1).toHavePassAbilityPrompt('Collect Bounty: Draw 2 cards');
-            context.player1.clickPrompt('Collect Bounty: Draw 2 cards');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.handSize).toBe(2);
         });
     });

--- a/test/server/core/abilities/keyword/Exploit.spec.ts
+++ b/test/server/core/abilities/keyword/Exploit.spec.ts
@@ -500,9 +500,9 @@ describe('Exploit keyword', function() {
 
             // resolve first Krell ability, second resolves automatically
             context.player1.clickPrompt('Draw a card');
-            context.player1.clickPrompt('Draw a card');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.handSize).toBe(1);
-            context.player1.clickPrompt('Draw a card');
+            context.player1.clickPrompt('Trigger');
             expect(context.player1.handSize).toBe(2);
         });
 

--- a/test/server/core/abilities/keyword/Overwhelm.spec.ts
+++ b/test/server/core/abilities/keyword/Overwhelm.spec.ts
@@ -127,7 +127,7 @@ describe('Overwhelm keyword', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.gorGrievoussPet);
-                context.player1.clickPrompt('Ambush');
+                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.deathStarStormtrooper);
 
                 expect(context.deathStarStormtrooper).toBeInZone('discard');

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -216,7 +216,7 @@ describe('Uniqueness rule', function() {
                 // triggered abilities from the remaining Kallus, including Ambush (which fizzles due to no attack target)
                 expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Ambush']);
                 context.player1.clickPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');     // this click is for the 'Pass' prompt
+                context.player1.clickPrompt('Trigger');     // this click is for the 'Pass' prompt
                 expect(context.player1.handSize).toBe(handSize + 1);
 
                 expect(context.player2).toBeActivePlayer();
@@ -243,7 +243,7 @@ describe('Uniqueness rule', function() {
                 // triggered abilities from the remaining Kallus, including Ambush (which fizzles due to attacker being defeated)
                 expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Ambush']);
                 context.player1.clickPrompt('Draw a card');
-                context.player1.clickPrompt('Draw a card');     // this click is for the 'Pass' prompt
+                context.player1.clickPrompt('Trigger');     // this click is for the 'Pass' prompt
                 expect(context.player1.handSize).toBe(handSize + 1);
 
                 expect(context.player2).toBeActivePlayer();
@@ -288,7 +288,7 @@ describe('Uniqueness rule', function() {
 
                 // triggered ability from defeated Motti
                 expect(context.player1).toHavePassAbilityPrompt('Ready a Villainy unit');
-                context.player1.clickPrompt('Ready a Villainy unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.mottiInHand.exhausted).toBe(false);
 
                 expect(context.player2).toBeActivePlayer();
@@ -312,7 +312,7 @@ describe('Uniqueness rule', function() {
 
                 // triggered ability from defeated Motti
                 expect(context.player1).toHavePassAbilityPrompt('Ready a Villainy unit');
-                context.player1.clickPrompt('Ready a Villainy unit');
+                context.player1.clickPrompt('Trigger');
                 expect(context.mottiInPlay.exhausted).toBe(false);
 
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/core/gameSteps/phases/SetupPhase.spec.ts
+++ b/test/server/core/gameSteps/phases/SetupPhase.spec.ts
@@ -51,16 +51,16 @@ describe('Setup Phase', function() {
 
                 // Mulligan step
                 // check if each player has correct prompt
-                expect(context.player1).toHaveExactPromptButtons(['Yes', 'No']);
-                expect(context.player2).toHaveExactPromptButtons(['Yes', 'No']);
+                expect(context.player1).toHaveExactPromptButtons(['Mulligan', 'Keep']);
+                expect(context.player2).toHaveExactPromptButtons(['Mulligan', 'Keep']);
 
 
                 // Check if player2 can still mulligan after player1 selects yes.
-                context.player1.clickPrompt('yes');
+                context.player1.clickPrompt('Mulligan');
                 expect(context.player1.hand).toEqual(beforeMulliganHand);
-                expect(context.player2).toHaveExactPromptButtons(['Yes', 'No']);
+                expect(context.player2).toHaveExactPromptButtons(['Mulligan', 'Keep']);
                 expect(context.player1).toHavePrompt('Waiting for opponent to choose whether to Mulligan or keep hand.');
-                context.player2.clickPrompt('no');
+                context.player2.clickPrompt('Keep');
 
                 const afterMulliganHand = context.player1.hand;
                 const afterPlayer2Hand = context.player2.hand;
@@ -175,9 +175,9 @@ describe('Setup Phase', function() {
                 expect(context.player2.handSize).toBe(6);
 
                 // Mulligan step
-                context.player1.clickPrompt('no');
+                context.player1.clickPrompt('Keep');
                 expect(context.player1).toHavePrompt('Waiting for opponent to choose whether to Mulligan or keep hand.');
-                context.player2.clickPrompt('no');
+                context.player2.clickPrompt('Keep');
 
                 // We check if player1's hand has the only selectable cards
                 expect(context.player1).toBeAbleToSelectExactly(context.player1.hand);

--- a/test/server/core/gameSteps/regroupWindow/RegroupPhase.spec.ts
+++ b/test/server/core/gameSteps/regroupWindow/RegroupPhase.spec.ts
@@ -157,7 +157,7 @@ describe('Regroup phase', function() {
 
                     // We check the timing of General Krells "When Defeated"
                     expect(context.player1).toHavePrompt('Trigger the ability \'Draw a card\' or pass');
-                    context.player1.clickPrompt('Draw a card');
+                    context.player1.clickPrompt('Trigger');
 
                     // Check board state
                     expect(context.ardentSympathizer.zoneName).toBe('discard');


### PR DESCRIPTION
- Optional ability prompt now says 'Trigger' instead of the full ability name on the button
- Mulligan and initiative prompts now have more descriptive button names instead of yes / no