### PR TITLE
Improve some common prompt issues

### DIFF
--- a/server/game/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.ts
+++ b/server/game/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.ts
@@ -38,7 +38,8 @@ export default class CassionAndorDedicatedToTheRebellion extends LeaderUnitCard 
 
     protected override setupLeaderUnitSideAbilities() {
         this.addTriggeredAbility({
-            title: 'When you deal damage to an enemy base: You may draw a card. Use this ability only once each round.',
+            title: 'Draw a card',
+            collectiveTrigger: true,
             when: {
                 onDamageDealt: (event, context) =>
                     event.card.isBase() &&

--- a/server/game/cards/04_JTL/leaders/BobaFettAnyMethodsNecessary.ts
+++ b/server/game/cards/04_JTL/leaders/BobaFettAnyMethodsNecessary.ts
@@ -16,6 +16,7 @@ export default class BobaFettAnyMethodsNecessary extends LeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Exhaust this leader',
             optional: true,
+            collectiveTrigger: true,
             when: {
                 onDamageDealt: (event, context) => event.damageSource.player === context.player && event.type !== DamageType.Combat && event.type !== DamageType.Overwhelm,
             },

--- a/server/game/core/ability/TriggeredAbilityContext.ts
+++ b/server/game/core/ability/TriggeredAbilityContext.ts
@@ -1,5 +1,6 @@
 import type { Card } from '../card/Card';
 import { AbilityContext, type IAbilityContextProperties } from './AbilityContext';
+import type TriggeredAbility from './TriggeredAbility';
 
 export interface ITriggeredAbilityContextProperties extends IAbilityContextProperties {
     // TODO: rename this to "triggeringEvent"
@@ -10,6 +11,7 @@ export interface ITriggeredAbilityContextProperties extends IAbilityContextPrope
 export class TriggeredAbilityContext<TSource extends Card = Card> extends AbilityContext<TSource> {
     public readonly event: any;
     public readonly overrideTitle?: string;
+    public override readonly ability: TriggeredAbility;
 
     public constructor(properties: ITriggeredAbilityContextProperties) {
         super(properties);

--- a/server/game/core/ability/abilityTargets/PlayerTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/PlayerTargetResolver.ts
@@ -93,6 +93,6 @@ export class PlayerTargetResolver extends TargetResolver<IPlayerTargetResolver<A
     private getDefaultPromptTitle(context: AbilityContext, isMultiSelect = false) {
         const abilityTitleStr = context.ability?.title ? ` for ability '${context.ability.title}'` : '';
 
-        return isMultiSelect ? `Choose any number of players${abilityTitleStr}` : `Choose a player${abilityTitleStr}`;
+        return isMultiSelect ? `Choose any number of players to target${abilityTitleStr}` : `Choose a player to target${abilityTitleStr}`;
     }
 }

--- a/server/game/core/ability/abilityTargets/PlayerTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/PlayerTargetResolver.ts
@@ -43,7 +43,10 @@ export class PlayerTargetResolver extends TargetResolver<IPlayerTargetResolver<A
         const choices = ['You', 'Opponent'];
 
         if (this.properties.mode === TargetMode.MultiplePlayers) { // Uses a HandlerMenuMultipleSelectionPrompt: handler takes an array of chosen items
-            const activePromptTitleConcrete = typeof this.properties.activePromptTitle === 'function' ? this.properties.activePromptTitle(context) : this.properties.activePromptTitle || 'Choose any number of players';
+            const activePromptTitle = typeof this.properties.activePromptTitle === 'function'
+                ? this.properties.activePromptTitle(context)
+                : this.properties.activePromptTitle || this.getDefaultPromptTitle(context, true);
+
             const multiSelect = true;
             const handler = (chosen) => {
                 chosen = chosen.map((choiceTitle) => {
@@ -60,9 +63,11 @@ export class PlayerTargetResolver extends TargetResolver<IPlayerTargetResolver<A
                 return true;
             };
 
-            Object.assign(promptProperties, { activePromptTitleConcrete, choices, multiSelect, handler });
+            Object.assign(promptProperties, { activePromptTitle, choices, multiSelect, handler });
         } else { // Uses a HandlerMenuPrompt: each choice gets its own handler, called right away when that choice is clicked
-            const activePromptTitleConcrete = typeof this.properties.activePromptTitle === 'function' ? this.properties.activePromptTitle(context) : this.properties.activePromptTitle || 'Choose a player';
+            const activePromptTitle = typeof this.properties.activePromptTitle === 'function'
+                ? this.properties.activePromptTitle(context)
+                : this.properties.activePromptTitle || this.getDefaultPromptTitle(context, false);
             const handlers = [player, player.opponent].map(
                 (chosenPlayer) => {
                     return () => {
@@ -71,7 +76,7 @@ export class PlayerTargetResolver extends TargetResolver<IPlayerTargetResolver<A
                 }
             );
 
-            Object.assign(promptProperties, { activePromptTitleConcrete, choices, handlers });
+            Object.assign(promptProperties, { activePromptTitle, choices, handlers });
             // TODO: figure out if we need these buttons
             /* if (player !== context.player.opponent && context.stage === Stage.PreTarget) {
                 if (!targetResults.noCostsFirstButton) {
@@ -83,5 +88,11 @@ export class PlayerTargetResolver extends TargetResolver<IPlayerTargetResolver<A
             }*/
         }
         context.game.promptWithHandlerMenu(player, promptProperties);
+    }
+
+    private getDefaultPromptTitle(context: AbilityContext, isMultiSelect = false) {
+        const abilityTitleStr = context.ability?.title ? ` for ability '${context.ability.title}'` : '';
+
+        return isMultiSelect ? `Choose any number of players${abilityTitleStr}` : `Choose a player${abilityTitleStr}`;
     }
 }

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -138,7 +138,14 @@ export abstract class TriggerWindowBase extends BaseStep {
         }
 
         // Check to if we're dealing with a multi-selection of the 'same' ability
-        const isMultiSelectAbility = this.isMultiSelectAbility(abilitiesToResolve, this.resolved.map((resolved) => resolved.ability));
+        let isMultiSelectAbility = this.isMultiSelectAbility(abilitiesToResolve, this.resolved.map((resolved) => resolved.ability));
+
+        // if an ability is triggered multiple times and uses a collective trigger, filter down to one instance of it
+        if (isMultiSelectAbility && abilitiesToResolve[0].ability.collectiveTrigger) {
+            abilitiesToResolve = [abilitiesToResolve[0]];
+            this.unresolved.set(this.currentlyResolvingPlayer, abilitiesToResolve);
+            isMultiSelectAbility = false;
+        }
 
         // if there's more than one ability still unresolved, prompt for next selection
         if (abilitiesToResolve.length > 1) {

--- a/test/server/cards/04_JTL/events/PlanetaryBombardment.spec.ts
+++ b/test/server/cards/04_JTL/events/PlanetaryBombardment.spec.ts
@@ -23,7 +23,7 @@ describe('Planetary Bombardment', function() {
 
             // Player 1 plays Planetary Bombardment and deals 12 indirect damage
             context.player1.clickCard(context.planetaryBombardment);
-            expect(context.player1).toHavePrompt('Select one');
+            expect(context.player1).toHavePrompt('Choose a player to target for ability \'Deal 8 indirect damage to a player. If you control a Capital Ship unit, deal 12 indirect damage instead\'');
 
             context.player1.clickPrompt('Opponent');
             expect(context.player2).toHavePrompt('Distribute 12 indirect damage among targets');
@@ -54,7 +54,7 @@ describe('Planetary Bombardment', function() {
 
             // Player 1 plays Planetary Bombardment and deals 8 indirect damage
             context.player1.clickCard(context.planetaryBombardment);
-            expect(context.player1).toHavePrompt('Select one');
+            expect(context.player1).toHavePrompt('Choose a player to target for ability \'Deal 8 indirect damage to a player. If you control a Capital Ship unit, deal 12 indirect damage instead\'');
             expect(context.p1Base.damage).toBe(0);
 
             context.player1.clickPrompt('You');

--- a/test/server/cards/04_JTL/events/TorpedoBarrage.spec.ts
+++ b/test/server/cards/04_JTL/events/TorpedoBarrage.spec.ts
@@ -16,7 +16,7 @@ describe('Torpedo Barrage', function() {
 
             // Player 1 plays Torpedo Barrage and deals 5 indirect damage
             context.player1.clickCard(context.torpedoBarrage);
-            expect(context.player1).toHavePrompt('Select one');
+            expect(context.player1).toHavePrompt('Choose a player to target for ability \'Deal 5 indirect damage to a player\'');
 
             context.player1.clickPrompt('Opponent');
             expect(context.player2).toHavePrompt('Distribute 5 indirect damage among targets');

--- a/test/server/cards/04_JTL/leaders/BobaFettAnyMethodsNecessary.spec.ts
+++ b/test/server/cards/04_JTL/leaders/BobaFettAnyMethodsNecessary.spec.ts
@@ -89,6 +89,59 @@ describe('Boba Fett, Any Methods Necessary', function() {
                 expect(context.bobaFett.exhausted).toBe(false);
             });
 
+            describe('when dealing simultaneous damage to multiple targets,', function () {
+                beforeEach(function () {
+                    return contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            leader: 'boba-fett#any-methods-necessary',
+                            groundArena: ['wampa'],
+                            hand: ['overwhelming-barrage']
+                        },
+                        player2: {
+                            groundArena: ['atst', 'consular-security-force']
+                        }
+                    });
+                });
+
+                it('should only show one trigger prompt and go away when triggered', function () {
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.overwhelmingBarrage);
+                    context.player1.clickCard(context.wampa);
+                    context.player1.setDistributeDamagePromptState(new Map([
+                        [context.atst, 3],
+                        [context.consularSecurityForce, 3],
+                    ]));
+
+                    expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
+                    context.player1.clickPrompt('Trigger');
+                    context.player1.clickPrompt('Opponent');
+                    expect(context.player2).toHavePrompt('Distribute 1 indirect damage among targets');
+                    context.player2.setDistributeIndirectDamagePromptState(new Map([
+                        [context.p2Base, 1],
+                    ]));
+
+                    expect(context.player2).toBeActivePlayer();
+                });
+
+                it('should only show one trigger prompt and go away when passed', function () {
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.overwhelmingBarrage);
+                    context.player1.clickCard(context.wampa);
+                    context.player1.setDistributeDamagePromptState(new Map([
+                        [context.atst, 3],
+                        [context.consularSecurityForce, 3],
+                    ]));
+
+                    expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader');
+                    context.player1.clickPrompt('Pass');
+
+                    expect(context.player2).toBeActivePlayer();
+                });
+            });
+
             it('does not deal 4 damage when deployed as a unit', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
Made the following prompts a little clearer:

- For indirect damage, added the ability title to the prompt and clarified that you are choosing the targeted player
- For Boba leader, added support for consolidating multiple triggers down to one