### PR TITLE
Add Krennic unit and explicit registration for "when defeated" abilities

### DIFF
--- a/server/game/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.ts
+++ b/server/game/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.ts
@@ -14,7 +14,7 @@ export default class BlackOneScourgeOfStarkillerBase extends NonLeaderUnitCard {
             title: 'Discard your hand',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true
             },
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.discardEntireHand((context) => ({ target: context.player })),

--- a/server/game/cards/01_SOR/units/GeneralKrellHeartlessTactician.ts
+++ b/server/game/cards/01_SOR/units/GeneralKrellHeartlessTactician.ts
@@ -19,7 +19,7 @@ export default class GeneralKrellHeartlessTactician extends NonLeaderUnitCard {
                 type: AbilityType.Triggered,
                 title: 'Draw a card',
                 optional: true,
-                when: { onCardDefeated: (event, context) => event.card === context.source },
+                when: { whenDefeated: true },
                 immediateEffect: AbilityHelper.immediateEffects.draw((context) => ({ target: context.player }))
             })
         });

--- a/server/game/cards/01_SOR/units/InfernoFourUnforgetting.ts
+++ b/server/game/cards/01_SOR/units/InfernoFourUnforgetting.ts
@@ -15,7 +15,7 @@ export default class InfernoFourUnforgetting extends NonLeaderUnitCard {
             title: 'Look at the top 2 cards of your deck. Put any number of them on the bottom of your deck and the rest on top in any order.',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.lookMoveDeckCardsTopOrBottom({ amount: 2 })
         });

--- a/server/game/cards/01_SOR/units/RuthlessRaider.ts
+++ b/server/game/cards/01_SOR/units/RuthlessRaider.ts
@@ -15,7 +15,7 @@ export default class RuthlessRaider extends NonLeaderUnitCard {
             title: 'Deal 2 damage to an enemy base and 2 damage to an enemy unit',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source
+                whenDefeated: true
             },
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.selectCard({

--- a/server/game/cards/02_SHD/leaders/GarSaxonViceroyofMandalore.ts
+++ b/server/game/cards/02_SHD/leaders/GarSaxonViceroyofMandalore.ts
@@ -31,7 +31,7 @@ export default class GarSaxonViceroyofMandalore extends LeaderUnitCard {
                     title: 'Return an upgrade that was attached to this unit to its owner\'s hand',
                     optional: true,
                     when: {
-                        onCardDefeated: (event, context) => event.card === context.source
+                        whenDefeated: true
                     },
                     targetResolver: {
                         zoneFilter: ZoneName.Discard,

--- a/server/game/cards/02_SHD/leaders/LandoCalrissianWithImpeccableTaste.ts
+++ b/server/game/cards/02_SHD/leaders/LandoCalrissianWithImpeccableTaste.ts
@@ -27,7 +27,7 @@ export default class LandoCalrissianWithImpeccableTaste extends LeaderUnitCard {
         };
     }
 
-    private buildDefeatResourceAbility(): IThenAbilityPropsWithSystems<AbilityContext> {
+    private buildDefeatResourceAbility(): IThenAbilityPropsWithSystems<AbilityContext<this>> {
         return {
             title: 'Defeat a resource you own and control',
             targetResolver: {

--- a/server/game/cards/02_SHD/units/DrydenVosOfferingNoEscape.ts
+++ b/server/game/cards/02_SHD/units/DrydenVosOfferingNoEscape.ts
@@ -18,6 +18,7 @@ export default class DrydenVos extends NonLeaderUnitCard {
     public override setupCardAbilities() {
         this.addWhenPlayedAbility({
             title: 'Choose a captured card guarded by a unit you control. You may play it for free under your control.',
+            optional: true,
             targetResolver: {
                 zoneFilter: [ZoneName.Capture],
                 cardCondition: (card, context) => this.checkIfTargetIsGuardedByControlledUnit(card, context),

--- a/server/game/cards/02_SHD/upgrades/InspiringMentor.ts
+++ b/server/game/cards/02_SHD/upgrades/InspiringMentor.ts
@@ -12,6 +12,8 @@ export default class InspiringMentor extends UpgradeCard {
     }
 
     public override setupCardAbilities() {
+        this.disableWhenDefeatedCheck = true;
+
         this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
 
         this.addGainTriggeredAbilityTargetingAttached({

--- a/server/game/cards/02_SHD/upgrades/InspiringMentor.ts
+++ b/server/game/cards/02_SHD/upgrades/InspiringMentor.ts
@@ -18,7 +18,7 @@ export default class InspiringMentor extends UpgradeCard {
             title: 'Give an Experience token to another friendly unit',
             when: {
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/03_TWI/events/InDefenseOfKamino.ts
+++ b/server/game/cards/03_TWI/events/InDefenseOfKamino.ts
@@ -19,7 +19,7 @@ export default class InDefenseOfKamino extends EventCard {
                     AbilityHelper.ongoingEffects.gainAbility({
                         type: AbilityType.Triggered,
                         title: 'Create a Clone Trooper token.',
-                        when: { onCardDefeated: (event, context) => event.card === context.source },
+                        when: { whenDefeated: true },
                         immediateEffect: AbilityHelper.immediateEffects.createCloneTrooper()
                     })
                 ],

--- a/server/game/cards/03_TWI/events/PyrrhicAssault.ts
+++ b/server/game/cards/03_TWI/events/PyrrhicAssault.ts
@@ -17,7 +17,7 @@ export default class PyrrhicAssault extends EventCard {
                 effect: AbilityHelper.ongoingEffects.gainAbility({
                     type: AbilityType.Triggered,
                     title: 'Deal 2 damage to an enemy unit.',
-                    when: { onCardDefeated: (event, context) => event.card === context.source },
+                    when: { whenDefeated: true },
                     targetResolver: {
                         controller: RelativePlayer.Opponent,
                         cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/03_TWI/leaders/NalaSeCloneEngineer.ts
+++ b/server/game/cards/03_TWI/leaders/NalaSeCloneEngineer.ts
@@ -34,7 +34,7 @@ export default class NalaSeCloneEngineer extends LeaderUnitCard {
             ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
                 type: AbilityType.Triggered,
                 title: 'Heal 2 damage from your base',
-                when: { onCardDefeated: (event, context) => event.card === context.source },
+                when: { whenDefeated: true },
                 immediateEffect: AbilityHelper.immediateEffects.heal((context) => ({
                     amount: 2,
                     target: context.player.base

--- a/server/game/cards/03_TWI/units/BattleDroidEscort.ts
+++ b/server/game/cards/03_TWI/units/BattleDroidEscort.ts
@@ -14,7 +14,7 @@ export default class BattleDroidEscort extends NonLeaderUnitCard {
             title: 'Create a Battle Droid token.',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createBattleDroid()
         });

--- a/server/game/cards/03_TWI/units/EliteP38Starfighter.ts
+++ b/server/game/cards/03_TWI/units/EliteP38Starfighter.ts
@@ -15,7 +15,7 @@ export default class EliteP38Starfighter extends NonLeaderUnitCard {
             title: 'Deal 1 damage to a unit',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source
+                whenDefeated: true
             },
             optional: true,
             targetResolver: {

--- a/server/game/cards/03_TWI/units/SteelaGerreraBelovedTactician.ts
+++ b/server/game/cards/03_TWI/units/SteelaGerreraBelovedTactician.ts
@@ -15,7 +15,7 @@ export default class SteelaGerreraBelovedTactician extends NonLeaderUnitCard {
             title: 'Deal 2 damage to your base',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source
+                whenDefeated: true
             },
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({

--- a/server/game/cards/04_JTL/units/AnnihilatorTaggesFlagship.ts
+++ b/server/game/cards/04_JTL/units/AnnihilatorTaggesFlagship.ts
@@ -17,7 +17,7 @@ export default class AnnihilatorTaggesFlagship extends NonLeaderUnitCard {
             optional: true,
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source
+                whenDefeated: true
             },
             targetResolver: {
                 controller: RelativePlayer.Opponent,

--- a/server/game/cards/04_JTL/units/DirectorKrennicOnTheVergeOfGreatness.ts
+++ b/server/game/cards/04_JTL/units/DirectorKrennicOnTheVergeOfGreatness.ts
@@ -1,0 +1,47 @@
+import AbilityHelper from '../../../AbilityHelper';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { CardType, RelativePlayer, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
+import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
+import * as AbilityLimit from '../../../core/ability/AbilityLimit';
+
+export default class DirectorKrennicOnTheVergeOfGreatness extends NonLeaderUnitCard {
+    private cardsPlayedThisPhaseWatcher: CardsPlayedThisPhaseWatcher;
+
+    protected override getImplementationId () {
+        return {
+            id: '6311662442',
+            internalName: 'director-krennic#on-the-verge-of-greatness',
+        };
+    }
+
+    protected override setupStateWatchers(registrar: StateWatcherRegistrar): void {
+        this.cardsPlayedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsPlayedThisPhase(registrar, this);
+    }
+
+    public override setupCardAbilities () {
+        this.addConstantAbility({
+            title: 'The first unit you play each round that has a "When Defeated" ability costs 1 resource less',
+            targetController: RelativePlayer.Self,
+            targetCardTypeFilter: CardType.BasicUnit,
+            targetZoneFilter: WildcardZoneName.AnyArena,
+            ongoingEffect: AbilityHelper.ongoingEffects.decreaseCost({
+                amount: 1,
+                cardTypeFilter: WildcardCardType.NonLeaderUnit,
+                match: (card) => this.isFirstUnitWithWhenDefeatedPlayedThisPhase(card),
+                limit: AbilityLimit.perRound(1)
+            }),
+        });
+    }
+
+    private isFirstUnitWithWhenDefeatedPlayedThisPhase(card) {
+        return card.isUnit() &&
+          card.getTriggeredAbilities().some((ability) => ability.isWhenDefeated) &&
+          !this.cardsPlayedThisPhaseWatcher.someCardPlayed((playedCardEntry) =>
+              playedCardEntry.playedAsType === CardType.BasicUnit &&
+              playedCardEntry.playedBy === card.controller &&
+              playedCardEntry.hasWhenDefeatedAbilities &&
+              playedCardEntry.card !== card
+          );
+    }
+}

--- a/server/game/cards/04_JTL/units/ExecutorMightOfTheEmpire.ts
+++ b/server/game/cards/04_JTL/units/ExecutorMightOfTheEmpire.ts
@@ -15,7 +15,7 @@ export default class ExecutorMightOfTheEmpire extends NonLeaderUnitCard {
             title: 'Create 3 TIE Fighter tokens.',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source
             },
             immediateEffect: AbilityHelper.immediateEffects.createTieFighter({ amount: 3 })

--- a/server/game/cards/04_JTL/units/FirstOrderStormtrooper.ts
+++ b/server/game/cards/04_JTL/units/FirstOrderStormtrooper.ts
@@ -15,7 +15,7 @@ export default class FirstOrderStormtrooper extends NonLeaderUnitCard {
             title: 'Deal 1 indirect damage to a player',
             when: {
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             targetResolver: {
                 mode: TargetMode.Player,

--- a/server/game/cards/04_JTL/units/LukeSkywalkerYouStillWithMe.ts
+++ b/server/game/cards/04_JTL/units/LukeSkywalkerYouStillWithMe.ts
@@ -10,7 +10,7 @@ export default class LukeSkywalkerYouStillWithMe extends NonLeaderUnitCard {
         };
     }
 
-    // TODO THIS PR: use whenDefeated: true instead of onCardDefeated
+    // TODO THRAWN2: use whenDefeated: true instead of onCardDefeated
 
     public override setupCardAbilities () {
         this.addPilotingAbility({

--- a/server/game/cards/04_JTL/units/LukeSkywalkerYouStillWithMe.ts
+++ b/server/game/cards/04_JTL/units/LukeSkywalkerYouStillWithMe.ts
@@ -10,6 +10,8 @@ export default class LukeSkywalkerYouStillWithMe extends NonLeaderUnitCard {
         };
     }
 
+    // TODO THIS PR: use whenDefeated: true instead of onCardDefeated
+
     public override setupCardAbilities () {
         this.addPilotingAbility({
             type: AbilityType.ReplacementEffect,

--- a/server/game/cards/04_JTL/units/ProfundityWeFight.ts
+++ b/server/game/cards/04_JTL/units/ProfundityWeFight.ts
@@ -15,7 +15,7 @@ export default class ProfundityWeFight extends NonLeaderUnitCard {
             title: 'Make a player discard a card from their hand',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             targetResolver: {
                 activePromptTitle: 'Choose a player to discard a card from their hand',

--- a/server/game/cards/04_JTL/units/ShuttleST149UnderKrennicsAuthority.ts
+++ b/server/game/cards/04_JTL/units/ShuttleST149UnderKrennicsAuthority.ts
@@ -16,7 +16,7 @@ export default class ShuttleST149UnderKrennicsAuthority extends NonLeaderUnitCar
             optional: true,
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             targetResolvers: {
                 chooseUpgrade: {

--- a/server/game/cards/04_JTL/units/TIEAmbushSquadron.ts
+++ b/server/game/cards/04_JTL/units/TIEAmbushSquadron.ts
@@ -14,7 +14,7 @@ export default class TIEAmbushSquadron extends NonLeaderUnitCard {
             title: 'Create a TIE Fighter token.',
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
-                onCardDefeated: (event, context) => event.card === context.source,
+                whenDefeated: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createTieFighter()
         });

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -138,6 +138,11 @@ export enum WildcardRelativePlayer {
 
 export type RelativePlayerFilter = RelativePlayer | WildcardRelativePlayer;
 
+export enum StandardTriggeredAbilityType {
+    WhenDefeated = 'whenDefeated',
+    OnAttack = 'onAttack'
+}
+
 export enum TargetMode {
     AutoSingle = 'autoSingle',
     // TODO: add 'Between'

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -103,7 +103,10 @@ class Game extends EventEmitter {
         this.registerGlobalRulesListeners();
 
         // TODO TWIN SUNS
-        Contract.assertArraySize(details.players, 2, 'Game must have exactly 2 players');
+        Contract.assertArraySize(
+            details.players, 2, `
+            Game must have exactly 2 players, received ${details.players.length}: ${details.players.map((player) => player.id).join(', ')}`
+        );
 
         details.players.forEach((player) => {
             this.playersAndSpectators[player.id] = new Player(

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -59,7 +59,7 @@ export default class TriggeredAbility extends CardAbility {
         return this.standardTriggerTypes.includes(StandardTriggeredAbilityType.OnAttack);
     }
 
-    public get isWhenDefeatedAbility() {
+    public get isWhenDefeated() {
         return this.standardTriggerTypes.includes(StandardTriggeredAbilityType.WhenDefeated);
     }
 

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -1,7 +1,8 @@
 import { CardAbility } from './CardAbility';
 import { TriggeredAbilityContext } from './TriggeredAbilityContext';
+import { EventName, StandardTriggeredAbilityType } from '../Constants';
 import { AbilityType, GameStateChangeRequired, RelativePlayer, Stage } from '../Constants';
-import type { ITriggeredAbilityProps, WhenType } from '../../Interfaces';
+import type { ITriggeredAbilityProps, WhenType, WhenTypeOrStandard } from '../../Interfaces';
 import type { GameEvent } from '../event/GameEvent';
 import type { Card } from '../card/Card';
 import type Game from '../Game';
@@ -43,14 +44,53 @@ interface IEventRegistration {
  */
 
 export default class TriggeredAbility extends CardAbility {
-    public when?: WhenType;
-    public aggregateWhen?: (events: GameEvent[], context: TriggeredAbilityContext) => boolean;
-    public anyPlayer: boolean;
-    public collectiveTrigger: boolean;
-    public eventRegistrations?: IEventRegistration[];
-    public eventsTriggeredFor: GameEvent[] = [];
+    private static parseStandardTriggerTypes(when: WhenTypeOrStandard): {
+        when: WhenType;
+        standardTriggerTypes: StandardTriggeredAbilityType[];
+    } {
+        const updatedWhen: WhenType = {};
+        const standardTriggerTypes = [];
+
+        for (const [trigger, value] of Object.entries(when)) {
+            if (typeof value === 'boolean') {
+                switch (trigger) {
+                    case StandardTriggeredAbilityType.WhenDefeated:
+                        updatedWhen[EventName.OnCardDefeated] = (event, context) => event.card === context.source;
+                        break;
+                    case StandardTriggeredAbilityType.OnAttack:
+                        updatedWhen[EventName.OnAttackDeclared] = (event, context) => event.attack.attacker === context.source;
+                        break;
+                    default:
+                        Contract.fail(`Unexpected standard trigger type: ${trigger}`);
+                }
+
+                standardTriggerTypes.push(trigger);
+            } else {
+                updatedWhen[trigger] = value;
+            }
+        }
+
+        return { when: updatedWhen, standardTriggerTypes };
+    }
+
+    public readonly when?: WhenType;
+    public readonly aggregateWhen?: (events: GameEvent[], context: TriggeredAbilityContext) => boolean;
+    public readonly anyPlayer: boolean;
+    public readonly collectiveTrigger: boolean;
+    public readonly standardTriggerTypes: StandardTriggeredAbilityType[] = [];
+
+    protected eventRegistrations?: IEventRegistration[];
+    protected eventsTriggeredFor: GameEvent[] = [];
 
     private readonly mustChangeGameState: GameStateChangeRequired;
+
+    public get isOnAttackAbility() {
+        return this.standardTriggerTypes.includes(StandardTriggeredAbilityType.OnAttack);
+    }
+
+    public get isWhenDefeatedAbility() {
+        return this.standardTriggerTypes.includes(StandardTriggeredAbilityType.WhenDefeated);
+    }
 
     public constructor(
         game: Game,
@@ -65,10 +105,13 @@ export default class TriggeredAbility extends CardAbility {
         }
 
         if ('when' in properties) {
-            this.when = properties.when;
+            const { when, standardTriggerTypes } = TriggeredAbility.parseStandardTriggerTypes(properties.when);
+            this.when = when;
+            this.standardTriggerTypes = standardTriggerTypes;
         } else if ('aggregateWhen' in properties) {
             this.aggregateWhen = properties.aggregateWhen;
         }
+
         this.collectiveTrigger = !!properties.collectiveTrigger;
 
         this.mustChangeGameState = !!this.properties.ifYouDo || !!this.properties.ifYouDoNot

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -44,35 +44,6 @@ interface IEventRegistration {
  */
 
 export default class TriggeredAbility extends CardAbility {
-    private static parseStandardTriggerTypes(when: WhenTypeOrStandard): {
-        when: WhenType;
-        standardTriggerTypes: StandardTriggeredAbilityType[];
-    } {
-        const updatedWhen: WhenType = {};
-        const standardTriggerTypes = [];
-
-        for (const [trigger, value] of Object.entries(when)) {
-            if (typeof value === 'boolean') {
-                switch (trigger) {
-                    case StandardTriggeredAbilityType.WhenDefeated:
-                        updatedWhen[EventName.OnCardDefeated] = (event, context) => event.card === context.source;
-                        break;
-                    case StandardTriggeredAbilityType.OnAttack:
-                        updatedWhen[EventName.OnAttackDeclared] = (event, context) => event.attack.attacker === context.source;
-                        break;
-                    default:
-                        Contract.fail(`Unexpected standard trigger type: ${trigger}`);
-                }
-
-                standardTriggerTypes.push(trigger);
-            } else {
-                updatedWhen[trigger] = value;
-            }
-        }
-
-        return { when: updatedWhen, standardTriggerTypes };
-    }
-
     public readonly when?: WhenType;
     public readonly aggregateWhen?: (events: GameEvent[], context: TriggeredAbilityContext) => boolean;
     public readonly anyPlayer: boolean;
@@ -105,7 +76,7 @@ export default class TriggeredAbility extends CardAbility {
         }
 
         if ('when' in properties) {
-            const { when, standardTriggerTypes } = TriggeredAbility.parseStandardTriggerTypes(properties.when);
+            const { when, standardTriggerTypes } = this.parseStandardTriggerTypes(properties.when);
             this.when = when;
             this.standardTriggerTypes = standardTriggerTypes;
         } else if ('aggregateWhen' in properties) {
@@ -136,6 +107,35 @@ export default class TriggeredAbility extends CardAbility {
                 window.addTriggeredAbilityToWindow(context);
             }
         }
+    }
+
+    private parseStandardTriggerTypes(when: WhenTypeOrStandard): {
+        when: WhenType;
+        standardTriggerTypes: StandardTriggeredAbilityType[];
+    } {
+        const updatedWhen: WhenType = {};
+        const standardTriggerTypes = [];
+
+        for (const [trigger, value] of Object.entries(when)) {
+            if (typeof value === 'boolean') {
+                switch (trigger) {
+                    case StandardTriggeredAbilityType.WhenDefeated:
+                        updatedWhen[EventName.OnCardDefeated] = (event, context) => event.card === context.source;
+                        break;
+                    case StandardTriggeredAbilityType.OnAttack:
+                        updatedWhen[EventName.OnAttackDeclared] = (event, context) => event.attack.attacker === context.source;
+                        break;
+                    default:
+                        Contract.fail(`Unexpected standard trigger type: ${trigger}`);
+                }
+
+                standardTriggerTypes.push(trigger);
+            } else {
+                updatedWhen[trigger] = value;
+            }
+        }
+
+        return { when: updatedWhen, standardTriggerTypes };
     }
 
     protected override controllerMeetsRequirements(context): boolean {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -362,7 +362,7 @@ export class Card extends OngoingEffectSource {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    protected validateCardAbilities(cardData: ICardDataJson) {
+    protected validateCardAbilities(cardText: string) {
     }
 
     // ******************************************* ABILITY HELPERS *******************************************

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -101,6 +101,7 @@ export class Card extends OngoingEffectSource {
     protected actionAbilities: ActionAbility[] = [];
     protected constantAbilities: IConstantAbility[] = [];
     protected _controller: Player;
+    protected disableWhenDefeatedCheck = false;
     protected _facedown = true;
     protected hiddenForController = true;      // TODO: is this correct handling of hidden / visible card state? not sure how this integrates with the client
     protected hiddenForOpponent = true;
@@ -358,6 +359,10 @@ export class Card extends OngoingEffectSource {
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     protected initializeStateForAbilitySetup() {
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    protected validateCardAbilities(cardData: ICardDataJson) {
     }
 
     // ******************************************* ABILITY HELPERS *******************************************

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -60,6 +60,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent implements IDeployableL
 
         this.setupLeaderUnitSide = true;
         this.setupLeaderUnitSideAbilities(this);
+        this.validateCardAbilities(cardData.deployBox);
     }
 
     protected deployActionAbilityProps(): Omit<IActionAbilityProps<this>, 'title' | 'condition' | 'zoneFilter' | 'immediateEffect'> {

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -134,6 +134,8 @@ export class UpgradeCard extends UpgradeCardParent implements IUpgradeCard, IPla
         });
     }
 
+    // TODO THIS PR: update the below to use the whenDefeated property
+
     /**
      * Adds an "attached card gains [X]" ability, where X is an "when defeated" triggered ability. You can provide a match function
      * to narrow down whether the effect is applied (for cases where the effect has conditions).

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -134,7 +134,7 @@ export class UpgradeCard extends UpgradeCardParent implements IUpgradeCard, IPla
         });
     }
 
-    // TODO THIS PR: update the below to use the whenDefeated property
+    // TODO THRAWN2: update the below to use the whenDefeated property
 
     /**
      * Adds an "attached card gains [X]" ability, where X is an "when defeated" triggered ability. You can provide a match function

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -21,7 +21,7 @@ import type { IUnitCard } from '../propertyMixins/UnitProperties';
 import type { Card } from '../Card';
 import type { AbilityContext } from '../../ability/AbilityContext';
 import { StandardTriggeredAbilityType } from '../../Constants';
-import type { ICardDataJson } from '../../../../utils/cardData/CardDataInterfaces';
+import * as Helpers from '../../utils/Helpers';
 
 const InPlayCardParent = WithCost(WithAllAbilityTypes(PlayableOrDeployableCard));
 
@@ -296,23 +296,17 @@ export class InPlayCard extends InPlayCardParent implements IInPlayCard {
         }
     }
 
-    protected override validateCardAbilities(cardData: ICardDataJson) {
-        if (!this.hasImplementationFile) {
+    protected override validateCardAbilities(cardText?: string) {
+        if (!this.hasImplementationFile || cardText == null) {
             return;
         }
 
         Contract.assertFalse(
             !this.disableWhenDefeatedCheck &&
-            cardData.text && this.hasSomeMatch(cardData.text, /(?:^|(?:\n)|(?:\/))When Defeated/g) &&
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:\n)|(?:\/))When Defeated/g) &&
             !this.triggeredAbilities.some((ability) => ability.isWhenDefeatedAbility),
             `Card ${this.internalName} has one or more 'When Defeated' keywords in its text but no corresponding ability definition or set property 'disableWhenDefeatedCheck' to true on card implementation`
         );
-    }
-
-    private hasSomeMatch(text: string, regex: RegExp) {
-        const matchIter = text.matchAll(regex);
-        const match = matchIter.next();
-        return !match.done;
     }
 
     // ******************************************** UNIQUENESS MANAGEMENT ********************************************

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -1,4 +1,4 @@
-import type { IConstantAbilityProps, ITriggeredAbilityBaseProps } from '../../../Interfaces';
+import type { IConstantAbilityProps, ITriggeredAbilityBaseProps, WhenTypeOrStandard } from '../../../Interfaces';
 import type TriggeredAbility from '../../ability/TriggeredAbility';
 import { ZoneName } from '../../Constants';
 import { CardType, RelativePlayer, WildcardZoneName } from '../../Constants';
@@ -20,6 +20,7 @@ import { SelectCardMode } from '../../gameSteps/PromptInterfaces';
 import type { IUnitCard } from '../propertyMixins/UnitProperties';
 import type { Card } from '../Card';
 import type { AbilityContext } from '../../ability/AbilityContext';
+import { StandardTriggeredAbilityType } from '../../Constants';
 
 const InPlayCardParent = WithCost(WithAllAbilityTypes(PlayableOrDeployableCard));
 
@@ -248,7 +249,8 @@ export class InPlayCard extends InPlayCardParent implements IInPlayCard {
     }
 
     protected addWhenDefeatedAbility(properties: ITriggeredAbilityBaseProps<this>): TriggeredAbility {
-        const triggeredProperties = Object.assign(properties, { when: { onCardDefeated: (event, context) => event.card === context.source } });
+        const when: WhenTypeOrStandard = { [StandardTriggeredAbilityType.WhenDefeated]: true };
+        const triggeredProperties = Object.assign(properties, { when });
         return this.addTriggeredAbility(triggeredProperties);
     }
 

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -304,7 +304,7 @@ export class InPlayCard extends InPlayCardParent implements IInPlayCard {
         Contract.assertFalse(
             !this.disableWhenDefeatedCheck &&
             cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:\n)|(?:\/))When Defeated/g) &&
-            !this.triggeredAbilities.some((ability) => ability.isWhenDefeatedAbility),
+            !this.triggeredAbilities.some((ability) => ability.isWhenDefeated),
             `Card ${this.internalName} has one or more 'When Defeated' keywords in its text but no corresponding ability definition or set property 'disableWhenDefeatedCheck' to true on card implementation`
         );
     }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -21,6 +21,7 @@ import type { IUnitCard } from '../propertyMixins/UnitProperties';
 import type { Card } from '../Card';
 import type { AbilityContext } from '../../ability/AbilityContext';
 import { StandardTriggeredAbilityType } from '../../Constants';
+import type { ICardDataJson } from '../../../../utils/cardData/CardDataInterfaces';
 
 const InPlayCardParent = WithCost(WithAllAbilityTypes(PlayableOrDeployableCard));
 
@@ -293,6 +294,25 @@ export class InPlayCard extends InPlayCardParent implements IInPlayCard {
                 this._mostRecentInPlayId += 1;
             }
         }
+    }
+
+    protected override validateCardAbilities(cardData: ICardDataJson) {
+        if (!this.hasImplementationFile) {
+            return;
+        }
+
+        Contract.assertFalse(
+            !this.disableWhenDefeatedCheck &&
+            cardData.text && this.hasSomeMatch(cardData.text, /(?:^|(?:\n)|(?:\/))When Defeated/g) &&
+            !this.triggeredAbilities.some((ability) => ability.isWhenDefeatedAbility),
+            `Card ${this.internalName} has one or more 'When Defeated' keywords in its text but no corresponding ability definition or set property 'disableWhenDefeatedCheck' to true on card implementation`
+        );
+    }
+
+    private hasSomeMatch(text: string, regex: RegExp) {
+        const matchIter = text.matchAll(regex);
+        const match = matchIter.next();
+        return !match.done;
     }
 
     // ******************************************** UNIQUENESS MANAGEMENT ********************************************

--- a/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
+++ b/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
@@ -11,7 +11,7 @@ export function WithStandardAbilitySetup<TBaseClass extends CardConstructor>(Bas
             const [Player, cardData] = this.unpackConstructorArgs(...args);
 
             this.setupCardAbilities(this);
-            this.validateCardAbilities(cardData);
+            this.validateCardAbilities(cardData.text);
 
             // if an implementation file is provided, enforce that all keywords requiring explicit setup have been set up
             if (this.hasImplementationFile) {

--- a/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
+++ b/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
@@ -8,7 +8,10 @@ export function WithStandardAbilitySetup<TBaseClass extends CardConstructor>(Bas
         public constructor(...args: any[]) {
             super(...args);
 
+            const [Player, cardData] = this.unpackConstructorArgs(...args);
+
             this.setupCardAbilities(this);
+            this.validateCardAbilities(cardData);
 
             // if an implementation file is provided, enforce that all keywords requiring explicit setup have been set up
             if (this.hasImplementationFile) {

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -159,6 +159,12 @@ export function mergeArrayProperty<TPropertySet extends { [key in TPropName]?: a
     return mergeProperty(propertySet, newPropName, newPropValue, (oldValue, newValue) => oldValue.concat(newValue));
 }
 
+export function hasSomeMatch(text: string, regex: RegExp) {
+    const matchIter = text.matchAll(regex);
+    const match = matchIter.next();
+    return !match.done;
+}
+
 function mergeProperty<TPropertySet extends { [key in TPropName]?: TMergeProperty }, TMergeProperty, TPropName extends string>(
     propertySet: TPropertySet,
     newPropName: TPropName,

--- a/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
@@ -1,4 +1,5 @@
 import { StateWatcher } from '../core/stateWatcher/StateWatcher';
+import type { CardType } from '../core/Constants';
 import { StateWatcherName } from '../core/Constants';
 import type { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
 import type Player from '../core/Player';
@@ -13,6 +14,8 @@ export interface PlayedCardEntry {
     playedBy: Player;
     parentCard?: IInPlayCard;
     parentCardInPlayId?: number;
+    hasWhenDefeatedAbilities?: boolean;
+    playedAsType: CardType;
 }
 
 export type ICardsPlayedThisPhase = PlayedCardEntry[];
@@ -58,7 +61,9 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<PlayedCardEntry[]>
                     parentCard: event.card.isUpgrade() && event.card.isAttached() ? event.card.parentCard : null,
                     parentCardInPlayId: event.card.isUpgrade() && event.card.parentCard?.canBeInPlay() ? event.card.parentCard.inPlayId : null,
                     inPlayId: event.card.inPlayId ?? null,
-                    playedBy: event.card.controller
+                    playedBy: event.card.controller,
+                    hasWhenDefeatedAbilities: event.card.canBeInPlay() && event.card.getTriggeredAbilities().some((ability) => ability.isWhenDefeated),
+                    playedAsType: event.card.cardType,
                 })
         });
     }

--- a/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsPlayedThisPhaseWatcher.ts
@@ -63,7 +63,7 @@ export class CardsPlayedThisPhaseWatcher extends StateWatcher<PlayedCardEntry[]>
                     inPlayId: event.card.inPlayId ?? null,
                     playedBy: event.card.controller,
                     hasWhenDefeatedAbilities: event.card.canBeInPlay() && event.card.getTriggeredAbilities().some((ability) => ability.isWhenDefeated),
-                    playedAsType: event.card.cardType,
+                    playedAsType: event.card.type,
                 })
         });
     }

--- a/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
+++ b/test/server/cards/01_SOR/events/TacticalAdvantage.spec.ts
@@ -1,7 +1,6 @@
 describe('Tactical Advantage', function () {
     integration(function (contextRef) {
         describe('Tactical Advantage\'s ability', function () {
-            // TODO THIS PR: rename to setupTestAsync
             beforeEach(function () {
                 return contextRef.setupTestAsync({
                     phase: 'action',

--- a/test/server/cards/04_JTL/units/DirectorKrennicOnTheVergeOfGreatness.spec.ts
+++ b/test/server/cards/04_JTL/units/DirectorKrennicOnTheVergeOfGreatness.spec.ts
@@ -1,0 +1,133 @@
+describe('Director Krennic, On the Verge of Greatness', function() {
+    integration(function(contextRef) {
+        describe('Krennic\'s constant ability', function() {
+            beforeEach(function () {
+                return contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'qira#i-alone-survived',
+                        base: 'tarkintown',
+                        hand: [
+                            'distant-patroller',
+                            'rhokai-gunship',
+                            'senatorial-corvette',
+                            'roger-roger',
+                            'wampa',
+                            'ruthless-raider'
+                        ],
+                        groundArena: ['director-krennic#on-the-verge-of-greatness']
+                    },
+                    player2: {
+                        leader: 'asajj-ventress#i-work-alone',
+                        hand: ['onyx-squadron-brute']
+                    }
+                });
+            });
+
+            it('reduces the cost of the first unit with a \'when defeated\' ability by 1', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.distantPatroller);
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+            });
+
+            it('does not reduce the cost of the second unit with a \'when defeated\' ability by 1', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.distantPatroller);
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.rhokaiGunship);
+                expect(context.player1.exhaustedResourceCount).toBe(3);
+            });
+
+            it('resets its limit with the phase', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.distantPatroller);
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+
+                context.moveToNextActionPhase();
+
+                context.player1.clickCard(context.rhokaiGunship);
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+            });
+
+            it('does not count opponent\'s units with "when defeated" abilities', function() {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.onyxSquadronBrute);
+                expect(context.player2.exhaustedResourceCount).toBe(2);
+
+                context.player1.clickCard(context.rhokaiGunship);
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+            });
+
+            it('does not count upgrades with "when defeated" abilities', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.rogerRoger);
+                context.player1.clickCard(context.directorKrennic);
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.rhokaiGunship);
+                expect(context.player1.exhaustedResourceCount).toBe(2);
+            });
+
+            it('does not count units without "when defeated" abilities', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.wampa);
+                expect(context.player1.exhaustedResourceCount).toBe(4);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.rhokaiGunship);
+                expect(context.player1.exhaustedResourceCount).toBe(5);
+            });
+
+            it('works on units that have one ability with multiple trigger types including "when defeated"', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.ruthlessRaider);
+                expect(context.player1.exhaustedResourceCount).toBe(5);
+            });
+        });
+
+        it('Krennic\'s constant ability does not work if the first unit with a "when defeated" ability was played prior to himself', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'qira#i-alone-survived',
+                    base: 'tarkintown',
+                    hand: [
+                        'distant-patroller',
+                        'rhokai-gunship',
+                        'director-krennic#on-the-verge-of-greatness'
+                    ],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.distantPatroller);
+            expect(context.player1.exhaustedResourceCount).toBe(2);
+
+            context.player2.passAction();
+
+            context.player1.clickCard(context.directorKrennic);
+            expect(context.player1.exhaustedResourceCount).toBe(4);
+
+            context.player2.passAction();
+
+            context.player1.clickCard(context.rhokaiGunship);
+            expect(context.player1.exhaustedResourceCount).toBe(6);
+        });
+    });
+});


### PR DESCRIPTION
Added the Krennic unit. So support him and other cards that interact with "when defeated" abilities, added a new type of ability registration that allows explicitly registering common ability types like that one. Also added a check in the card text itself to ensure that we always register when defeated abilities correctly.

![image](https://github.com/user-attachments/assets/16e475d8-a889-4d80-9688-8fff6746e5cd)
