### PR TITLE
#QuickMatchmakingRequeueFix

### DIFF
--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -46,10 +46,10 @@ export class Lobby {
     private readonly testGameBuilder?: any;
 
     private game: Game;
-    private users: LobbyUser[] = [];
+    public users: LobbyUser[] = [];
     private lobbyOwnerId: string;
-    private gameType: MatchType;
-    private gameFormat: SwuGameFormat;
+    public gameType: MatchType;
+    public gameFormat: SwuGameFormat;
     private rematchRequest?: RematchRequest = null;
 
     public constructor(


### PR DESCRIPTION
- Added a fix for requeuing. The problem occurred when a user refreshed the page when matched with a player. Their socket was reinitialized and were added to the lobby without a requeue event listener. 