### PR TITLE
Fix issue with ordering on multi-trigger for the same ability

### DIFF
--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -233,7 +233,10 @@ export abstract class TriggerWindowBase extends BaseStep {
     protected postResolutionUpdate(resolver) {
         const unresolvedAbilitiesForPlayer = this.getCurrentlyResolvingAbilities();
 
-        const justResolvedAbility = unresolvedAbilitiesForPlayer.find((context) => context.ability === resolver.context.ability);
+        const justResolvedAbility = unresolvedAbilitiesForPlayer.find((context) =>
+            context.ability === resolver.context.ability &&
+            context.event === resolver.context.event
+        );
 
         // if we can't find the ability to remove from the list, we have to error or else get stuck in an infinite loop
         if (justResolvedAbility == null) {

--- a/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
@@ -643,5 +643,68 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 expect(context.grogu.damage).toBe(1);
             });
         });
+
+        describe('Jango Fett\'s deployed leader ability', function() {
+            it('should trigger correctly on multiple targets based on the selected target from the trigger window', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: {
+                            card: 'jango-fett#concealing-the-conspiracy',
+                            deployed: true
+                        },
+                        hand: ['war-juggernaut']
+                    },
+                    player2: {
+                        leader: {
+                            card: 'admiral-piett#commanding-the-armada',
+                            deployed: true
+                        },
+                        groundArena: ['pantoran-starship-thief', 'captain-tarkin#full-forward-assault'],
+                        spaceArena: ['quasar-tie-carrier']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.warJuggernaut);
+                context.player1.clickCard(context.pantoranStarshipThief);
+                context.player1.clickCard(context.captainTarkin);
+                context.player1.clickCard(context.quasarTieCarrier);
+                context.player1.clickCard(context.admiralPiett);
+                context.player1.clickPrompt('Done');
+
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Exhaust the damaged enemy unit: Pantoran Starship Thief',
+                    'Exhaust the damaged enemy unit: Admiral Piett',
+                    'Exhaust the damaged enemy unit: Captain Tarkin',
+                    'Exhaust the damaged enemy unit: Quasar TIE Carrier'
+                ]);
+
+                context.player1.clickPrompt('Exhaust the damaged enemy unit: Captain Tarkin');
+                context.player1.clickPrompt('Trigger');
+                expect(context.captainTarkin.exhausted).toBeTrue();
+
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Exhaust the damaged enemy unit: Pantoran Starship Thief',
+                    'Exhaust the damaged enemy unit: Admiral Piett',
+                    'Exhaust the damaged enemy unit: Quasar TIE Carrier'
+                ]);
+                context.player1.clickPrompt('Exhaust the damaged enemy unit: Pantoran Starship Thief');
+                context.player1.clickPrompt('Trigger');
+                expect(context.pantoranStarshipThief.exhausted).toBeTrue();
+
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Exhaust the damaged enemy unit: Admiral Piett',
+                    'Exhaust the damaged enemy unit: Quasar TIE Carrier'
+                ]);
+                context.player1.clickPrompt('Exhaust the damaged enemy unit: Quasar TIE Carrier');
+                context.player1.clickPrompt('Trigger');
+                expect(context.quasarTieCarrier.exhausted).toBeTrue();
+
+                context.player1.clickPrompt('Trigger');
+                expect(context.admiralPiett.exhausted).toBeTrue();
+            });
+        });
     });
 });


### PR DESCRIPTION
There was an issue where if the same ability was triggered multiple times in the same window (e.g. Jango leader) then abilities would resolve in random order when chosen from the trigger menu