### PR TITLE
Relax MoveCard contract check

### DIFF
--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -297,7 +297,7 @@ export function moveCard<TContext extends AbilityContext = AbilityContext>(prope
     return new MoveCardSystem<TContext>(propertyFactory);
 }
 
-export function moveToBottomOfDeck<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IMoveCardProperties, TContext> = {}) {
+export function moveToBottomOfDeck<TContext extends AbilityContext = AbilityContext>(propertyFactory: Omit<PropsFactory<IMoveCardProperties, TContext>, 'destination'> = {}) {
     return new MoveCardSystem<TContext>(
         GameSystem.appendToPropertiesOrPropertyFactory<IMoveCardProperties, 'destination'>(
             propertyFactory,

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -28,7 +28,7 @@ import * as Contract from '../core/utils/Contract';
  * @property shuffleMovedCards - Indicates whether all targets should be shuffled before added into the destination.
  */
 export interface IMoveCardProperties extends ICardTargetSystemProperties {
-    destination?: Exclude<MoveZoneDestination, ZoneName.Discard | ZoneName.SpaceArena | ZoneName.GroundArena | ZoneName.Resource>;
+    destination: Exclude<MoveZoneDestination, ZoneName.Discard | ZoneName.SpaceArena | ZoneName.GroundArena | ZoneName.Resource>;
     shuffle?: boolean;
     shuffleMovedCards?: boolean;
 }
@@ -110,14 +110,15 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
         const properties = this.generatePropertiesFromContext(context, additionalProperties) as IMoveCardProperties;
         const { destination } = properties;
 
+        Contract.assertNotNullLike(destination);
+
         if (card.isToken()) {
             Contract.assertTrue(destination !== ZoneName.Base, `${destination} is not a valid zone for a token card`);
         } else {
             // Ensure that we have a valid destination and that the card can be moved there
-            Contract.assertTrue(
-                destination && context.player.isLegalZoneForCardType(card.type, destination),
-                `${destination} is not a valid zone for ${card.type}`
-            );
+            if (!context.player.isLegalZoneForCardType(card.type, destination)) {
+                return false;
+            }
         }
 
         // Ensure that if the card is returning to the hand, it must be in the discard pile or in play or be a resource


### PR DESCRIPTION
MoveCardSystem had a very strict contract check in canAffect making it illegal to even ask if a card could be moved to an illegal zone. This was triggering some hard-to-identify errors in the logs and is probably too strong of a check anyway. Reduced it to just returning `false` in that case.