### PR TITLE
Update Kazuda game message and basic damage messages

### DIFF
--- a/server/game/actions/PlayEventAction.ts
+++ b/server/game/actions/PlayEventAction.ts
@@ -7,12 +7,6 @@ export class PlayEventAction extends PlayCardAction {
     public override executeHandler(context: PlayCardContext): void {
         Contract.assertTrue(context.source.isEvent());
 
-        context.game.addMessage(
-            '{0} plays {1}',
-            context.player,
-            context.source,
-        );
-
         this.moveEventToDiscard(context);
         context.game.resolveAbility(context.source.getEventAbility().createContext());
     }

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -20,7 +20,8 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                     cardTypeFilter: WildcardCardType.Unit,
                     controller: RelativePlayer.Self,
                     innerSystem: AbilityHelper.immediateEffects.forThisRoundCardEffect({
-                        effect: AbilityHelper.ongoingEffects.loseAllAbilities()
+                        effect: AbilityHelper.ongoingEffects.loseAllAbilities(),
+                        ongoingEffectDescription: 'remove all abilities from'
                     })
                 }),
                 AbilityHelper.immediateEffects.playerLastingEffect({
@@ -61,7 +62,9 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                 immediateEffect: AbilityHelper.immediateEffects.forThisRoundCardEffect({
                     effect: AbilityHelper.ongoingEffects.loseAllAbilities()
                 })
-            }
+            },
+            effect: 'blanks all abilities on {1}',
+            effectArgs: (context) => [context.target]
         });
     }
 }

--- a/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
+++ b/server/game/cards/04_JTL/leaders/KazudaXionoBestPilotInTheGalaxy.ts
@@ -43,7 +43,8 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                 controller: RelativePlayer.Self,
                 canChooseNoCards: true,
                 immediateEffect: AbilityHelper.immediateEffects.forThisRoundCardEffect({
-                    effect: AbilityHelper.ongoingEffects.loseAllAbilities()
+                    effect: AbilityHelper.ongoingEffects.loseAllAbilities(),
+                    ongoingEffectDescription: 'remove all abilities from'
                 })
             }
         });
@@ -60,11 +61,10 @@ export default class KazudaXionoBestPilotInTheGalaxy extends LeaderUnitCard {
                 controller: RelativePlayer.Self,
                 canChooseNoCards: true,
                 immediateEffect: AbilityHelper.immediateEffects.forThisRoundCardEffect({
-                    effect: AbilityHelper.ongoingEffects.loseAllAbilities()
+                    effect: AbilityHelper.ongoingEffects.loseAllAbilities(),
+                    ongoingEffectDescription: 'remove all abilities from'
                 })
-            },
-            effect: 'blanks all abilities on {1}',
-            effectArgs: (context) => [context.target]
+            }
         });
     }
 }

--- a/server/game/core/ability/CardAbility.ts
+++ b/server/game/core/ability/CardAbility.ts
@@ -113,19 +113,6 @@ export abstract class CardAbility extends CardAbilityStep {
     }
 
     public override displayMessage(context, messageVerb = context.source.isEvent() ? 'plays' : 'uses') {
-        if (
-            context.source.isEvent() &&
-            context.source.zoneName !== ZoneName.Discard
-        ) {
-            this.game.addMessage(
-                '{0} plays {1} from {2} {3}',
-                context.player,
-                context.source,
-                context.source.controller === context.player ? 'their' : 'their opponent\'s',
-                this.getZoneMessage(context.source.zoneName, context)
-            );
-        }
-
         if (this.properties.message) {
             let messageArgs = this.properties.messageArgs;
             if (typeof messageArgs === 'function') {

--- a/server/game/core/gameSystem/LastingEffectPropertiesBase.ts
+++ b/server/game/core/gameSystem/LastingEffectPropertiesBase.ts
@@ -9,6 +9,7 @@ interface ILastingEffectPropertiesAnyDuration extends IGameSystemProperties {
     ability?: PlayerOrCardAbility;
     condition?: (context: AbilityContext) => boolean;
     effect?: any;
+    ongoingEffectDescription?: string;
 }
 
 interface ILastingEffectPropertiesSetDuration extends ILastingEffectPropertiesAnyDuration {

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -1,9 +1,10 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
-import { EffectName, EventName, WildcardZoneName } from '../core/Constants';
+import { Duration, EffectName, EventName, WildcardZoneName } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { ILastingEffectPropertiesBase } from '../core/gameSystem/LastingEffectPropertiesBase';
+import * as Contract from '../core/utils/Contract';
 
 export interface ICardLastingEffectProperties extends Omit<ILastingEffectPropertiesBase, 'target'>, ICardTargetSystemProperties {}
 
@@ -14,11 +15,11 @@ export interface ICardLastingEffectProperties extends Omit<ILastingEffectPropert
 export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardTargetSystem<TContext, ICardLastingEffectProperties> {
     public override readonly name: string = 'applyCardLastingEffect';
     public override readonly eventName = EventName.OnEffectApplied;
-    public override readonly effectDescription: string = 'apply a lasting effect to {0}';
     protected override readonly defaultProperties: ICardLastingEffectProperties = {
         duration: null,
         effect: [],
-        ability: null
+        ability: null,
+        ongoingEffectDescription: null
     };
 
     public eventHandler(event, additionalProperties?): void {
@@ -42,6 +43,35 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         );
 
         return this.filterApplicableEffects(card, effects);
+    }
+
+    public override getEffectMessage(context: TContext, additionalProperties?: any): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        const description = properties.ongoingEffectDescription ?? 'apply a lasting effect to';
+        let durationStr: string;
+        switch (properties.duration) {
+            case Duration.UntilEndOfAttack:
+                durationStr = ' for this attack';
+                break;
+            case Duration.UntilEndOfPhase:
+                durationStr = ' for this phase';
+                break;
+            case Duration.UntilEndOfRound:
+                durationStr = ' for the rest of the round';
+                break;
+            case Duration.WhileSourceInPlay:
+                durationStr = ' while in play';
+                break;
+            case Duration.Persistent:
+            case Duration.Custom:
+                durationStr = '';
+                break;
+            default:
+                Contract.fail(`Unknown duration: ${properties.duration}`);
+        }
+
+        return [`${description} {0}${durationStr}`, [properties.target]];
     }
 
     public override generatePropertiesFromContext(context: TContext, additionalProperties = {}): ICardLastingEffectProperties {

--- a/server/game/gameSystems/CardPhaseLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardPhaseLastingEffectSystem.ts
@@ -13,7 +13,6 @@ export type ICardPhaseLastingEffectProperties = Omit<ICardLastingEffectPropertie
 export class CardPhaseLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardLastingEffectSystem<TContext> {
     public override readonly name = 'applyCardPhaseLastingEffect';
     public override readonly eventName = EventName.OnEffectApplied;
-    public override readonly effectDescription = 'apply an effect to {0} for the phase';
     protected override readonly defaultProperties: ICardLastingEffectProperties = {
         duration: null,
         effect: [],

--- a/server/game/gameSystems/CardRoundLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardRoundLastingEffectSystem.ts
@@ -13,7 +13,6 @@ export type ICardRoundLastingEffectProperties = Omit<ICardLastingEffectPropertie
 export class CardRoundLastingEffectSystem<TContext extends AbilityContext = AbilityContext> extends CardLastingEffectSystem<TContext> {
     public override readonly name = 'applyCardRoundLastingEffect';
     public override readonly eventName = EventName.OnEffectApplied;
-    public override readonly effectDescription = 'apply an effect to {0} for the round';
     protected override readonly defaultProperties: ICardLastingEffectProperties = {
         duration: null,
         effect: [],

--- a/server/game/gameSystems/DamageSystem.ts
+++ b/server/game/gameSystems/DamageSystem.ts
@@ -291,11 +291,25 @@ export class DamageSystem<TContext extends AbilityContext = AbilityContext, TPro
     }
 
     // TODO: might need to refactor getEffectMessage generally so that it has access to the event, doesn't really work for some of the damage scenarios currently
-    // public override getEffectMessage(context: TContext): [string, any[]] {
-    //     const properties = this.generatePropertiesFromContext(context);
+    public override getEffectMessage(context: TContext): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context);
 
-    //     const damageTypeStr = isCombatDamage ? ' combat' : '';
+        let amountStr = '';
+        if ('amount' in properties && typeof properties.amount === 'number') {
+            amountStr = `${properties.amount} `;
+        }
 
-    //     return ['deal {0}{1} damage to {2}', [amount, damageTypeStr, target]];
-    // }
+        let damageTypeStr = '';
+        if (properties.type === DamageType.Combat) {
+            damageTypeStr = 'combat ';
+        } else if ('isIndirect' in properties && properties.isIndirect) {
+            damageTypeStr = 'indirect ';
+        } else if ('isUnpreventable' in properties && properties.isUnpreventable) {
+            damageTypeStr = 'unpreventable ';
+        } else if (properties.type === DamageType.Overwhelm) {
+            damageTypeStr = 'overwhelm ';
+        }
+
+        return [`deal ${amountStr}${damageTypeStr}damage to {0}`, [properties.target]];
+    }
 }


### PR DESCRIPTION
Did some light cleanup on the game message system and made it so that the Kazuda effect now says the name of the target, as well as "basic" damage cases in which only a single target is being damaged with a fixed amount (eg Daring Raid, basic attacks).