### PR TITLE
noGloryTests

### DIFF
--- a/test/server/cards/01_SOR/units/AdmiralMottiBrazenAndScornful.spec.ts
+++ b/test/server/cards/01_SOR/units/AdmiralMottiBrazenAndScornful.spec.ts
@@ -61,5 +61,27 @@ describe('Admiral Motti', function() {
                 expect(context.player2).toBeActivePlayer();
             });
         });
+
+        it('should work with No Glory, Only Results', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['admiral-motti#brazen-and-scornful']
+                },
+                player2: {
+                    hand: ['no-glory-only-results'],
+                    groundArena: [{ card: 'maul#shadow-collective-visionary', exhausted: true }],
+                    hasInitiative: true
+                }
+            });
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.noGloryOnlyResults);
+            context.player2.clickCard(context.admiralMotti);
+            context.player2.clickCard(context.maul);
+            expect(context.maul.exhausted).toBe(false);
+
+            context.player1.passAction();
+        });
     });
 });

--- a/test/server/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.spec.ts
+++ b/test/server/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.spec.ts
@@ -73,5 +73,30 @@ describe('Black One', function() {
                 expect(context.p1Base.damage).toBe(15);
             });
         });
+
+        it('should work with No Glory, Only Results', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['black-one#scourge-of-starkiller-base']
+                },
+                player2: {
+                    hand: ['no-glory-only-results'],
+                    deck: ['confiscate', 'waylay', 'isb-agent'],
+                    hasInitiative: true
+                }
+            });
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.noGloryOnlyResults);
+            context.player2.clickCard(context.blackOne);
+            context.player2.clickPrompt('Trigger');
+            expect(context.player2.handSize).toBe(3);
+            expect(context.confiscate).toBeInZone('hand', context.player2);
+            expect(context.waylay).toBeInZone('hand', context.player2);
+            expect(context.isbAgent).toBeInZone('hand', context.player2);
+
+            context.player1.passAction();
+        });
     });
 });

--- a/test/server/cards/01_SOR/units/GreedoSlowOnTheDraw.spec.ts
+++ b/test/server/cards/01_SOR/units/GreedoSlowOnTheDraw.spec.ts
@@ -87,6 +87,29 @@ describe('Greedo, Slow on the Draw', function () {
                 // deck is empty, nothing to discard, no prompt
                 expect(context.player2).toBeActivePlayer();
             });
+
+            it('should work with No Glory, Only Results', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['greedo#slow-on-the-draw', 'wampa']
+                    },
+                    player2: {
+                        hand: ['no-glory-only-results'],
+                        deck: ['protector'],
+                        hasInitiative: true
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.noGloryOnlyResults);
+                context.player2.clickCard(context.greedo);
+                context.player2.clickPrompt('Trigger');
+                context.player2.clickCard(context.wampa);
+                expect(context.wampa.damage).toBe(2);
+
+                context.player1.passAction();
+            });
         });
     });
 });

--- a/test/server/cards/01_SOR/units/K2SOCassiansCounterpart.spec.ts
+++ b/test/server/cards/01_SOR/units/K2SOCassiansCounterpart.spec.ts
@@ -50,5 +50,28 @@ describe('K-2SO, Cassian\'s Counterpart', function() {
                 expect(context.p2Base.damage).toBe(5);
             });
         });
+
+        it('should work with No Glory, Only Results', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['k2so#cassians-counterpart', 'wampa']
+                },
+                player2: {
+                    hand: ['no-glory-only-results'],
+                    groundArena: ['maul#shadow-collective-visionary'],
+                    hasInitiative: true
+                }
+            });
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.noGloryOnlyResults);
+            context.player2.clickCard(context.k2so);
+            expect(context.player2).toHaveExactPromptButtons(['Deal 3 damage to opponent\'s base', 'The opponent discards a card']);
+            context.player2.clickPrompt('Deal 3 damage to opponent\'s base');
+            expect(context.p1Base.damage).toBe(3);
+
+            context.player1.passAction();
+        });
     });
 });

--- a/test/server/cards/01_SOR/units/RuthlessRaider.spec.ts
+++ b/test/server/cards/01_SOR/units/RuthlessRaider.spec.ts
@@ -43,5 +43,30 @@ describe('Ruthless Raider', function() {
                 expect(context.greenSquadronAwing).toBeInZone('discard');
             });
         });
+
+        it('should work with No Glory, Only Results', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['wampa'],
+                    spaceArena: ['ruthless-raider']
+                },
+                player2: {
+                    hand: ['no-glory-only-results'],
+                    groundArena: ['maul#shadow-collective-visionary'],
+                    hasInitiative: true
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.noGloryOnlyResults);
+            context.player2.clickCard(context.ruthlessRaider);
+            expect(context.player2).toBeAbleToSelectExactly([context.wampa]);
+            context.player2.clickCard(context.wampa);
+            expect(context.ruthlessRaider).toBeInZone('discard', context.player1);
+
+            context.player1.passAction();
+        });
     });
 });

--- a/test/server/cards/01_SOR/units/StarWingScout.spec.ts
+++ b/test/server/cards/01_SOR/units/StarWingScout.spec.ts
@@ -65,6 +65,29 @@ describe('Star Wing Scout', function () {
                     expect(context.player1.handSize).toBe(0);
                 });
             });
+
+            it('should work with No Glory, Only Results', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: ['star-wing-scout']
+                    },
+                    player2: {
+                        hand: ['no-glory-only-results'],
+                        deck: ['battlefield-marine', 'vanguard-infantry'],
+                        hasInitiative: true
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.noGloryOnlyResults);
+                context.player2.clickCard(context.starWingScout);
+                expect(context.player2.handSize).toBe(2);
+                expect(context.battlefieldMarine).toBeInZone('hand', context.player2);
+                expect(context.vanguardInfantry).toBeInZone('hand', context.player2);
+
+                context.player1.passAction();
+            });
         });
     });
 });

--- a/test/server/cards/01_SOR/units/VanguardInfantry.spec.ts
+++ b/test/server/cards/01_SOR/units/VanguardInfantry.spec.ts
@@ -51,5 +51,28 @@ describe('Vanguard Infantry', function() {
                 expect(context.cartelSpacer).toHaveExactUpgradeNames([]);
             });
         });
+
+        it('should work with No Glory, Only Results', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['vanguard-infantry', 'wampa']
+                },
+                player2: {
+                    hand: ['no-glory-only-results'],
+                    groundArena: ['maul#shadow-collective-visionary'],
+                    hasInitiative: true
+                }
+            });
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.noGloryOnlyResults);
+            context.player2.clickCard(context.vanguardInfantry);
+            expect(context.player2).toBeAbleToSelectExactly([context.maul, context.wampa]);
+            context.player2.clickCard(context.maul);
+            expect(context.maul).toHaveExactUpgradeNames(['experience']);
+
+            context.player1.passAction();
+        });
     });
 });


### PR DESCRIPTION
No glory tests added to 7 cards
vanguard infantry - Give 1 experience token
Ruthless raider - 2 damage to base, 2 damage to unit
k2so - 3 damage to opponent base, or discard a card
black one - discard hand, if do draw 3 cards
star wing scout - have initiative draw 2 cards
greedo - mill deck, if non unit, deal 2 damage to ground unit
motti - ready a villiany unit
