### PR TITLE
Fix prevention abilities on Chewbacca pilot and Luke pilot leader

### DIFF
--- a/server/game/IDamageOrDefeatSource.ts
+++ b/server/game/IDamageOrDefeatSource.ts
@@ -18,7 +18,8 @@ export enum DamageSourceType {
 export enum DefeatSourceType {
     Ability = 'ability',
     Attack = 'attack',
-    FrameworkEffect = 'frameworkEffect', // TODO: this is a workaround until we get the comp 3.0 rules
+    NonCombatDamage = 'nonCombatDamage',
+    FrameworkEffect = 'frameworkEffect',
     UniqueRule = 'uniqueRule'
 }
 
@@ -31,7 +32,7 @@ export interface IDamagedOrDefeatedByAttack extends IDamageOrDefeatSourceBase {
 }
 
 export interface IDamagedOrDefeatedByAbility extends IDamageOrDefeatSourceBase {
-    type: DamageSourceType.Ability | DefeatSourceType.Ability;
+    type: DamageSourceType.Ability | DefeatSourceType.Ability | DefeatSourceType.NonCombatDamage;
     card: Card;
     // TODO: We should eventually make this non-optional when we can update all the
     //       existing code and guarantee that it's always set.

--- a/server/game/cards/04_JTL/leaders/LukeSkywalkerHeroOfYavin.ts
+++ b/server/game/cards/04_JTL/leaders/LukeSkywalkerHeroOfYavin.ts
@@ -1,7 +1,8 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
-import { AbilityRestriction, AbilityType, Trait, WildcardCardType } from '../../../core/Constants';
+import { AbilityType, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
+import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 
 export default class LukeSkywalkerHeroOfYavin extends LeaderUnitCard {
@@ -39,18 +40,15 @@ export default class LukeSkywalkerHeroOfYavin extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities() {
         this.addPilotingAbility({
+            type: AbilityType.ReplacementEffect,
             title: 'This upgrade can\'t be defeated by enemy card abilities',
-            type: AbilityType.Constant,
-            ongoingEffect: [
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeDefeated,
-                    restrictedActionCondition: (context) => context.player !== this.controller && context.target === this,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.ReturnToHand,
-                    restrictedActionCondition: (context) => context.player !== this.controller && context.target === this,
-                })
-            ]
+            zoneFilter: WildcardZoneName.AnyArena,
+            when: {
+                onCardDefeated: (event, context) =>
+                    event.card === context.source &&
+                    event.defeatSource.type === DefeatSourceType.Ability &&
+                    event.defeatSource.player !== context.player
+            }
         });
 
         this.addPilotingGainAbilityTargetingAttached({

--- a/server/game/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.ts
+++ b/server/game/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../../../server/game/AbilityHelper';
 import { NonLeaderUnitCard } from '../../../../../server/game/core/card/NonLeaderUnitCard';
-import { AbilityRestriction, AbilityType } from '../../../../../server/game/core/Constants';
+import { AbilityRestriction, AbilityType, ZoneName } from '../../../../../server/game/core/Constants';
+import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 
 export default class ChewbaccaFaithfulFirstMate extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -11,18 +12,18 @@ export default class ChewbaccaFaithfulFirstMate extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities() {
-        this.addConstantAbility({
+        this.addReplacementEffectAbility({
             title: 'This unit can\'t be defeated or returned to hand by enemy card abilities',
-            ongoingEffect: [
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.ReturnToHand,
-                    restrictedActionCondition: (context) => context.player !== this.controller,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeDefeated,
-                    restrictedActionCondition: (context) => context.player !== this.controller,
-                })
-            ]
+            when: {
+                onCardDefeated: (event, context) =>
+                    event.card === context.source &&
+                    event.defeatSource.type === DefeatSourceType.Ability &&
+                    event.defeatSource.player !== context.player,
+                onCardMoved: (event, context) =>
+                    event.card === context.source &&
+                    event.destination === ZoneName.Hand &&
+                    event.context.player !== context.player
+            }
         });
 
         this.addPilotingGainAbilityTargetingAttached({

--- a/server/game/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.ts
+++ b/server/game/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.ts
@@ -1,6 +1,5 @@
-import AbilityHelper from '../../../../../server/game/AbilityHelper';
 import { NonLeaderUnitCard } from '../../../../../server/game/core/card/NonLeaderUnitCard';
-import { AbilityRestriction, AbilityType, ZoneName } from '../../../../../server/game/core/Constants';
+import { AbilityType, ZoneName } from '../../../../../server/game/core/Constants';
 import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 
 export default class ChewbaccaFaithfulFirstMate extends NonLeaderUnitCard {
@@ -27,18 +26,18 @@ export default class ChewbaccaFaithfulFirstMate extends NonLeaderUnitCard {
         });
 
         this.addPilotingGainAbilityTargetingAttached({
-            type: AbilityType.Constant,
-            title: 'This unit can\'t be captured or damaged by enemy card abilities',
-            ongoingEffect: [
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.ReturnToHand,
-                    restrictedActionCondition: (context) => context.player !== this.controller,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeDefeated,
-                    restrictedActionCondition: (context) => context.player !== this.controller,
-                })
-            ]
+            type: AbilityType.ReplacementEffect,
+            title: 'This unit can\'t be defeated or returned to hand by enemy card abilities',
+            when: {
+                onCardDefeated: (event, context) =>
+                    event.card === context.source &&
+                    event.defeatSource.type === DefeatSourceType.Ability &&
+                    event.defeatSource.player !== context.player,
+                onCardMoved: (event, context) =>
+                    event.card === context.source &&
+                    event.destination === ZoneName.Hand &&
+                    event.context.player !== context.player
+            }
         });
     }
 }

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -13,6 +13,7 @@ import type { IUnitCard } from '../card/propertyMixins/UnitProperties';
 import type { IPlayableOrDeployableCard } from '../card/baseClasses/PlayableOrDeployableCard';
 import type { ILastKnownInformation } from '../../gameSystems/DefeatCardSystem';
 import type { IUpgradeCard } from '../card/CardInterfaces';
+import { DefeatSourceType } from '../../IDamageOrDefeatSource';
 
 export interface ICardTargetSystemProperties extends IGameSystemProperties {
     target?: Card | Card[];
@@ -244,7 +245,7 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
             // if no override, the default behavior is to defeat the attachment
             if (!removeUpgradeEvent) {
                 removeUpgradeEvent = context.game.actions
-                    .defeat({ target: upgrade })
+                    .frameworkDefeat({ target: upgrade, defeatSource: DefeatSourceType.FrameworkEffect })
                     .generateEvent(context.game.getFrameworkContext());
             }
 

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -7,7 +7,7 @@ import { CardTargetSystem, type ICardTargetSystemProperties } from '../core/game
 import type Player from '../core/Player';
 import * as Contract from '../core/utils/Contract';
 import type { IDamageSource, IDefeatSource } from '../IDamageOrDefeatSource';
-import { DamageSourceType, DefeatSourceType } from '../IDamageOrDefeatSource';
+import { DefeatSourceType } from '../IDamageOrDefeatSource';
 
 export interface IDefeatCardPropertiesBase extends ICardTargetSystemProperties {
     defeatSource?: IDamageSource | DefeatSourceType.Ability | DefeatSourceType.UniqueRule | DefeatSourceType.FrameworkEffect;
@@ -95,13 +95,16 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
 
         event.isDefeatedByAttackerDamage = false;
         if (typeof defeatSource === 'object') {
-            eventDefeatSource = defeatSource;
+            eventDefeatSource = { ...defeatSource };
 
             event.isDefeatedByAttackerDamage =
-                eventDefeatSource.type === DamageSourceType.Attack &&
+                eventDefeatSource.type === DefeatSourceType.Attack &&
                 eventDefeatSource.damageDealtBy === eventDefeatSource.attack.attacker;
-            if (eventDefeatSource?.type === DamageSourceType.Attack) {
+
+            if (eventDefeatSource?.type === DefeatSourceType.Attack) {
                 eventDefeatSource.player = eventDefeatSource.damageDealtBy.controller;
+            } else {
+                eventDefeatSource.type = DefeatSourceType.NonCombatDamage;
             }
         } else {
             eventDefeatSource = this.buildDefeatSourceForType(defeatSource, event, context);
@@ -115,7 +118,7 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
 
         // TODO: confirm that this works when the player controlling the ability is different than the player controlling the card (e.g., bounty)
         return {
-            type: DamageSourceType.Ability,
+            type: DefeatSourceType.Ability,
             player: context.player,
             card: context.source,
             event

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -63,6 +63,8 @@ import type { IExhaustSystemProperties } from './ExhaustSystem';
 import { ExhaustSystem } from './ExhaustSystem';
 import type { IFlipDoubleSidedLeaderProperties } from './FlipDoubleSidedLeaderSystem';
 import { FlipDoubleSidedLeaderSystem } from './FlipDoubleSidedLeaderSystem';
+import type { IFrameworkDefeatCardProperties } from './FrameworkDefeatCardSystem';
+import { FrameworkDefeatCardSystem } from './FrameworkDefeatCardSystem';
 import type { IGiveExperienceProperties } from './GiveExperienceSystem';
 import { GiveExperienceSystem } from './GiveExperienceSystem';
 import type { IGiveShieldProperties } from './GiveShieldSystem';
@@ -254,6 +256,9 @@ export function forThisRoundCardEffect<TContext extends AbilityContext = Ability
 }
 export function forThisAttackCardEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ICardAttackLastingEffectProperties, TContext>) {
     return new CardAttackLastingEffectSystem<TContext>(propertyFactory);
+}
+export function frameworkDefeat<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IFrameworkDefeatCardProperties, TContext>) {
+    return new FrameworkDefeatCardSystem<TContext>(propertyFactory);
 }
 export function giveExperience<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IGiveExperienceProperties, TContext> = {}) {
     return new GiveExperienceSystem<TContext>(propertyFactory);

--- a/test/server/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.spec.ts
+++ b/test/server/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.spec.ts
@@ -131,6 +131,39 @@ describe('Chewbacca, Faithful First Mate', function() {
                 expect(context.player1).toBeActivePlayer();
             });
 
+            it('should allow the attached unit to be defeated by friendly card abilities when stolen', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chewbacca);
+                context.player1.clickPrompt('Play Chewbacca with Piloting');
+                context.player1.clickCard(context.homeOne);
+
+                context.player2.clickCard(context.noGloryOnlyResults);
+                context.player2.clickCard(context.homeOne);
+
+                expect(context.homeOne).toBeInZone('discard');
+                expect(context.chewbacca).toBeInZone('discard');
+            });
+
+            it('should allow the attached unit to be returned to its owner\'s hand by friendly card abilities when stolen', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chewbacca);
+                context.player1.clickPrompt('Play Chewbacca with Piloting');
+                context.player1.clickCard(context.homeOne);
+
+                context.player2.clickCard(context.changeOfHeart);
+                context.player2.clickCard(context.homeOne);
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.homeOne);
+
+                expect(context.homeOne).toBeInZone('hand', context.player1);
+                expect(context.chewbacca).toBeInZone('discard', context.player1);
+            });
+
             // TODO: Add test interaction with Force Lightning or Imprisioned
 
             // Unit tests for unit side of the card

--- a/test/server/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.spec.ts
+++ b/test/server/cards/04_JTL/units/ChewbaccaFaithfulFirstMate.spec.ts
@@ -11,7 +11,16 @@ describe('Chewbacca, Faithful First Mate', function() {
                     },
                     player2: {
                         spaceArena: ['avenger#hunting-star-destroyer'],
-                        hand: ['waylay', 'rivals-fall', 'confiscate', 'open-fire', 'bamboozle', 'emperor-palpatine#master-of-the-dark-side'],
+                        hand: [
+                            'waylay',
+                            'rivals-fall',
+                            'confiscate',
+                            'open-fire',
+                            'bamboozle',
+                            'emperor-palpatine#master-of-the-dark-side',
+                            'no-glory-only-results',
+                            'change-of-heart'
+                        ],
                     }
                 });
             });
@@ -194,6 +203,35 @@ describe('Chewbacca, Faithful First Mate', function() {
 
                 expect(context.chewbacca).toBeInZone('discard', context.player1);
                 expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should be defeated by friendly card abilities when stolen as a unit', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chewbacca);
+                context.player1.clickPrompt('Play Chewbacca');
+
+                context.player2.clickCard(context.noGloryOnlyResults);
+                context.player2.clickCard(context.chewbacca);
+
+                expect(context.chewbacca).toBeInZone('discard');
+            });
+
+            it('should be returned to owner\'s hand by friendly card abilities when stolen as a unit', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chewbacca);
+                context.player1.clickPrompt('Play Chewbacca');
+
+                context.player2.clickCard(context.changeOfHeart);
+                context.player2.clickCard(context.chewbacca);
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.chewbacca);
+
+                expect(context.chewbacca).toBeInZone('hand', context.player1);
             });
 
             // TODO: Add test interaction with Force Lightning or Imprisioned


### PR DESCRIPTION
Chewbacca pilot was incorrectly preventing defeat effects by the owner's opponent even when stolen. Luke was not preventing defeat effects again himself correctly. Solved both of these by moving them over to being replacement effects, which is what FFG says they are supposed to be with a recent clarification.