### PR TITLE
Fix non-leader pilot bug and add better error handling for card condition cases

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -143,8 +143,8 @@ class Game extends EventEmitter {
      * Reports errors from the game engine back to the router
      * @param {Error} e
      */
-    reportError(e) {
-        this.router.handleError(this, e);
+    reportError(e, severeGameMessage = false) {
+        this.router.handleError(this, e, severeGameMessage);
     }
 
     /**

--- a/server/game/core/card/NonLeaderUnitCard.ts
+++ b/server/game/core/card/NonLeaderUnitCard.ts
@@ -24,7 +24,7 @@ export class NonLeaderUnitCard extends NonLeaderUnitCardParent implements INonLe
     }
 
     public override isNonLeaderUnit(): this is INonLeaderUnitCard {
-        return !this.isLeaderAttachedToThis();
+        return !this.isAttached() && !this.isLeaderAttachedToThis();
     }
 
     public override canChangeController(): this is ICardCanChangeControllers {

--- a/server/game/core/gameSteps/AbilityResolver.js
+++ b/server/game/core/gameSteps/AbilityResolver.js
@@ -330,7 +330,7 @@ class AbilityResolver extends BaseStepWithPipeline {
         try {
             return this.pipeline.continue(this.game);
         } catch (err) {
-            this.game.reportError(err);
+            this.game.reportError(err, true);
 
             // if we hit an error resolving an ability, try to close out the ability gracefully and move on
             // to see if we can preserve a playable game state

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -163,14 +163,14 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
         return this.canAffect(event.card, event.context, additionalProperties, GameStateChangeRequired.MustFullyResolve);
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         // if a unit is pending defeat (damage >= hp but defeat not yet resolved), always return canAffect() = false unless
         // we're the system that is enacting the defeat
         if (card.isUnit() && card.isInPlay() && card.pendingDefeat) {
             return false;
         }
 
-        return super.canAffect(card, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 
     protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties: any = {}): void {
@@ -321,6 +321,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
     }
 
     protected addLastKnownInformationToEvent(event: any, card: Card): void {
+        Contract.assertTrue((card as any).damage === 0);
         // build last known information for the card before event window resolves to ensure that no state has yet changed
         event.setPreResolutionEffect((event) => {
             event.lastKnownInformation = this.buildLastKnownInformation(card);

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -321,7 +321,6 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
     }
 
     protected addLastKnownInformationToEvent(event: any, card: Card): void {
-        Contract.assertTrue((card as any).damage === 0);
         // build last known information for the card before event window resolves to ensure that no state has yet changed
         event.setPreResolutionEffect((event) => {
             event.lastKnownInformation = this.buildLastKnownInformation(card);

--- a/server/game/core/gameSystem/GameSystem.ts
+++ b/server/game/core/gameSystem/GameSystem.ts
@@ -101,6 +101,10 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
     // IMPORTANT: this method is referred to in the debugging guide. if we change the signature, we should upgrade the guide.
     public abstract eventHandler(event: GameEvent, additionalProperties: any): void;
 
+    protected canAffectInternal(target: GameObject | GameObject[], context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        return this.isTargetTypeValid(target);
+    }
+
     /**
      * Composes a property object for configuring the {@link GameSystem}'s execution using the following sources, in order of decreasing priority:
      * - `this.properties ?? this.propertyFactory(context)`
@@ -148,7 +152,13 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
      */
     // IMPORTANT: this method is referred to in the debugging guide. if we change the signature, we should upgrade the guide.
     public canAffect(target: GameObject | GameObject[], context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
-        return this.isTargetTypeValid(target);
+        try {
+            return this.canAffectInternal(target, context, additionalProperties, mustChangeGameState);
+        } catch (err) {
+            // if there's an error in the canAffect method, we want to report it but not throw an exception so as to try and preserve the game state
+            context.game?.reportError(err, false);
+            return false;
+        }
     }
 
     /**

--- a/server/game/core/gameSystem/PlayerTargetSystem.ts
+++ b/server/game/core/gameSystem/PlayerTargetSystem.ts
@@ -30,8 +30,8 @@ export abstract class PlayerTargetSystem<TContext extends AbilityContext = Abili
     }
 
     // override to force the argument type to be Player
-    public override canAffect(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
-        return super.canAffect(target, context, additionalProperties, mustChangeGameState);
+    public override canAffectInternal(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
+        return super.canAffectInternal(target, context, additionalProperties, mustChangeGameState);
     }
 
     // override to force the argument type to be Player

--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -1,5 +1,4 @@
 
-import assert from 'assert';
 
 export enum AssertMode {
     Assert,
@@ -20,7 +19,7 @@ class AssertContractCheckImpl implements IContractCheckImpl {
         }
 
         if (process.env.ENVIRONMENT === 'development') {
-            assert.fail(`Contract assertion failure: ${message}`);
+            throw new Error(`Contract assertion failure: ${message}`);
         } else {
             throw new Error(`Contract assertion failure: ${message}`);
         }

--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -1,4 +1,5 @@
 
+import assert from 'assert';
 
 export enum AssertMode {
     Assert,
@@ -19,7 +20,7 @@ class AssertContractCheckImpl implements IContractCheckImpl {
         }
 
         if (process.env.ENVIRONMENT === 'development') {
-            throw new Error(`Contract assertion failure: ${message}`);
+            assert.fail(`Contract assertion failure: ${message}`);
         } else {
             throw new Error(`Contract assertion failure: ${message}`);
         }

--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -40,7 +40,7 @@ export class AttachUpgradeSystem<TContext extends AbilityContext = AbilityContex
         return ['attach {1} to {0}', [properties.target, properties.upgrade]];
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const contextCopy = context.copy({ source: card });
 
@@ -64,7 +64,7 @@ export class AttachUpgradeSystem<TContext extends AbilityContext = AbilityContex
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     public override checkEventCondition(event, additionalProperties): boolean {

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -92,7 +92,7 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
     }
 
     /** This method is checking whether cards are a valid target for an attack. */
-    public override canAffect(targetCard: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(targetCard: Card, context: TContext, additionalProperties = {}): boolean {
         if (!targetCard.isUnit() && !targetCard.isBase()) {
             return false;
         }
@@ -104,7 +104,7 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         if (!properties.attacker.isInPlay()) {
             return false;
         }
-        if (!super.canAffect(targetCard, context)) {
+        if (!super.canAffectInternal(targetCard, context)) {
             return false;
         }
         if (targetCard === properties.attacker || targetCard.controller === properties.attacker.controller) {

--- a/server/game/gameSystems/CaptureSystem.ts
+++ b/server/game/gameSystems/CaptureSystem.ts
@@ -23,7 +23,7 @@ export class CaptureSystem<TContext extends AbilityContext = AbilityContext, TPr
         this.leavesPlayEventHandler(event.card, ZoneName.Capture, event.context, () => event.card.moveToCaptureZone(event.captor.captureZone));
     }
 
-    public override canAffect(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         if (!card.isUnit() || !card.isInPlay()) {
             return false;
         }
@@ -33,7 +33,7 @@ export class CaptureSystem<TContext extends AbilityContext = AbilityContext, TPr
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     public override generatePropertiesFromContext(context: TContext, additionalProperties?: any) {

--- a/server/game/gameSystems/CardAttackLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardAttackLastingEffectSystem.ts
@@ -35,11 +35,11 @@ export class CardAttackLastingEffectSystem<TContext extends AbilityContext = Abi
         return super.updateEvent(event, target, context, additionalProperties);
     }
 
-    public override canAffect(card: Card, context: TContext) {
+    public override canAffectInternal(card: Card, context: TContext) {
         if (!card.isUnit()) {
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 }

--- a/server/game/gameSystems/CardLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardLastingEffectSystem.ts
@@ -92,12 +92,12 @@ export class CardLastingEffectSystem<TContext extends AbilityContext = AbilityCo
         event.effectProperties = effectProperties;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         const { effectFactories, effectProperties } = this.getEffectFactoriesAndProperties(card, context, additionalProperties);
 
         const effects = effectFactories.map((factory) => factory(context.game, context.source, effectProperties));
 
-        return super.canAffect(card, context) && this.filterApplicableEffects(card, effects).length > 0;
+        return super.canAffectInternal(card, context) && this.filterApplicableEffects(card, effects).length > 0;
     }
 
     private getEffectFactoriesAndProperties(card: Card, context: TContext, additionalProperties = {}) {

--- a/server/game/gameSystems/CollectBountySystem.ts
+++ b/server/game/gameSystems/CollectBountySystem.ts
@@ -29,7 +29,7 @@ export class CollectBountySystem<TContext extends AbilityContext = AbilityContex
     }
 
     // since the actual effect of the bounty is resolved in a sub-window, we don't check its effects here
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         return card === context.source;
     }
 

--- a/server/game/gameSystems/ConditionalSystem.ts
+++ b/server/game/gameSystems/ConditionalSystem.ts
@@ -32,7 +32,7 @@ export class ConditionalSystem<TContext extends AbilityContext = AbilityContext>
         return this.getGameAction(context).getEffectMessage(context);
     }
 
-    public override canAffect(target: any, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(target: any, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         return this.getGameAction(context, additionalProperties).canAffect(target, context, additionalProperties, mustChangeGameState);
     }
 

--- a/server/game/gameSystems/DamageSystem.ts
+++ b/server/game/gameSystems/DamageSystem.ts
@@ -111,7 +111,7 @@ export class DamageSystem<TContext extends AbilityContext = AbilityContext, TPro
         return event.sourceEventForExcessDamage.availableExcessDamage;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context);
         if (
             properties.type === DamageType.Overwhelm && 'contingentSourceEvent' in properties &&
@@ -152,7 +152,7 @@ export class DamageSystem<TContext extends AbilityContext = AbilityContext, TPro
             }
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties) {

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -70,7 +70,7 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
         return ['defeat {0}', [properties.target]];
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         if (card.zoneName !== ZoneName.Resource && (!card.canBeInPlay() || !card.isInPlay())) {
             return false;
         }
@@ -78,7 +78,7 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
         if ((properties.isCost || mustChangeGameState !== GameStateChangeRequired.None) && card.hasRestriction(AbilityRestriction.BeDefeated, context)) {
             return false;
         }
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected override addPropertiesToEvent(event: any, card: Card, context: TContext, additionalProperties?: any): void {

--- a/server/game/gameSystems/DelayedEffectSystem.ts
+++ b/server/game/gameSystems/DelayedEffectSystem.ts
@@ -1,7 +1,7 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import { PerGameAbilityLimit, type IAbilityLimit } from '../core/ability/AbilityLimit';
 import type { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
-import { Duration, EventName } from '../core/Constants';
+import { Duration, EventName, GameStateChangeRequired } from '../core/Constants';
 import type { GameEvent } from '../core/event/GameEvent';
 import type { IGameSystemProperties } from '../core/gameSystem/GameSystem';
 import { GameSystem } from '../core/gameSystem/GameSystem';
@@ -137,5 +137,9 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
             default:
                 Contract.fail(`Unknown delayed effect type: ${delayedEffectType}`);
         }
+    }
+
+    protected override canAffectInternal(target: GameObject, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        return this.isTargetTypeValid(target);
     }
 }

--- a/server/game/gameSystems/DeployAndAttachPilotLeaderSystem.ts
+++ b/server/game/gameSystems/DeployAndAttachPilotLeaderSystem.ts
@@ -35,14 +35,14 @@ export class DeployAndAttachPilotLeaderSystem<TContext extends AbilityContext = 
         return ['deploy {0} and attach it to {1}', [properties.leaderPilotCard, properties.target]];
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         const properties = this.generatePropertiesFromContext(context);
 
         if (!card.isUnit() || !card.canAttachPilot(properties.leaderPilotCard, PlayType.Piloting)) {
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected override addPropertiesToEvent(event: any, card: Card, context: TContext, additionalProperties?: any): void {

--- a/server/game/gameSystems/DeployLeaderSystem.ts
+++ b/server/game/gameSystems/DeployLeaderSystem.ts
@@ -27,11 +27,11 @@ export class DeployLeaderSystem<TContext extends AbilityContext = AbilityContext
         return ['deploy {0}', [properties.target]];
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         if (!card.isLeader() || card.isDeployableLeader() && card.deployed) {
             return false;
         }
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected override updateEvent(event, card: Card, context: TContext, additionalProperties: any = {}) {

--- a/server/game/gameSystems/DetachPilotSystem.ts
+++ b/server/game/gameSystems/DetachPilotSystem.ts
@@ -48,11 +48,11 @@ export class DetachPilotSystem<TContext extends AbilityContext = AbilityContext>
         ]);
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         if (!EnumHelpers.isUnitUpgrade(card.type)) {
             return false;
         }
 
-        return super.canAffect(card, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 }

--- a/server/game/gameSystems/DiscardCardsFromHandSystem.ts
+++ b/server/game/gameSystems/DiscardCardsFromHandSystem.ts
@@ -48,7 +48,7 @@ export class DiscardCardsFromHandSystem<TContext extends AbilityContext = Abilit
         return ['make {0} {1}discard {2} cards from {3}', [context.player, properties.random ? 'randomly ' : '', properties.amount, properties.target]];
     }
 
-    public override canAffect(playerOrPlayers: Player | Player[], context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(playerOrPlayers: Player | Player[], context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         for (const player of Helpers.asArray(playerOrPlayers)) {
             const properties = this.generatePropertiesFromContext(context, additionalProperties);
             const availableHand = player.hand.filter((card) => properties.cardCondition(card, context) && EnumHelpers.cardTypeMatches(card.type, properties.cardTypeFilter));
@@ -61,7 +61,7 @@ export class DiscardCardsFromHandSystem<TContext extends AbilityContext = Abilit
                 return false;
             }
 
-            if (!super.canAffect(player, context, additionalProperties)) {
+            if (!super.canAffectInternal(player, context, additionalProperties)) {
                 return false;
             }
         }

--- a/server/game/gameSystems/DiscardFromDeckSystem.ts
+++ b/server/game/gameSystems/DiscardFromDeckSystem.ts
@@ -23,7 +23,7 @@ export class DiscardFromDeckSystem<TContext extends AbilityContext = AbilityCont
         return ['discard ' + (properties.amount + (properties.amount > 1 ? ' cards' : ' card') + ' from deck'), []];
     }
 
-    public override canAffect(player: Player, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(player: Player, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         const players = Array.isArray(player) ? player : [player];
@@ -44,7 +44,7 @@ export class DiscardFromDeckSystem<TContext extends AbilityContext = AbilityCont
                 return false;
             }
 
-            if (!super.canAffect(currentPlayer, context, additionalProperties)) {
+            if (!super.canAffectInternal(currentPlayer, context, additionalProperties)) {
                 return false;
             }
         }

--- a/server/game/gameSystems/DiscardSpecificCardSystem.ts
+++ b/server/game/gameSystems/DiscardSpecificCardSystem.ts
@@ -16,8 +16,8 @@ export class DiscardSpecificCardSystem<TContext extends AbilityContext = Ability
         event.context.game.addMessage(`${event.card.owner.name} discards ${event.card.name}`);
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: Record<string, any> = {}): boolean {
-        return card.zoneName !== ZoneName.Discard && super.canAffect(card, context, additionalProperties);
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: Record<string, any> = {}): boolean {
+        return card.zoneName !== ZoneName.Discard && super.canAffectInternal(card, context, additionalProperties);
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/server/game/gameSystems/DistributeAmongTargetsSystem.ts
+++ b/server/game/gameSystems/DistributeAmongTargetsSystem.ts
@@ -117,7 +117,7 @@ export abstract class DistributeAmongTargetsSystem<
         return properties;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const player =
             (properties.player === RelativePlayer.Opponent && context.player.opponent) ||

--- a/server/game/gameSystems/DrawSpecificCardSystem.ts
+++ b/server/game/gameSystems/DrawSpecificCardSystem.ts
@@ -56,7 +56,7 @@ export class DrawSpecificCardSystem<TContext extends AbilityContext = AbilityCon
         ];
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         const { changePlayer } = this.generatePropertiesFromContext(context, additionalProperties) as IDrawSpecificCardProperties;
         return (
             (!changePlayer ||
@@ -64,7 +64,7 @@ export class DrawSpecificCardSystem<TContext extends AbilityContext = AbilityCon
                 !card.anotherUniqueInPlay(context.player))) &&
                 (context.player.isLegalZoneForCardType(card.type, ZoneName.Hand)) &&
                 !EnumHelpers.isArena(card.zoneName) &&
-                super.canAffect(card, context)
+                super.canAffectInternal(card, context)
         );
     }
 

--- a/server/game/gameSystems/DrawSystem.ts
+++ b/server/game/gameSystems/DrawSystem.ts
@@ -26,9 +26,9 @@ export class DrawSystem<TContext extends AbilityContext = AbilityContext> extend
         return ['draw ' + properties.amount + (properties.amount > 1 ? ' cards' : ' card'), []];
     }
 
-    public override canAffect(player: Player, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(player: Player, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        return properties.amount !== 0 && super.canAffect(player, context);
+        return properties.amount !== 0 && super.canAffectInternal(player, context);
     }
 
     public override defaultTargets(context: TContext): Player[] {

--- a/server/game/gameSystems/ExecuteHandlerSystem.ts
+++ b/server/game/gameSystems/ExecuteHandlerSystem.ts
@@ -31,7 +31,7 @@ export class ExecuteHandlerSystem<TContext extends AbilityContext = AbilityConte
         return true;
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         return true;
     }
 

--- a/server/game/gameSystems/ExhaustOrReadySystem.ts
+++ b/server/game/gameSystems/ExhaustOrReadySystem.ts
@@ -11,7 +11,7 @@ export abstract class ExhaustOrReadySystem<TContext extends AbilityContext = Abi
     // TODO - do I add a WildcardCardType.Leader?
     protected override readonly targetTypeFilter = [WildcardCardType.Unit, CardType.Event, WildcardCardType.Upgrade, CardType.Leader];
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         if (
             !EnumHelpers.isArena(card.zoneName) &&
             card.zoneName !== ZoneName.Resource &&
@@ -28,6 +28,6 @@ export abstract class ExhaustOrReadySystem<TContext extends AbilityContext = Abi
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 }

--- a/server/game/gameSystems/ExhaustResourcesSystem.ts
+++ b/server/game/gameSystems/ExhaustResourcesSystem.ts
@@ -36,11 +36,11 @@ export class ExhaustResourcesSystem<TContext extends AbilityContext = AbilityCon
         return ['spending {1} resources', [properties.amount]];
     }
 
-    public override canAffect(player: Player, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(player: Player, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.amount > 0 &&
           player.readyResourceCount > 0 &&
-          super.canAffect(player, context, additionalProperties, mustChangeGameState) &&
+          super.canAffectInternal(player, context, additionalProperties, mustChangeGameState) &&
             player.readyResourceCount >= properties.amount;
     }
 

--- a/server/game/gameSystems/ExhaustSystem.ts
+++ b/server/game/gameSystems/ExhaustSystem.ts
@@ -18,14 +18,14 @@ export class ExhaustSystem<TContext extends AbilityContext = AbilityContext> ext
         event.card.exhaust();
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
-        if (!super.canAffect(card, context, additionalProperties, mustChangeGameState)) {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        if (!super.canAffectInternal(card, context, additionalProperties, mustChangeGameState)) {
             return false;
         }
 
         const { isCost } = this.generatePropertiesFromContext(context);
 
-        // can safely cast here b/c the type was checked in super.canAffect
+        // can safely cast here b/c the type was checked in super.canAffectInternal
         if ((isCost || mustChangeGameState !== GameStateChangeRequired.None) && (card as ICardWithExhaustProperty).exhausted) {
             return false;
         }

--- a/server/game/gameSystems/FlipAndAttachPilotLeaderSystem.ts
+++ b/server/game/gameSystems/FlipAndAttachPilotLeaderSystem.ts
@@ -34,7 +34,7 @@ export class FlipAndAttachPilotLeaderSystem<TContext extends AbilityContext = Ab
         return ['flip {0} and attach it to {1}', [properties.leaderPilotCard, properties.target]];
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         const properties = this.generatePropertiesFromContext(context);
 
         if (!card.isUnit()) {
@@ -45,7 +45,7 @@ export class FlipAndAttachPilotLeaderSystem<TContext extends AbilityContext = Ab
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected override addPropertiesToEvent(event: any, card: Card, context: TContext, additionalProperties?: any): void {

--- a/server/game/gameSystems/FlipDoubleSidedLeaderSystem.ts
+++ b/server/game/gameSystems/FlipDoubleSidedLeaderSystem.ts
@@ -25,10 +25,10 @@ export class FlipDoubleSidedLeaderSystem<TContext extends AbilityContext = Abili
         return ['deploy {0}', [properties.target]];
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         if (!card.isDoubleSidedLeader()) {
             return false;
         }
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 }

--- a/server/game/gameSystems/FrameworkDefeatCardSystem.ts
+++ b/server/game/gameSystems/FrameworkDefeatCardSystem.ts
@@ -40,7 +40,7 @@ export class FrameworkDefeatCardSystem<TContext extends AbilityContext = Ability
     }
 
     // fully override the base canAffect method since nothing can interrupt defeat due to framework effect
-    public override canAffect(card: Card): boolean {
+    public override canAffectInternal(card: Card): boolean {
         return card.canBeInPlay() && card.isInPlay();
     }
 

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -32,7 +32,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         return ['attach {0} {1}s to {2}', [properties.amount, this.getTokenType(), properties.target]];
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context);
 
         Contract.assertNotNullLike(context);
@@ -47,7 +47,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected abstract getTokenType(): TokenUpgradeName;

--- a/server/game/gameSystems/HealSystem.ts
+++ b/server/game/gameSystems/HealSystem.ts
@@ -24,7 +24,7 @@ export class HealSystem<TContext extends AbilityContext = AbilityContext> extend
         return ['heal {1} damage from {0}', [amount, target]];
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context);
         if (!card.canBeDamaged()) {
             return false;
@@ -35,7 +35,7 @@ export class HealSystem<TContext extends AbilityContext = AbilityContext> extend
         if ((properties.isCost || mustChangeGameState !== GameStateChangeRequired.None) && (properties.amount === 0 || card.damage === 0 || card.hasRestriction(AbilityRestriction.BeHealed, context))) {
             return false;
         }
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties): void {

--- a/server/game/gameSystems/IndirectDamageToPlayerSystem.ts
+++ b/server/game/gameSystems/IndirectDamageToPlayerSystem.ts
@@ -53,14 +53,14 @@ export class IndirectDamageToPlayerSystem<TContext extends AbilityContext = Abil
         return ['deal {0} indirect damage to {1}', [indirectDamageAmount, properties.target]];
     }
 
-    public override canAffect(player: Player, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(player: Player, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         if (properties.amount <= 0) {
             return false;
         }
 
-        return super.canAffect(player, context);
+        return super.canAffectInternal(player, context);
     }
 
     public override defaultTargets(context: TContext): Player[] {

--- a/server/game/gameSystems/InitiateAttackSystem.ts
+++ b/server/game/gameSystems/InitiateAttackSystem.ts
@@ -54,11 +54,11 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
         event.optional = properties.optional ?? context.ability.optional;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         if (
             !card.isUnit() ||
-            !super.canAffect(card, context) ||
+            !super.canAffectInternal(card, context) ||
             !properties.attackerCondition(card, context)
         ) {
             return false;

--- a/server/game/gameSystems/LookMoveDeckCardsTopOrBottomSystem.ts
+++ b/server/game/gameSystems/LookMoveDeckCardsTopOrBottomSystem.ts
@@ -58,7 +58,7 @@ export class LookMoveDeckCardsTopOrBottomSystem<TContext extends AbilityContext 
         return [context.player];
     }
 
-    public override canAffect(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
+    public override canAffectInternal(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
         let nonAraTarget: Player;
 
         if (Array.isArray(target)) {
@@ -77,7 +77,7 @@ export class LookMoveDeckCardsTopOrBottomSystem<TContext extends AbilityContext 
             return false;
         }
 
-        return super.canAffect(target, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(target, context, additionalProperties, mustChangeGameState);
     }
 
     // Helper method for pushing the move card event into the events array.

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -108,7 +108,7 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
         event.shuffle = properties.shuffle;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties) as IMoveCardProperties;
         const { destination } = properties;
 
@@ -142,7 +142,7 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
         }
 
         // Call the super implementation
-        return super.canAffect(card, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 
     protected override processTargets(target: Card | Card[], context: TContext) {

--- a/server/game/gameSystems/MoveUnitBetweenArenasSystem.ts
+++ b/server/game/gameSystems/MoveUnitBetweenArenasSystem.ts
@@ -74,7 +74,7 @@ export class MoveUnitBetweenArenasSystem<TContext extends AbilityContext = Abili
         event.destination = this.getDestination(properties);
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const { moveType } = this.generatePropertiesFromContext(context, additionalProperties);
 
         if (
@@ -84,7 +84,7 @@ export class MoveUnitBetweenArenasSystem<TContext extends AbilityContext = Abili
             return false;
         }
 
-        return super.canAffect(card, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 
     private getDestination(properties: IMoveUnitBetweenArenasProperties): ZoneName {

--- a/server/game/gameSystems/NoActionSystem.ts
+++ b/server/game/gameSystems/NoActionSystem.ts
@@ -26,7 +26,7 @@ export class NoActionSystem<TContext extends AbilityContext = AbilityContext> ex
         return allowTargetSelection;
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         const { hasLegalTarget: allowTargetSelection } = this.generatePropertiesFromContext(context);
         return allowTargetSelection;
     }

--- a/server/game/gameSystems/PayCardPrintedCostSystem.ts
+++ b/server/game/gameSystems/PayCardPrintedCostSystem.ts
@@ -19,7 +19,7 @@ export class PayCardPrintedCostSystem<TContext extends AbilityContext = AbilityC
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public override eventHandler(): void {}
 
-    public override canAffect(card: Card, context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         if (!card.hasCost()) {
@@ -30,7 +30,7 @@ export class PayCardPrintedCostSystem<TContext extends AbilityContext = AbilityC
             amount: card.cost
         }).canAffect(properties.player, context, {}, mustChangeGameState);
 
-        return canPayCost && super.canAffect(card, context, additionalProperties, mustChangeGameState);
+        return canPayCost && super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties?: any): void {

--- a/server/game/gameSystems/PlayCardSystem.ts
+++ b/server/game/gameSystems/PlayCardSystem.ts
@@ -79,12 +79,12 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
         event.optional = properties.optional ?? context.ability.optional;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {
         if (!card.isPlayable()) {
             return false;
         }
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        if (!super.canAffect(card, context)) {
+        if (!super.canAffectInternal(card, context)) {
             return false;
         }
 

--- a/server/game/gameSystems/PlayerLastingEffectSystem.ts
+++ b/server/game/gameSystems/PlayerLastingEffectSystem.ts
@@ -1,6 +1,6 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { RelativePlayer } from '../core/Constants';
-import { EventName } from '../core/Constants';
+import { EventName, GameStateChangeRequired } from '../core/Constants';
 import type { GameEvent } from '../core/event/GameEvent';
 import type { GameObject } from '../core/GameObject';
 import { GameSystem } from '../core/gameSystem/GameSystem';
@@ -53,5 +53,9 @@ export class PlayerLastingEffectSystem<TContext extends AbilityContext = Ability
     // TODO: refactor GameSystem so this class doesn't need to override this method (it isn't called since we override hasLegalTarget)
     protected override isTargetTypeValid(target: GameObject): boolean {
         return false;
+    }
+
+    protected override canAffectInternal(target: GameObject, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        return this.isTargetTypeValid(target);
     }
 }

--- a/server/game/gameSystems/PutIntoPlaySystem.ts
+++ b/server/game/gameSystems/PutIntoPlaySystem.ts
@@ -49,10 +49,10 @@ export class PutIntoPlaySystem<TContext extends AbilityContext = AbilityContext>
         return ['put {0} into play', [target]];
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         const contextCopy = context.copy({ source: card });
         const player = this.getPutIntoPlayPlayer(contextCopy, card);
-        if (!super.canAffect(card, context)) {
+        if (!super.canAffectInternal(card, context)) {
             return false;
         } else if (!card.canBeInPlay() || card.isInPlay()) {
             return false;

--- a/server/game/gameSystems/ReadyResourcesSystem.ts
+++ b/server/game/gameSystems/ReadyResourcesSystem.ts
@@ -22,7 +22,7 @@ export class ReadyResourcesSystem<TContext extends AbilityContext = AbilityConte
         return amount === 1 ? ['ready a resource', []] : ['ready {0} resources', [amount]];
     }
 
-    public override canAffect(player: Player, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(player: Player, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const { isCost, amount } = this.generatePropertiesFromContext(context);
 
         // if this is a cost or an "if you do" condition, must ready all required resources
@@ -35,7 +35,7 @@ export class ReadyResourcesSystem<TContext extends AbilityContext = AbilityConte
             return false;
         }
 
-        return super.canAffect(player, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(player, context, additionalProperties, mustChangeGameState);
     }
 
     public override defaultTargets(context: TContext): Player[] {

--- a/server/game/gameSystems/ReadySystem.ts
+++ b/server/game/gameSystems/ReadySystem.ts
@@ -22,14 +22,14 @@ export class ReadySystem<TContext extends AbilityContext = AbilityContext> exten
         event.card.ready();
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
-        if (!super.canAffect(card, context)) {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        if (!super.canAffectInternal(card, context)) {
             return false;
         }
 
         const { isCost } = this.generatePropertiesFromContext(context);
 
-        // can safely cast here b/c the type was checked in super.canAffect
+        // can safely cast here b/c the type was checked in super.canAffectInternal
         if ((isCost || mustChangeGameState !== GameStateChangeRequired.None) && !(card as ICardWithExhaustProperty).exhausted) {
             return false;
         }

--- a/server/game/gameSystems/ReplacementEffectSystem.ts
+++ b/server/game/gameSystems/ReplacementEffectSystem.ts
@@ -121,4 +121,8 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
     protected override isTargetTypeValid(target: GameObject): boolean {
         return false;
     }
+
+    protected override canAffectInternal(target: GameObject, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        return this.isTargetTypeValid(target);
+    }
 }

--- a/server/game/gameSystems/RescueSystem.ts
+++ b/server/game/gameSystems/RescueSystem.ts
@@ -19,12 +19,12 @@ export class RescueSystem<TContext extends AbilityContext = AbilityContext, TPro
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public eventHandler(event): void {}
 
-    public override canAffect(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         if (!card.isUnit() || !card.isCaptured()) {
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/server/game/gameSystems/ResourceCardSystem.ts
+++ b/server/game/gameSystems/ResourceCardSystem.ts
@@ -75,7 +75,7 @@ export class ResourceCardSystem<TContext extends AbilityContext = AbilityContext
         event.resourceControllingPlayer = this.getResourceControllingPlayer(properties, context);
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const { targetPlayer } = this.generatePropertiesFromContext(context, additionalProperties) as IResourceCardProperties;
 
         const resourceControllingPlayer = this.getResourceControllingPlayer({ targetPlayer }, context);
@@ -96,7 +96,7 @@ export class ResourceCardSystem<TContext extends AbilityContext = AbilityContext
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     private getResourceControllingPlayer(properties: IResourceCardProperties, context: TContext) {

--- a/server/game/gameSystems/RevealSystem.ts
+++ b/server/game/gameSystems/RevealSystem.ts
@@ -31,9 +31,9 @@ export class RevealSystem<TContext extends AbilityContext = AbilityContext> exte
         return true;
     }
 
-    public override canAffect(card: Card, context: TContext): boolean {
+    public override canAffectInternal(card: Card, context: TContext): boolean {
         if (card.zoneName === ZoneName.Deck || card.zoneName === ZoneName.Hand || card.zoneName === ZoneName.Resource) {
-            return super.canAffect(card, context);
+            return super.canAffectInternal(card, context);
         }
         return false;
     }

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -74,7 +74,7 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
             return false;
         }
         const player = properties.player || context.player;
-        return this.getDeck(player).length > 0 && super.canAffect(player, context);
+        return this.getDeck(player).length > 0 && super.canAffectInternal(player, context);
     }
 
     public override generatePropertiesFromContext(context: TContext, additionalProperties = {}) {

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -97,7 +97,7 @@ export class SelectCardSystem<TContext extends AbilityContext = AbilityContext> 
         return properties;
     }
 
-    public override canAffect(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         const player =
             (properties.checkTarget && context.choosingPlayerOverride) ||

--- a/server/game/gameSystems/SelectPlayerSystem.ts
+++ b/server/game/gameSystems/SelectPlayerSystem.ts
@@ -35,7 +35,7 @@ export class SelectPlayerSystem<TContext extends AbilityContext = AbilityContext
         return properties;
     }
 
-    public override canAffect(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
+    public override canAffectInternal(target: Player | Player[], context: TContext, additionalProperties?: any, mustChangeGameState?: GameStateChangeRequired): boolean {
         const properties = super.generatePropertiesFromContext(context, additionalProperties);
         return properties.innerSystem.canAffect(target, context, additionalProperties, mustChangeGameState);
     }

--- a/server/game/gameSystems/SequentialSystem.ts
+++ b/server/game/gameSystems/SequentialSystem.ts
@@ -67,7 +67,7 @@ export class SequentialSystem<TContext extends AbilityContext = AbilityContext> 
         return gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context));
     }
 
-    public override canAffect(target: GameObject, context: TContext, additionalProperties = {}): boolean {
+    public override canAffectInternal(target: GameObject, context: TContext, additionalProperties = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.gameSystems.some((gameSystem) => gameSystem.canAffect(target, context));
     }

--- a/server/game/gameSystems/SimultaneousSystem.ts
+++ b/server/game/gameSystems/SimultaneousSystem.ts
@@ -50,7 +50,7 @@ export class SimultaneousGameSystem<TContext extends AbilityContext = AbilityCon
         return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
     }
 
-    public override canAffect(target: GameObject, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(target: GameObject, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         return properties.gameSystems.some((gameSystem) => gameSystem.canAffect(target, context, additionalProperties, mustChangeGameState));
     }

--- a/server/game/gameSystems/TakeControlOfResourceSystem.ts
+++ b/server/game/gameSystems/TakeControlOfResourceSystem.ts
@@ -33,14 +33,14 @@ export class TakeControlOfResourceSystem<TContext extends AbilityContext = Abili
         }
     }
 
-    public override canAffect(player: Player | Player[], context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(player: Player | Player[], context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const takingResourcePlayer = this.playerFromArray(player);
 
         if (mustChangeGameState !== GameStateChangeRequired.None && takingResourcePlayer.opponent.resources.length === 0) {
             return false;
         }
 
-        return super.canAffect(takingResourcePlayer, context);
+        return super.canAffectInternal(takingResourcePlayer, context);
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/server/game/gameSystems/TakeControlOfUnitSystem.ts
+++ b/server/game/gameSystems/TakeControlOfUnitSystem.ts
@@ -20,7 +20,7 @@ export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityCo
         event.card.takeControl(event.newController);
     }
 
-    public override canAffect(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, _additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         if (!card.canBeInPlay() || !card.isInPlay()) {
             return false;
         }
@@ -30,7 +30,7 @@ export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityCo
             return false;
         }
 
-        return super.canAffect(card, context);
+        return super.canAffectInternal(card, context);
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/server/game/gameSystems/UseWhenDefeatedSystem.ts
+++ b/server/game/gameSystems/UseWhenDefeatedSystem.ts
@@ -67,7 +67,7 @@ export class UseWhenDefeatedSystem<TContext extends AbilityContext = AbilityCont
     }
 
     // Since the actual When Defeated effect is resolved in a sub-window, we don't check its effects here
-    public override canAffect(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+    public override canAffectInternal(card: Card, context: TContext, additionalProperties: any = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
         const { resolvedAbilityEvent } = this.generatePropertiesFromContext(context);
 
         if (resolvedAbilityEvent === null) {
@@ -106,7 +106,7 @@ export class UseWhenDefeatedSystem<TContext extends AbilityContext = AbilityCont
             }
         }
 
-        return super.canAffect(card, context, additionalProperties, mustChangeGameState);
+        return super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 
     private getOnDefeatEvent(resolvedAbilityEvent: any) {

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -490,7 +490,7 @@ export class Lobby {
 
 
     // TODO: Review this to make sure we're getting the info we need for debugging
-    public handleError(game: Game, e: Error) {
+    public handleError(game: Game, e: Error, severeGameMessage = false) {
         logger.error(`Lobby ${this.id}: handleError: `, e);
 
         // const gameState = game.getState();
@@ -513,7 +513,7 @@ export class Lobby {
         //     }
         // }
 
-        if (game) {
+        if (game && severeGameMessage) {
             game.addMessage(
                 `A Server error has occured processing your game state, apologies.  Your game may now be in an inconsistent state, or you may be able to continue. The error has been logged. If this happens again, please take a screenshot and reach out in the Karabast discord (game id ${this.id})`,
             );

--- a/test/server/core/abilities/keyword/Piloting.spec.ts
+++ b/test/server/core/abilities/keyword/Piloting.spec.ts
@@ -329,5 +329,24 @@ describe('Piloting keyword', function() {
             expect(context.idenVersio).toBeInZone('groundArena');
             expect(context.player1.exhaustedResourceCount).toBe(3); // +2 for sneak attack and +1 for iden (3pt discount)
         });
+
+        it('An attached pilot should not be returned by abilities searching for non-leader units', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    base: 'tarkintown'
+                },
+                player2: {
+                    spaceArena: [{ card: 'ruthless-raider', damage: 1, upgrades: ['darth-vader#scourge-of-squadrons'] }]
+                }
+            });
+
+            const { context } = contextRef;
+
+            // no error should happen in this test
+            context.player1.clickCard(context.tarkintown);
+            context.player1.clickCard(context.ruthlessRaider);
+            expect(context.ruthlessRaider.damage).toBe(4);
+        });
     });
 });


### PR DESCRIPTION
We had a bug where attached non-leader pilots were reporting true for `isNonLeaderUnit()`, and with the recent fix their properties this meant that things were trying to read their `damage` property and getting an error.

With the recent change to error handling this causes a game state failure. Added wrappers around the common pathways for checking whether a card can be targeted by an effect so that if that check excepts they'll just silently report an error and return "false" for that target. In 99% of cases this should preserve game state correctly.