### PR TITLE
Card and Zone Initial State Changes 

### DIFF
--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -7,6 +7,7 @@ export interface IGameObjectBaseState {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
 export interface GameObjectRef<T extends GameObjectBase = GameObjectBase> {
+    __isRef: true;
     uuid: string;
 }
 
@@ -29,6 +30,7 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     ) {
         // @ts-expect-error state is a generic object that is defined by the deriving classes, it's essentially w/e the children want it to be.
         this.state = {};
+        // All state defaults *must* happen before registration, so we can't rely on the derived constructor to set the defaults as register will already be called.
         this.onSetupDefaultState();
         this.game.gameObjectManager.register(this);
     }
@@ -37,11 +39,16 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     protected onSetupDefaultState() { }
 
+    /** Sets the state.  */
     public setState(state: T) {
         this.state = state;
     }
 
+    /** A function for game to call on all objects after all state has been set. for example, to cache calculated values. */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public onAfterSetState() { }
+
     public getRef<T extends GameObjectBase = this>(): GameObjectRef<T> {
-        return { uuid: this.state.uuid };
+        return { __isRef: true, uuid: this.state.uuid };
     }
 }

--- a/server/game/core/GameObjectManager.ts
+++ b/server/game/core/GameObjectManager.ts
@@ -15,7 +15,11 @@ export class GameObjectManager {
         this._gameObjectMapping = new Map<string, GameObjectBase>();
     }
 
-    public get<T extends GameObjectBase>(gameObjectRef: GameObjectRef<T>): T {
+    public get<T extends GameObjectBase>(gameObjectRef: GameObjectRef<T>): T | null {
+        if (!gameObjectRef?.uuid) {
+            return null;
+        }
+
         const ref = this._gameObjectMapping.get(gameObjectRef.uuid);
         Contract.assertNotNullLike(ref, `Tried to get a Game Object but the UUID is not registered ${gameObjectRef.uuid}. This *VERY* bad and should not be possible w/o breaking the engine, stop everything and fix this now.`);
         return ref as T;

--- a/server/game/core/GameObjectManager.ts
+++ b/server/game/core/GameObjectManager.ts
@@ -15,8 +15,10 @@ export class GameObjectManager {
         this._gameObjectMapping = new Map<string, GameObjectBase>();
     }
 
-    public get<T extends GameObjectBase>(gameObjectRef: GameObjectRef<T>): T | undefined {
-        return this._gameObjectMapping.get(gameObjectRef.uuid) as (T | undefined);
+    public get<T extends GameObjectBase>(gameObjectRef: GameObjectRef<T>): T {
+        const ref = this._gameObjectMapping.get(gameObjectRef.uuid);
+        Contract.assertNotNullLike(ref, `Tried to get a Game Object but the UUID is not registered ${gameObjectRef.uuid}. This *VERY* bad and should not be possible w/o breaking the engine, stop everything and fix this now.`);
+        return ref as T;
     }
 
     public register(gameObject: GameObjectBase | GameObjectBase[]) {

--- a/server/game/core/Player.js
+++ b/server/game/core/Player.js
@@ -58,19 +58,19 @@ class Player extends GameObject {
         this.disconnected = false;
         this.left = false;
 
-        this.handZone = new HandZone(this);
-        this.resourceZone = new ResourceZone(this);
-        this.discardZone = new DiscardZone(this);
+        this.handZone = new HandZone(game, this);
+        this.resourceZone = new ResourceZone(game, this);
+        this.discardZone = new DiscardZone(game, this);
         this.canTakeActionsThisPhase = null;
 
         // mainly used for staging tokens when they are created / removed
-        this.outsideTheGameZone = new OutsideTheGameZone(this);
+        this.outsideTheGameZone = new OutsideTheGameZone(game, this);
 
         /** @type {BaseZone} */
         this.baseZone = null;
 
         /** @type {DeckZone} */
-        this.deckZone = new DeckZone(this);
+        this.deckZone = new DeckZone(game, this);
 
         this.damageToBase = null;
 
@@ -699,7 +699,7 @@ class Player extends GameObject {
             new PlayableZone(PlayType.PlayFromOutOfPlay, this.discardZone),
         ];
 
-        this.baseZone = new BaseZone(this, this.base, this.leader);
+        this.baseZone = new BaseZone(this.game, this, this.base, this.leader);
 
         this.decklist = preparedDecklist;
     }

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -71,7 +71,7 @@ export class Attack extends GameObject {
 
     // TODO: if we end up using this we need to refactor it to reflect attacks in SWU (i.e., show HP)
     public getTotalsForDisplay(): string {
-        return `${this.attacker.name}: ${this.getAttackerTotalPower()} vs ${this.getTargetTotalPower()}: ${this.target.name}`;
+        return `${this.attacker.title}: ${this.getAttackerTotalPower()} vs ${this.getTargetTotalPower()}: ${this.target.title}`;
     }
 
     private getUnitPower(involvedUnit: IUnitCard): StatisticTotal {

--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -71,7 +71,7 @@ export class Attack extends GameObject {
 
     // TODO: if we end up using this we need to refactor it to reflect attacks in SWU (i.e., show HP)
     public getTotalsForDisplay(): string {
-        return `${this.attacker.title}: ${this.getAttackerTotalPower()} vs ${this.getTargetTotalPower()}: ${this.target.title}`;
+        return `${this.attacker.name}: ${this.getAttackerTotalPower()} vs ${this.getTargetTotalPower()}: ${this.target.name}`;
     }
 
     private getUnitPower(involvedUnit: IUnitCard): StatisticTotal {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -114,11 +114,26 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     protected actionAbilities: ActionAbility[] = [];
     protected constantAbilities: IConstantAbility[] = [];
     protected disableWhenDefeatedCheck = false;
-    protected movedFromZone?: ZoneName = null;
     protected triggeredAbilities: TriggeredAbility[] = [];
 
     private nextAbilityIdx = 0;
     private _zone: Zone;
+
+    protected get hiddenForController() {
+        return this.state.hiddenForController;
+    }
+
+    protected get hiddenForOpponent() {
+        return this.state.hiddenForOpponent;
+    }
+
+    protected get movedFromZone() {
+        return this.state.movedFromZone;
+    }
+
+    protected set movedFromZone(value: ZoneName | null) {
+        this.state.movedFromZone = value;
+    }
 
 
     // ******************************************** PROPERTY GETTERS ********************************************

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -1,6 +1,7 @@
 import type { IActionAbilityProps, IConstantAbilityProps, ISetId, Zone, ITriggeredAbilityProps } from '../../Interfaces';
 import { ActionAbility } from '../ability/ActionAbility';
 import type PlayerOrCardAbility from '../ability/PlayerOrCardAbility';
+import type { IOngoingEffectSourceState } from '../ongoingEffect/OngoingEffectSource';
 import { OngoingEffectSource } from '../ongoingEffect/OngoingEffectSource';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
@@ -35,9 +36,22 @@ import type { ICardWithTriggeredAbilities } from './propertyMixins/TriggeredAbil
 import type { ICardDataJson } from '../../../utils/cardData/CardDataInterfaces';
 import type { ICardWithActionAbilities } from './propertyMixins/ActionAbilityRegistration';
 import type { ICardWithConstantAbilities } from './propertyMixins/ConstantAbilityRegistration';
+import type { GameObjectRef } from '../GameObjectBase';
 
 // required for mixins to be based on this class
-export type CardConstructor = new (...args: any[]) => Card;
+export type CardConstructor<T extends ICardState = ICardState> = new (...args: any[]) => Card<T>;
+
+export interface ICardState extends IOngoingEffectSourceState {
+
+    facedown: boolean;
+    hasImplementationFile: boolean;
+    hiddenForController: boolean;
+    hiddenForOpponent: boolean;
+
+    controllerRef: GameObjectRef<Player>;
+
+    movedFromZone: ZoneName | null;
+}
 
 /**
  * The base class for all card types. Any shared properties among all cards will be present here.
@@ -46,7 +60,7 @@ export type CardConstructor = new (...args: any[]) => Card;
  * or {@link Card.canBeExhausted} to confirm that the card has the expected properties and then cast
  * to the specific card type or one of the union types in `CardTypes.js` as needed.
  */
-export class Card extends OngoingEffectSource {
+export class Card<T extends ICardState = ICardState> extends OngoingEffectSource<T> {
     public static checkHasNonKeywordAbilityText(cardData: ICardDataJson) {
         if (cardData.types.includes('leader')) {
             return true;

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -271,6 +271,15 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
         this.initializeStateForAbilitySetup();
     }
 
+    protected override onSetupDefaultState() {
+        super.onSetupDefaultState();
+
+        this.state.facedown = true;
+        this.state.hiddenForController = false;
+        this.state.hiddenForOpponent = false;
+        this.state.movedFromZone = null;
+    }
+
 
     // ******************************************* ABILITY GETTERS *******************************************
     /**

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -280,7 +280,6 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
         this.state.movedFromZone = null;
     }
 
-
     // ******************************************* ABILITY GETTERS *******************************************
     /**
      * `SWU 7.2.1`: An action ability is an ability indicated by the bolded word “Action.” Most action

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -117,6 +117,7 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     protected triggeredAbilities: TriggeredAbility[] = [];
 
     private nextAbilityIdx = 0;
+    // STATE TODO: How do we store the zone in state?
     private _zone: Zone;
 
     protected get hiddenForController() {

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -51,6 +51,7 @@ export interface ICardState extends IOngoingEffectSourceState {
     controllerRef: GameObjectRef<Player>;
 
     movedFromZone: ZoneName | null;
+    nextAbilityIdx: number;
 }
 
 /**
@@ -116,7 +117,6 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     protected disableWhenDefeatedCheck = false;
     protected triggeredAbilities: TriggeredAbility[] = [];
 
-    private nextAbilityIdx = 0;
     // STATE TODO: How do we store the zone in state?
     private _zone: Zone;
 
@@ -434,8 +434,8 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
 
     /** Increments the ability index counter used for adding an index number to an ability's ID */
     private getNextAbilityIdx() {
-        this.nextAbilityIdx++;
-        return this.nextAbilityIdx - 1;
+        this.state.nextAbilityIdx++;
+        return this.state.nextAbilityIdx - 1;
     }
 
 

--- a/server/game/core/card/DoubleSidedLeaderCard.ts
+++ b/server/game/core/card/DoubleSidedLeaderCard.ts
@@ -3,10 +3,15 @@ import type { Aspect } from '../Constants';
 import { ZoneName } from '../Constants';
 import type { IActionAbilityProps, IConstantAbilityProps, ITriggeredAbilityProps } from '../../Interfaces';
 import { WithLeaderProperties, type ILeaderCard } from './propertyMixins/LeaderProperties';
+import type { IPlayableOrDeployableCardState } from './baseClasses/PlayableOrDeployableCard';
 import { PlayableOrDeployableCard } from './baseClasses/PlayableOrDeployableCard';
 import { WithAllAbilityTypes } from './propertyMixins/AllAbilityTypeRegistrations';
 
-const DoubleSidedLeaderCardParent = WithLeaderProperties(WithAllAbilityTypes(PlayableOrDeployableCard));
+const DoubleSidedLeaderCardParent = WithLeaderProperties(WithAllAbilityTypes(PlayableOrDeployableCard<IDoubleSidedLeaderCardState>));
+
+export interface IDoubleSidedLeaderCardState extends IPlayableOrDeployableCardState {
+    onStartingSide: boolean;
+}
 
 export interface IDoubleSidedLeaderCard extends ILeaderCard {
     get onStartingSide(): boolean;
@@ -14,7 +19,6 @@ export interface IDoubleSidedLeaderCard extends ILeaderCard {
 }
 
 export class DoubleSidedLeaderCard extends DoubleSidedLeaderCardParent implements IDoubleSidedLeaderCard {
-    protected _onStartingSide = true;
     protected setupLeaderBackSide = false;
 
     public constructor(owner: Player, cardData: any) {
@@ -24,8 +28,13 @@ export class DoubleSidedLeaderCard extends DoubleSidedLeaderCardParent implement
         this.setupLeaderBackSideAbilities(this);
     }
 
+    protected override onSetupDefaultState() {
+        super.onSetupDefaultState();
+        this.state.onStartingSide = true;
+    }
+
     public get onStartingSide() {
-        return this._onStartingSide;
+        return this.state.onStartingSide;
     }
 
     public override get aspects(): Aspect[] {
@@ -48,7 +57,7 @@ export class DoubleSidedLeaderCard extends DoubleSidedLeaderCardParent implement
     }
 
     public flipLeader() {
-        this._onStartingSide = !this._onStartingSide;
+        this.state.onStartingSide = !this.state.onStartingSide;
     }
 
     public override initializeForStartZone(): void {
@@ -60,7 +69,7 @@ export class DoubleSidedLeaderCard extends DoubleSidedLeaderCardParent implement
     }
 
     public override getSummary(activePlayer: Player): string {
-        return { ...super.getSummary(activePlayer), onStartingSide: this._onStartingSide };
+        return { ...super.getSummary(activePlayer), onStartingSide: this.state.onStartingSide };
     }
 
     protected override addActionAbility(properties: IActionAbilityProps<this>) {

--- a/server/game/core/card/DoubleSidedLeaderCard.ts
+++ b/server/game/core/card/DoubleSidedLeaderCard.ts
@@ -3,15 +3,11 @@ import type { Aspect } from '../Constants';
 import { ZoneName } from '../Constants';
 import type { IActionAbilityProps, IConstantAbilityProps, ITriggeredAbilityProps } from '../../Interfaces';
 import { WithLeaderProperties, type ILeaderCard } from './propertyMixins/LeaderProperties';
-import type { IPlayableOrDeployableCardState } from './baseClasses/PlayableOrDeployableCard';
 import { PlayableOrDeployableCard } from './baseClasses/PlayableOrDeployableCard';
 import { WithAllAbilityTypes } from './propertyMixins/AllAbilityTypeRegistrations';
 
-const DoubleSidedLeaderCardParent = WithLeaderProperties(WithAllAbilityTypes(PlayableOrDeployableCard<IDoubleSidedLeaderCardState>));
+const DoubleSidedLeaderCardParent = WithLeaderProperties(WithAllAbilityTypes(PlayableOrDeployableCard));
 
-export interface IDoubleSidedLeaderCardState extends IPlayableOrDeployableCardState {
-    onStartingSide: boolean;
-}
 
 export interface IDoubleSidedLeaderCard extends ILeaderCard {
     get onStartingSide(): boolean;

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -13,15 +13,10 @@ import { DeployLeaderSystem } from '../../gameSystems/DeployLeaderSystem';
 import type { ActionAbility } from '../ability/ActionAbility';
 import type { ILeaderCard } from './propertyMixins/LeaderProperties';
 import { WithLeaderProperties } from './propertyMixins/LeaderProperties';
-import type { IInPlayCardState } from './baseClasses/InPlayCard';
 import { InPlayCard } from './baseClasses/InPlayCard';
 import AbilityHelper from '../../AbilityHelper';
 
-const LeaderUnitCardParent = WithUnitProperties(WithLeaderProperties(InPlayCard<ILeaderUnitCardState>));
-
-export interface ILeaderUnitCardState extends IInPlayCardState {
-    deployed: boolean;
-}
+const LeaderUnitCardParent = WithUnitProperties(WithLeaderProperties(InPlayCard));
 
 /** Represents a deployable leader in a deployed state (i.e., is also a unit) */
 export interface ILeaderUnitCard extends ILeaderCard, IUnitCard {}

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -28,7 +28,7 @@ export interface IDeployableLeaderCard extends ILeaderUnitCard {
     undeploy(): void;
 }
 
-export class LeaderUnitCard extends LeaderUnitCardParent implements IDeployableLeaderCard {
+export class LeaderUnitCardInternal extends LeaderUnitCardParent implements IDeployableLeaderCard {
     protected _deployed = false;
     protected setupLeaderUnitSide;
     protected deployEpicActionLimit: EpicActionLimit;
@@ -232,4 +232,8 @@ export class LeaderUnitCard extends LeaderUnitCardParent implements IDeployableL
             epicDeployActionSpent: this.deployEpicActionLimit.isAtMax(this.owner)
         };
     }
+}
+
+export class LeaderUnitCard extends LeaderUnitCardInternal {
+    protected override state: never;
 }

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -15,7 +15,7 @@ const NonLeaderUnitCardParent = WithUnitProperties(WithStandardAbilitySetup(InPl
 
 export interface INonLeaderUnitCard extends IUnitCard, IPlayableCard {}
 
-export class NonLeaderUnitCard extends NonLeaderUnitCardParent implements INonLeaderUnitCard, ICardCanChangeControllers {
+export class NonLeaderUnitCardInternal extends NonLeaderUnitCardParent implements INonLeaderUnitCard, ICardCanChangeControllers {
     public constructor(owner: Player, cardData: any) {
         super(owner, cardData);
 
@@ -80,4 +80,9 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent implements INonLe
     public override checkIsAttachable(): void {
         Contract.assertTrue(this.hasSomeTrait(Trait.Pilot));
     }
+}
+
+/** used for derived implementations classes. */
+export class NonLeaderUnitCard extends NonLeaderUnitCardInternal {
+    protected override state: never;
 }

--- a/server/game/core/card/TokenCards.ts
+++ b/server/game/core/card/TokenCards.ts
@@ -12,12 +12,16 @@ export interface ITokenUpgradeCard extends ITokenCard, IUpgradeCard {}
 export interface ITokenUnitCard extends ITokenCard, IUnitCard {}
 
 export class TokenUnitCard extends TokenUnitParent implements ITokenUnitCard {
+    protected override state: never;
+
     public override isTokenUnit(): this is ITokenUnitCard {
         return true;
     }
 }
 
 export class TokenUpgradeCard extends TokenUpgradeParent implements ITokenUpgradeCard {
+    protected override state: never;
+
     public override isTokenUpgrade(): this is ITokenUpgradeCard {
         return true;
     }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -65,10 +65,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
     public readonly printedUpgradeHp: number;
     public readonly printedUpgradePower: number;
 
-    protected _disableOngoingEffectsForDefeat?: boolean = null;
-    protected _mostRecentInPlayId = -1;
     protected _parentCard?: IUnitCard = null;
-    protected _pendingDefeat?: boolean = null;
 
     protected attachCondition: (card: Card) => boolean;
 
@@ -79,8 +76,8 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
      * Can only be true if pendingDefeat is also true.
      */
     public get disableOngoingEffectsForDefeat() {
-        this.assertPropertyEnabledForZone(this._disableOngoingEffectsForDefeat, 'disableOngoingEffectsForDefeat');
-        return this._disableOngoingEffectsForDefeat;
+        this.assertPropertyEnabledForZone(this.state.disableOngoingEffectsForDefeat, 'disableOngoingEffectsForDefeat');
+        return this.state.disableOngoingEffectsForDefeat;
     }
 
     /**
@@ -90,7 +87,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
      */
     public get inPlayId() {
         this.assertPropertyEnabledForZoneBoolean(EnumHelpers.isArena(this.zoneName), 'inPlayId');
-        return this._mostRecentInPlayId;
+        return this.state.mostRecentInPlayId;
     }
 
     /**
@@ -103,7 +100,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
             'mostRecentInPlayId'
         );
 
-        return this._mostRecentInPlayId;
+        return this.state.mostRecentInPlayId;
     }
 
     /** The card that this card is underneath */
@@ -122,8 +119,8 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
      * When this is true, most systems cannot target the card.
      */
     public get pendingDefeat() {
-        this.assertPropertyEnabledForZone(this._pendingDefeat, 'pendingDefeat');
-        return this._pendingDefeat;
+        this.assertPropertyEnabledForZone(this.state.pendingDefeat, 'pendingDefeat');
+        return this.state.pendingDefeat;
     }
 
     public constructor(owner: Player, cardData: any) {
@@ -157,8 +154,8 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
     }
 
     protected setPendingDefeatEnabled(enabledStatus: boolean) {
-        this._pendingDefeat = enabledStatus ? false : null;
-        this._disableOngoingEffectsForDefeat = enabledStatus ? false : null;
+        this.state.pendingDefeat = enabledStatus ? false : null;
+        this.state.disableOngoingEffectsForDefeat = enabledStatus ? false : null;
     }
 
     public checkIsAttachable(): void {
@@ -291,14 +288,14 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
 
             // increment to a new in-play id if we're entering play, indicating that we are now a new "copy" of this card (SWU 8.6.4)
             if (!EnumHelpers.isArena(prevZone)) {
-                this._mostRecentInPlayId += 1;
+                this.state.mostRecentInPlayId += 1;
             }
         } else {
             this.setPendingDefeatEnabled(false);
 
             // if we're moving from a visible zone (discard, capture) to a hidden zone, increment the in-play id to represent the loss of information (card becomes a new copy)
             if (EnumHelpers.isHiddenFromOpponent(this.zoneName, RelativePlayer.Self) && !EnumHelpers.isHiddenFromOpponent(prevZone, RelativePlayer.Self)) {
-                this._mostRecentInPlayId += 1;
+                this.state.mostRecentInPlayId += 1;
             }
         }
     }
@@ -320,8 +317,8 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
     public registerPendingUniqueDefeat() {
         Contract.assertTrue(this.getDuplicatesInPlayForController().length === 1);
 
-        this._pendingDefeat = true;
-        this._disableOngoingEffectsForDefeat = true;
+        this.state.pendingDefeat = true;
+        this.state.disableOngoingEffectsForDefeat = true;
     }
 
     public checkUnique() {

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -4,7 +4,7 @@ import { ZoneName } from '../../Constants';
 import { CardType, RelativePlayer, WildcardZoneName } from '../../Constants';
 import type Player from '../../Player';
 import * as EnumHelpers from '../../utils/EnumHelpers';
-import type { IDecreaseCostAbilityProps, IIgnoreAllAspectPenaltiesProps, IIgnoreSpecificAspectPenaltyProps, IPlayableOrDeployableCard } from './PlayableOrDeployableCard';
+import type { IDecreaseCostAbilityProps, IIgnoreAllAspectPenaltiesProps, IIgnoreSpecificAspectPenaltyProps, IPlayableOrDeployableCard, IPlayableOrDeployableCardState } from './PlayableOrDeployableCard';
 import { PlayableOrDeployableCard } from './PlayableOrDeployableCard';
 import * as Contract from '../../utils/Contract';
 import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
@@ -26,7 +26,14 @@ import * as Helpers from '../../utils/Helpers';
 const InPlayCardParent = WithCost(WithAllAbilityTypes(PlayableOrDeployableCard));
 
 // required for mixins to be based on this class
-export type InPlayCardConstructor = new (...args: any[]) => InPlayCard;
+export type InPlayCardConstructor<T extends IInPlayCardState = IInPlayCardState> = new (...args: any[]) => InPlayCard<T>;
+
+export interface IInPlayCardState extends IPlayableOrDeployableCardState {
+    disableOngoingEffectsForDefeat: boolean | null;
+    mostRecentInPlayId: number;
+    pendingDefeat: boolean | null;
+    movedFromZone: ZoneName | null;
+}
 
 export interface IInPlayCard extends IPlayableOrDeployableCard, ICardWithCostProperty, ICardWithActionAbilities, ICardWithConstantAbilities, ICardWithTriggeredAbilities {
     readonly printedUpgradeHp: number;
@@ -54,7 +61,7 @@ export interface IInPlayCard extends IPlayableOrDeployableCard, ICardWithCostPro
  * 2. Defeat state management
  * 3. Uniqueness management
  */
-export class InPlayCard extends InPlayCardParent implements IInPlayCard {
+export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends InPlayCardParent<T> implements IInPlayCard {
     public readonly printedUpgradeHp: number;
     public readonly printedUpgradePower: number;
 

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -145,6 +145,14 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
         }
     }
 
+    protected override onSetupDefaultState() {
+        super.onSetupDefaultState();
+
+        this.state.pendingDefeat = null;
+        this.state.mostRecentInPlayId = -1;
+        this.state.disableOngoingEffectsForDefeat = null;
+    }
+
     public isInPlay(): boolean {
         return EnumHelpers.isArena(this.zoneName);
     }

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -12,13 +12,14 @@ import { CostAdjustType } from '../../cost/CostAdjuster';
 import type Player from '../../Player';
 import * as Contract from '../../utils/Contract';
 import * as Helpers from '../../utils/Helpers';
+import type { ICardState } from '../Card';
 import { Card } from '../Card';
 import type { ICardWithCostProperty } from '../propertyMixins/Cost';
 
 export type IPlayCardActionOverrides = Omit<IPlayCardActionPropertiesBase, 'playType'>;
 
 // required for mixins to be based on this class
-export type PlayableOrDeployableCardConstructor = new (...args: any[]) => PlayableOrDeployableCard;
+export type PlayableOrDeployableCardConstructor<T extends IPlayableOrDeployableCardState = IPlayableOrDeployableCardState> = new (...args: any[]) => PlayableOrDeployableCard<T>;
 
 export interface IDecreaseCostAbilityProps<TSource extends Card = Card> extends Omit<IIncreaseOrDecreaseCostAdjusterProperties, 'cardTypeFilter' | 'match' | 'costAdjustType'> {
     title: string;
@@ -52,12 +53,16 @@ export interface IPlayableCard extends IPlayableOrDeployableCard, ICardWithCostP
     buildPlayCardAction(properties: IPlayCardActionProperties): PlayCardAction;
 }
 
+export interface IPlayableOrDeployableCardState extends ICardState {
+    exhausted: boolean | null;
+}
+
 /**
  * Subclass of {@link Card} that represents shared features of all non-base cards.
  * Implements the basic pieces for a card to be able to be played (non-leader) or deployed (leader),
  * as well as exhausted status.
  */
-export class PlayableOrDeployableCard extends Card implements IPlayableOrDeployableCard {
+export class PlayableOrDeployableCard<T extends IPlayableOrDeployableCardState = IPlayableOrDeployableCardState> extends Card<T> {
     private _exhausted?: boolean = null;
 
     public get exhausted(): boolean {

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -63,16 +63,14 @@ export interface IPlayableOrDeployableCardState extends ICardState {
  * as well as exhausted status.
  */
 export class PlayableOrDeployableCard<T extends IPlayableOrDeployableCardState = IPlayableOrDeployableCardState> extends Card<T> {
-    private _exhausted?: boolean = null;
-
     public get exhausted(): boolean {
-        this.assertPropertyEnabledForZone(this._exhausted, 'exhausted');
-        return this._exhausted;
+        this.assertPropertyEnabledForZone(this.state.exhausted, 'exhausted');
+        return this.state.exhausted;
     }
 
     public set exhausted(val: boolean) {
-        this.assertPropertyEnabledForZone(this._exhausted, 'exhausted');
-        this._exhausted = val;
+        this.assertPropertyEnabledForZone(this.state.exhausted, 'exhausted');
+        this.state.exhausted = val;
     }
 
     // see Card constructor for list of expected args
@@ -188,13 +186,13 @@ export class PlayableOrDeployableCard<T extends IPlayableOrDeployableCardState =
     }
 
     public exhaust() {
-        this.assertPropertyEnabledForZone(this._exhausted, 'exhausted');
-        this._exhausted = true;
+        this.assertPropertyEnabledForZone(this.state.exhausted, 'exhausted');
+        this.state.exhausted = true;
     }
 
     public ready() {
-        this.assertPropertyEnabledForZone(this._exhausted, 'exhausted');
-        this._exhausted = false;
+        this.assertPropertyEnabledForZone(this.state.exhausted, 'exhausted');
+        this.state.exhausted = false;
     }
 
     public override canBeExhausted(): this is IPlayableOrDeployableCard {
@@ -203,11 +201,11 @@ export class PlayableOrDeployableCard<T extends IPlayableOrDeployableCardState =
 
     public override getSummary(activePlayer: Player) {
         return { ...super.getSummary(activePlayer),
-            exhausted: this._exhausted };
+            exhausted: this.state.exhausted };
     }
 
     protected setExhaustEnabled(enabledStatus: boolean) {
-        this._exhausted = enabledStatus ? true : null;
+        this.state.exhausted = enabledStatus ? true : null;
     }
 
     /**
@@ -241,7 +239,7 @@ export class PlayableOrDeployableCard<T extends IPlayableOrDeployableCardState =
             return;
         }
 
-        this._controller = newController;
+        this.controller = newController;
 
         const moveDestination = moveTo || this.zone.name;
 

--- a/server/game/core/card/propertyMixins/ActionAbilityRegistration.ts
+++ b/server/game/core/card/propertyMixins/ActionAbilityRegistration.ts
@@ -1,6 +1,6 @@
 import type { IActionAbilityProps } from '../../../Interfaces';
 import type { ActionAbility } from '../../ability/ActionAbility';
-import type { CardConstructor } from '../Card';
+import type { CardConstructor, ICardState } from '../Card';
 import * as Contract from '../../utils/Contract';
 
 export interface ICardWithActionAbilities {
@@ -9,7 +9,7 @@ export interface ICardWithActionAbilities {
 }
 
 /** Mixin function that adds the ability to register action abilities to a base card class. */
-export function WithActionAbilities<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
+export function WithActionAbilities<TBaseClass extends CardConstructor<TState>, TState extends ICardState>(BaseClass: TBaseClass) {
     return class WithActionAbilities extends BaseClass {
         protected addActionAbility(properties: IActionAbilityProps<this>): ActionAbility {
             const ability = this.createActionAbility(properties);

--- a/server/game/core/card/propertyMixins/ConstantAbilityRegistration.ts
+++ b/server/game/core/card/propertyMixins/ConstantAbilityRegistration.ts
@@ -1,7 +1,7 @@
 import type { IConstantAbilityProps } from '../../../Interfaces';
 import { WildcardZoneName } from '../../Constants';
 import type { IConstantAbility } from '../../ongoingEffect/IConstantAbility';
-import type { CardConstructor } from '../Card';
+import type { CardConstructor, ICardState } from '../Card';
 import * as Contract from '../../utils/Contract';
 
 export interface ICardWithConstantAbilities {
@@ -10,7 +10,7 @@ export interface ICardWithConstantAbilities {
 }
 
 /** Mixin function that adds the ability to register constant abilities to a base card class. */
-export function WithConstantAbilities<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
+export function WithConstantAbilities<TBaseClass extends CardConstructor<TState>, TState extends ICardState>(BaseClass: TBaseClass) {
     return class WithConstantAbilities extends BaseClass {
         protected addConstantAbility(properties: IConstantAbilityProps<this>): IConstantAbility {
             const ability = this.createConstantAbility(properties);

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -36,7 +36,8 @@ export function WithDamage<TBaseClass extends CardConstructor<TState>, TState ex
         // STATE TODO: How do we handle full objects? This would need to be saved as a activeAttackRef (likely it's UUID)
         private _activeAttack?: Attack = null;
 
-        protected override onSetupDefaultState(): void {
+        protected override onSetupDefaultState() {
+            super.onSetupDefaultState();
             this.state.attackEnabled = false;
         }
 

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -1,6 +1,6 @@
 import type { Attack } from '../../attack/Attack';
 import * as Contract from '../../utils/Contract';
-import type { Card, CardConstructor } from '../Card';
+import type { Card, CardConstructor, ICardState } from '../Card';
 import type Player from '../../Player';
 import type { ICardWithPrintedHpProperty } from './PrintedHp';
 import { WithPrintedHp } from './PrintedHp';
@@ -18,26 +18,32 @@ export interface ICardWithDamageProperty extends ICardWithPrintedHpProperty {
     removeDamage(amount: number): number;
 }
 
+export interface IWithDamageState extends ICardState {
+    attackEnabled: boolean;
+    damage?: number;
+    // TODO: This is the idea, but I don't know how attack IDs will work.
+    activeAttackUuid?: any;
+}
+
 /**
  * Mixin function that adds the `damage` property and corresponding methods to a base class.
  * This is effectively a subclass of the mixin {@link WithPrintedHp}.
  */
-export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
+export function WithDamage<TBaseClass extends CardConstructor<TState>, TState extends ICardState>(BaseClass: TBaseClass) {
     const HpClass = WithPrintedHp(BaseClass);
 
-    return class WithDamage extends HpClass implements ICardWithDamageProperty {
+    return class WithDamage extends (HpClass as typeof HpClass & CardConstructor<TState & IWithDamageState>) implements ICardWithDamageProperty {
+        // STATE TODO: How do we handle full objects? This would need to be saved as a activeAttackRef (likely it's UUID)
         private _activeAttack?: Attack = null;
-        private attackEnabled = false;
-        private _damage?: number;
 
         public setActiveAttack(attack: Attack) {
             Contract.assertNotNullLike(attack);
-            this.assertPropertyEnabledForZoneBoolean(this.attackEnabled, 'activeAttack');
+            this.assertPropertyEnabledForZoneBoolean(this.state.attackEnabled, 'activeAttack');
             this._activeAttack = attack;
         }
 
         public unsetActiveAttack() {
-            this.assertPropertyEnabledForZoneBoolean(this.attackEnabled, 'activeAttack');
+            this.assertPropertyEnabledForZoneBoolean(this.state.attackEnabled, 'activeAttack');
             if (this._activeAttack !== null) {
                 this._activeAttack = null;
             }
@@ -48,22 +54,22 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         }
 
         public get activeAttack() {
-            this.assertPropertyEnabledForZoneBoolean(this.attackEnabled, 'activeAttack');
+            this.assertPropertyEnabledForZoneBoolean(this.state.attackEnabled, 'activeAttack');
             return this._activeAttack;
         }
 
         public get damage(): number {
-            this.assertPropertyEnabledForZone(this._damage, 'damage');
-            return this._damage;
+            this.assertPropertyEnabledForZone(this.state.damage, 'damage');
+            return this.state.damage;
         }
 
         protected set damage(value: number) {
-            this.assertPropertyEnabledForZone(this._damage, 'damage');
-            this._damage = value;
+            this.assertPropertyEnabledForZone(this.state.damage, 'damage');
+            this.state.damage = value;
         }
 
         public get remainingHp(): number {
-            this.assertPropertyEnabledForZone(this._damage, 'damage');
+            this.assertPropertyEnabledForZone(this.state.damage, 'damage');
             return Math.max(0, this.getHp() - this.damage);
         }
 
@@ -81,7 +87,7 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
             // damage source is only needed for tracking cause of defeat on units but we should enforce that it's provided consistently
             Contract.assertNotNullLike(source);
 
-            this.assertPropertyEnabledForZone(this._damage, 'damage');
+            this.assertPropertyEnabledForZone(this.state.damage, 'damage');
 
             if (amount === 0) {
                 return 0;
@@ -100,7 +106,7 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         /** @returns The amount of damage actually removed */
         public removeDamage(amount: number): number {
             Contract.assertNonNegative(amount);
-            this.assertPropertyEnabledForZone(this._damage, 'damage');
+            this.assertPropertyEnabledForZone(this.state.damage, 'damage');
 
             if (amount === 0 || this.damage === 0) {
                 return 0;
@@ -113,11 +119,11 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
         }
 
         protected setDamageEnabled(enabledStatus: boolean) {
-            this._damage = enabledStatus ? 0 : null;
+            this.state.damage = enabledStatus ? 0 : null;
         }
 
         public override getSummary(activePlayer: Player) {
-            return { ...super.getSummary(activePlayer), damage: this._damage };
+            return { ...super.getSummary(activePlayer), damage: this.state.damage };
         }
 
         protected setActiveAttackEnabled(enabledStatus: boolean) {
@@ -129,7 +135,7 @@ export function WithDamage<TBaseClass extends CardConstructor>(BaseClass: TBaseC
                 Contract.assertIsNullLike(this._activeAttack, `Moved ${this.internalName} to ${this.zoneName} but it has an active attack set`);
             }
 
-            this.attackEnabled = enabledStatus;
+            this.state.attackEnabled = enabledStatus;
         }
     };
 }

--- a/server/game/core/card/propertyMixins/Damage.ts
+++ b/server/game/core/card/propertyMixins/Damage.ts
@@ -36,6 +36,10 @@ export function WithDamage<TBaseClass extends CardConstructor<TState>, TState ex
         // STATE TODO: How do we handle full objects? This would need to be saved as a activeAttackRef (likely it's UUID)
         private _activeAttack?: Attack = null;
 
+        protected override onSetupDefaultState(): void {
+            this.state.attackEnabled = false;
+        }
+
         public setActiveAttack(attack: Attack) {
             Contract.assertNotNullLike(attack);
             this.assertPropertyEnabledForZoneBoolean(this.state.attackEnabled, 'activeAttack');

--- a/server/game/core/card/propertyMixins/LeaderProperties.ts
+++ b/server/game/core/card/propertyMixins/LeaderProperties.ts
@@ -2,13 +2,18 @@ import type { ZoneName } from '../../Constants';
 import { CardType } from '../../Constants';
 import * as Contract from '../../utils/Contract';
 import type Player from '../../Player';
-import type { PlayableOrDeployableCardConstructor } from '../baseClasses/PlayableOrDeployableCard';
+import type { IPlayableOrDeployableCardState, PlayableOrDeployableCardConstructor } from '../baseClasses/PlayableOrDeployableCard';
 import { PlayableOrDeployableCard, type ICardWithExhaustProperty } from '../baseClasses/PlayableOrDeployableCard';
 
 export const LeaderPropertiesCard = WithLeaderProperties(PlayableOrDeployableCard);
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ILeaderCard extends ICardWithExhaustProperty {}
+
+export interface ILeaderPropertiesCardState extends IPlayableOrDeployableCardState {
+    deployed: boolean;
+    onStartingSide: boolean;
+}
 
 /**
  * Mixin function that adds the standard properties for a unit (leader or non-leader) to a base class.
@@ -18,8 +23,8 @@ export interface ILeaderCard extends ICardWithExhaustProperty {}
  * - the {@link InitiateAttackAction} ability so that the card can attack
  * - the ability to have attached upgrades
  */
-export function WithLeaderProperties<TBaseClass extends PlayableOrDeployableCardConstructor>(BaseClass: TBaseClass) {
-    return class AsLeader extends BaseClass implements ILeaderCard {
+export function WithLeaderProperties<TState extends IPlayableOrDeployableCardState, TBaseClass extends PlayableOrDeployableCardConstructor = PlayableOrDeployableCardConstructor>(BaseClass: TBaseClass) {
+    return class AsLeader extends (BaseClass as typeof BaseClass & PlayableOrDeployableCardConstructor<TState & ILeaderPropertiesCardState>) implements ILeaderCard {
         // see Card constructor for list of expected args
         public constructor(...args: any[]) {
             super(...args);

--- a/server/game/core/card/propertyMixins/PrintedPower.ts
+++ b/server/game/core/card/propertyMixins/PrintedPower.ts
@@ -1,14 +1,18 @@
 import * as Contract from '../../utils/Contract';
-import type { Card, CardConstructor } from '../Card';
+import type { Card, CardConstructor, ICardState } from '../Card';
 
 export interface ICardWithPrintedPowerProperty extends Card {
     readonly printedPower: number;
     getPower(): number;
 }
 
+// export interface IWithPrintedPowerState extends ICardState {
+//     printedPower: number;
+// }
+
 /** Mixin function that adds the `printedPower` property to a base class. */
-export function WithPrintedPower<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
-    return class WithPrintedPower extends BaseClass {
+export function WithPrintedPower<TBaseClass extends CardConstructor<TState>, TState extends ICardState>(BaseClass: TBaseClass) {
+    return class WithPrintedPower extends (BaseClass as TBaseClass & CardConstructor<TState>) {
         public readonly printedPower: number;
 
         // see Card constructor for list of expected args

--- a/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
+++ b/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
@@ -1,8 +1,8 @@
 import * as Contract from '../../utils/Contract';
-import type { CardConstructor } from '../Card';
+import type { CardConstructor, ICardState } from '../Card';
 
 /** Mixin function that creates a version of the base class that is a Token. */
-export function WithStandardAbilitySetup<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
+export function WithStandardAbilitySetup<TBaseClass extends CardConstructor<TState>, TState extends ICardState>(BaseClass: TBaseClass) {
     return class WithStandardAbilitySetup extends BaseClass {
         // see Card constructor for list of expected args
         public constructor(...args: any[]) {

--- a/server/game/core/card/propertyMixins/TriggeredAbilityRegistration.ts
+++ b/server/game/core/card/propertyMixins/TriggeredAbilityRegistration.ts
@@ -1,7 +1,7 @@
 import type { IReplacementEffectAbilityProps, ITriggeredAbilityProps } from '../../../Interfaces';
 import ReplacementEffectAbility from '../../ability/ReplacementEffectAbility';
 import type TriggeredAbility from '../../ability/TriggeredAbility';
-import type { Card, CardConstructor } from '../Card';
+import type { Card, CardConstructor, ICardState } from '../Card';
 import * as Contract from '../../utils/Contract';
 
 export interface ICardWithTriggeredAbilities {
@@ -13,7 +13,7 @@ export interface ICardWithTriggeredAbilities {
 }
 
 /** Mixin function that adds the ability to register triggered abilities to a base card class. */
-export function WithTriggeredAbilities<TBaseClass extends CardConstructor>(BaseClass: TBaseClass) {
+export function WithTriggeredAbilities<TBaseClass extends CardConstructor<TState>, TState extends ICardState>(BaseClass: TBaseClass) {
     return class WithTriggeredAbilities extends BaseClass {
         /**
          * `SWU 7.6.1`: Triggered abilities have bold text indicating their triggering condition, starting with the word

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -4,7 +4,7 @@ import { AbilityRestriction, AbilityType, CardType, EffectName, EventName, Keywo
 import StatsModifierWrapper from '../../ongoingEffect/effectImpl/StatsModifierWrapper';
 import type { IOngoingCardEffect } from '../../ongoingEffect/IOngoingCardEffect';
 import * as Contract from '../../utils/Contract';
-import type { IInPlayCard, InPlayCardConstructor } from '../baseClasses/InPlayCard';
+import type { IInPlayCard, IInPlayCardState, InPlayCardConstructor } from '../baseClasses/InPlayCard';
 import { InPlayCard } from '../baseClasses/InPlayCard';
 import type { ICardWithDamageProperty } from './Damage';
 import { WithDamage } from './Damage';
@@ -38,6 +38,10 @@ import type { PilotLimitModifier } from '../../ongoingEffect/effectImpl/PilotLim
 import type { AbilityContext } from '../../ability/AbilityContext';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
+export interface IUnitPropertiesCardState extends IInPlayCardState {
+    // placeholder code, not used.
+    defaultArenaInternal: Arena;
+}
 
 type IAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = IAbilityPropsWithType<TTarget> & IGainCondition<TSource>;
 
@@ -77,11 +81,11 @@ export interface IUnitCard extends IInPlayCard, ICardWithDamageProperty, ICardWi
  * - the {@link InitiateAttackAction} ability so that the card can attack
  * - the ability to have attached upgrades
  */
-export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(BaseClass: TBaseClass) {
+export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TState>, TState extends IInPlayCardState>(BaseClass: TBaseClass) {
     // create a "base" class that has the damage, hp, and power properties from other mixins
     const StatsAndDamageClass = WithDamage(WithPrintedPower(BaseClass));
 
-    return class AsUnit extends StatsAndDamageClass implements IUnitCard {
+    return class AsUnit extends (StatsAndDamageClass as typeof StatsAndDamageClass & InPlayCardConstructor<TState & IUnitPropertiesCardState>) implements IUnitCard {
         public static registerRulesListeners(game: Game) {
             // register listeners for when-played keyword abilities (see comment in EventWindow.ts for explanation of 'postResolve')
             game.on(EventName.OnUnitEntersPlay + ':postResolve', (event) => {

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -738,7 +738,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
                 return;
             }
 
-            if (this.damage >= this.getHp() && !this._pendingDefeat) {
+            if (this.damage >= this.getHp() && !this.state.pendingDefeat) {
                 // add defeat event to window
                 this.game.addSubwindowEvents(
                     new FrameworkDefeatCardSystem({ target: this, defeatSource: source })
@@ -746,7 +746,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
                 );
 
                 // mark that this unit has a defeat pending so that other effects targeting it will not resolve
-                this._pendingDefeat = true;
+                this.state.pendingDefeat = true;
             }
         }
 

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -36,11 +36,13 @@ import type { ILeaderCard } from './LeaderProperties';
 import type { ILeaderUnitCard } from '../LeaderUnitCard';
 import type { PilotLimitModifier } from '../../ongoingEffect/effectImpl/PilotLimitModifier';
 import type { AbilityContext } from '../../ability/AbilityContext';
+import type { GameObjectRef } from '../../GameObjectBase';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
 export interface IUnitPropertiesCardState extends IInPlayCardState {
     // placeholder code, not used.
     defaultArenaInternal: Arena;
+    captureZone: GameObjectRef<CaptureZone> | null;
 }
 
 type IAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = IAbilityPropsWithType<TTarget> & IGainCondition<TSource>;
@@ -122,7 +124,6 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
         // ************************************* FIELDS AND PROPERTIES *************************************
         public readonly defaultArena: Arena;
 
-        protected _captureZone?: CaptureZone = null;
         protected _upgrades?: IUpgradeCard[] = null;
         protected pilotingActionAbilities: ActionAbility[];
         protected pilotingConstantAbilities: IConstantAbility[];
@@ -137,13 +138,13 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
         private _whileInPlayKeywordAbilities?: IConstantAbility[] = null;
 
         public get capturedUnits() {
-            this.assertPropertyEnabledForZone(this._captureZone, 'capturedUnits');
-            return this._captureZone.cards;
+            this.assertPropertyEnabledForZone(this.state.captureZone, 'capturedUnits');
+            return this.captureZone.cards;
         }
 
         public get captureZone() {
-            this.assertPropertyEnabledForZone(this._captureZone, 'captureZone');
-            return this._captureZone;
+            this.assertPropertyEnabledForZone(this.state.captureZone, 'captureZone');
+            return this.game.gameObjectManager.get(this.state.captureZone);
         }
 
         public get upgrades(): IUpgradeCard[] {
@@ -247,7 +248,8 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
         }
 
         protected setCaptureZoneEnabled(enabledStatus: boolean) {
-            this._captureZone = enabledStatus ? new CaptureZone(this.owner, this) : null;
+            const zone = enabledStatus ? new CaptureZone(this.game, this.owner, this) : null;
+            this.state.captureZone = zone?.getRef();
         }
 
         protected override setDamageEnabled(enabledStatus: boolean): void {

--- a/server/game/core/ongoingEffect/OngoingEffectSource.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectSource.ts
@@ -1,3 +1,4 @@
+import type { IGameObjectState } from '../GameObject';
 import { GameObject } from '../GameObject.js';
 
 import { Duration, WildcardZoneName } from '../Constants.js';
@@ -5,7 +6,11 @@ import type { OngoingEffect } from './OngoingEffect';
 
 // This class is inherited by Card and also represents Framework effects
 
-export class OngoingEffectSource extends GameObject {
+// Here mostly as a placeholder.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface IOngoingEffectSourceState extends IGameObjectState { }
+
+export class OngoingEffectSource<T extends IOngoingEffectSourceState = IOngoingEffectSourceState> extends GameObject<T> {
     public constructor(game, name = 'Framework effect') {
         super(game, name);
     }

--- a/server/game/core/zone/BaseZone.ts
+++ b/server/game/core/zone/BaseZone.ts
@@ -1,6 +1,7 @@
 import type { IBaseCard } from '../card/BaseCard';
 import type { ILeaderCard } from '../card/propertyMixins/LeaderProperties';
 import { ZoneName } from '../Constants';
+import type Game from '../Game';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
 import type { IZoneCardFilterProperties } from './ZoneAbstract';
@@ -29,8 +30,8 @@ export class BaseZone extends ZoneAbstract<ILeaderCard | IBaseCard> {
         return this._leader;
     }
 
-    public constructor(owner: Player, base: IBaseCard, leader: ILeaderCard) {
-        super(owner);
+    public constructor(game: Game, owner: Player, base: IBaseCard, leader: ILeaderCard) {
+        super(game, owner);
 
         this.hiddenForPlayers = null;
         this.name = ZoneName.Base;

--- a/server/game/core/zone/CaptureZone.ts
+++ b/server/game/core/zone/CaptureZone.ts
@@ -1,6 +1,7 @@
 import type { Card } from '../card/Card';
 import type { IUnitCard } from '../card/propertyMixins/UnitProperties';
 import { ZoneName } from '../Constants';
+import type Game from '../Game';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
 import { SimpleZone } from './SimpleZone';
@@ -10,10 +11,10 @@ export class CaptureZone extends SimpleZone<IUnitCard> {
     public override readonly hiddenForPlayers: null;
     public override readonly name: ZoneName.Capture;
 
-    public constructor(owner: Player, captor: Card) {
+    public constructor(game: Game, owner: Player, captor: Card) {
         Contract.assertTrue(captor.isUnit(), `Attempting to create a capture zone with card ${captor.internalName} but it is not a unit card`);
 
-        super(owner);
+        super(game, owner);
 
         this.hiddenForPlayers = null;
         this.name = ZoneName.Capture;
@@ -22,10 +23,10 @@ export class CaptureZone extends SimpleZone<IUnitCard> {
     }
 
     public override addCard(card: IUnitCard) {
-        Contract.assertFalse(this._cards.includes(card), `Attempting to add card ${card.internalName} to ${this} twice`);
+        Contract.assertFalse(this.cards.includes(card), `Attempting to add card ${card.internalName} to ${this} twice`);
         Contract.assertTrue(card.isNonLeaderUnit(), `Attempting to add card ${card.internalName} to ${this} but it is not a non-leader unit card`);
 
-        this._cards.push(card);
+        this.state.cards.push(card.getRef());
     }
 
     public override toString() {

--- a/server/game/core/zone/ConcreteArenaZone.ts
+++ b/server/game/core/zone/ConcreteArenaZone.ts
@@ -2,29 +2,35 @@ import type { IInPlayCard } from '../card/baseClasses/InPlayCard';
 import type { Card } from '../card/Card';
 import type { ZoneName } from '../Constants';
 import type Game from '../Game';
+import type { GameObjectRef, IGameObjectBaseState } from '../GameObjectBase';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
 import type { IArenaZoneCardFilterProperties } from './ConcreteOrMetaArenaZone';
 import { ConcreteOrMetaArenaZone } from './ConcreteOrMetaArenaZone';
 import type { IAddRemoveZone } from './ZoneAbstract';
 
+export interface IConcreteArenaZoneState extends IGameObjectBaseState {
+    cards: GameObjectRef<IInPlayCard>[];
+}
+
 /**
  * Base class for the "concrete" arena zones - ground and space - which are not the meta-zone AllArenasZone
  */
-export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone implements IAddRemoveZone {
+export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone<IConcreteArenaZoneState> implements IAddRemoveZone {
     public override readonly hiddenForPlayers: null;
     public abstract override readonly name: ZoneName;
     public override readonly owner: Game;
 
-    protected _cards = new Map<Player, IInPlayCard[]>();
+    // STATE: This is a "cached" state field, it's a field derived from one or more values on the state object, and needs to be updated after a state change.
+    protected _playerCards = new Map<Player, IInPlayCard[]>();
 
     public override get cards(): IInPlayCard[] {
-        return Array.from(this._cards.values()).flat();
+        return this.state.cards.map((x) => this.game.gameObjectManager.get(x));
     }
 
     public override get count() {
         let cardCount = 0;
-        this._cards.forEach((cards) => cardCount += cards.length);
+        this._playerCards.forEach((cards) => cardCount += cards.length);
         return cardCount;
     }
 
@@ -33,8 +39,12 @@ export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone implemen
 
         this.hiddenForPlayers = null;
 
-        this._cards.set(player1, []);
-        this._cards.set(player2, []);
+        this._playerCards.set(player1, []);
+        this._playerCards.set(player2, []);
+    }
+
+    protected override onSetupDefaultState() {
+        this.state.cards = [];
     }
 
     public override getCards(filter?: IArenaZoneCardFilterProperties): IInPlayCard[] {
@@ -42,7 +52,7 @@ export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone implemen
 
         let cards: IInPlayCard[] = [];
 
-        for (const [player, playerCards] of this._cards) {
+        for (const [player, playerCards] of this._playerCards) {
             if (!filter?.controller || filter.controller === player) {
                 cards = cards.concat(playerCards.filter(filterFn));
             }
@@ -53,45 +63,68 @@ export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone implemen
 
     public addCard(card: IInPlayCard) {
         const controller = card.controller;
-        const cardListForController = this._cards.get(controller);
+        const cardListForController = this._playerCards.get(controller);
+        const cardIdx = this.state.cards.findIndex((x) => x.uuid === card.uuid);
 
-        Contract.assertHasKey(this._cards, controller, `Attempting to add card ${card.internalName} to ${this} but the controller ${controller} is not registered`);
-        Contract.assertFalse(this._cards.get(controller.opponent).includes(card), `Attempting to add card ${card.internalName} for ${controller} to ${this} but it is already in the arena for the opponent`);
+        Contract.assertHasKey(this._playerCards, controller, `Attempting to add card ${card.internalName} to ${this} but the controller ${controller} is not registered`);
+        Contract.assertFalse(this._playerCards.get(controller.opponent).includes(card), `Attempting to add card ${card.internalName} for ${controller} to ${this} but it is already in the arena for the opponent`);
         Contract.assertFalse(cardListForController.includes(card), `Attempting to add card ${card.internalName} for ${controller} to ${this} twice`);
+        Contract.assertTrue(cardIdx === -1, `Attempting to add card ${card.internalName} to ${this} twice`);
 
         cardListForController.push(card);
+        this.state.cards.push(card.getRef());
     }
 
     public removeCard(card: Card) {
         Contract.assertTrue(card.canBeInPlay());
 
         const controller = card.controller;
-        const cardListForController = this._cards.get(controller);
-        const cardIdx = cardListForController.indexOf(card);
+        const cardListForController = this._playerCards.get(controller);
+        const playerCardIdx = cardListForController.indexOf(card);
+        const cardIdx = this.state.cards.findIndex((x) => x.uuid === card.uuid);
 
-        Contract.assertHasKey(this._cards, controller, `Attempting to add card ${card.internalName} to ${this} but the controller ${controller} is not registered`);
-        Contract.assertFalse(this._cards.get(controller.opponent).includes(card), `Attempting to remove card ${card.internalName} for controller ${controller} from ${this} but it is in the arena for the opponent`);
-        Contract.assertFalse(cardIdx === -1, `Attempting to remove card ${card.internalName} for ${controller} from ${this} but it does not exist`);
+        Contract.assertHasKey(this._playerCards, controller, `Attempting to add card ${card.internalName} to ${this} but the controller ${controller} is not registered`);
+        Contract.assertFalse(this._playerCards.get(controller.opponent).includes(card), `Attempting to remove card ${card.internalName} for controller ${controller} from ${this} but it is in the arena for the opponent`);
+        Contract.assertFalse(playerCardIdx === -1, `Attempting to remove card ${card.internalName} for ${controller} from ${this} but it does not exist`);
+        Contract.assertFalse(cardIdx === -1, `Attempting to remove card ${card.internalName} from ${this} but it does not exist`);
 
-        cardListForController.splice(cardIdx, 1);
+        cardListForController.splice(playerCardIdx, 1);
+        this.state.cards.splice(cardIdx, 1);
     }
 
     public updateController(card: Card) {
         Contract.assertTrue(card.canBeInPlay());
 
-        const controllerCardsList = this._cards.get(card.controller);
+        const controllerCardsList = this._playerCards.get(card.controller);
 
         // card is already in its controller's list, nothing to do
         if (controllerCardsList.includes(card)) {
             return;
         }
 
-        const opponentCardsList = this._cards.get(card.controller.opponent);
+        const opponentCardsList = this._playerCards.get(card.controller.opponent);
         const removeCardIdx = opponentCardsList.indexOf(card);
 
         Contract.assertTrue(removeCardIdx !== -1, `Attempting to update controller of card ${card.internalName} to ${card.controller} in ${this} but it is not in the arena`);
 
         opponentCardsList.splice(removeCardIdx, 1);
         controllerCardsList.push(card);
+        // No `this.cards.state` change required.
+    }
+
+    // Unused but setup as an example for future use.
+    public override onAfterSetState() {
+        super.onAfterSetState();
+
+        this._playerCards.forEach((playerCards) => {
+            // In JS, this will clear the array under the hood.
+            playerCards.length = 0;
+        });
+
+        // Now that the cached player-card mappings are cleared, re-add them to the array.
+        const cards = this.cards;
+        for (const card of cards) {
+            this._playerCards.get(card.controller).push(card);
+        }
     }
 }

--- a/server/game/core/zone/ConcreteOrMetaArenaZone.ts
+++ b/server/game/core/zone/ConcreteOrMetaArenaZone.ts
@@ -3,6 +3,7 @@ import type { IUnitCard } from '../card/propertyMixins/UnitProperties';
 import type { UpgradeCard } from '../card/UpgradeCard';
 import { WildcardCardType } from '../Constants';
 import type Game from '../Game';
+import type { IGameObjectBaseState } from '../GameObjectBase';
 import type Player from '../Player';
 import type { IZoneCardFilterProperties } from './ZoneAbstract';
 import { ZoneAbstract } from './ZoneAbstract';
@@ -14,7 +15,7 @@ export interface IArenaZoneCardFilterProperties extends IZoneCardFilterPropertie
 /**
  * Base class for arena zones, including the meta-zone for all arenas
  */
-export abstract class ConcreteOrMetaArenaZone extends ZoneAbstract<IInPlayCard> {
+export abstract class ConcreteOrMetaArenaZone<TState extends IGameObjectBaseState = IGameObjectBaseState> extends ZoneAbstract<IInPlayCard, TState> {
     public override readonly hiddenForPlayers: null;
     public override readonly owner: Game;
 

--- a/server/game/core/zone/DeckZone.ts
+++ b/server/game/core/zone/DeckZone.ts
@@ -9,45 +9,59 @@ import type { IAddRemoveZone, IZoneCardFilterProperties } from './ZoneAbstract';
 import { ZoneAbstract } from './ZoneAbstract';
 import type { GameEvent } from '../event/GameEvent';
 import type { IPlayableCard } from '../card/baseClasses/PlayableOrDeployableCard';
+import type Game from '../Game';
+import type { GameObjectRef, IGameObjectBaseState } from '../GameObjectBase';
 
-export class DeckZone extends ZoneAbstract<IPlayableCard> implements IAddRemoveZone {
-    public override readonly hiddenForPlayers: WildcardRelativePlayer.Any;
-    public override readonly owner: Player;
-    public override readonly name: ZoneName.Deck;
-
-    protected _deck: IPlayableCard[] = [];
+export interface IDeckZoneState extends IGameObjectBaseState {
+    deck: GameObjectRef<IPlayableCard>[];
 
     // cards that have been selected for a search effect are considered "in the deck zone" but not "in the deck"
     // while the effect is resolving (see SWU 8.27.7).
     // These cards will be moved back to deck if they are somehow still there at the end of the action (e.g. the
     // U-Wing into ... into opponent Regional Governor scenario).
-    protected searchingCards: IPlayableCard[] = [];
+    searchingCards: GameObjectRef<IPlayableCard>[];
+}
+
+export class DeckZone extends ZoneAbstract<IPlayableCard, IDeckZoneState> implements IAddRemoveZone {
+    public override readonly hiddenForPlayers: WildcardRelativePlayer.Any;
+    public override readonly owner: Player;
+    public override readonly name: ZoneName.Deck;
 
     public override get cards(): IPlayableCard[] {
-        return [...this._deck, ...this.searchingCards];
+        return this.state.deck.concat(this.state.searchingCards).map((x) => this.game.gameObjectManager.get(x));
     }
 
     public get deck(): IPlayableCard[] {
-        return [...this._deck];
+        return this.state.deck.map((x) => this.game.gameObjectManager.get(x));
+    }
+
+    public get searchingCards(): IPlayableCard[] {
+        return this.state.searchingCards.map((x) => this.game.gameObjectManager.get(x));
     }
 
     public override get count() {
-        return this._deck.length;
+        return this.state.deck.length;
     }
 
     public get topCard(): IPlayableCard | null {
-        return this._deck.length > 0 ? this._deck[0] : null;
+        return this.state.deck.length > 0 ? this.game.gameObjectManager.get(this.state.deck[0]) : null;
     }
 
-    public constructor(owner: Player) {
-        super(owner);
+    public constructor(game: Game, owner: Player) {
+        super(game, owner);
 
         this.hiddenForPlayers = WildcardRelativePlayer.Any;
         this.name = ZoneName.Deck;
     }
 
+    protected override onSetupDefaultState(): void {
+        super.onSetupDefaultState();
+        this.state.deck = [];
+        this.state.searchingCards = [];
+    }
+
     public initialize(cards: IPlayableCard[]) {
-        this._deck = cards;
+        this.state.deck = cards.map((x) => x.getRef());
 
         cards.forEach((card) => card.initializeZone(this));
     }
@@ -71,8 +85,9 @@ export class DeckZone extends ZoneAbstract<IPlayableCard> implements IAddRemoveZ
     public getTopCards(numCards: number) {
         Contract.assertNonNegative(numCards);
 
-        const cardsToGet = Math.min(numCards, this._deck.length);
-        return this._deck.slice(0, cardsToGet);
+        const deck = this.deck;
+        const cardsToGet = Math.min(numCards, deck.length);
+        return deck.slice(0, cardsToGet);
     }
 
     public addCardToTop(card: IPlayableCard) {
@@ -90,10 +105,10 @@ export class DeckZone extends ZoneAbstract<IPlayableCard> implements IAddRemoveZ
 
         switch (zone) {
             case DeckZoneDestination.DeckTop:
-                this._deck.unshift(card);
+                this.state.deck.unshift(card.getRef());
                 return;
             case DeckZoneDestination.DeckBottom:
-                this._deck.push(card);
+                this.state.deck.push(card.getRef());
                 return;
             default:
                 Contract.fail(`Unknown value for DeckZoneDestination enum: ${zone}`);
@@ -101,14 +116,15 @@ export class DeckZone extends ZoneAbstract<IPlayableCard> implements IAddRemoveZ
     }
 
     public removeTopCard(): IPlayableCard | null {
-        return this._deck.pop() ?? null;
+        const card = this.state.deck.pop();
+        return card ? this.game.gameObjectManager.get(card) : null;
     }
 
     public removeCard(card: Card) {
         Contract.assertTrue(card.isPlayable());
 
-        const foundCardInDeckIdx = this.tryGetCardIdx(card, this._deck);
-        const foundCardInSearchingCardsIdx = this.tryGetCardIdx(card, this.searchingCards);
+        const foundCardInDeckIdx = this.tryGetCardIdx(card, this.state.deck);
+        const foundCardInSearchingCardsIdx = this.tryGetCardIdx(card, this.state.searchingCards);
 
         Contract.assertFalse(
             foundCardInDeckIdx == null && foundCardInSearchingCardsIdx == null,
@@ -120,15 +136,15 @@ export class DeckZone extends ZoneAbstract<IPlayableCard> implements IAddRemoveZ
         );
 
         if (foundCardInDeckIdx != null) {
-            this._deck.splice(foundCardInDeckIdx, 1);
+            this.state.deck.splice(foundCardInDeckIdx, 1);
             return;
         }
 
-        this.searchingCards.splice(foundCardInSearchingCardsIdx, 1);
+        this.state.searchingCards.splice(foundCardInSearchingCardsIdx, 1);
     }
 
     public shuffle(randomGenerator: seedrandom) {
-        this._deck = Helpers.shuffle(this._deck, randomGenerator);
+        this.state.deck = Helpers.shuffle(this.state.deck, randomGenerator);
     }
 
     /**
@@ -140,28 +156,28 @@ export class DeckZone extends ZoneAbstract<IPlayableCard> implements IAddRemoveZ
         for (const card of Helpers.asArray(cards)) {
             Contract.assertTrue(card.isPlayable());
 
-            const foundCardInDeckIdx = this.tryGetCardIdx(card, this._deck);
+            const foundCardInDeckIdx = this.tryGetCardIdx(card, this.state.deck);
             Contract.assertNotNullLike(
                 foundCardInDeckIdx,
                 `Attempting to move card ${card.internalName} to the searching area of ${this} but it is not in the deck. Its current zone is ${card.zone}.`
             );
 
-            this._deck.splice(foundCardInDeckIdx, 1);
-            this.searchingCards.push(card);
+            this.state.deck.splice(foundCardInDeckIdx, 1);
+            this.state.searchingCards.push(card.getRef());
         }
 
         triggeringEvent.addCleanupHandler(() => {
             for (const card of this.searchingCards) {
-                Contract.assertFalse(this._deck.includes(card), `Attempting to move ${card.internalName} back to deck from search area but it is already in the deck`);
-                this._deck.push(card);
+                Contract.assertFalse(this.state.deck.some((x) => x.uuid === card.uuid), `Attempting to move ${card.internalName} back to deck from search area but it is already in the deck`);
+                this.state.deck.push(card.getRef());
             }
 
-            this.searchingCards = [];
+            this.state.searchingCards = [];
         });
     }
 
-    private tryGetCardIdx(card: IPlayableCard, list: IPlayableCard[]): number | null {
-        const idx = list.indexOf(card);
+    private tryGetCardIdx(card: IPlayableCard, list: GameObjectRef<IPlayableCard>[]): number | null {
+        const idx = list.findIndex((x) => x.uuid === card.uuid);
         return idx === -1 ? null : idx;
     }
 

--- a/server/game/core/zone/DiscardZone.ts
+++ b/server/game/core/zone/DiscardZone.ts
@@ -1,5 +1,6 @@
 import type { IPlayableCard } from '../card/baseClasses/PlayableOrDeployableCard';
 import { ZoneName } from '../Constants';
+import type Game from '../Game';
 import type Player from '../Player';
 import { SimpleZone } from './SimpleZone';
 
@@ -7,8 +8,8 @@ export class DiscardZone extends SimpleZone<IPlayableCard> {
     public override readonly hiddenForPlayers: null;
     public override readonly name: ZoneName.Discard;
 
-    public constructor(owner: Player) {
-        super(owner);
+    public constructor(game: Game, owner: Player) {
+        super(game, owner);
 
         this.hiddenForPlayers = null;
         this.name = ZoneName.Discard;

--- a/server/game/core/zone/HandZone.ts
+++ b/server/game/core/zone/HandZone.ts
@@ -1,5 +1,6 @@
 import type { IPlayableCard } from '../card/baseClasses/PlayableOrDeployableCard';
 import { ZoneName, RelativePlayer } from '../Constants';
+import type Game from '../Game';
 import type Player from '../Player';
 import { SimpleZone } from './SimpleZone';
 
@@ -7,8 +8,8 @@ export class HandZone extends SimpleZone<IPlayableCard> {
     public override readonly hiddenForPlayers: RelativePlayer.Opponent;
     public override readonly name: ZoneName.Hand;
 
-    public constructor(owner: Player) {
-        super(owner);
+    public constructor(game: Game, owner: Player) {
+        super(game, owner);
 
         this.hiddenForPlayers = RelativePlayer.Opponent;
         this.name = ZoneName.Hand;

--- a/server/game/core/zone/OutsideTheGameZone.ts
+++ b/server/game/core/zone/OutsideTheGameZone.ts
@@ -1,5 +1,6 @@
 import type { Card } from '../card/Card';
 import { ZoneName } from '../Constants';
+import type Game from '../Game';
 import type Player from '../Player';
 import { SimpleZone } from './SimpleZone';
 
@@ -10,8 +11,8 @@ export class OutsideTheGameZone extends SimpleZone<Card> {
     public override readonly hiddenForPlayers: null;
     public override readonly name: ZoneName.OutsideTheGame;
 
-    public constructor(owner: Player) {
-        super(owner);
+    public constructor(game: Game, owner: Player) {
+        super(game, owner);
 
         this.hiddenForPlayers = null;
         this.name = ZoneName.OutsideTheGame;

--- a/server/game/core/zone/SimpleZone.ts
+++ b/server/game/core/zone/SimpleZone.ts
@@ -1,47 +1,57 @@
 import type { Card } from '../card/Card';
 import type { ZoneName } from '../Constants';
+import type Game from '../Game';
+import type { GameObjectRef, IGameObjectBaseState } from '../GameObjectBase';
 import type Player from '../Player';
 import * as Contract from '../utils/Contract';
 import type { IAddRemoveZone, IZoneCardFilterProperties } from './ZoneAbstract';
 import { ZoneAbstract } from './ZoneAbstract';
 
+export interface ISimpleZoneState<TCard extends Card> extends IGameObjectBaseState {
+    cards: GameObjectRef<TCard>[];
+}
+
 /**
  * Base class for zones that are basically just a list of cards with no special behavior
  */
-export abstract class SimpleZone<TCard extends Card> extends ZoneAbstract<TCard> implements IAddRemoveZone {
+export abstract class SimpleZone<TCard extends Card> extends ZoneAbstract<TCard, ISimpleZoneState<TCard>> implements IAddRemoveZone {
     public abstract override readonly name: ZoneName;
     public override readonly owner: Player;
 
-    protected _cards: TCard[] = [];
+    // protected _cards: TCard[] = [];
 
     public override get cards(): TCard[] {
-        return [...this._cards];
+        return this.state.cards.map((x) => this.game.gameObjectManager.get(x));
     }
 
     public override get count() {
-        return this._cards.length;
+        return this.state.cards.length;
     }
 
-    public constructor(owner: Player) {
-        super(owner);
+    public constructor(game: Game, owner: Player) {
+        super(game, owner);
+    }
+
+    protected override onSetupDefaultState() {
+        this.state.cards = [];
     }
 
     public override getCards(filter?: IZoneCardFilterProperties): TCard[] {
-        return this._cards.filter(this.buildFilterFn(filter));
+        return this.cards.filter(this.buildFilterFn(filter));
     }
 
     public addCard(card: TCard) {
-        Contract.assertFalse(this._cards.includes(card), `Attempting to add card ${card.internalName} to ${this} twice`);
+        Contract.assertFalse(this.cards.includes(card), `Attempting to add card ${card.internalName} to ${this} twice`);
         Contract.assertEqual(card.controller, this.owner, `Attempting to add card ${card.internalName} to ${this} but its controller is ${card.controller}`);
 
-        this._cards.push(card);
+        this.state.cards.push(card.getRef());
     }
 
     public removeCard(card: Card) {
-        const cardIdx = this._cards.indexOf(card as TCard);
+        const cardIdx = this.cards.indexOf(card as TCard);
 
         Contract.assertFalse(cardIdx === -1, `Attempting to remove card ${card.internalName} from ${this} but it is not there. Its current zone is ${card.zone}.`);
 
-        this._cards.splice(cardIdx, 1);
+        this.state.cards.splice(cardIdx, 1);
     }
 }

--- a/server/game/core/zone/ZoneAbstract.ts
+++ b/server/game/core/zone/ZoneAbstract.ts
@@ -4,6 +4,8 @@ import type { Aspect, CardTypeFilter, KeywordName, ZoneName, MoveZoneDestination
 import type Player from '../Player';
 import type Game from '../Game';
 import * as EnumHelpers from '../utils/EnumHelpers';
+import type { IGameObjectBaseState } from '../GameObjectBase';
+import { GameObjectBase } from '../GameObjectBase';
 
 /**
  * Collection of filters for searching cards in a zone.
@@ -31,7 +33,7 @@ export interface IAddRemoveZone {
 /**
  * Base class for all Zone types. Defines some common properties and methods.
  */
-export abstract class ZoneAbstract<TCard extends Card> {
+export abstract class ZoneAbstract<TCard extends Card, TState extends IGameObjectBaseState = IGameObjectBaseState> extends GameObjectBase<TState> {
     public readonly owner: Player | Game;
 
     /** Set of players that this zone is hidden for. If `null`, not hidden for any player. */
@@ -45,8 +47,9 @@ export abstract class ZoneAbstract<TCard extends Card> {
         return this.getCards();
     }
 
-    public constructor(owner: Player | Game) {
-        this.owner = owner;
+    public constructor(game: Game, owner?: Player) {
+        super(game);
+        this.owner = owner ?? game;
     }
 
     /** Get the cards from this zone with an optional filter */
@@ -85,7 +88,7 @@ export abstract class ZoneAbstract<TCard extends Card> {
         Contract.assertTrue(!zone || zone === this.name, `Attempting to move ${card.internalName} to ${this} with incorrect zone parameter: ${zone}`);
     }
 
-    public toString() {
+    public override toString() {
         return ('game' in this.owner ? `${this.owner.name}:` : '') + this.name;
     }
 }


### PR DESCRIPTION
#### Initial Card State Setup
I've setup basic state definitions for all of the card classes. A number of the higher objects don't have state just overrides, so I was able to skip those. 

Mixins did make it harder, but if you pass in a state interface to the initial class being mixed in it still can work.
```ts
const NonLeaderUnitCardParent = WithUnitProperties(WithStandardAbilitySetup(InPlayCard<INonLeaderUnitCardState>));
```

I kinda got the mixins themselves working to extend the state object definition, but if you take a look at it, it's _ugly_. But it's the best I could do without doing a deep dive into TS typings 😅.

I don't think I captured _all_ state for Cards, but this at least puts the backbone in, so I don't have to worry about branch desyncs.

#### Game Object Manager
GameObjectManager's get method now throws an error if it is given a valid obj/UUID but it can't find it. Because GameObjectRefs should only ever be created from existing objects (ie they should only ever be created from a obj.getRef() call), if the engine is given an UUID and can't find it, something is fundamentally broken (something should be in the state object but isn't) and we need to know ASAP. 

Related, but the GameObjectRef system works flawlessly so far, so that's good news.

#### Zone Changes
Zones are now derived from GameObjectBase.  This means we can use GameObjectRef<Zone> (see Card.ts for an example). Converted the two base classes (SimpleZone and ConcreteArenaZone) that track cards to use the state object.

ConcreteArenaZone had a noticeable rework, it now keeps all of the cards in a list but now maintains the Map object as "cached" value. I added a "onAfterStateSetup" method to GameObjectBase to call on objects after an Undo is triggered, so that they can refresh any values that are computations based on state (such as as the Map in this case). This does mean ConcreteArenaZone is now maintaining two sets of objects, which is not my favorite. I could probably add simplify this down further but it's functional for now.