### PR TITLE
Logger switch for CloudWatch newlines

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,15 +1,11 @@
 import * as winston from 'winston';
 
+
+const isRunningInAWS = !!process.env.AWS_EXECUTION_ENV;
+
 const logFormatter = winston.format.printf(({ timestamp, level, message, stack }) => {
     const log = `${timestamp} [${level}]: ${message}`;
-
-    // Cloud watch cannot handle multi-line logs, so we need to replace newlines with a literal '\n'
-    if (process.env.AWS_EXECUTION_ENV) {
-        return stack ? `${log} ${stack.replace(/\n/g, '\\n')}` : log;
-    }
-
-    // Otherwise, keep multi-line formatting for local readability
-    return stack ? `${log}\n${stack}` : log;
+    return stack ? log + '\n' + stack : log;
 });
 
 export const logger = winston.createLogger({
@@ -17,6 +13,6 @@ export const logger = winston.createLogger({
     format: winston.format.combine(
         winston.format.timestamp(),
         winston.format.errors({ stack: true }),
-        logFormatter
+        isRunningInAWS ? winston.format.json() : logFormatter
     )
 });

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -2,7 +2,14 @@ import * as winston from 'winston';
 
 const logFormatter = winston.format.printf(({ timestamp, level, message, stack }) => {
     const log = `${timestamp} [${level}]: ${message}`;
-    return stack ? log + '\n' + stack : log;
+
+    // Cloud watch cannot handle multi-line logs, so we need to replace newlines with a literal '\n'
+    if (process.env.AWS_EXECUTION_ENV) {
+        return stack ? `${log} ${stack.replace(/\n/g, '\\n')}` : log;
+    }
+
+    // Otherwise, keep multi-line formatting for local readability
+    return stack ? `${log}\n${stack}` : log;
 });
 
 export const logger = winston.createLogger({


### PR DESCRIPTION
Added a switch to the logger to do literal newlines for CloudWatch when running under the AWS environment.  This will collapse a stack trace into a singular entries with explicit new line characters (hopefully rendering correctly when selected via LogInsight)