### PR TITLE
Fix Gideon Hask and Iden Versio triggers with pilots

### DIFF
--- a/server/game/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.ts
+++ b/server/game/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.ts
@@ -2,6 +2,7 @@ import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import * as EnumHelpers from '../../../core/utils/EnumHelpers.js';
 
 export default class IdenVersioInfernoSquadCommander extends LeaderUnitCard {
     private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
@@ -35,7 +36,7 @@ export default class IdenVersioInfernoSquadCommander extends LeaderUnitCard {
         this.addTriggeredAbility({
             title: 'When an opponent\'s unit is defeated, heal 1 from base',
             when: {
-                onCardDefeated: (event, context) => event.card.controller !== context.player
+                onCardDefeated: (event, context) => EnumHelpers.isUnit(event.lastKnownInformation.type) && event.card.controller !== context.player
             },
             immediateEffect: AbilityHelper.immediateEffects.heal((context) => {
                 return { amount: 1, target: context.player.base };

--- a/server/game/cards/01_SOR/units/GideonHaskRuthlessLoyalist.ts
+++ b/server/game/cards/01_SOR/units/GideonHaskRuthlessLoyalist.ts
@@ -1,6 +1,7 @@
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer } from '../../../core/Constants';
 import AbilityHelper from '../../../AbilityHelper';
+import * as EnumHelpers from '../../../core/utils/EnumHelpers.js';
 
 export default class GideonHaskRuthlessLoyalist extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,7 +15,7 @@ export default class GideonHaskRuthlessLoyalist extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Give an Experience token to a friendly unit',
             when: {
-                onCardDefeated: (event, context) => event.card.isUnit() && event.card.controller !== context.player
+                onCardDefeated: (event, context) => EnumHelpers.isUnit(event.lastKnownInformation.type) && event.card.controller !== context.player
             },
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/test/server/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.spec.ts
+++ b/test/server/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.spec.ts
@@ -69,7 +69,7 @@ describe('Iden Version, Inferno Squad Commander', function() {
                         base: { card: 'dagobah-swamp', damage: 5 }
                     },
                     player2: {
-                        groundArena: ['specforce-soldier', 'atst'],
+                        groundArena: [{ card: 'x34-landspeeder', upgrades: ['wingman-victor-three#backstabber'] }, 'atst'],
                     }
                 });
             });
@@ -86,7 +86,7 @@ describe('Iden Version, Inferno Squad Commander', function() {
 
                 // case 2: enemy unit defeated
                 context.player1.clickCard(context.wampa);
-                context.player1.clickCard(context.specforceSoldier);
+                context.player1.clickCard(context.x34Landspeeder);
                 expect(context.p1Base.damage).toBe(4);
             });
 

--- a/test/server/cards/01_SOR/units/GideonHaskRuthlessLoyalist.spec.ts
+++ b/test/server/cards/01_SOR/units/GideonHaskRuthlessLoyalist.spec.ts
@@ -6,18 +6,16 @@ describe('Gideon Hask, Ruthless Loyalist', function () {
                     phase: 'action',
                     player1: {
                         groundArena: ['wampa', 'battlefield-marine', 'blizzard-assault-atat'],
+                        spaceArena: [{ card: 'cartel-spacer', upgrades: ['r2d2#artooooooooo'] }],
                     },
                     player2: {
                         hand: ['rivals-fall'],
                         groundArena: ['gideon-hask#ruthless-loyalist', 'specforce-soldier', 'atst'],
                     },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
                 });
             });
 
-            it('should give an Experience to a friendly unit', function () {
+            it('should give an Experience to a friendly unit when an enemy unit is defeated', function () {
                 const { context } = contextRef;
 
                 // Defeating an enemy unit by battle
@@ -29,31 +27,55 @@ describe('Gideon Hask, Ruthless Loyalist', function () {
 
                 expect(context.gideonHask).toHaveExactUpgradeNames(['experience']);
 
-                // Friendly unit dies nothing happens
-                expect(context.player2).toBeActivePlayer();
+                // Defeating an enemy unit using Vanquish
+                context.player2.clickCard(context.rivalsFall);
+                context.player2.clickCard(context.wampa);
+
+                expect(context.player2).toBeAbleToSelectExactly([context.specforceSoldier, context.gideonHask, context.atst]);
+                context.player2.clickCard(context.gideonHask);
+
+                expect(context.gideonHask).toHaveExactUpgradeNames(['experience', 'experience']);
+            });
+
+            it('should do nothing when a friendly unit is defeated', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
                 context.player2.clickCard(context.specforceSoldier);
                 context.player2.clickCard(context.wampa);
 
                 expect(context.player1).toBeActivePlayer();
+            });
 
-                // Defeating an enemy unit using Vanquish
-                context.player1.passAction();
-                context.player2.clickCard(context.rivalsFall);
-                context.player2.clickCard(context.wampa);
+            it('should trigger even if Gideon Hask is defeated', function () {
+                const { context } = contextRef;
 
-                expect(context.player2).toBeAbleToSelectExactly([context.gideonHask, context.atst]);
-                context.player2.clickCard(context.gideonHask);
-
-                expect(context.gideonHask).toHaveExactUpgradeNames(['experience', 'experience']);
-
-                // Ability triggers even if Gideon Hask is defeated
-                expect(context.player1).toBeActivePlayer();
                 context.setDamage(context.blizzardAssaultAtat, 5);
                 context.player1.clickCard(context.blizzardAssaultAtat);
                 context.player1.clickCard(context.gideonHask);
                 context.player1.clickPrompt('You');
                 context.player1.clickPrompt('Pass');
+
+                context.player2.clickCard(context.atst);
+
                 expect(context.atst).toHaveExactUpgradeNames(['experience']);
+            });
+
+            it('should trigger once if an enemy unit with a pilot is defeated', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.rivalsFall);
+                context.player2.clickCard(context.cartelSpacer);
+
+                expect(context.player2).toBeAbleToSelectExactly([context.specforceSoldier, context.gideonHask, context.atst]);
+
+                context.player2.clickCard(context.gideonHask);
+
+                expect(context.gideonHask).toHaveExactUpgradeNames(['experience']);
+                expect(context.player1).toBeActivePlayer();
             });
         });
     });


### PR DESCRIPTION
They were both triggering when a pilot (upgrade) was defeated.

| Iden Versio | Gideon Hask |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/6e1205fb-4d97-4feb-860b-43a686695ec0) | ![image](https://github.com/user-attachments/assets/c949a8fa-77b7-4d1d-9710-7b0c2257a225) |

