### PR TITLE
Fix Rich Reward

### DIFF
--- a/server/game/cards/03_TWI/events/ConsolidationOfPower.ts
+++ b/server/game/cards/03_TWI/events/ConsolidationOfPower.ts
@@ -14,10 +14,10 @@ export default class ConsolidationOfPower extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Choose any number of friendly units. You may play a unit from your hand if its cost is less than or equal to the combined power of the chosen units for free. Then, defeat the chosen units.',
-            optional: true,
             targetResolvers: {
                 friendlyUnits: {
                     mode: TargetMode.Unlimited,
+                    canChooseNoCards: true,
                     cardTypeFilter: WildcardCardType.Unit,
                     zoneFilter: WildcardZoneName.AnyArena,
                     controller: RelativePlayer.Self,

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -165,8 +165,7 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
             if (passPrompt) {
                 buttons.push({ text: passPrompt.buttonText, arg: passPrompt.arg });
                 passPrompt.hasBeenShown = true;
-            }
-            if (this.selector.optional) {
+            } else if (this.selector.optional) {
                 // If the selector is for a single card and it will automatically fire on selection,
                 // uses the 'done' arg so that the prompt doesn't show both 'Choose no target' and 'Done' buttons.
                 buttons.push({

--- a/test/server/cards/02_SHD/units/FennRauProtectorOfConcordDawn.spec.ts
+++ b/test/server/cards/02_SHD/units/FennRauProtectorOfConcordDawn.spec.ts
@@ -23,7 +23,7 @@ describe('Fenn Rau Protector of Concord Dawn\'s ability', function () {
                 context.academyTraining,
                 context.jediLightsaber,
             ]);
-            expect(context.player1).toHaveChooseNoTargetButton();
+            expect(context.player1).toHavePassAbilityButton();
             context.player1.clickCard(context.jediLightsaber);
             context.player1.clickCard(context.fennRau);
             expect(context.player1.readyResourceCount).toBe(2);

--- a/test/server/cards/02_SHD/upgrades/RichReward.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/RichReward.spec.ts
@@ -11,10 +11,7 @@ describe('Rich Reward', function() {
                     player2: {
                         groundArena: ['wampa'],
                         spaceArena: ['concord-dawn-interceptors']
-                    },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
+                    }
                 });
 
                 const { context } = contextRef;
@@ -73,15 +70,13 @@ describe('Rich Reward', function() {
                     },
                     player2: {
                         groundArena: [{ card: 'phaseiii-dark-trooper', upgrades: ['rich-reward'] }]
-                    },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
+                    }
                 });
 
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.phaseiiiDarkTrooper);
 
                 // bounty trigger still appears even though there's no effect, b/c the player still needs to decide whether to "collect the bounty"
                 // Dark Trooper ability happens in same window

--- a/test/server/cards/03_TWI/events/ConsolidationOfPower.spec.ts
+++ b/test/server/cards/03_TWI/events/ConsolidationOfPower.spec.ts
@@ -37,8 +37,8 @@ describe('Consolidation of power', function () {
                     context.battlefieldMarine,
                     context.allianceXwing,
                 ]);
-                expect(context.player1).toHavePassAbilityButton();
-                context.player1.clickPrompt('Pass');
+                expect(context.player1).toHaveChooseNoTargetButton();
+                context.player1.clickPrompt('Choose no target');
                 expect(context.player2).toBeActivePlayer();
                 context.player2.passAction();
 


### PR DESCRIPTION
We were showing both "Pass" and "Choose no target" on some prompts, which was pushing the "Done" button under the hand. Fixed this in the card target resolver and fixed the Consolidation of Power implementation to have the correct UX flow.