### PR TITLE
Kazuda Xiono, Best Pilot in the Galaxy

### DIFF
--- a/server/game/cards/01_SOR/events/NoGoodToMeDead.ts
+++ b/server/game/cards/01_SOR/events/NoGoodToMeDead.ts
@@ -1,5 +1,5 @@
 import AbilityHelper from '../../../AbilityHelper';
-import { AbilityRestriction, Duration, WildcardCardType } from '../../../core/Constants';
+import { AbilityRestriction, WildcardCardType } from '../../../core/Constants';
 import { EventCard } from '../../../core/card/EventCard';
 
 export default class NoGoodToMeDead extends EventCard {
@@ -17,9 +17,8 @@ export default class NoGoodToMeDead extends EventCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                     AbilityHelper.immediateEffects.exhaust(),
-                    AbilityHelper.immediateEffects.cardLastingEffect({
-                        effect: AbilityHelper.ongoingEffects.cardCannot(AbilityRestriction.Ready),
-                        duration: Duration.UntilEndOfRound
+                    AbilityHelper.immediateEffects.forThisRoundCardEffect({
+                        effect: AbilityHelper.ongoingEffects.cardCannot(AbilityRestriction.Ready)
                     })
                 ])
             },

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -43,5 +43,22 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                 })
             }
         });
+
+        this.addGainTriggeredAbilityTargetingAttached({
+            title: 'Choose any number of friendly units',
+            when: {
+                onAttackDeclared: (event, context) => event.attack.attacker === context.source
+            },
+            targetResolver: {
+                activePromptTitle: 'Choose friendly units that will lose all abilities for this round',
+                mode: TargetMode.Unlimited,
+                cardTypeFilter: WildcardCardType.Unit,
+                controller: RelativePlayer.Self,
+                canChooseNoCards: true,
+                immediateEffect: AbilityHelper.immediateEffects.forThisRoundCardEffect({
+                    effect: AbilityHelper.ongoingEffects.loseAllAbilities()
+                })
+            }
+        });
     }
 }

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
-import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { RelativePlayer, TargetMode, WildcardCardType } from '../../../core/Constants';
 
 export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -23,6 +23,22 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                     })
                 })
             ])
+        });
+    }
+
+    protected override setupLeaderUnitSideAbilities() {
+        this.addOnAttackAbility({
+            title: 'Choose any number of friendly units',
+            targetResolver: {
+                activePromptTitle: 'Choose friendly units that will lose all abilities for this round',
+                mode: TargetMode.Unlimited,
+                cardTypeFilter: WildcardCardType.Unit,
+                controller: RelativePlayer.Self,
+                canChooseNoCards: true,
+                immediateEffect: AbilityHelper.immediateEffects.forThisRoundCardEffect({
+                    effect: AbilityHelper.ongoingEffects.loseAllAbilities()
+                })
+            }
         });
     }
 }

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -21,6 +21,9 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                     innerSystem: AbilityHelper.immediateEffects.forThisRoundCardEffect({
                         effect: AbilityHelper.ongoingEffects.loseAllAbilities()
                     })
+                }),
+                AbilityHelper.immediateEffects.forThisPhaseCardEffect({
+                    effect: AbilityHelper.ongoingEffects.additionalAction()
                 })
             ])
         });

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -1,0 +1,28 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
+
+export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '4531112134',
+            internalName: 'kazuda-xiono#best-pilot-in-the-galaxy'
+        };
+    }
+
+    protected override setupLeaderSideAbilities() {
+        this.addActionAbility({
+            title: 'Select a friendly unit',
+            cost: AbilityHelper.costs.exhaustSelf(),
+            immediateEffect: AbilityHelper.immediateEffects.simultaneous([
+                AbilityHelper.immediateEffects.selectCard({
+                    cardTypeFilter: WildcardCardType.Unit,
+                    controller: RelativePlayer.Self,
+                    innerSystem: AbilityHelper.immediateEffects.forThisRoundCardEffect({
+                        effect: AbilityHelper.ongoingEffects.loseAllAbilities()
+                    })
+                })
+            ])
+        });
+    }
+}

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -11,6 +11,7 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
     }
 
     protected override setupLeaderSideAbilities() {
+        this.addPilotDeploy();
         this.addActionAbility({
             title: 'Select a friendly unit',
             cost: AbilityHelper.costs.exhaustSelf(),

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -45,7 +45,7 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
             }
         });
 
-        this.addGainTriggeredAbilityTargetingAttached({
+        this.addPilotingGainTriggeredAbilityTargetingAttached({
             title: 'Choose any number of friendly units',
             when: {
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source

--- a/server/game/core/GameObject.ts
+++ b/server/game/core/GameObject.ts
@@ -33,6 +33,10 @@ export abstract class GameObject {
         this.ongoingEffects = this.ongoingEffects.filter((e) => e !== ongoingEffect);
     }
 
+    public removeOngoingEffects(type: EffectName) {
+        this.ongoingEffects = this.ongoingEffects.filter((e) => e.type !== type);
+    }
+
     public getOngoingEffectValues<V = any>(type: EffectName): V[] {
         const filteredEffects = this.getOngoingEffects().filter((ongoingEffect) => ongoingEffect.type === type);
         return filteredEffects.map((ongoingEffect) => ongoingEffect.getValue(this));

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -81,14 +81,14 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent implements INonLe
     }
 
     public override getActionAbilities(): ActionAbility[] {
-        return this.isBlank() ? [] : this.actionAbilities;
+        return this.isBlank() ? [] : super.getActionAbilities();
     }
 
     public override getTriggeredAbilities(): TriggeredAbility[] {
-        return this.isBlank() ? [] : this.triggeredAbilities;
+        return this.isBlank() ? [] : super.getTriggeredAbilities();
     }
 
     public override getConstantAbilities(): IConstantAbility[] {
-        return this.isBlank() ? [] : this.constantAbilities;
+        return this.isBlank() ? [] : super.getConstantAbilities();
     }
 }

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -13,6 +13,7 @@ import { PlayUpgradeAction } from '../../actions/PlayUpgradeAction';
 import type { ActionAbility } from '../ability/ActionAbility';
 import type TriggeredAbility from '../ability/TriggeredAbility';
 import type { IConstantAbility } from '../ongoingEffect/IConstantAbility';
+import type { KeywordInstance } from '../ability/KeywordInstance';
 
 const NonLeaderUnitCardParent = WithUnitProperties(WithStandardAbilitySetup(InPlayCard));
 
@@ -78,6 +79,10 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent implements INonLe
 
     public override checkIsAttachable(): void {
         Contract.assertTrue(this.hasSomeKeyword(KeywordName.Piloting));
+    }
+
+    public override getKeywords(): KeywordInstance[] {
+        return this.isBlank() ? [] : super.getKeywords();
     }
 
     public override getActionAbilities(): ActionAbility[] {

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -10,6 +10,9 @@ import type { IPlayCardActionProperties } from '../ability/PlayCardAction';
 import type { IPlayableCard } from './baseClasses/PlayableOrDeployableCard';
 import type { ICardCanChangeControllers } from './CardInterfaces';
 import { PlayUpgradeAction } from '../../actions/PlayUpgradeAction';
+import type { ActionAbility } from '../ability/ActionAbility';
+import type TriggeredAbility from '../ability/TriggeredAbility';
+import type { IConstantAbility } from '../ongoingEffect/IConstantAbility';
 
 const NonLeaderUnitCardParent = WithUnitProperties(WithStandardAbilitySetup(InPlayCard));
 
@@ -73,8 +76,19 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent implements INonLe
         }
     }
 
-
     public override checkIsAttachable(): void {
         Contract.assertTrue(this.hasSomeKeyword(KeywordName.Piloting));
+    }
+
+    public override getActionAbilities(): ActionAbility[] {
+        return this.isBlank() ? [] : this.actionAbilities;
+    }
+
+    public override getTriggeredAbilities(): TriggeredAbility[] {
+        return this.isBlank() ? [] : this.triggeredAbilities;
+    }
+
+    public override getConstantAbilities(): IConstantAbility[] {
+        return this.isBlank() ? [] : this.constantAbilities;
     }
 }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -17,7 +17,7 @@ import type { ICardCanChangeControllers, IUpgradeCard } from './CardInterfaces';
 
 type IConstantAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = IConstantAbilityProps<TTarget> & IGainCondition<TSource>;
 
-type ITriggeredAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityProps<TTarget> & IGainCondition<TSource>;
+export type ITriggeredAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityProps<TTarget> & IGainCondition<TSource>;
 
 type ITriggeredAbilityBasePropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityBaseProps<TTarget> & IGainCondition<TSource>;
 

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -36,6 +36,7 @@ import type { ILeaderCard } from './LeaderProperties';
 import type { ILeaderUnitCard } from '../LeaderUnitCard';
 import type { PilotLimitModifier } from '../../ongoingEffect/effectImpl/PilotLimitModifier';
 import type { AbilityContext } from '../../ability/AbilityContext';
+import type { ITriggeredAbilityPropsWithGainCondition } from '../UpgradeCard';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
 
@@ -391,10 +392,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             });
         }
 
-        public addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps<IUnitCard>) {
+        public addPilotingGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityPropsWithGainCondition<this, IUnitCard>) {
+            const { gainCondition, ...gainedAbilityProperties } = properties;
+
             this.addPilotingConstantAbilityTargetingAttached({
                 title: 'Give triggered ability to the attached card',
-                ongoingEffect: OngoingEffectLibrary.gainAbility({ type: AbilityType.Triggered, ...properties })
+                condition: this.addZoneCheckToGainCondition(gainCondition),
+                ongoingEffect: OngoingEffectLibrary.gainAbility({ type: AbilityType.Triggered, ...gainedAbilityProperties })
             });
         }
 

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -391,6 +391,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             });
         }
 
+        public addGainTriggeredAbilityTargetingAttached(properties: ITriggeredAbilityProps<IUnitCard>) {
+            this.addPilotingConstantAbilityTargetingAttached({
+                title: 'Give triggered ability to the attached card',
+                ongoingEffect: OngoingEffectLibrary.gainAbility({ type: AbilityType.Triggered, ...properties })
+            });
+        }
+
         public override getTriggeredAbilities(): TriggeredAbility[] {
             let triggeredAbilities = EnumHelpers.isUnitUpgrade(this.getType()) ? this.pilotingTriggeredAbilities : super.getTriggeredAbilities();
 

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -1,4 +1,4 @@
-import { PhaseName } from '../../Constants';
+import { EffectName, PhaseName } from '../../Constants';
 import type Game from '../../Game';
 import type Player from '../../Player';
 import { Phase } from './Phase';
@@ -35,7 +35,15 @@ export class ActionPhase extends Phase {
 
     private rotateActiveQueueNextAction() {
         // breaks the action loop if both players have passed
-        this.game.queueSimpleStep(() => this.game.rotateActivePlayer(), 'rotateActivePlayer');
+        this.game.queueSimpleStep(() => {
+            const activePlayer = this.game.getActivePlayer();
+            if (activePlayer && activePlayer.hasOngoingEffect(EffectName.AdditionalAction)) {
+                activePlayer.removeOngoingEffects(EffectName.AdditionalAction);
+            } else {
+                this.game.rotateActivePlayer();
+            }
+        }, 'rotateActivePlayer');
+
         this.game.queueSimpleStep(() => {
             if (this.game.actionPhaseActivePlayer !== null) {
                 this.game.queueSimpleStep(() => this.queueNextAction(), 'queueNextAction');

--- a/server/game/gameSystems/CardRoundLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardRoundLastingEffectSystem.ts
@@ -1,0 +1,28 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import { GameSystem } from '../core/gameSystem/GameSystem';
+import type { ICardLastingEffectProperties } from './CardLastingEffectSystem';
+import { CardLastingEffectSystem } from './CardLastingEffectSystem';
+import { Duration, EventName } from '../core/Constants';
+
+export type ICardRoundLastingEffectProperties = Omit<ICardLastingEffectProperties, 'duration'>;
+
+/**
+ * Helper subclass of {@link CardLastingEffectSystem} that specifically creates lasting effects targeting cards
+ * for the rest of the current round.
+ */
+export class CardRoundLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardLastingEffectSystem<TContext> {
+    public override readonly name = 'applyCardRoundLastingEffect';
+    public override readonly eventName = EventName.OnEffectApplied;
+    public override readonly effectDescription = 'apply an effect to {0} for the round';
+    protected override readonly defaultProperties: ICardLastingEffectProperties = {
+        duration: null,
+        effect: [],
+        ability: null
+    };
+
+    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
+    public constructor(propertiesOrPropertyFactory: ICardRoundLastingEffectProperties | ((context?: AbilityContext) => ICardRoundLastingEffectProperties)) {
+        const propertyWithDurationType = GameSystem.appendToPropertiesOrPropertyFactory<ICardLastingEffectProperties, 'duration'>(propertiesOrPropertyFactory, { duration: Duration.UntilEndOfRound });
+        super(propertyWithDurationType);
+    }
+}

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -128,6 +128,8 @@ import type { IDeployAndAttachLeaderPilotProperties as IDeployAndAttachPilotLead
 import { DeployAndAttachPilotLeaderSystem as DeployAndAttachPilotLeaderSystem } from './DeployAndAttachPilotLeaderSystem';
 import type { ISelectPlayerProperties } from './SelectPlayerSystem';
 import { SelectPlayerSystem } from './SelectPlayerSystem';
+import type { ICardRoundLastingEffectProperties } from './CardRoundLastingEffectSystem';
+import { CardRoundLastingEffectSystem } from './CardRoundLastingEffectSystem';
 
 
 type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
@@ -236,6 +238,9 @@ export function flipDoubleSidedLeader<TContext extends AbilityContext = AbilityC
 }
 export function forThisPhaseCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardPhaseLastingEffectProperties, TContext>) {
     return new CardPhaseLastingEffectSystem<TContext>(propertyFactory);
+}
+export function forThisRoundCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactor: PropsFactory<ICardRoundLastingEffectProperties, TContext>) {
+    return new CardRoundLastingEffectSystem<TContext>(propertyFactor);
 }
 export function forThisAttackCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardAttackLastingEffectProperties, TContext>) {
     return new CardAttackLastingEffectSystem<TContext>(propertyFactory);

--- a/server/game/ongoingEffects/OngoingEffectLibrary.ts
+++ b/server/game/ongoingEffects/OngoingEffectLibrary.ts
@@ -192,7 +192,7 @@ export = {
     // participatesFromHome: (properties) => OngoingEffectBuilder.card.static(EffectName.ParticipatesFromHome, properties),
     // unlessActionCost: (properties) => OngoingEffectBuilder.card.static(EffectName.UnlessActionCost, properties),
     // // Player effects
-    // additionalAction: (amount = 1) => OngoingEffectBuilder.player.static(EffectName.AdditionalAction, amount),
+    additionalAction: (amount = 1) => OngoingEffectBuilder.player.static(EffectName.AdditionalAction, amount),
     // additionalCardPlayed: (amount = 1) => OngoingEffectBuilder.player.flexible(EffectName.AdditionalCardPlayed, amount),
     // additionalCharactersInConflict: (amount) =>
     //     OngoingEffectBuilder.player.flexible(EffectName.AdditionalCharactersInConflict, amount),

--- a/server/game/ongoingEffects/OngoingEffectLibrary.ts
+++ b/server/game/ongoingEffects/OngoingEffectLibrary.ts
@@ -118,6 +118,7 @@ export = {
                     KeywordHelpers.keywordFromProperties(keywordOrKeywordProperties));
         }
     },
+    loseAllAbilities: () => OngoingEffectBuilder.card.static(EffectName.Blank),
     loseKeyword: (keyword: KeywordName) => OngoingEffectBuilder.card.static(EffectName.LoseKeyword, new LoseKeyword(keyword)),
     // gainAllAbilities,
     // gainAllAbilitiesDynamic: (match) =>

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -21,7 +21,8 @@ describe('Lose All Abilities', function() {
                             'red-three#unstoppable',
                             'general-krell#heartless-tactician',
                             'entrenched',
-                            'attack-pattern-delta'
+                            'attack-pattern-delta',
+                            'shadowed-intentions'
                         ],
                         groundArena: [
                             'academy-defense-walker',
@@ -40,7 +41,8 @@ describe('Lose All Abilities', function() {
                             'unshakeable-will',
                             'supreme-leader-snoke#shadow-ruler',
                             'satine-kryze#committed-to-peace',
-                            'change-of-heart'
+                            'change-of-heart',
+                            'takedown'
                         ],
                         groundArena: [
                             'consular-security-force'
@@ -205,10 +207,28 @@ describe('Lose All Abilities', function() {
             it('cannot gain new constant abilities from upgrades while the effect is active', function() {
                 const { context } = contextRef;
 
-                // Use Kazuda's ability on Grogu
+                // Deploy Kazuda
                 context.player1.clickCard(context.kazudaXiono);
-                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickPrompt('Deploy Kazuda Xiono');
+                context.player2.passAction();
+
+                // Attach Shadowed Intentions to Contracted Hunter to give it a constant ability
+                context.player1.clickCard(context.shadowedIntentions);
+                context.player1.clickCard(context.contractedHunter);
+                context.player2.passAction();
+
+                // Attack with Kazuda to remove Grogu and Contracted Hunter's abilities
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickCard(context.consularSecurityForce);
                 context.player1.clickCard(context.grogu);
+                context.player1.clickCard(context.contractedHunter);
+                context.player1.clickPrompt('Done');
+
+                // Player 2 plays Takedown to defeat Contracted Hunter because he is not protected by Shadowed Intentions
+                context.player2.clickCard(context.takedown);
+                context.player2.clickCard(context.contractedHunter);
+
+                expect(context.contractedHunter).toBeInZone('discard');
 
                 // Play Squad Support on Grogu to attempt to give it a constant ability
                 context.player1.clickCard(context.squadSupport);

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -512,7 +512,7 @@ describe('Lose All Abilities', function() {
             });
         });
 
-        describe('some meta-relavant cases worth covering:', function() {
+        describe('Some meta-relavant and edge cases worth covering:', function() {
             beforeEach(async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
@@ -539,11 +539,7 @@ describe('Lose All Abilities', function() {
                     },
                     player2: {
                         hand: [
-                            // 'unshakeable-will',
-                            // 'supreme-leader-snoke#shadow-ruler',
-                            // 'satine-kryze#committed-to-peace',
-                            // 'change-of-heart',
-                            // 'takedown'
+                            'takedown'
                         ],
                         groundArena: [
                             'consular-security-force',
@@ -638,6 +634,30 @@ describe('Lose All Abilities', function() {
 
                 expect(context.devastator).toBeInZone('deck');
                 expect(context.maKlounkee).toBeInZone('deck');
+            });
+
+            it('can remove a bounty from a stolen unit', function() {
+                const { context } = contextRef;
+
+                // Play traitorous to steal Val
+                context.player1.clickCard(context.traitorous);
+                context.player1.clickCard(context.val);
+                context.player2.passAction();
+
+                // Attack with Kazuda to remove Val's abilities
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickCard(context.consularSecurityForce);
+                context.player1.clickCard(context.val);
+                context.player1.clickPrompt('Done');
+
+                // Player 2 defeats Val with takedown
+                context.player2.clickCard(context.takedown);
+                context.player2.clickCard(context.val);
+
+                // No abilities to resolve
+                expect(context.player2).not.toHaveExactPromptButtons(['You', 'Opponent']);
+
+                context.moveToRegroupPhase();
             });
         });
     });

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -1,7 +1,7 @@
 // From Comprehensive Rules v4.0, 8.15.2:
-//     If an ability causes a card to "lose all abilities," the card ceases to have any
-//     abilities, including abilities given to it by other cards, for the duration of the
-//     "lose" effect. The card cannot gain abilities for the duration of the effect.
+//   If an ability causes a card to "lose all abilities," the card ceases to have any
+//   abilities, including abilities given to it by other cards, for the duration of the
+//   "lose" effect. The card cannot gain abilities for the duration of the effect.
 describe('Lose All Abilities', function() {
     integration(function(contextRef) {
         describe('A unit that loses all abilities for a duration', function() {
@@ -509,6 +509,135 @@ describe('Lose All Abilities', function() {
                     context.academyDefenseWalker
                 ]);
                 context.player1.clickCard(context.consularSecurityForce);
+            });
+        });
+
+        describe('some meta-relavant cases worth covering:', function() {
+            beforeEach(async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'kazuda-xiono#best-pilot-in-the-galaxy', deployed: true },
+                        hand: [
+                            'sneak-attack',
+                            'ruthless-raider',
+                            'trench-run',
+                            'traitorous'
+                        ],
+                        groundArena: [
+                            // 'academy-defense-walker',
+                            // 'contracted-hunter',
+                            // 'grogu#irresistible',
+                            // 'liberated-slaves',
+                            // '97th-legion#keeping-the-peace-on-sullust',
+                            // 'battlefield-marine'
+                        ],
+                        spaceArena: [
+                            'millennium-falcon#piece-of-junk',
+                            'fireball#an-explosion-with-wings'
+                        ]
+                    },
+                    player2: {
+                        hand: [
+                            // 'unshakeable-will',
+                            // 'supreme-leader-snoke#shadow-ruler',
+                            // 'satine-kryze#committed-to-peace',
+                            // 'change-of-heart',
+                            // 'takedown'
+                        ],
+                        groundArena: [
+                            'consular-security-force',
+                            'val#loyal-to-the-end'
+                        ],
+                        deck: [
+                            'devastator#inescapable',
+                            'ma-klounkee'
+                        ]
+                    }
+                });
+            });
+
+            it('SOR Millennium Falcon\'s tax can be avoided by removing its ability for the round', function() {
+                const { context } = contextRef;
+
+                // Attack with Kazuda to activate ability
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickCard(context.p2Base);
+
+                // Choose Millennium Falcon to remove its ability
+                context.player1.clickCard(context.millenniumFalcon);
+                context.player1.clickPrompt('Done');
+
+                // Move to next action phase
+                context.moveToNextActionPhase();
+
+                // Falcon tax was not paid
+                expect(context.player1.exhaustedResourceCount).toBe(0);
+
+                // Effect has expired, move to next phase
+                context.moveToRegroupPhase();
+
+                // Resource
+                context.player1.clickPrompt('Done');
+                context.player2.clickPrompt('Done');
+
+                // Falcon tax is back
+                expect(context.player1).toHaveEnabledPromptButtons(['Pay 1 resource', 'Return this unit to her owner\'s hand']);
+                context.player1.clickPrompt('Pay 1 resource');
+                expect(context.player1).toBeActivePlayer();
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+            });
+
+            it('if Ruthless Raider\'s abilities are removed for the round, its when-defeated will not trigger if it dies during the regroup phase', function() {
+                const { context } = contextRef;
+
+                // Sneak Attack Ruthless Raider
+                context.player1.clickCard(context.sneakAttack);
+                context.player1.clickCard(context.ruthlessRaider);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.p2Base.damage).toBe(2);
+
+                context.player2.passAction();
+
+                // Attack with Kazuda to remove Ruthless Raider's abilities (and others to suppress prompts)
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickCard(context.consularSecurityForce);
+                context.player1.clickCard(context.ruthlessRaider);
+                context.player1.clickCard(context.millenniumFalcon);
+                context.player1.clickCard(context.fireball);
+                context.player1.clickPrompt('Done');
+
+                // Move to the regroup phase
+                context.moveToRegroupPhase();
+
+                // Ruthless Raider is defeated and Player 2's base took no more damage
+                expect(context.ruthlessRaider).toBeInZone('discard');
+                expect(context.p2Base.damage).toBe(2);
+            });
+
+            it('can remove negative effects of events like Trench Run', function() {
+                const { context } = contextRef;
+
+                // Attack with Kazuda to remove Fireball's ability
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickCard(context.consularSecurityForce);
+                context.player1.clickCard(context.fireball);
+                context.player1.clickPrompt('Done');
+
+                context.player2.passAction();
+
+                // Play Trench Run on Fireball
+                context.player1.clickCard(context.trenchRun);
+                context.player1.clickCard(context.fireball);
+                context.player1.clickCard(context.p2Base);
+
+                // Fireball attacked with the buff (3 + 4), but cards were not discarded and it took no damage
+                expect(context.p2Base.damage).toBe(7);
+                expect(context.fireball.damage).toBe(0);
+
+                expect(context.devastator).toBeInZone('deck');
+                expect(context.maKlounkee).toBeInZone('deck');
             });
         });
     });

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -23,7 +23,7 @@ describe('Effects that cause a unit to "Lose All Abilities"', function() {
                             'academy-defense-walker',
                             'contracted-hunter',
                             'grogu#irresistible',
-                            'battlefield-marine',
+                            'liberated-slaves',
                             '97th-legion#keeping-the-peace-on-sullust'
                         ],
                         spaceArena: [
@@ -263,21 +263,21 @@ describe('Effects that cause a unit to "Lose All Abilities"', function() {
             it('cannot gain new triggered abilities from events while the effect is active', function() {
                 const { context } = contextRef;
 
-                // Use Kazuda's ability on Battlefield Marine
+                // Use Kazuda's ability on Liberated Slaves
                 context.player1.clickCard(context.kazudaXiono);
                 context.player1.clickPrompt('Select a friendly unit');
-                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.liberatedSlaves);
 
-                // Play Heroic Sacrifice to attempt to give Battlefield Marine a triggered ability
+                // Play Heroic Sacrifice to attempt to give Liberated Slaves a triggered ability
                 context.player1.clickCard(context.heroicSacrifice);
-                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.liberatedSlaves);
                 context.player1.clickCard(context.consularSecurityForce);
 
-                // Battlefield Marine is not defeated because it does not have the "On Attack" ability from Heroic Sacrifce
-                expect(context.battlefieldMarine).toBeInZone('groundArena');
+                // Liberated Slaves is not defeated because it does not have the "On Attack" ability from Heroic Sacrifce
+                expect(context.liberatedSlaves).toBeInZone('groundArena');
 
                 expect(context.consularSecurityForce.damage).toBe(5);
-                expect(context.battlefieldMarine.damage).toBe(2);
+                expect(context.liberatedSlaves.damage).toBe(3);
             });
         });
     });

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -205,8 +205,6 @@ describe('Lose All Abilities', function() {
             it('cannot gain new constant abilities from upgrades while the effect is active', function() {
                 const { context } = contextRef;
 
-                pending('Gained constant abilities from upgrades are not currently implemented');
-
                 // Use Kazuda's ability on Grogu
                 context.player1.clickCard(context.kazudaXiono);
                 context.player1.clickPrompt('Select a friendly unit');

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -13,7 +13,11 @@ describe('Effects that cause a unit to "Lose All Abilities"', function() {
                         hand: [
                             'protector',
                             'vambrace-grappleshot',
-                            'squad-support'
+                            'squad-support',
+                            'strategic-acumen',
+                            'swoop-racer',
+                            'breaking-in',
+                            'heroic-sacrifice'
                         ],
                         groundArena: [
                             'academy-defense-walker',
@@ -27,6 +31,7 @@ describe('Effects that cause a unit to "Lose All Abilities"', function() {
                         ]
                     },
                     player2: {
+                        hand: ['unshakeable-will'],
                         groundArena: [
                             'consular-security-force'
                         ]
@@ -34,143 +39,147 @@ describe('Effects that cause a unit to "Lose All Abilities"', function() {
                 });
             });
 
-            // it('loses keyword abilities until the effect expires', function() {
-            //     const { context } = contextRef;
+            // Abilities printed on units
 
-            //     // Use Kazuda's ability on Academy Defense Walker
-            //     context.player1.clickCard(context.kazudaXiono);
-            //     context.player1.clickPrompt('Select a friendly unit');
-            //     context.player1.clickCard(context.academyDefenseWalker);
-            //     context.player1.passAction();
+            it('loses keyword abilities until the effect expires', function() {
+                const { context } = contextRef;
 
-            //     // Academy Defense Walker no longer has Sentinel
-            //     context.player2.clickCard(context.consularSecurityForce);
-            //     expect(context.player2).toBeAbleToSelect(context.p1Base);
-            //     context.player2.clickCard(context.p1Base);
+                // Use Kazuda's ability on Academy Defense Walker
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.academyDefenseWalker);
+                context.player1.passAction();
 
-            //     // Effect expires
-            //     context.moveToNextActionPhase();
-            //     context.player1.passAction();
+                // Academy Defense Walker no longer has Sentinel
+                context.player2.clickCard(context.consularSecurityForce);
+                expect(context.player2).toBeAbleToSelect(context.p1Base);
+                context.player2.clickCard(context.p1Base);
 
-            //     // Academy Defense Walker has Sentinel back
-            //     context.player2.clickCard(context.consularSecurityForce);
-            //     expect(context.player2).toBeAbleToSelectExactly([context.academyDefenseWalker]);
-            //     context.player2.clickCard(context.academyDefenseWalker);
-            // });
+                // Effect expires
+                context.moveToNextActionPhase();
+                context.player1.passAction();
 
-            // it('loses triggered abilities until the effect expires', function() {
-            //     const { context } = contextRef;
+                // Academy Defense Walker has Sentinel back
+                context.player2.clickCard(context.consularSecurityForce);
+                expect(context.player2).toBeAbleToSelectExactly([context.academyDefenseWalker]);
+                context.player2.clickCard(context.academyDefenseWalker);
+            });
 
-            //     // Use Kazuda's ability on Contracted Hunter
-            //     context.player1.clickCard(context.kazudaXiono);
-            //     context.player1.clickPrompt('Select a friendly unit');
-            //     context.player1.clickCard(context.contractedHunter);
+            it('loses triggered abilities until the effect expires', function() {
+                const { context } = contextRef;
 
-            //     context.moveToNextActionPhase();
+                // Use Kazuda's ability on Contracted Hunter
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.contractedHunter);
 
-            //     // Contracted Hunter is still in play because his triggered ability was removed
-            //     expect(context.contractedHunter).toBeInZone('groundArena');
+                context.moveToNextActionPhase();
 
-            //     // Effect expires
-            //     context.moveToNextActionPhase();
+                // Contracted Hunter is still in play because his triggered ability was removed
+                expect(context.contractedHunter).toBeInZone('groundArena');
 
-            //     // Contracted Hunter is defeated because his triggered ability is back
-            //     expect(context.contractedHunter).toBeInZone('discard');
-            // });
+                // Effect expires
+                context.moveToNextActionPhase();
 
-            // it('loses constant abilities until the effect expires', function() {
-            //     const { context } = contextRef;
+                // Contracted Hunter is defeated because his triggered ability is back
+                expect(context.contractedHunter).toBeInZone('discard');
+            });
 
-            //     // Use Kazuda's ability on Strafing Gunship
-            //     context.player1.clickCard(context.kazudaXiono);
-            //     context.player1.clickPrompt('Select a friendly unit');
-            //     context.player1.clickCard(context.strafingGunship);
+            it('loses constant abilities until the effect expires', function() {
+                const { context } = contextRef;
 
-            //     // Attack with Strafing Gunship, it can only attack the base
-            //     context.player1.clickCard(context.strafingGunship);
-            //     expect(context.player1).toBeAbleToSelectExactly([context.p2Base]);
-            //     context.player1.clickCard(context.p2Base);
+                // Use Kazuda's ability on Strafing Gunship
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.strafingGunship);
 
-            //     // Effect expires
-            //     context.moveToNextActionPhase();
+                // Attack with Strafing Gunship, it can only attack the base
+                context.player1.clickCard(context.strafingGunship);
+                expect(context.player1).toBeAbleToSelectExactly([context.p2Base]);
+                context.player1.clickCard(context.p2Base);
 
-            //     // Strafing Gunship can attack ground units again
-            //     context.player1.clickCard(context.strafingGunship);
-            //     expect(context.player1).toBeAbleToSelectExactly([
-            //         context.p2Base,
-            //         context.consularSecurityForce
-            //     ]);
-            //     context.player1.clickCard(context.consularSecurityForce);
-            // });
+                // Effect expires
+                context.moveToNextActionPhase();
 
-            // it('loses action abilities until the effect expires', function() {
-            //     const { context } = contextRef;
+                // Strafing Gunship can attack ground units again
+                context.player1.clickCard(context.strafingGunship);
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.p2Base,
+                    context.consularSecurityForce
+                ]);
+                context.player1.clickCard(context.consularSecurityForce);
+            });
 
-            //     // Use Kazuda's ability on Grogu
-            //     context.player1.clickCard(context.kazudaXiono);
-            //     context.player1.clickPrompt('Select a friendly unit');
-            //     context.player1.clickCard(context.grogu);
+            it('loses action abilities until the effect expires', function() {
+                const { context } = contextRef;
 
-            //     // Grogu no longer has an action ability
-            //     context.player1.clickCard(context.grogu);
+                // Use Kazuda's ability on Grogu
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.grogu);
 
-            //     expect(context.player1).not.toHaveEnabledPromptButton('Exhaust an enemy unit');
-            //     expect(context.player1).toBeAbleToSelect(context.consularSecurityForce);
+                // Grogu no longer has an action ability
+                context.player1.clickCard(context.grogu);
 
-            //     context.player1.clickCard(context.consularSecurityForce);
-            //     expect(context.consularSecurityForce.exhausted).toBeFalse();
+                expect(context.player1).not.toHaveEnabledPromptButton('Exhaust an enemy unit');
+                expect(context.player1).toBeAbleToSelect(context.consularSecurityForce);
 
-            //     // Effect expires
-            //     context.moveToNextActionPhase();
+                context.player1.clickCard(context.consularSecurityForce);
+                expect(context.consularSecurityForce.exhausted).toBeFalse();
 
-            //     // Grogu has his action ability back
-            //     context.player1.clickCard(context.grogu);
-            //     expect(context.player1).toHaveEnabledPromptButton('Exhaust an enemy unit');
-            //     context.player1.clickPrompt('Exhaust an enemy unit');
-            //     context.player1.clickCard(context.consularSecurityForce);
-            //     expect(context.consularSecurityForce.exhausted).toBeTrue();
-            // });
+                // Effect expires
+                context.moveToNextActionPhase();
 
-            // it('cannot gain new keyword abilities while the effect is active', function() {
-            //     const { context } = contextRef;
+                // Grogu has his action ability back
+                context.player1.clickCard(context.grogu);
+                expect(context.player1).toHaveEnabledPromptButton('Exhaust an enemy unit');
+                context.player1.clickPrompt('Exhaust an enemy unit');
+                context.player1.clickCard(context.consularSecurityForce);
+                expect(context.consularSecurityForce.exhausted).toBeTrue();
+            });
 
-            //     // Use Kazuda's ability on Academy Defense Walker
-            //     context.player1.clickCard(context.kazudaXiono);
-            //     context.player1.clickPrompt('Select a friendly unit');
-            //     context.player1.clickCard(context.academyDefenseWalker);
+            // Abilities gained from upgrades
 
-            //     // Play Protector on Academy Defense Walker to attempt to give it Sentinel again
-            //     context.player1.clickCard(context.protector);
-            //     context.player1.clickCard(context.academyDefenseWalker);
+            it('cannot gain new keyword abilities from upgrades while the effect is active', function() {
+                const { context } = contextRef;
 
-            //     // Academy Defense Walker does not have Sentinel
-            //     context.player2.clickCard(context.consularSecurityForce);
-            //     expect(context.player2).toBeAbleToSelect(context.p1Base);
-            //     context.player2.clickCard(context.p1Base);
-            // });
+                // Use Kazuda's ability on Academy Defense Walker
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.academyDefenseWalker);
 
-            // it('cannot gain new triggered abilities while the effect is active', function() {
-            //     const { context } = contextRef;
+                // Play Protector on Academy Defense Walker to attempt to give it Sentinel again
+                context.player1.clickCard(context.protector);
+                context.player1.clickCard(context.academyDefenseWalker);
 
-            //     // Use Kazuda's ability on Grogu
-            //     context.player1.clickCard(context.kazudaXiono);
-            //     context.player1.clickPrompt('Select a friendly unit');
-            //     context.player1.clickCard(context.grogu);
+                // Academy Defense Walker does not have Sentinel
+                context.player2.clickCard(context.consularSecurityForce);
+                expect(context.player2).toBeAbleToSelect(context.p1Base);
+                context.player2.clickCard(context.p1Base);
+            });
 
-            //     // Play Vambrace Grappleshot on Grogu to attempt to give it a triggered ability
-            //     context.player1.clickCard(context.vambraceGrappleshot);
-            //     context.player1.clickCard(context.grogu);
+            it('cannot gain new triggered abilities from upgrades while the effect is active', function() {
+                const { context } = contextRef;
 
-            //     context.player2.passAction();
+                // Use Kazuda's ability on Grogu
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.grogu);
 
-            //     // Academy Defense Walker does not have the On Attack ability
-            //     context.player1.clickCard(context.grogu);
-            //     context.player1.clickCard(context.consularSecurityForce);
+                // Play Vambrace Grappleshot on Grogu to attempt to give it a triggered ability
+                context.player1.clickCard(context.vambraceGrappleshot);
+                context.player1.clickCard(context.grogu);
 
-            //     expect(context.consularSecurityForce.exhausted).toBeFalse();
-            // });
+                context.player2.passAction();
 
-            it('cannot gain new constant abilities while the effect is active', function() {
+                // Academy Defense Walker does not have the On Attack ability
+                context.player1.clickCard(context.grogu);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.consularSecurityForce.exhausted).toBeFalse();
+            });
+
+            it('cannot gain new constant abilities from upgrades while the effect is active', function() {
                 const { context } = contextRef;
 
                 // Use Kazuda's ability on Grogu
@@ -194,8 +203,82 @@ describe('Effects that cause a unit to "Lose All Abilities"', function() {
                 expect(context.grogu.getHp()).toBe(7);
             });
 
-            // it('cannot gain new action abilities while the effect is active', async function() {
-            // });
+            it('cannot gain new action abilities from upgrades while the effect is active', function() {
+                const { context } = contextRef;
+
+                // Use Kazuda's ability on Academy Defense Walker
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.academyDefenseWalker);
+
+                // Play Strategic Acumen on Academy Defense Walker to attempt to give it an action ability
+                context.player1.clickCard(context.strategicAcumen);
+                context.player1.clickCard(context.academyDefenseWalker);
+
+                context.player2.passAction();
+
+                // Academy Defense Walker does not have an action ability
+                context.player1.clickCard(context.academyDefenseWalker);
+                expect(context.player1).not.toHaveEnabledPromptButton('Play a unit from your hand. It costs 1 less');
+                expect(context.player1).toBeAbleToSelect(context.p2Base);
+                context.player1.clickCard(context.p2Base);
+
+                // Effect expires
+                context.moveToNextActionPhase();
+
+                // Academy Defense Walker has its gained action ability
+                context.player1.clickCard(context.academyDefenseWalker);
+                expect(context.player1).toHaveEnabledPromptButton('Play a unit from your hand. It costs 1 less');
+                context.player1.clickPrompt('Play a unit from your hand. It costs 1 less');
+                expect(context.player1).toBeAbleToSelect(context.swoopRacer);
+                context.player1.clickCard(context.swoopRacer);
+
+                expect(context.academyDefenseWalker.exhausted).toBeTrue();
+                expect(context.swoopRacer).toBeInZone('groundArena');
+            });
+
+            // Abilities gained from events
+
+            it('cannot gain new keyword abilities from events while the effect is active', function() {
+                const { context } = contextRef;
+
+                // Player 2 gives Consular Security Force Sentinel
+                context.player1.passAction();
+                context.player2.clickCard(context.unshakeableWill);
+                context.player2.clickCard(context.consularSecurityForce);
+
+                // Use Kazuda's ability on Academy Defense Walker
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.academyDefenseWalker);
+
+                // Play Breaking In to attempt to give Academy Defense Walker Saboteur
+                context.player1.clickCard(context.breakingIn);
+                context.player1.clickCard(context.academyDefenseWalker);
+
+                // Academy Defense Walker cannot attack the base because it does not have Saboteur
+                expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce]);
+            });
+
+            it('cannot gain new triggered abilities from events while the effect is active', function() {
+                const { context } = contextRef;
+
+                // Use Kazuda's ability on Battlefield Marine
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.battlefieldMarine);
+
+                // Play Heroic Sacrifice to attempt to give Battlefield Marine a triggered ability
+                context.player1.clickCard(context.heroicSacrifice);
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.consularSecurityForce);
+
+                // Battlefield Marine is not defeated because it does not have the "On Attack" ability from Heroic Sacrifce
+                expect(context.battlefieldMarine).toBeInZone('groundArena');
+
+                expect(context.consularSecurityForce.damage).toBe(5);
+                expect(context.battlefieldMarine.damage).toBe(2);
+            });
         });
     });
 });

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -1,0 +1,201 @@
+// From Comprehensive Rules v4.0, 8.15.2:
+//     If an ability causes a card to "lose all abilities," the card ceases to have any
+//     abilities, including abilities given to it by other cards, for the duration of the
+//     "lose" effect. The card cannot gain abilities for the duration of the effect.
+describe('Effects that cause a unit to "Lose All Abilities"', function() {
+    integration(function(contextRef) {
+        describe('For a specific duration', function() {
+            beforeEach(async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy',
+                        hand: [
+                            'protector',
+                            'vambrace-grappleshot',
+                            'squad-support'
+                        ],
+                        groundArena: [
+                            'academy-defense-walker',
+                            'contracted-hunter',
+                            'grogu#irresistible',
+                            'battlefield-marine',
+                            '97th-legion#keeping-the-peace-on-sullust'
+                        ],
+                        spaceArena: [
+                            'strafing-gunship'
+                        ]
+                    },
+                    player2: {
+                        groundArena: [
+                            'consular-security-force'
+                        ]
+                    }
+                });
+            });
+
+            // it('loses keyword abilities until the effect expires', function() {
+            //     const { context } = contextRef;
+
+            //     // Use Kazuda's ability on Academy Defense Walker
+            //     context.player1.clickCard(context.kazudaXiono);
+            //     context.player1.clickPrompt('Select a friendly unit');
+            //     context.player1.clickCard(context.academyDefenseWalker);
+            //     context.player1.passAction();
+
+            //     // Academy Defense Walker no longer has Sentinel
+            //     context.player2.clickCard(context.consularSecurityForce);
+            //     expect(context.player2).toBeAbleToSelect(context.p1Base);
+            //     context.player2.clickCard(context.p1Base);
+
+            //     // Effect expires
+            //     context.moveToNextActionPhase();
+            //     context.player1.passAction();
+
+            //     // Academy Defense Walker has Sentinel back
+            //     context.player2.clickCard(context.consularSecurityForce);
+            //     expect(context.player2).toBeAbleToSelectExactly([context.academyDefenseWalker]);
+            //     context.player2.clickCard(context.academyDefenseWalker);
+            // });
+
+            // it('loses triggered abilities until the effect expires', function() {
+            //     const { context } = contextRef;
+
+            //     // Use Kazuda's ability on Contracted Hunter
+            //     context.player1.clickCard(context.kazudaXiono);
+            //     context.player1.clickPrompt('Select a friendly unit');
+            //     context.player1.clickCard(context.contractedHunter);
+
+            //     context.moveToNextActionPhase();
+
+            //     // Contracted Hunter is still in play because his triggered ability was removed
+            //     expect(context.contractedHunter).toBeInZone('groundArena');
+
+            //     // Effect expires
+            //     context.moveToNextActionPhase();
+
+            //     // Contracted Hunter is defeated because his triggered ability is back
+            //     expect(context.contractedHunter).toBeInZone('discard');
+            // });
+
+            // it('loses constant abilities until the effect expires', function() {
+            //     const { context } = contextRef;
+
+            //     // Use Kazuda's ability on Strafing Gunship
+            //     context.player1.clickCard(context.kazudaXiono);
+            //     context.player1.clickPrompt('Select a friendly unit');
+            //     context.player1.clickCard(context.strafingGunship);
+
+            //     // Attack with Strafing Gunship, it can only attack the base
+            //     context.player1.clickCard(context.strafingGunship);
+            //     expect(context.player1).toBeAbleToSelectExactly([context.p2Base]);
+            //     context.player1.clickCard(context.p2Base);
+
+            //     // Effect expires
+            //     context.moveToNextActionPhase();
+
+            //     // Strafing Gunship can attack ground units again
+            //     context.player1.clickCard(context.strafingGunship);
+            //     expect(context.player1).toBeAbleToSelectExactly([
+            //         context.p2Base,
+            //         context.consularSecurityForce
+            //     ]);
+            //     context.player1.clickCard(context.consularSecurityForce);
+            // });
+
+            // it('loses action abilities until the effect expires', function() {
+            //     const { context } = contextRef;
+
+            //     // Use Kazuda's ability on Grogu
+            //     context.player1.clickCard(context.kazudaXiono);
+            //     context.player1.clickPrompt('Select a friendly unit');
+            //     context.player1.clickCard(context.grogu);
+
+            //     // Grogu no longer has an action ability
+            //     context.player1.clickCard(context.grogu);
+
+            //     expect(context.player1).not.toHaveEnabledPromptButton('Exhaust an enemy unit');
+            //     expect(context.player1).toBeAbleToSelect(context.consularSecurityForce);
+
+            //     context.player1.clickCard(context.consularSecurityForce);
+            //     expect(context.consularSecurityForce.exhausted).toBeFalse();
+
+            //     // Effect expires
+            //     context.moveToNextActionPhase();
+
+            //     // Grogu has his action ability back
+            //     context.player1.clickCard(context.grogu);
+            //     expect(context.player1).toHaveEnabledPromptButton('Exhaust an enemy unit');
+            //     context.player1.clickPrompt('Exhaust an enemy unit');
+            //     context.player1.clickCard(context.consularSecurityForce);
+            //     expect(context.consularSecurityForce.exhausted).toBeTrue();
+            // });
+
+            // it('cannot gain new keyword abilities while the effect is active', function() {
+            //     const { context } = contextRef;
+
+            //     // Use Kazuda's ability on Academy Defense Walker
+            //     context.player1.clickCard(context.kazudaXiono);
+            //     context.player1.clickPrompt('Select a friendly unit');
+            //     context.player1.clickCard(context.academyDefenseWalker);
+
+            //     // Play Protector on Academy Defense Walker to attempt to give it Sentinel again
+            //     context.player1.clickCard(context.protector);
+            //     context.player1.clickCard(context.academyDefenseWalker);
+
+            //     // Academy Defense Walker does not have Sentinel
+            //     context.player2.clickCard(context.consularSecurityForce);
+            //     expect(context.player2).toBeAbleToSelect(context.p1Base);
+            //     context.player2.clickCard(context.p1Base);
+            // });
+
+            // it('cannot gain new triggered abilities while the effect is active', function() {
+            //     const { context } = contextRef;
+
+            //     // Use Kazuda's ability on Grogu
+            //     context.player1.clickCard(context.kazudaXiono);
+            //     context.player1.clickPrompt('Select a friendly unit');
+            //     context.player1.clickCard(context.grogu);
+
+            //     // Play Vambrace Grappleshot on Grogu to attempt to give it a triggered ability
+            //     context.player1.clickCard(context.vambraceGrappleshot);
+            //     context.player1.clickCard(context.grogu);
+
+            //     context.player2.passAction();
+
+            //     // Academy Defense Walker does not have the On Attack ability
+            //     context.player1.clickCard(context.grogu);
+            //     context.player1.clickCard(context.consularSecurityForce);
+
+            //     expect(context.consularSecurityForce.exhausted).toBeFalse();
+            // });
+
+            it('cannot gain new constant abilities while the effect is active', function() {
+                const { context } = contextRef;
+
+                // Use Kazuda's ability on Grogu
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.grogu);
+
+                // Play Squad Support on Grogu to attempt to give it a constant ability
+                context.player1.clickCard(context.squadSupport);
+                context.player1.clickCard(context.grogu);
+
+                // Grogu does not have a power or HP boost
+                expect(context.grogu.getPower()).toBe(0);
+                expect(context.grogu.getHp()).toBe(5);
+
+                // Effect expires
+                context.moveToNextActionPhase();
+
+                // Grogu has his power and HP boost
+                expect(context.grogu.getPower()).toBe(2);
+                expect(context.grogu.getHp()).toBe(7);
+            });
+
+            // it('cannot gain new action abilities while the effect is active', async function() {
+            // });
+        });
+    });
+});

--- a/test/scenarios/ability/LoseAllAbilities.spec.ts
+++ b/test/scenarios/ability/LoseAllAbilities.spec.ts
@@ -369,6 +369,7 @@ describe('Lose All Abilities', function() {
 
             it('cannot gain new action abilities from other units while the effect is active', function() {
                 const { context } = contextRef;
+                const satinePromptText = 'Discard cards from an opponent\'s deck equal to half this unit\'s remaining HP, rounded up';
 
                 // Use Kazuda's ability on Liberated Slaves
                 context.player1.clickCard(context.kazudaXiono);
@@ -381,10 +382,17 @@ describe('Lose All Abilities', function() {
 
                 // Liberated Slaves does not have the action ability from Satine Kryze
                 context.player1.clickCard(context.liberatedSlaves);
+                expect(context.player1).not.toHaveEnabledPromptButton(satinePromptText);
+                context.player1.clickCard(context.consularSecurityForce);
 
-                pending('Satine Kryze needs to be implemented before this test case can be completed');
+                // Effect expires
+                context.moveToNextActionPhase();
 
-                expect(context.player1).not.toHaveEnabledPromptButton('Mill');
+                // Liberated Slaves has the action ability gained from Satine Kryze
+                context.player1.clickCard(context.liberatedSlaves);
+                expect(context.player1).toHaveEnabledPromptButton(satinePromptText);
+                context.player1.clickPrompt(satinePromptText);
+                expect(context.liberatedSlaves.exhausted).toBeTrue();
             });
 
             // TODO: There are not currently any units that give other units constant abilities

--- a/test/server/cards/04_JTL/leaders/KazudaZionoBestPilotInTheGalaxy.spec.ts
+++ b/test/server/cards/04_JTL/leaders/KazudaZionoBestPilotInTheGalaxy.spec.ts
@@ -1,0 +1,43 @@
+describe('Kazuda Ziono, Best Pilot in the Galaxy', function() {
+    integration(function(contextRef) {
+        describe('leader ability', function() {
+            it('should remove all abilites from a friendly unit, and let the controller take an extra action', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'emperors-royal-guard',
+                            'emperor-palpatine#master-of-the-dark-side'
+                        ],
+                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy'
+                    },
+                    player2: {
+                        hand: ['open-fire'],
+                        groundArena: [
+                            'consular-security-force'
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt('Select a friendly unit');
+                context.player1.clickCard(context.emperorsRoyalGuard);
+
+                // Opponent attacks base because ERG is not sentinel
+                context.player2.clickCard(context.consularSecurityForce);
+                expect(context.player2).toBeAbleToSelect(context.p1Base);
+                context.player2.clickCard(context.p1Base);
+
+                context.player1.passAction();
+
+                // Opponent plays Open Fire, defeating ERG because it no longer has the HP modifier
+                context.player2.clickCard(context.openFire);
+                context.player2.clickCard(context.emperorsRoyalGuard);
+
+                expect(context.emperorsRoyalGuard).toBeInZone('discard');
+            });
+        });
+    });
+});

--- a/test/server/cards/04_JTL/leaders/KazudaZionoBestPilotInTheGalaxy.spec.ts
+++ b/test/server/cards/04_JTL/leaders/KazudaZionoBestPilotInTheGalaxy.spec.ts
@@ -1,103 +1,123 @@
 
 describe('Kazuda Ziono, Best Pilot in the Galaxy', function() {
     integration(function(contextRef) {
-        describe('leader ability', function() {
-            it('should remove constant abilites from a friendly unit, and let the controller take an extra action', async function() {
-                await contextRef.setupTestAsync({
+        describe('Kazuda\'s undeployed leader ability', function() {
+            beforeEach(function () {
+                return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        groundArena: [
-                            '97th-legion#keeping-the-peace-on-sullust'
-                        ],
-                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy'
+                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy',
+                        groundArena: ['contracted-hunter'],
+                        spaceArena: ['fireball#an-explosion-with-wings']
                     },
                     player2: {
-                        groundArena: ['consular-security-force']
+                        hand: ['superlaser-blast'],
+                        groundArena: ['consular-security-force'],
+                        spaceArena: ['tieln-fighter']
                     }
                 });
-
-                const { context } = contextRef;
-
-                context.player1.clickCard(context.kazudaXiono);
-                context.player1.clickPrompt('Select a friendly unit');
-                context.player1.clickCard(context._97thLegion);
-
-                // 97th Legion is immediately defeated because it has 0 hp
-                expect(context._97thLegion).toBeInZone('discard');
-
-                // Player 1 should be able to take an extra action
-                expect(context.player1).toBeActivePlayer();
-                expect(context.kazudaXiono.exhausted).toBeTrue();
             });
 
-            it('should remove triggered abilites from a friendly unit for the current round only', async function() {
-                await contextRef.setupTestAsync({
-                    phase: 'action',
-                    player1: {
-                        groundArena: [
-                            'contracted-hunter'
-                        ],
-                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy'
-                    },
-                    player2: {
-                        groundArena: ['consular-security-force']
-                    }
-                });
+            // FYI: More extensive "lose all abilities" tests can be found in LoseAllAbilities.spec.ts
 
+            it('removes all abilities from a friendly unit for the round, and allows the controller to take another action', function() {
                 const { context } = contextRef;
 
                 // Use Kazuda's ability on Contracted Hunter
                 context.player1.clickCard(context.kazudaXiono);
+
+                expect(context.player1).toHaveEnabledPromptButton('Select a friendly unit');
                 context.player1.clickPrompt('Select a friendly unit');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.fireball, context.contractedHunter]);
                 context.player1.clickCard(context.contractedHunter);
 
-                context.player1.passAction();
+                expect(context.kazudaXiono.exhausted).toBeTrue();
 
-                context.moveToNextActionPhase();
+                // Player 1 can take another action
+                expect(context.player1).toBeActivePlayer();
+                context.player1.clickCard(context.fireball);
+                context.player1.clickCard(context.p2Base);
 
-                // Contracted Hunter is still in play because his triggered ability was removed
+                // Begin regroup phase
+                context.moveToRegroupPhase();
+
+                // Contracted Hunter is still in play because his treiggered ability was removed
                 expect(context.contractedHunter).toBeInZone('groundArena');
 
-                context.moveToNextActionPhase();
+                // Move to the regroup phase of the next round
+                context.nextPhase();
+                context.moveToRegroupPhase();
+
+                // Resolve simultaneous triggers
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat this unit',
+                    'Deal 1 damage to this unit.',
+                ]);
+                context.player1.clickPrompt('Defeat this unit');
 
                 // Contracted Hunter is defeated because his triggered ability is back
                 expect(context.contractedHunter).toBeInZone('discard');
             });
 
-            it('should remove action abilities from a friendly unit for the current round only', async function() {
-                await contextRef.setupTestAsync({
-                    phase: 'action',
-                    player1: {
-                        groundArena: ['grogu#irresistible'],
-                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy'
-                    },
-                    player2: {
-                        groundArena: ['consular-security-force']
-                    }
-                });
-
+            it('cannot soft pass if there is no friendly target because the controller must take another action', function() {
                 const { context } = contextRef;
 
-                // Use Kazuda's ability on Grogu
+                context.player1.passAction();
+                context.player2.clickCard(context.superlaserBlast);
+
+                expect(context.player1.groundArena.length).toBe(0);
+                expect(context.player1.spaceArena.length).toBe(0);
+
+                // Use Kazuda's ability with no friendly units on board
                 context.player1.clickCard(context.kazudaXiono);
                 context.player1.clickPrompt('Select a friendly unit');
-                context.player1.clickCard(context.grogu);
 
-                // Grogu no longer has an action ability
-                context.player1.clickCard(context.grogu);
+                // Kazuda is exhausted, but it is still Player 1's turn
+                expect(context.kazudaXiono.exhausted).toBeTrue();
+                expect(context.player1).toBeActivePlayer();
 
-                expect(context.player1).not.toHaveEnabledPromptButton('Exhaust an enemy unit');
-                expect(context.player1).toBeAbleToSelect(context.consularSecurityForce);
+                // If both players pass, the phase ends as normal
+                context.player1.passAction();
+                context.player2.passAction();
 
+                expect(context.game.currentPhase).toBe('regroup');
+            });
+        });
+
+        describe('Kazuda\'s deployed unit ability', function() {
+            beforeEach(function () {
+                return contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'kazuda-xiono#best-pilot-in-the-galaxy', deployed: true },
+                        hand: ['heroic-sacrifice'],
+                        groundArena: [
+                            'contracted-hunter',
+                            'k2so#cassians-counterpart'
+                        ],
+                        spaceArena: [
+                            'fireball#an-explosion-with-wings',
+                            'millennium-falcon#piece-of-junk'
+                        ]
+                    },
+                    player2: {
+                        hand: ['superlaser-blast'],
+                        groundArena: ['consular-security-force'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+            });
+
+            it('can select no units to lose abilities', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.kazudaXiono);
                 context.player1.clickCard(context.consularSecurityForce);
 
-                context.moveToNextActionPhase();
+                expect(context.player1).toHaveEnabledPromptButton('Choose no target');
 
-                // Grogu has his action ability back
-                context.player1.clickCard(context.grogu);
-                expect(context.player1).toHaveEnabledPromptButton('Exhaust an enemy unit');
-
-                context.allowTestToEndWithOpenPrompt = true;
+                context.player1.clickPrompt('Choose no target');
             });
         });
     });

--- a/test/server/cards/04_JTL/leaders/KazudaZionoBestPilotInTheGalaxy.spec.ts
+++ b/test/server/cards/04_JTL/leaders/KazudaZionoBestPilotInTheGalaxy.spec.ts
@@ -24,6 +24,10 @@ describe('Kazuda Ziono, Best Pilot in the Galaxy', function() {
 
                 // 97th Legion is immediately defeated because it has 0 hp
                 expect(context._97thLegion).toBeInZone('discard');
+
+                // Player 1 should be able to take an extra action
+                expect(context.player1).toBeActivePlayer();
+                expect(context.kazudaXiono.exhausted).toBeTrue();
             });
 
             it('should remove triggered abilites from a friendly unit for the current round only', async function() {
@@ -46,6 +50,8 @@ describe('Kazuda Ziono, Best Pilot in the Galaxy', function() {
                 context.player1.clickCard(context.kazudaXiono);
                 context.player1.clickPrompt('Select a friendly unit');
                 context.player1.clickCard(context.contractedHunter);
+
+                context.player1.passAction();
 
                 context.moveToNextActionPhase();
 
@@ -76,8 +82,6 @@ describe('Kazuda Ziono, Best Pilot in the Galaxy', function() {
                 context.player1.clickCard(context.kazudaXiono);
                 context.player1.clickPrompt('Select a friendly unit');
                 context.player1.clickCard(context.grogu);
-
-                context.player2.passAction();
 
                 // Grogu no longer has an action ability
                 context.player1.clickCard(context.grogu);


### PR DESCRIPTION
## Summary of changes

 - Implement a mechanism for "lose all abilities"
 - Implement a mechanism that allows a player to take an extra action
 - Implement Kazuda Xiodo leader, utilizing the above
 - Add a comprehensive test suite for scenarios where a unit "loses all abilities"
 - Add a `CardRoundLastingEffectSystem` (No Good to Me Dead is updated to use this)

Note: One test case is marked as `pending` because blanking keywords needs a little extra work

| Undeployed | Deployed |
| :---: | :---: |
| <img src=https://github.com/user-attachments/assets/3cb68dd3-42bf-4843-8e57-8652043cb0a2> | <img src=https://github.com/user-attachments/assets/ec489d18-c414-4337-b293-709bcc1996e4> |