### PR TITLE
Fixes to various "gain constant ability" effects

### DIFF
--- a/server/game/cards/03_TWI/upgrades/ShadowedIntentions.ts
+++ b/server/game/cards/03_TWI/upgrades/ShadowedIntentions.ts
@@ -11,7 +11,7 @@ export default class ShadowedIntentions extends UpgradeCard {
     }
 
     protected override setupCardAbilities() {
-        this.addConstantAbilityTargetingAttached({
+        this.addGainConstantAbilityTargetingAttached({
             title: 'This unit can\'t be captured, defeated, or returned to its owner\'s hand by enemy card abilities',
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.cardCannot({

--- a/server/game/cards/03_TWI/upgrades/SquadSupport.ts
+++ b/server/game/cards/03_TWI/upgrades/SquadSupport.ts
@@ -14,7 +14,7 @@ export default class SquadSupport extends UpgradeCard {
     public override setupCardAbilities() {
         this.setAttachCondition((card: Card) => !card.isLeader());
 
-        this.addConstantAbilityTargetingAttached({
+        this.addGainConstantAbilityTargetingAttached({
             title: 'This unit gets +1/+1 for each Trooper unit you control.',
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((target) => {
                 const trooperUnits = target.controller.getUnitsInPlayWithTrait(Trait.Trooper);

--- a/server/game/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.ts
+++ b/server/game/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../../../server/game/AbilityHelper';
 import { NonLeaderUnitCard } from '../../../../../server/game/core/card/NonLeaderUnitCard';
-import { AbilityRestriction } from '../../../../../server/game/core/Constants';
+import { AbilityRestriction, AbilityType } from '../../../../../server/game/core/Constants';
 
 export default class ChewbaccaFaithfulFirstMate extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -25,7 +25,8 @@ export default class ChewbaccaFaithfulFirstMate extends NonLeaderUnitCard {
             ]
         });
 
-        this.addPilotingConstantAbilityTargetingAttached({
+        this.addPilotingGainAbilityTargetingAttached({
+            type: AbilityType.Constant,
             title: 'This unit can\'t be captured or damaged by enemy card abilities',
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.cardCannot({

--- a/server/game/cards/04_JTL/units/JarekYeagerCoordinatingWithTheResistance.ts
+++ b/server/game/cards/04_JTL/units/JarekYeagerCoordinatingWithTheResistance.ts
@@ -1,4 +1,3 @@
-import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, ZoneName } from '../../../core/Constants';
 
@@ -11,10 +10,9 @@ export default class JarekYeagerCoordinatingWithTheResistance extends NonLeaderU
     }
 
     public override setupCardAbilities() {
-        this.addPilotingConstantAbilityTargetingAttached({
-            title: 'While you control a ground unit and a space unit, attached unit gains Sentinel',
-            condition: (context) => context.player.getCardsInZone(ZoneName.SpaceArena).length > 0 && context.player.getCardsInZone(ZoneName.GroundArena).length > 0,
-            ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
+        this.addPilotingGainKeywordTargetingAttached({
+            gainCondition: (context) => context.player.getCardsInZone(ZoneName.SpaceArena).length > 0 && context.player.getCardsInZone(ZoneName.GroundArena).length > 0,
+            keyword: KeywordName.Sentinel
         });
     }
 }

--- a/server/game/cards/04_JTL/units/R2D2Artooooooooo.ts
+++ b/server/game/cards/04_JTL/units/R2D2Artooooooooo.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { WildcardZoneName } from '../../../core/Constants';
+import { AbilityType, WildcardZoneName } from '../../../core/Constants';
 
 export default class R2D2Artooooooooo extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -11,8 +11,9 @@ export default class R2D2Artooooooooo extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities () {
-        this.addPilotingConstantAbilityTargetingAttached({
+        this.addPilotingGainAbilityTargetingAttached({
             title: 'You may play or deploy 1 additional Pilot on this unit',
+            type: AbilityType.Constant,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyPilotingLimit({ amount: 1 })
         });
 

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -15,6 +15,8 @@ import type { IUnitCard } from './propertyMixins/UnitProperties';
 import type { IPlayableCard } from './baseClasses/PlayableOrDeployableCard';
 import type { ICardCanChangeControllers, IUpgradeCard } from './CardInterfaces';
 
+type IConstantAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = IConstantAbilityProps<TTarget> & IGainCondition<TSource>;
+
 type ITriggeredAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityProps<TTarget> & IGainCondition<TSource>;
 
 type ITriggeredAbilityBasePropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityBaseProps<TTarget> & IGainCondition<TSource>;
@@ -80,6 +82,20 @@ export class UpgradeCard extends UpgradeCardParent implements IUpgradeCard, IPla
             matchTarget: (card, context) => card === context.source.parentCard && (!properties.matchTarget || properties.matchTarget(card, context)),
             targetController: WildcardRelativePlayer.Any,   // this means that the effect continues to work even if the other player gains control of the upgrade
             ongoingEffect: properties.ongoingEffect
+        });
+    }
+
+    /**
+     * Adds an "attached card gains [X]" ability, where X is a triggered ability. You can provide a match function
+     * to narrow down whether the effect is applied (for cases where the effect has conditions).
+     */
+    protected addGainConstantAbilityTargetingAttached(properties: IConstantAbilityPropsWithGainCondition<this, IUnitCard>) {
+        const { gainCondition, ...gainedAbilityProperties } = properties;
+
+        this.addConstantAbilityTargetingAttached({
+            title: 'Give ability to the attached card',
+            condition: this.addZoneCheckToGainCondition(gainCondition),
+            ongoingEffect: OngoingEffectLibrary.gainAbility({ type: AbilityType.Constant, ...gainedAbilityProperties })
         });
     }
 

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -12,7 +12,7 @@ import type { ICardWithPrintedPowerProperty } from './PrintedPower';
 import { WithPrintedPower } from './PrintedPower';
 import * as EnumHelpers from '../../utils/EnumHelpers';
 import type { Card } from '../Card';
-import type { IAbilityPropsWithType, IConstantAbilityProps, IGainCondition, IKeywordProperties, ITriggeredAbilityBaseProps, ITriggeredAbilityProps } from '../../../Interfaces';
+import type { IAbilityPropsWithType, IConstantAbilityProps, IGainCondition, IKeywordPropertiesWithGainCondition, ITriggeredAbilityBaseProps, ITriggeredAbilityProps } from '../../../Interfaces';
 import { BountyKeywordInstance } from '../../ability/KeywordInstance';
 import { KeywordWithAbilityDefinition } from '../../ability/KeywordInstance';
 import TriggeredAbility from '../../ability/TriggeredAbility';
@@ -371,10 +371,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             });
         }
 
-        public addPilotingGainKeywordTargetingAttached(properties: IKeywordProperties) {
+        public addPilotingGainKeywordTargetingAttached(properties: IKeywordPropertiesWithGainCondition<this>) {
+            const { gainCondition, ...gainedKeywordProperties } = properties;
+
             this.addPilotingConstantAbilityTargetingAttached({
                 title: 'Give keyword to the attached card',
-                ongoingEffect: OngoingEffectLibrary.gainKeyword(properties)
+                condition: this.addZoneCheckToGainCondition(gainCondition),
+                ongoingEffect: OngoingEffectLibrary.gainKeyword(gainedKeywordProperties)
             });
         }
 


### PR DESCRIPTION
Fixed a couple of subtle issues related to various effects granting a constant ability to the attached unit.

- The Piloting helper was not correctly adding a zone filter to the `gainCondition` check, which can result in exceptions happening in some cases
- In several cases we had mis-implemented an ability from an upgrade where it says the attached unit _gains_ a constant ability targeting itself, and were instead using the upgrade as the ability source. This came up during testing for Kazuda since it has implications for how his ability impacts those cards. Should be fixed now.