### PR TITLE
endlessLegions

### DIFF
--- a/server/game/cards/02_SHD/events/EndlessLegions.ts
+++ b/server/game/cards/02_SHD/events/EndlessLegions.ts
@@ -20,6 +20,7 @@ export default class EndlessLegions extends EventCard {
             title: 'Reveal any number of resources you control',
             targetResolver: {
                 mode: TargetMode.Unlimited,
+                canChooseNoCards: true,
                 zoneFilter: ZoneName.Resource,
                 controller: RelativePlayer.Self,
                 immediateEffect: AbilityHelper.immediateEffects.reveal({

--- a/test/server/cards/02_SHD/events/EndlessLegions.spec.ts
+++ b/test/server/cards/02_SHD/events/EndlessLegions.spec.ts
@@ -224,5 +224,38 @@ describe('Endless Legions', function() {
 
             expect(context.player2).toBeActivePlayer();
         });
+
+        it('Endless Legionsl\'s event ability should play no cards if no units are revealed', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'grand-moff-tarkin#oversector-governor',
+                    hand: ['endless-legions'],
+                    base: 'echo-base',
+                    resources: [
+                        'discerning-veteran',
+                        'snowspeeder',
+                        'specforce-soldier',
+                        'ruthless-raider',
+                        'tieln-fighter',
+                        'frozen-in-carbonite',
+                        'confiscate',
+                        'pyke-sentinel',
+                        'battlefield-marine',
+                        'admiral-piett#captain-of-the-executor',
+                        'relentless#konstantines-folly',
+                        'clone-commander-cody#commanding-the-212th',
+                        'arquitens-assault-cruiser',
+                        'resupply',
+                        'wrecker#boom',
+                    ]
+                },
+            });
+
+            const { context } = contextRef;
+            context.player1.clickCard(context.endlessLegions);
+            context.player1.clickPrompt('Choose no target');
+            expect(context.player2).toBeActivePlayer();
+        });
     });
 });


### PR DESCRIPTION
Updated code with canChooseNoCards: true,
and updated test for player to choose no target 
![image](https://github.com/user-attachments/assets/968c2615-8769-49d0-ad99-0c62c5b0f560)
