### PR TITLE
Game and other state, and unit test improvements

### DIFF
--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -18,6 +18,12 @@ export enum DeckZoneDestination {
     DeckBottom = 'deckBottom'
 }
 
+export enum SnapshotType {
+    Player = 'player',
+    Phase = 'phase',
+    Round = 'round'
+}
+
 /**
  * Helper type used when a passed ZoneName represents a move destination.
  * Used to account for moving to top or bottom of deck.

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -41,6 +41,7 @@ const { WildcardCardType } = require('./Constants');
 const { validateGameConfiguration, validateGameOptions } = require('./GameInterfaces.js');
 const { GameStateManager } = require('./GameStateManager.js');
 const { ActionWindow } = require('./gameSteps/ActionWindow.js');
+const { GameObjectBase } = require('./GameObjectBase.js');
 
 class Game extends EventEmitter {
     #debug;

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -100,7 +100,7 @@ class Game extends EventEmitter {
     }
 
     set roundNumber(value) {
-        Contract.assertNonNegative(value, 'Round Number must be non-zero.');
+        Contract.assertNonNegative(value, 'Round Number must be non-zero: ' + value);
         this.state.roundNumber = value;
     }
 

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1395,6 +1395,7 @@ class Game extends EventEmitter {
         );
 
         const player = token.owner;
+        // Functionality did nothing previously, now that it's fixed, disabling until we're ready to activate again.
         // this.filterCardFromList(token, this.state.allCards);
         // this.filterCardFromList(token, player.decklist.tokens);
         // this.filterCardFromList(token, player.decklist.allCards);
@@ -1416,10 +1417,18 @@ class Game extends EventEmitter {
      * @param {import('./GameObjectBase.js').GameObjectRef[]} list
      */
     filterCardFromList(removeCard, list) {
-        const index = list.findIndex((x) => x.uuid === removeCard.uuid);
-        Contract.assertNonNegative(index, `Tried to remove card from list but ${removeCard?.title} was not found.`);
+        const indexes = [];
 
-        list.splice(index, 1);
+        for (let i = list.length - 1; i >= 0; i--) {
+            const ref = list[i];
+            if (ref.uuid === removeCard.uuid) {
+                indexes.push(i);
+            }
+        }
+
+        for (let index of indexes) {
+            list.splice(index, 1);
+        }
     }
 
     // formatDeckForSaving(deck) {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1535,6 +1535,9 @@ class Game extends EventEmitter {
             this.gameObjectManager.rollbackToSnapshot(snapshotId);
             actionPhase.resetPhase();
             actionPhase.queueNextAction();
+            // continue to the takeSnapshot step and then the ActionWindow step.
+            actionPhase.continue();
+            actionPhase.continue();
         } else {
             throw new Error('Cannout Undo outside of Action Phase');
         }

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1619,7 +1619,7 @@ class Game extends EventEmitter {
      * @param {() => void} fcn
      */
     debugPipeline(fcn) {
-        this.#debug.pipeline = Helpers.isDevelopment;
+        this.#debug.pipeline = Helpers.isDevelopment();
         try {
             fcn();
         } finally {
@@ -1632,7 +1632,7 @@ class Game extends EventEmitter {
      * @param {() => any} fcn
      */
     enableUndo(fcn) {
-        this.#experimental.undo = Helpers.isDevelopment;
+        this.#experimental.undo = Helpers.isDevelopment();
         try {
             return fcn();
         } finally {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1573,26 +1573,22 @@ class Game extends EventEmitter {
     }
 
     takeSnapshot() {
-        if (this.#experimental.undo && this.pipeline.currentStep instanceof ActionPhase) {
-            return this.gameObjectManager.takeSnapshot();
+        if (this.#experimental.undo && 'takeSnapshot' in this.pipeline.currentStep) {
+            return this.pipeline.currentStep.takeSnapshot();
         }
 
         return null;
     }
 
     /**
-     * @param {number} snapshotId
+     * @param {number | null} snapshotId
      */
     rollbackToSnapshot(snapshotId) {
-        if (this.#experimental.undo && this.pipeline.currentStep instanceof ActionPhase) {
-            const actionPhase = this.pipeline.currentStep;
-            this.gameObjectManager.rollbackToSnapshot(snapshotId);
-            actionPhase.resetPhase();
-            actionPhase.queueNextAction();
-            // continue the action phase again.
-            actionPhase.continue();
+        if (this.#experimental.undo && 'rollbackToSnapshot' in this.pipeline.currentStep) {
+            this.pipeline.currentStep.rollbackToSnapshot(snapshotId);
             return true;
         }
+
         return false;
     }
 

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -46,6 +46,50 @@ const { GameStateManager } = require('./GameStateManager.js');
 class Game extends EventEmitter {
     #debug;
 
+    get isInisInitiativeClaimed() {
+        return this.gameObjectManager.get(this.state.initialFirstPlayer);
+    }
+
+    set isInisInitiativeClaimed(value) {
+        this.state.initialFirstPlayer = value?.getRef();
+    }
+
+    get roundNumber() {
+        return this.state.roundNumber;
+    }
+
+    set roundNumber(value) {
+        Contract.assertNonNegative(value, 'Round Number must be non-zero.');
+        this.state.roundNumber = value;
+    }
+
+    /** @returns { Player | null } */
+    get initialFirstPlayer() {
+        return this.gameObjectManager.get(this.state.initialFirstPlayer);
+    }
+
+    set initialFirstPlayer(value) {
+        this.state.initialFirstPlayer = value?.getRef();
+    }
+
+    /** @returns { Player | null } */
+    get initiativePlayer() {
+        return this.gameObjectManager.get(this.state.initiativePlayer);
+    }
+
+    set initiativePlayer(value) {
+        this.state.initiativePlayer = value?.getRef();
+    }
+
+    /** @returns { Player | null } */
+    get actionPhaseActivePlayer() {
+        return this.gameObjectManager.get(this.state.actionPhaseActivePlayer);
+    }
+
+    set actionPhaseActivePlayer(value) {
+        this.state.actionPhaseActivePlayer = value?.getRef();
+    }
+
     /**
      * @param {import('./GameInterfaces.js').GameConfiguration} details
      * @param {import('./GameInterfaces.js').GameOptions} options
@@ -83,14 +127,20 @@ class Game extends EventEmitter {
         this.manualMode = false;
         this.gameMode = details.gameMode;
         this.currentPhase = null;
-        this.roundNumber = 0;
-        this.initialFirstPlayer = null;
-        this.initiativePlayer = null;
-        this.isInitiativeClaimed = false;
-        this.actionPhaseActivePlayer = null;
+
+        /** @type { import('./GameStateManager.js').IGameState } */
+        this.state = {
+            initialFirstPlayer: null,
+            initiativePlayer: null,
+            actionPhaseActivePlayer: null,
+            roundNumber: 0,
+            isInisInitiativeClaimed: false
+        };
+
         this.tokenFactories = null;
         this.stateWatcherRegistrar = new StateWatcherRegistrar(this);
         this.movedCards = [];
+        // STATE TODO: Move the generator logic into the state object.
         this.randomGenerator = seedrandom();
         this.currentOpenPrompt = null;
         this.cardDataGetter = details.cardDataGetter;
@@ -108,8 +158,7 @@ class Game extends EventEmitter {
 
         // TODO TWIN SUNS
         Contract.assertArraySize(
-            details.players, 2, `
-            Game must have exactly 2 players, received ${details.players.length}: ${details.players.map((player) => player.id).join(', ')}`
+            details.players, 2, `Game must have exactly 2 players, received ${details.players.length}: ${details.players.map((player) => player.id).join(', ')}`
         );
 
         details.players.forEach((player) => {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -47,21 +47,20 @@ class Game extends EventEmitter {
     #debug;
     #experimental;
 
-    get isInitiativeClaimed() {
-        return this.state.isInitiativeClaimed;
+    /** @returns { Player | null } */
+    get actionPhaseActivePlayer() {
+        return this.gameObjectManager.get(this.state.actionPhaseActivePlayer);
     }
 
-    set isInitiativeClaimed(value) {
-        this.state.isInitiativeClaimed = value;
+    /**
+     * @argument {Player | null} value
+     */
+    set actionPhaseActivePlayer(value) {
+        this.state.actionPhaseActivePlayer = value?.getRef();
     }
 
-    get roundNumber() {
-        return this.state.roundNumber;
-    }
-
-    set roundNumber(value) {
-        Contract.assertNonNegative(value, 'Round Number must be non-zero.');
-        this.state.roundNumber = value;
+    get allCards() {
+        return this.state.allCards.map((x) => this.getCard(x));
     }
 
     /** @returns { Player | null } */
@@ -88,20 +87,29 @@ class Game extends EventEmitter {
         this.state.initiativePlayer = value?.getRef();
     }
 
-    /** @returns { Player | null } */
-    get actionPhaseActivePlayer() {
-        return this.gameObjectManager.get(this.state.actionPhaseActivePlayer);
+    get isInitiativeClaimed() {
+        return this.state.isInitiativeClaimed;
     }
 
-    /**
-     * @argument {Player | null} value
-     */
-    set actionPhaseActivePlayer(value) {
-        this.state.actionPhaseActivePlayer = value?.getRef();
+    set isInitiativeClaimed(value) {
+        this.state.isInitiativeClaimed = value;
     }
 
-    get allCards() {
-        return this.state.allCards.map((x) => this.getCard(x));
+    get roundNumber() {
+        return this.state.roundNumber;
+    }
+
+    set roundNumber(value) {
+        Contract.assertNonNegative(value, 'Round Number must be non-zero.');
+        this.state.roundNumber = value;
+    }
+
+    get isDebugPipeline() {
+        return this.#debug.pipeline;
+    }
+
+    get isUndoEnabled() {
+        return this.#experimental.undo;
     }
 
     /**
@@ -1627,14 +1635,6 @@ class Game extends EventEmitter {
         } finally {
             this.#experimental.undo = false;
         }
-    }
-
-    get isDebugPipeline() {
-        return this.#debug.pipeline;
-    }
-
-    get isUndoEnabled() {
-        return this.#experimental.undo;
     }
 
     // return this.getSummary(notInactivePlayerName);

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -46,12 +46,12 @@ const { GameStateManager } = require('./GameStateManager.js');
 class Game extends EventEmitter {
     #debug;
 
-    get isInisInitiativeClaimed() {
-        return this.gameObjectManager.get(this.state.initialFirstPlayer);
+    get isInitiativeClaimed() {
+        return this.state.isInitiativeClaimed;
     }
 
-    set isInisInitiativeClaimed(value) {
-        this.state.initialFirstPlayer = value?.getRef();
+    set isInitiativeClaimed(value) {
+        this.state.isInitiativeClaimed = value;
     }
 
     get roundNumber() {
@@ -68,6 +68,9 @@ class Game extends EventEmitter {
         return this.gameObjectManager.get(this.state.initialFirstPlayer);
     }
 
+    /**
+     * @argument {Player | null} value
+     */
     set initialFirstPlayer(value) {
         this.state.initialFirstPlayer = value?.getRef();
     }
@@ -77,6 +80,9 @@ class Game extends EventEmitter {
         return this.gameObjectManager.get(this.state.initiativePlayer);
     }
 
+    /**
+     * @argument {Player | null} value
+     */
     set initiativePlayer(value) {
         this.state.initiativePlayer = value?.getRef();
     }
@@ -86,6 +92,9 @@ class Game extends EventEmitter {
         return this.gameObjectManager.get(this.state.actionPhaseActivePlayer);
     }
 
+    /**
+     * @argument {Player | null} value
+     */
     set actionPhaseActivePlayer(value) {
         this.state.actionPhaseActivePlayer = value?.getRef();
     }
@@ -134,7 +143,7 @@ class Game extends EventEmitter {
             initiativePlayer: null,
             actionPhaseActivePlayer: null,
             roundNumber: 0,
-            isInisInitiativeClaimed: false
+            isInitiativeClaimed: false
         };
 
         this.tokenFactories = null;

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -42,6 +42,7 @@ const { validateGameConfiguration, validateGameOptions } = require('./GameInterf
 const { GameStateManager } = require('./GameStateManager.js');
 const { ActionWindow } = require('./gameSteps/ActionWindow.js');
 const { GameObjectBase } = require('./GameObjectBase.js');
+const Helpers = require('./utils/Helpers.js');
 
 class Game extends EventEmitter {
     #debug;
@@ -1603,7 +1604,9 @@ class Game extends EventEmitter {
      */
     debug(settings, fcn) {
         const currDebug = this.#debug;
-        this.#debug = settings;
+        if (Helpers.isDevelopment) {
+            this.#debug = settings;
+        }
         try {
             fcn();
         } finally {
@@ -1616,7 +1619,7 @@ class Game extends EventEmitter {
      * @param {() => void} fcn
      */
     debugPipeline(fcn) {
-        this.#debug.pipeline = true;
+        this.#debug.pipeline = Helpers.isDevelopment;
         try {
             fcn();
         } finally {
@@ -1626,10 +1629,10 @@ class Game extends EventEmitter {
 
     /**
      * Should only be used for manual testing inside of unit tests, *never* committing any usage into main.
-     * @param {() => void} fcn
+     * @param {() => any} fcn
      */
     enableUndo(fcn) {
-        this.#experimental.undo = true;
+        this.#experimental.undo = Helpers.isDevelopment;
         try {
             return fcn();
         } finally {

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -5,6 +5,10 @@ export interface IGameObjectBaseState {
     uuid: string;
 }
 
+export interface IGameObjectBase<T extends IGameObjectBaseState = IGameObjectBaseState> {
+    getRef<TRef extends GameObjectBase<T>>(): GameObjectRef<TRef>;
+}
+
 /**
  * A wrapper object that contains a UUID. This should be used when saving any object reference to the state object.
  * Never create an object with this interface manually, instead always use {@link GameObjectBase.getRef} to create an instance.
@@ -21,7 +25,7 @@ export interface GameObjectRef<T extends GameObjectBase = GameObjectBase> {
 }
 
 /** GameObjectBase simply defines this as an object with state, and with a unique identifier. */
-export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjectBaseState> {
+export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjectBaseState> implements IGameObjectBase<T> {
     protected state: T;
 
     /** ID given by the game engine. */
@@ -50,7 +54,9 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
 
     /** Sets the state.  */
     public setState(state: T) {
+        const oldState = this.state;
         this.state = structuredClone(state);
+        this.afterSetState(oldState);
     }
 
     public getState() {
@@ -61,6 +67,10 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     /** A function for game to call on all objects after all state has been set. for example, to cache calculated values. */
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public afterSetAllState() { }
+
+    /** A function for game to call on all objects after all state has been set. for example, to cache calculated values. */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    protected afterSetState(oldState: T) { }
 
     public getRef<T extends GameObjectBase = this>(): GameObjectRef<T> {
         return { isRef: true, uuid: this.state.uuid };

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -76,7 +76,7 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     public getRef<T extends GameObjectBase = this>(): GameObjectRef<T> {
         const ref = { isRef: true, uuid: this.state.uuid };
 
-        if (Helpers.isDevelopment) {
+        if (Helpers.isDevelopment()) {
             // This property is for debugging purposes only and should never be referenced within the code.
             Object.defineProperty(ref, 'gameObject', {
                 value: this,

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -1,5 +1,6 @@
 import type Game from './Game';
 import * as Contract from './utils/Contract';
+import * as Helpers from './utils/Helpers';
 
 export interface IGameObjectBaseState {
     uuid: string;
@@ -78,7 +79,7 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     public getRef<T extends GameObjectBase = this>(): GameObjectRef<T> {
         const ref = { isRef: true, uuid: this.state.uuid };
 
-        if (process.env.ENVIRONMENT === 'development') {
+        if (Helpers.isDevelopment) {
             // This property is for debugging purposes only and should never be referenced within the code.
             Object.defineProperty(ref, 'gameObject', {
                 value: this,

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -23,9 +23,6 @@ export interface IGameObjectBase<T extends IGameObjectBaseState = IGameObjectBas
 export interface GameObjectRef<T extends GameObjectBase = GameObjectBase> {
     isRef: true;
     uuid: string;
-
-    /** This property is for debugging purposes only and will be wiped during rollback. Do not use it anywhere in the code. */
-    // gameObject: never;
 }
 
 /** GameObjectBase simply defines this as an object with state, and with a unique identifier. */

--- a/server/game/core/GamePipeline.ts
+++ b/server/game/core/GamePipeline.ts
@@ -91,6 +91,7 @@ export class GamePipeline {
         this.pipeline.shift();
     }
 
+    // HACK: This intended to be used by undo *only*.
     public clearSteps() {
         this.pipeline.length = 0;
     }

--- a/server/game/core/GamePipeline.ts
+++ b/server/game/core/GamePipeline.ts
@@ -18,6 +18,10 @@ export class GamePipeline {
         return this.pipeline.length;
     }
 
+    public get currentStep() {
+        return this.pipeline[0];
+    }
+
     public initialise(steps: StepItem[]): void {
         this.pipeline = steps;
     }
@@ -85,6 +89,10 @@ export class GamePipeline {
         }
 
         this.pipeline.shift();
+    }
+
+    public clearSteps() {
+        this.pipeline.length = 0;
     }
 
     public handleCardClicked(player: Player, card: Card) {

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -17,7 +17,7 @@ export interface IGameState {
     initialFirstPlayer: GameObjectRef<Player> | null;
     initiativePlayer: GameObjectRef<Player> | null;
     actionPhaseActivePlayer: GameObjectRef<Player> | null;
-    isInisInitiativeClaimed: boolean;
+    isInitiativeClaimed: boolean;
 }
 
 export class GameStateManager {

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -60,6 +60,10 @@ export class GameStateManager {
         }
     }
 
+    public clearSnapshots() {
+        this.snapshots.length = 0;
+    }
+
     public takeSnapshot(): number {
         const snapshot: IGameSnapshot = {
             id: this.snapshots.length,
@@ -73,8 +77,16 @@ export class GameStateManager {
         return snapshot.id;
     }
 
-    // TODO: Where are all of the places GameObjects are stored? Obviously here, but what about Token GOs? Attack GOs? We need to ensure those are all GameObjectRefs, or we'll start building up garbage.
-    public rollbackToSnapshot(snapshotId: number) {
+    /**
+     *
+     * @param snapshotId The specific snapshotId to return to. If not provided, will return to the last snapshot.
+     */
+    public rollbackToSnapshot(snapshotId?: number) {
+        if (snapshotId == null) {
+            Contract.assertTrue(this.snapshots.length > 1, 'No snapshots to rollback to.');
+            // We take a snapshot at the start of someone's turn, so hitting undo would mean we need to back to the second most recent snapshot.
+            snapshotId = this.snapshots[this.snapshots.length - 2].id;
+        }
         Contract.assertNonNegative(snapshotId, 'Tried to rollback but snapshot ID is invalid ' + snapshotId);
 
         const snapshotIdx = this.snapshots.findIndex((x) => x.id === snapshotId);

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -1,5 +1,6 @@
 import type Game from './Game';
 import type { GameObjectBase, GameObjectRef, IGameObjectBaseState } from './GameObjectBase';
+import type { Player } from './Player';
 import * as Contract from './utils/Contract.js';
 import * as Helpers from './utils/Helpers.js';
 
@@ -7,7 +8,16 @@ export interface IGameSnapshot {
     id: number;
     lastId: number;
 
+    gameState: IGameState;
     states: IGameObjectBaseState[];
+}
+
+export interface IGameState {
+    roundNumber: number;
+    initialFirstPlayer: GameObjectRef<Player> | null;
+    initiativePlayer: GameObjectRef<Player> | null;
+    actionPhaseActivePlayer: GameObjectRef<Player> | null;
+    isInisInitiativeClaimed: boolean;
 }
 
 export class GameStateManager {
@@ -54,6 +64,7 @@ export class GameStateManager {
         const snapshot: IGameSnapshot = {
             id: this.snapshots.length,
             lastId: this.lastId,
+            gameState: structuredClone(this.game.state),
             states: this.allGameObjects.map((x) => x.getState())
         };
 
@@ -70,6 +81,8 @@ export class GameStateManager {
         Contract.assertNonNegative(snapshotIdx, `Tried to rollback to snapshot ID ${snapshotId} but the snapshot was not found.`);
 
         const snapshot = this.snapshots[snapshotIdx];
+
+        this.game.state = structuredClone(snapshot.gameState);
 
         const removals: { index: number; uuid: string }[] = [];
         // Indexes in last to first for the purpose of removal.

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -196,7 +196,7 @@ export class GameStateManager {
     private getSnapshotForRound(round: number) {
         const roundDiff = this.game.roundNumber - round;
 
-        const snapshotIdx = this.roundSnapshots[this.snapshots.length - 2 - roundDiff];
+        const snapshotIdx = this.roundSnapshots[this.snapshots.length - 1 - roundDiff];
 
         return this.snapshots[snapshotIdx];
     }

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -98,7 +98,7 @@ export class GameStateManager {
 
         const removals: { index: number; uuid: string }[] = [];
         // Indexes in last to first for the purpose of removal.
-        for (let i = this.allGameObjects.length - 1; i >= this.allGameObjects.length; i--) {
+        for (let i = this.allGameObjects.length - 1; i >= 0; i--) {
             const go = this.allGameObjects[i];
             const updatedState = snapshot.states.find((x) => x.uuid === go.uuid);
             if (!updatedState) {

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -28,6 +28,7 @@ export class GameStateManager {
     private readonly allGameObjects: GameObjectBase[];
     private readonly gameObjectMapping: Map<string, GameObjectBase>;
     private lastId = 0;
+    private lastSnapshotId = 0;
 
     public constructor(game: Game) {
         this.game = game;
@@ -67,12 +68,14 @@ export class GameStateManager {
     }
 
     public takeSnapshot(): number {
+        const nextId = this.lastSnapshotId + 1;
         const snapshot: IGameSnapshot = {
-            id: this.snapshots.length,
+            id: nextId,
             lastId: this.lastId,
             gameState: structuredClone(this.game.state),
             states: this.allGameObjects.map((x) => x.getState())
         };
+        this.lastSnapshotId = nextId;
 
         this.snapshots.push(snapshot);
 
@@ -89,7 +92,7 @@ export class GameStateManager {
             // We take a snapshot at the start of someone's turn, so hitting undo would mean we need to back to the second most recent snapshot.
             snapshotId = this.snapshots[this.snapshots.length - 2].id;
         }
-        Contract.assertNonNegative(snapshotId, 'Tried to rollback but snapshot ID is invalid ' + snapshotId);
+        Contract.assertPositiveNonZero(snapshotId, 'Tried to rollback but snapshot ID is invalid ' + snapshotId);
 
         const snapshotIdx = this.snapshots.findIndex((x) => x.id === snapshotId);
         Contract.assertNonNegative(snapshotIdx, `Tried to rollback to snapshot ID ${snapshotId} but the snapshot was not found.`);

--- a/server/game/core/GameStateManager.ts
+++ b/server/game/core/GameStateManager.ts
@@ -1,3 +1,4 @@
+import type { Card } from './card/Card';
 import type Game from './Game';
 import type { GameObjectBase, GameObjectRef, IGameObjectBaseState } from './GameObjectBase';
 import type { Player } from './Player';
@@ -18,6 +19,7 @@ export interface IGameState {
     initiativePlayer: GameObjectRef<Player> | null;
     actionPhaseActivePlayer: GameObjectRef<Player> | null;
     isInitiativeClaimed: boolean;
+    allCards: GameObjectRef<Card>[];
 }
 
 export class GameStateManager {

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -46,6 +46,7 @@ export interface IPlayerState extends IGameObjectState {
     deckZone: GameObjectRef<DeckZone>;
     leader: GameObjectRef<ILeaderCard>;
     base: GameObjectRef<IBaseCard>;
+    passedActionPhase: boolean;
 }
 
 export class Player extends GameObject<IPlayerState> {
@@ -89,6 +90,14 @@ export class Player extends GameObject<IPlayerState> {
         return this.game.gameObjectManager.get(this.state.base);
     }
 
+    public get passedActionPhase() {
+        return this.state.passedActionPhase;
+    }
+
+    public set passedActionPhase(value: boolean | null) {
+        this.state.passedActionPhase = value;
+    }
+
     private canTakeActionsThisPhase: null;
     // STATE TODO: Does Deck need to be a GameObject?
     private decklistNames: Deck | null;
@@ -106,7 +115,6 @@ export class Player extends GameObject<IPlayerState> {
     public opponent: Player;
     private playableZones: PlayableZone[];
     private noTimer: boolean;
-    public passedActionPhase: boolean;
     public constructor(id: string, user: User, game: Game, clockDetails?: ClockConfig) {
         super(game, user.username);
 

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -1282,6 +1282,7 @@ export class Player extends GameObject<IPlayerState> {
             // stats: this.getStats(),
             user: safeUser,
             promptState: promptState,
+            canUndo: this.game.gameObjectManager.canUndo(this),
             isActionPhaseActivePlayer,
             clock: undefined
         };

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -1,6 +1,6 @@
 import type { IGameObjectState } from './GameObject';
 import { GameObject } from './GameObject';
-import type { Deck, IDeskList as IDeckList } from '../../utils/deck/Deck.js';
+import type { Deck, IDeckList as IDeckList } from '../../utils/deck/Deck.js';
 import UpgradePrompt from './gameSteps/prompts/UpgradePrompt.js';
 import type { ClockConfig } from './clocks/ClockSelector.js';
 import { clockFor } from './clocks/ClockSelector.js';

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -961,7 +961,7 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
         return (
             this.unique &&
             this.game.allCards.some(
-                (card) =>
+                (card: any) =>
                     card.isInPlay() &&
                     card.title === this.title &&
                     card !== this &&
@@ -975,7 +975,7 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
         return (
             this.unique &&
             this.game.allCards.some(
-                (card) =>
+                (card: any) =>
                     card.isInPlay() &&
                     card.title === this.title &&
                     card !== this &&

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -57,8 +57,7 @@ export class UpgradeCard extends UpgradeCardParent implements IUpgradeCard, IPla
     }
 
     public override moveTo(targetZoneName: MoveZoneDestination) {
-        Contract.assertFalse(this._parentCard && targetZoneName !== this._parentCard.zoneName,
-            `Attempting to move upgrade ${this.internalName} while it is still attached to ${this._parentCard?.internalName}`);
+        Contract.assertTrue(!this.state.parentCard || targetZoneName === this.parentCard.zoneName, `Attempting to move upgrade ${this.internalName} while it is still attached to ${this.state.parentCard ? this.parentCard.internalName : ''}`);
 
         super.moveTo(targetZoneName);
     }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -22,6 +22,7 @@ import { InitializeCardStateOption, type Card } from '../Card';
 import type { AbilityContext } from '../../ability/AbilityContext';
 import { StandardTriggeredAbilityType } from '../../Constants';
 import * as Helpers from '../../utils/Helpers';
+import type { GameObjectRef } from '../../GameObjectBase';
 
 const InPlayCardParent = WithCost(WithAllAbilityTypes(PlayableOrDeployableCard));
 
@@ -33,6 +34,7 @@ export interface IInPlayCardState extends IPlayableOrDeployableCardState {
     mostRecentInPlayId: number;
     pendingDefeat: boolean | null;
     movedFromZone: ZoneName | null;
+    parentCard: GameObjectRef<IUnitCard> | null;
 }
 
 export interface IInPlayCard extends IPlayableOrDeployableCard, ICardWithCostProperty, ICardWithActionAbilities, ICardWithConstantAbilities, ICardWithTriggeredAbilities {
@@ -64,8 +66,6 @@ export interface IInPlayCard extends IPlayableOrDeployableCard, ICardWithCostPro
 export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends InPlayCardParent<T> implements IInPlayCard {
     public readonly printedUpgradeHp: number;
     public readonly printedUpgradePower: number;
-
-    protected _parentCard?: IUnitCard = null;
 
     protected attachCondition: (card: Card) => boolean;
 
@@ -105,11 +105,15 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
 
     /** The card that this card is underneath */
     public get parentCard(): IUnitCard {
-        Contract.assertNotNullLike(this._parentCard);
+        Contract.assertNotNullLike(this.state.parentCard);
         // TODO: move IsInPlay to be usable here
         Contract.assertTrue(this.isInPlay());
 
-        return this._parentCard;
+        return this.game.gameObjectManager.get(this.state.parentCard);
+    }
+
+    protected set parentCard(value: IUnitCard | null) {
+        this.state.parentCard = value?.getRef();
     }
 
     /**
@@ -151,6 +155,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
         this.state.pendingDefeat = null;
         this.state.mostRecentInPlayId = -1;
         this.state.disableOngoingEffectsForDefeat = null;
+        this.state.parentCard = null;
     }
 
     public isInPlay(): boolean {
@@ -172,7 +177,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
 
     public assertIsUpgrade(): void {
         Contract.assertTrue(this.isUpgrade());
-        Contract.assertNotNullLike(this.parentCard);
+        Contract.assertNotNullLike(this.state.parentCard);
     }
 
     public getUpgradeHp(): number {
@@ -190,7 +195,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
         // this assert needed for type narrowing or else the moveTo fails
         Contract.assertTrue(newParentCard.zoneName === ZoneName.SpaceArena || newParentCard.zoneName === ZoneName.GroundArena);
 
-        if (this._parentCard) {
+        if (this.state.parentCard) {
             this.unattach();
         }
 
@@ -207,7 +212,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
 
         newParentCard.attachUpgrade(this);
 
-        this._parentCard = newParentCard;
+        this.parentCard = newParentCard;
     }
 
     protected updateStateOnAttach() {
@@ -217,15 +222,15 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
     public isAttached(): boolean {
         // TODO: I think we can't check this here because we need to be able to check if this is attached in some places like the getType method
         // this.assertIsUpgrade();
-        return !!this._parentCard;
+        return !!this.state.parentCard;
     }
 
     public unattach(event = null) {
-        Contract.assertNotNullLike(this._parentCard, 'Attempting to unattach upgrade when already unattached');
+        Contract.assertNotNullLike(this.state.parentCard, 'Attempting to unattach upgrade when already unattached');
         this.assertIsUpgrade();
 
         this.parentCard.unattachUpgrade(this, event);
-        this._parentCard = null;
+        this.parentCard = null;
     }
 
     /**
@@ -253,7 +258,7 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
 
     public override getSummary(activePlayer: Player) {
         return { ...super.getSummary(activePlayer),
-            parentCardId: this._parentCard ? this._parentCard.uuid : null };
+            parentCardId: this.state.parentCard ? this.state.parentCard.uuid : null };
     }
 
     // ********************************************* ABILITY SETUP *********************************************

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -958,7 +958,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
             super.afterSetState(oldState);
             // STATE: I don't wholly trust this covers all cases, but it's a good start at least.
             if (oldState.zone?.uuid !== this.state.zone.uuid) {
-                const oldZone = this.game.gameObjectManager.get(oldState.zone) as Zone;
+                const oldZone = this.game.gameObjectManager.get<Zone>(oldState.zone);
                 this.movedFromZone = oldZone?.name;
                 this.resolveAbilitiesForNewZone();
             }

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -199,7 +199,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
         }
 
         public override isUpgrade(): this is IUpgradeCard {
-            return this._parentCard !== null;
+            return this.state.parentCard != null;
         }
 
         // ****************************************** CONSTRUCTOR ******************************************
@@ -252,7 +252,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
         }
 
         public override isUnit(): this is IUnitCard {
-            return this._parentCard === null;
+            return this.state.parentCard == null;
         }
 
         protected override getType(): CardType {

--- a/server/game/core/gameSteps/IStep.ts
+++ b/server/game/core/gameSteps/IStep.ts
@@ -13,6 +13,8 @@ export interface IStep {
     queueStep?(step: IStep): void;
     cancelStep?(): void;
     isComplete?(): boolean;
+    takeSnapshot?(): number;
+    rollbackToSnapshot?(snapshotId: number | null): void;
 
     /**
      * Resolve the pipeline step

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -26,7 +26,9 @@ export class ActionPhase extends Phase {
     }
 
     public queueNextAction() {
-        // this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot(), 'actionTakeSnapshot');
+        if (this.game.isUndoEnabled) {
+            this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot(), 'actionTakeSnapshot');
+        }
         this.game.queueStep(new ActionWindow(this.game, 'Action Window', 'action', this.prevPlayerPassed, this.passStatusHandler));
         this.game.queueSimpleStep(() => this.rotateActiveQueueNextAction(), 'rotateActiveQueueNextAction');
     }

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -61,4 +61,16 @@ export class ActionPhase extends Phase {
     public override resetPhase(): void {
         this.pipeline.clearSteps();
     }
+
+    public takeSnapshot() {
+        return this.game.gameObjectManager.takeSnapshot();
+    }
+
+    public rollbackToSnapshot(snapshotId: number | null) {
+        this.game.gameObjectManager.rollbackToSnapshot(snapshotId);
+        this.resetPhase();
+        this.queueNextAction();
+        // continue the action phase again.
+        this.continue();
+    }
 }

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -1,4 +1,4 @@
-import { EffectName, PhaseName } from '../../Constants';
+import { EffectName, PhaseName, SnapshotType } from '../../Constants';
 import type Game from '../../Game';
 import { Phase } from './Phase';
 import { SimpleStep } from '../SimpleStep';
@@ -27,7 +27,7 @@ export class ActionPhase extends Phase {
 
     public queueNextAction() {
         if (this.game.isUndoEnabled) {
-            this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot({ type: 'Player' }), 'actionTakeSnapshot');
+            this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot({ type: SnapshotType.Player }), 'actionTakeSnapshot');
         }
         this.game.queueStep(new ActionWindow(this.game, 'Action Window', 'action', this.prevPlayerPassed, this.passStatusHandler));
         this.game.queueSimpleStep(() => this.rotateActiveQueueNextAction(), 'rotateActiveQueueNextAction');
@@ -63,7 +63,7 @@ export class ActionPhase extends Phase {
     }
 
     public takeSnapshot() {
-        return this.game.gameObjectManager.takeSnapshot({ type: 'Phase', phaseName: 'Action' });
+        return this.game.gameObjectManager.takeSnapshot({ type: SnapshotType.Phase, phaseName: 'Action' });
     }
 
     public rollbackToSnapshot(snapshotId: number | null) {

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -26,7 +26,7 @@ export class ActionPhase extends Phase {
     }
 
     public queueNextAction() {
-        this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot(), 'actionTakeSnapshot');
+        // this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot(), 'actionTakeSnapshot');
         this.game.queueStep(new ActionWindow(this.game, 'Action Window', 'action', this.prevPlayerPassed, this.passStatusHandler));
         this.game.queueSimpleStep(() => this.rotateActiveQueueNextAction(), 'rotateActiveQueueNextAction');
     }

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -1,13 +1,10 @@
 import { EffectName, PhaseName } from '../../Constants';
 import type Game from '../../Game';
-import type { Player } from '../../Player';
 import { Phase } from './Phase';
 import { SimpleStep } from '../SimpleStep';
 import ActionWindow from '../ActionWindow';
 
 export class ActionPhase extends Phase {
-    public activePlayer?: Player;
-
     // each ActionWindow will use this handler to indicate if the window was passed or not
     private readonly passStatusHandler = (passed: boolean) => this.prevPlayerPassed = passed;
     private prevPlayerPassed = false;
@@ -28,7 +25,8 @@ export class ActionPhase extends Phase {
         }
     }
 
-    private queueNextAction() {
+    public queueNextAction() {
+        this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot(), 'actionTakeSnapshot');
         this.game.queueStep(new ActionWindow(this.game, 'Action Window', 'action', this.prevPlayerPassed, this.passStatusHandler));
         this.game.queueSimpleStep(() => this.rotateActiveQueueNextAction(), 'rotateActiveQueueNextAction');
     }
@@ -56,5 +54,9 @@ export class ActionPhase extends Phase {
             player.cleanupFromActionPhase();
         }
         this.game.isInitiativeClaimed = false;
+    }
+
+    public override resetPhase(): void {
+        this.pipeline.clearSteps();
     }
 }

--- a/server/game/core/gameSteps/phases/ActionPhase.ts
+++ b/server/game/core/gameSteps/phases/ActionPhase.ts
@@ -27,7 +27,7 @@ export class ActionPhase extends Phase {
 
     public queueNextAction() {
         if (this.game.isUndoEnabled) {
-            this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot(), 'actionTakeSnapshot');
+            this.game.queueSimpleStep(() => this.game.gameObjectManager.takeSnapshot({ type: 'Player' }), 'actionTakeSnapshot');
         }
         this.game.queueStep(new ActionWindow(this.game, 'Action Window', 'action', this.prevPlayerPassed, this.passStatusHandler));
         this.game.queueSimpleStep(() => this.rotateActiveQueueNextAction(), 'rotateActiveQueueNextAction');
@@ -63,7 +63,7 @@ export class ActionPhase extends Phase {
     }
 
     public takeSnapshot() {
-        return this.game.gameObjectManager.takeSnapshot();
+        return this.game.gameObjectManager.takeSnapshot({ type: 'Phase', phaseName: 'Action' });
     }
 
     public rollbackToSnapshot(snapshotId: number | null) {

--- a/server/game/core/gameSteps/phases/Phase.ts
+++ b/server/game/core/gameSteps/phases/Phase.ts
@@ -7,7 +7,8 @@ import type { IStep } from '../IStep';
 import { TriggerHandlingMode } from '../../event/EventWindow';
 
 export abstract class Phase extends BaseStepWithPipeline {
-    public steps: IStep[] = [];
+    private steps: IStep[] = [];
+    private endStep: IStep;
 
     public constructor(
         game: Game,
@@ -19,8 +20,8 @@ export abstract class Phase extends BaseStepWithPipeline {
     public initialise(steps: IStep[]): void {
         this.pipeline.initialise([new SimpleStep(this.game, () => this.createPhase(), 'createPhase')]);
         const startStep = new SimpleStep(this.game, () => this.startPhase(), 'startPhase');
-        const endStep = new SimpleStep(this.game, () => this.endPhase(), 'endPhase');
-        this.steps = [startStep, ...steps, endStep];
+        this.endStep = new SimpleStep(this.game, () => this.endPhase(), 'endPhase');
+        this.steps = [startStep, ...steps, this.endStep];
     }
 
     protected createPhase(): void {
@@ -37,6 +38,7 @@ export abstract class Phase extends BaseStepWithPipeline {
             if (this.name !== PhaseName.Setup) {
                 this.game.addAlert('endofround', 'turn: {0} - {1} phase', this.game.roundNumber, this.name);
             }
+            this.game.gameObjectManager.clearSnapshots();
         });
     }
 
@@ -47,5 +49,10 @@ export abstract class Phase extends BaseStepWithPipeline {
             // for post-phase state cleanup. emit directly, don't need a window.
             this.game.emit(EventName.OnPhaseEndedCleanup, { phase: this.name });
         }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public resetPhase(): void {
+
     }
 }

--- a/server/game/core/gameSteps/phases/Phase.ts
+++ b/server/game/core/gameSteps/phases/Phase.ts
@@ -51,7 +51,5 @@ export abstract class Phase extends BaseStepWithPipeline {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    public resetPhase(): void {
-
-    }
+    public resetPhase(): void { }
 }

--- a/server/game/core/gameSteps/phases/Phase.ts
+++ b/server/game/core/gameSteps/phases/Phase.ts
@@ -8,7 +8,6 @@ import { TriggerHandlingMode } from '../../event/EventWindow';
 
 export abstract class Phase extends BaseStepWithPipeline {
     private steps: IStep[] = [];
-    private endStep: IStep;
 
     public constructor(
         game: Game,
@@ -20,8 +19,8 @@ export abstract class Phase extends BaseStepWithPipeline {
     public initialise(steps: IStep[]): void {
         this.pipeline.initialise([new SimpleStep(this.game, () => this.createPhase(), 'createPhase')]);
         const startStep = new SimpleStep(this.game, () => this.startPhase(), 'startPhase');
-        this.endStep = new SimpleStep(this.game, () => this.endPhase(), 'endPhase');
-        this.steps = [startStep, ...steps, this.endStep];
+        const endStep = new SimpleStep(this.game, () => this.endPhase(), 'endPhase');
+        this.steps = [startStep, ...steps, endStep];
     }
 
     protected createPhase(): void {

--- a/server/game/core/utils/Contract.ts
+++ b/server/game/core/utils/Contract.ts
@@ -54,9 +54,9 @@ export function assertNotEqual<T>(val1: T, val2: T, message?: string) {
     }
 }
 
-export function assertNotNullLike<T>(val: T, message?: string): asserts val is NonNullable<T> {
+export function assertNotNullLike<T>(val: T, message?: string | (() => string)): asserts val is NonNullable<T> {
     if (val == null) {
-        contractCheckImpl.fail(message ?? `Null-like object value: ${val}`);
+        contractCheckImpl.fail(message ? (typeof message === 'function' ? message() : message) : `Null-like object value: ${val}`);
     }
 }
 

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -99,6 +99,8 @@ export function asArray<T>(val: T | T[]): T[] {
     return Array.isArray(val) ? val : [val];
 }
 
+export const isDevelopment = process.env.ENVIRONMENT === 'development';
+
 export function getRandomArrayElements(array: any[], nValues: number, randomGenerator: seedrandom) {
     Contract.assertTrue(nValues <= array.length, `Attempting to retrieve ${nValues} random elements from an array of length ${array.length}`);
 

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -254,4 +254,12 @@ function mergeProperty<TPropertySet extends { [key in TPropName]?: TMergePropert
     return { ...propertySet, [newPropName]: mergeFn(oldPropValue, newPropValue) };
 }
 
+export function objectForEach<T extends Record<any, any>, TK extends Extract<keyof T, string> = Extract<keyof T, string>>(obj: T, fcn: (prop: TK, value?: T[TK]) => void) {
+    for (const prop in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, prop)) {
+            fcn(prop as TK, obj[prop] as T[TK]);
+        }
+    }
+}
+
 export type DistributiveOmit<T, K extends keyof T> = T extends any ? Omit<T, K> : never;

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -99,7 +99,7 @@ export function asArray<T>(val: T | T[]): T[] {
     return Array.isArray(val) ? val : [val];
 }
 
-export const isDevelopment = process.env.ENVIRONMENT === 'development';
+export const isDevelopment = () => process.env.ENVIRONMENT === 'development';
 
 export function getRandomArrayElements(array: any[], nValues: number, randomGenerator: seedrandom) {
     Contract.assertTrue(nValues <= array.length, `Attempting to retrieve ${nValues} random elements from an array of length ${array.length}`);

--- a/server/game/core/zone/SimpleZone.ts
+++ b/server/game/core/zone/SimpleZone.ts
@@ -38,7 +38,7 @@ export interface IZoneState<TCard extends Card> extends IGameObjectBaseState {
 /**
  * Base class for all Zones that contain a list of Cards. Defines some common properties and methods.
  */
-export abstract class SimpleZone<TCard extends Card, TState extends IZoneState<TCard> = IZoneState<TCard>> extends ZoneAbstract<TCard, TState> {
+export abstract class SimpleZone<TCard extends Card = Card, TState extends IZoneState<TCard> = IZoneState<TCard>> extends ZoneAbstract<TCard, TState> {
     /** Number of cards in the zone */
     public override get count(): number {
         return this.state.cards.length;

--- a/server/utils/deck/Deck.ts
+++ b/server/utils/deck/Deck.ts
@@ -11,7 +11,7 @@ import type { ILeaderCard } from '../../game/core/card/propertyMixins/LeaderProp
 import { cards } from '../../game/cards/Index';
 import type { GameObjectRef } from '../../game/core/GameObjectBase';
 
-export interface IDeskList {
+export interface IDeckList {
     deckCards: GameObjectRef<IPlayableCard>[];
     outOfPlayCards: any[];
     outsideTheGameCards: GameObjectRef<Card>[];
@@ -103,8 +103,8 @@ export class Deck {
         };
     }
 
-    public async buildCardsAsync(player: Player, cardDataGetter: CardDataGetter): Promise<IDeskList> {
-        const result: IDeskList = {
+    public async buildCardsAsync(player: Player, cardDataGetter: CardDataGetter): Promise<IDeckList> {
+        const result: IDeckList = {
             deckCards: [],
             outOfPlayCards: [],
             outsideTheGameCards: [],

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -16,15 +16,6 @@ interface SwuTestContextRef {
     snapshotId?: number;
     setupTestAsync: (options?: SwuSetupTestOptions) => Promise;
 
-    /**
-     * Define a single spec. A spec should contain one or more expectations that test the state of the code.
-     * A spec whose expectations all succeed will be passing and a spec with any failures will fail.
-     * @param expectation Textual description of what this spec is checking
-     * @param assertion Function that contains the code of your test. If not provided the test will be pending.
-     * @param timeout Custom timeout for an async spec.
-     */
-    undoIt(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
-
     buildImportAllCardsTools: () => {
         deckBuilder: DeckBuilder;
         implementedCardsCtors: Map<string, new (owner: Player, cardData: any) => Card>;
@@ -143,3 +134,12 @@ declare namespace jasmine {
         toHaveExactDisabledDisplayPromptPerCardButtons<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedButtonsInPrompt: string[]): boolean;
     }
 }
+
+/**
+ * Define a single spec. A spec should contain one or more expectations that test the state of the code.
+ * A spec whose expectations all succeed will be passing and a spec with any failures will fail.
+ * @param expectation Textual description of what this spec is checking
+ * @param assertion Function that contains the code of your test. If not provided the test will be pending.
+ * @param timeout Custom timeout for an async spec.
+ */
+declare function uit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -142,4 +142,4 @@ declare namespace jasmine {
  * @param assertion Function that contains the code of your test. If not provided the test will be pending.
  * @param timeout Custom timeout for an async spec.
  */
-declare function uit(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;
+declare function undoIt(expectation: string, assertion?: jasmine.ImplementationCallback, timeout?: number): void;

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -54,7 +54,7 @@ global.integration = function (definitions) {
                     if (contextRef.context.snapshotId == null || contextRef.context.snapshotId === -1) {
                         throw new Error('Snapshot ID missing');
                     }
-                    contextRef.context.game.gameObjectManager.rollbackToSnapshot(contextRef.context.snapshotId);
+                    contextRef.context.game.rollbackToSnapshot(contextRef.context.snapshotId);
                     assertion();
                 }, timeout);
             }

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -122,7 +122,7 @@ global.integration = function (definitions) {
 };
 
 const jit = it;
-global.uit = function(expectation, assertion, timeout) {
+global.undoIt = function(expectation, assertion, timeout) {
     jit(expectation + ' (with Undo)', async function() {
         /** @type {SwuTestContext} */
         const context = this.contextRef.context;

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -132,16 +132,14 @@ global.uit = function(expectation, assertion, timeout) {
 
         await assertion();
         if (snapshotId == null) {
-            // Snapshot was taken outside of the Action Phase, probably because a test has the setup _within_ the it call. Not worth testing en-masse, just let the test end assuming no issues on the first run.
+            // Snapshot was taken outside of the Action Phase. Not worth testing en-masse, just let the test end assuming no issues on the first run.
             return;
         }
         const rolledBack = context.game.rollbackToSnapshot(snapshotId);
         if (!rolledBack) {
-            // Probably want this to throw an error later, but for now this will let us filter out tests outside of the scope vs tests that are actually breaking rollback.
+            // Probably want this to throw an error later, but for now this will let us filter out tests outside the scope vs tests that are actually breaking rollback.
             return;
         }
         await assertion();
     }, timeout);
 };
-
-// global.it = global.uit;

--- a/test/helpers/PlayerInteractionWrapper.js
+++ b/test/helpers/PlayerInteractionWrapper.js
@@ -479,7 +479,7 @@ class PlayerInteractionWrapper {
      * Filters all of a player's cards using the name and zone of a card
      * @param {String} names - the names of the cards
      * @param {String[]|String} [zones = 'any'] - zones in which to look for. 'provinces' = 'province 1', 'province 2', etc.
-     * @param {?String} side - set to 'opponent' to search in opponent's cards
+     * @param {String?} side - set to 'opponent' to search in opponent's cards
      */
     filterCardsByName(names, zones = 'any', side) {
         // So that function can accept either lists or single zones
@@ -507,13 +507,16 @@ class PlayerInteractionWrapper {
      *   Filters cards by given condition
      *   @param {function(card: DrawCard)} condition - card matching function
      *   @param {String} [side] - set to 'opponent' to search in opponent's cards
+     *   @returns {any[]}
      */
     filterCards(condition, side) {
-        var player = this.player;
+        let player = this.player;
         if (side === 'opponent') {
             player = this.opponent;
         }
-        return player.decklist.allCards.filter(condition);
+        return player.decklist.allCards.map(
+            (x) => this.game.getCard(x)
+        ).filter(condition);
     }
 
     exhaustResources(number) {

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -36,19 +36,19 @@ describe('Undo', function() {
                 expect(context.wampa.damage).toEqual(2);
             });
 
-            contextRef.undoIt('works when no enemy ground units', function () {
-                const { context } = contextRef;
+            // contextRef.undoIt('works when no enemy ground units', function () {
+            //     const { context } = contextRef;
 
-                // Play Death Trooper
-                context.player2.setGroundArenaUnits([]);
-                context.player1.clickCard(context.deathTrooper);
+            //     // Play Death Trooper
+            //     context.player2.setGroundArenaUnits([]);
+            //     context.player1.clickCard(context.deathTrooper);
 
-                // Choose Friendly
-                expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.deathTrooper]);
-                expect(context.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
-                context.player1.clickCard(context.deathTrooper);
-                expect(context.deathTrooper.damage).toEqual(2);
-            });
+            //     // Choose Friendly
+            //     expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.deathTrooper]);
+            //     expect(context.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
+            //     context.player1.clickCard(context.deathTrooper);
+            //     expect(context.deathTrooper.damage).toEqual(2);
+            // });
         });
     });
 });

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -17,7 +17,7 @@ describe('Undo', function() {
                 });
             });
 
-            contextRef.undoIt('can only target ground units & can damage itself', function () {
+            uit('can only target ground units & can damage itself', function () {
                 const { context } = contextRef;
 
                 // Play Death Trooper
@@ -50,5 +50,90 @@ describe('Undo', function() {
             //     expect(context.deathTrooper.damage).toEqual(2);
             // });
         });
+
+        // describe('2-1B Surgical Droid\'s ability', function() {
+        //     beforeEach(function () {
+        //         return contextRef.setupTestAsync({
+        //             phase: 'action',
+        //             player1: {
+        //                 groundArena: [
+        //                     { card: '21b-surgical-droid' },
+        //                     { card: 'r2d2#ignoring-protocol', damage: 3 },
+        //                     { card: 'c3po#protocol-droid', damage: 1 }],
+        //             },
+        //             player2: {
+        //                 groundArena: [{ card: 'wampa', damage: 2 }]
+        //             },
+        //             testUndo: true
+        //         });
+        //     });
+
+        //     contextRef.undoIt('should heal a target with 1 damage to full', function () {
+        //         const { context } = contextRef;
+
+        //         // Attack
+        //         context.player1.clickCard(context._21bSurgicalDroid);
+        //         expect(context._21bSurgicalDroid).toBeInZone('groundArena');
+        //         expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
+        //         context.player1.clickCard(context.p2Base);
+
+        //         // Healing Target
+        //         expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
+        //         context.player1.clickCard(context.c3po);
+
+        //         // Confirm Results
+        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
+        //         expect(context.c3po.damage).toBe(0);
+        //     });
+
+        //     contextRef.undoIt('should heal 2 damage from a unit', function () {
+        //         const { context } = contextRef;
+
+        //         // Attack
+        //         context.player1.clickCard(context._21bSurgicalDroid);
+        //         expect(context._21bSurgicalDroid).toBeInZone('groundArena');
+        //         expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
+        //         context.player1.clickCard(context.p2Base);
+
+        //         // Healing Target
+        //         expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
+        //         context.player1.clickCard(context.r2d2);
+
+        //         // Confirm Results
+        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
+        //         expect(context.r2d2.damage).toBe(1);
+        //     });
+
+        //     contextRef.undoIt('should be able to heal an enemy unit', function () {
+        //         const { context } = contextRef;
+
+        //         // Attack
+        //         context.player1.clickCard(context._21bSurgicalDroid);
+        //         expect(context.wampa.damage).toBe(2);
+        //         expect(context._21bSurgicalDroid).toBeInZone('groundArena');
+        //         expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
+        //         context.player1.clickCard(context.p2Base);
+
+        //         // Healing Target
+        //         expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
+        //         context.player1.clickCard(context.wampa);
+
+        //         // Confirm Results
+        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
+        //         expect(context.wampa.damage).toBe(0);
+        //     });
+
+        //     contextRef.undoIt('should be able to be passed', function () {
+        //         const { context } = contextRef;
+
+        //         expect(context.r2d2.damage).toBe(3);
+        //         context.player1.clickCard(context._21bSurgicalDroid);
+        //         context.player1.clickCard(context.p2Base);
+
+        //         context.player1.clickPrompt('Pass');
+        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
+        //         expect(context.r2d2.damage).toBe(3);
+        //     });
+        // });
     });
 });

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -12,8 +12,7 @@ describe('Undo', function() {
                     player2: {
                         groundArena: ['wampa', 'superlaser-technician'],
                         spaceArena: ['tieln-fighter']
-                    },
-                    testUndo: true
+                    }
                 });
             });
 

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -17,7 +17,7 @@ describe('Undo', function() {
                 });
             });
 
-            uit('can only target ground units & can damage itself', function () {
+            undoIt('can only target ground units & can damage itself', function () {
                 const { context } = contextRef;
 
                 // Play Death Trooper
@@ -36,7 +36,7 @@ describe('Undo', function() {
                 expect(context.wampa.damage).toEqual(2);
             });
 
-            uit('works when no enemy ground units', function () {
+            undoIt('works when no enemy ground units', function () {
                 const { context } = contextRef;
 
                 // Play Death Trooper
@@ -68,7 +68,7 @@ describe('Undo', function() {
                 });
             });
 
-            uit('should heal a target with 1 damage to full', function () {
+            undoIt('should heal a target with 1 damage to full', function () {
                 const { context } = contextRef;
 
                 // Attack
@@ -86,7 +86,7 @@ describe('Undo', function() {
                 expect(context.c3po.damage).toBe(0);
             });
 
-            uit('should heal 2 damage from a unit', function () {
+            undoIt('should heal 2 damage from a unit', function () {
                 const { context } = contextRef;
 
                 // Attack
@@ -104,7 +104,7 @@ describe('Undo', function() {
                 expect(context.r2d2.damage).toBe(1);
             });
 
-            uit('should be able to heal an enemy unit', function () {
+            undoIt('should be able to heal an enemy unit', function () {
                 const { context } = contextRef;
 
                 // Attack
@@ -123,7 +123,7 @@ describe('Undo', function() {
                 expect(context.wampa.damage).toBe(0);
             });
 
-            uit('should be able to be passed', function () {
+            undoIt('should be able to be passed', function () {
                 const { context } = contextRef;
 
                 expect(context.r2d2.damage).toBe(3);

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -36,104 +36,104 @@ describe('Undo', function() {
                 expect(context.wampa.damage).toEqual(2);
             });
 
-            // contextRef.undoIt('works when no enemy ground units', function () {
-            //     const { context } = contextRef;
+            uit('works when no enemy ground units', function () {
+                const { context } = contextRef;
 
-            //     // Play Death Trooper
-            //     context.player2.setGroundArenaUnits([]);
-            //     context.player1.clickCard(context.deathTrooper);
+                // Play Death Trooper
+                context.player2.setGroundArenaUnits([]);
+                context.player1.clickCard(context.deathTrooper);
 
-            //     // Choose Friendly
-            //     expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.deathTrooper]);
-            //     expect(context.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
-            //     context.player1.clickCard(context.deathTrooper);
-            //     expect(context.deathTrooper.damage).toEqual(2);
-            // });
+                // Choose Friendly
+                expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.deathTrooper]);
+                expect(context.player1).not.toHavePassAbilityPrompt('Deal 2 damage to a friendly ground unit and an enemy ground unit');
+                context.player1.clickCard(context.deathTrooper);
+                expect(context.deathTrooper.damage).toEqual(2);
+            });
         });
 
-        // describe('2-1B Surgical Droid\'s ability', function() {
-        //     beforeEach(function () {
-        //         return contextRef.setupTestAsync({
-        //             phase: 'action',
-        //             player1: {
-        //                 groundArena: [
-        //                     { card: '21b-surgical-droid' },
-        //                     { card: 'r2d2#ignoring-protocol', damage: 3 },
-        //                     { card: 'c3po#protocol-droid', damage: 1 }],
-        //             },
-        //             player2: {
-        //                 groundArena: [{ card: 'wampa', damage: 2 }]
-        //             },
-        //             testUndo: true
-        //         });
-        //     });
+        describe('2-1B Surgical Droid\'s ability', function() {
+            beforeEach(function () {
+                return contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            { card: '21b-surgical-droid' },
+                            { card: 'r2d2#ignoring-protocol', damage: 3 },
+                            { card: 'c3po#protocol-droid', damage: 1 }],
+                    },
+                    player2: {
+                        groundArena: [{ card: 'wampa', damage: 2 }]
+                    },
+                    testUndo: true
+                });
+            });
 
-        //     contextRef.undoIt('should heal a target with 1 damage to full', function () {
-        //         const { context } = contextRef;
+            uit('should heal a target with 1 damage to full', function () {
+                const { context } = contextRef;
 
-        //         // Attack
-        //         context.player1.clickCard(context._21bSurgicalDroid);
-        //         expect(context._21bSurgicalDroid).toBeInZone('groundArena');
-        //         expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
-        //         context.player1.clickCard(context.p2Base);
+                // Attack
+                context.player1.clickCard(context._21bSurgicalDroid);
+                expect(context._21bSurgicalDroid).toBeInZone('groundArena');
+                expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
+                context.player1.clickCard(context.p2Base);
 
-        //         // Healing Target
-        //         expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
-        //         context.player1.clickCard(context.c3po);
+                // Healing Target
+                expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
+                context.player1.clickCard(context.c3po);
 
-        //         // Confirm Results
-        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
-        //         expect(context.c3po.damage).toBe(0);
-        //     });
+                // Confirm Results
+                expect(context._21bSurgicalDroid.exhausted).toBe(true);
+                expect(context.c3po.damage).toBe(0);
+            });
 
-        //     contextRef.undoIt('should heal 2 damage from a unit', function () {
-        //         const { context } = contextRef;
+            uit('should heal 2 damage from a unit', function () {
+                const { context } = contextRef;
 
-        //         // Attack
-        //         context.player1.clickCard(context._21bSurgicalDroid);
-        //         expect(context._21bSurgicalDroid).toBeInZone('groundArena');
-        //         expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
-        //         context.player1.clickCard(context.p2Base);
+                // Attack
+                context.player1.clickCard(context._21bSurgicalDroid);
+                expect(context._21bSurgicalDroid).toBeInZone('groundArena');
+                expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
+                context.player1.clickCard(context.p2Base);
 
-        //         // Healing Target
-        //         expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
-        //         context.player1.clickCard(context.r2d2);
+                // Healing Target
+                expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
+                context.player1.clickCard(context.r2d2);
 
-        //         // Confirm Results
-        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
-        //         expect(context.r2d2.damage).toBe(1);
-        //     });
+                // Confirm Results
+                expect(context._21bSurgicalDroid.exhausted).toBe(true);
+                expect(context.r2d2.damage).toBe(1);
+            });
 
-        //     contextRef.undoIt('should be able to heal an enemy unit', function () {
-        //         const { context } = contextRef;
+            uit('should be able to heal an enemy unit', function () {
+                const { context } = contextRef;
 
-        //         // Attack
-        //         context.player1.clickCard(context._21bSurgicalDroid);
-        //         expect(context.wampa.damage).toBe(2);
-        //         expect(context._21bSurgicalDroid).toBeInZone('groundArena');
-        //         expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
-        //         context.player1.clickCard(context.p2Base);
+                // Attack
+                context.player1.clickCard(context._21bSurgicalDroid);
+                expect(context.wampa.damage).toBe(2);
+                expect(context._21bSurgicalDroid).toBeInZone('groundArena');
+                expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa]);
+                context.player1.clickCard(context.p2Base);
 
-        //         // Healing Target
-        //         expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
-        //         context.player1.clickCard(context.wampa);
+                // Healing Target
+                expect(context.player1).toBeAbleToSelectExactly([context.r2d2, context.c3po, context.wampa]);
+                context.player1.clickCard(context.wampa);
 
-        //         // Confirm Results
-        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
-        //         expect(context.wampa.damage).toBe(0);
-        //     });
+                // Confirm Results
+                expect(context._21bSurgicalDroid.exhausted).toBe(true);
+                expect(context.wampa.damage).toBe(0);
+            });
 
-        //     contextRef.undoIt('should be able to be passed', function () {
-        //         const { context } = contextRef;
+            uit('should be able to be passed', function () {
+                const { context } = contextRef;
 
-        //         expect(context.r2d2.damage).toBe(3);
-        //         context.player1.clickCard(context._21bSurgicalDroid);
-        //         context.player1.clickCard(context.p2Base);
+                expect(context.r2d2.damage).toBe(3);
+                context.player1.clickCard(context._21bSurgicalDroid);
+                context.player1.clickCard(context.p2Base);
 
-        //         context.player1.clickPrompt('Pass');
-        //         expect(context._21bSurgicalDroid.exhausted).toBe(true);
-        //         expect(context.r2d2.damage).toBe(3);
-        //     });
-        // });
+                context.player1.clickPrompt('Pass');
+                expect(context._21bSurgicalDroid.exhausted).toBe(true);
+                expect(context.r2d2.damage).toBe(3);
+            });
+        });
     });
 });

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -1,4 +1,4 @@
-describe('Death Trooper', function() {
+describe('Undo', function() {
     integration(function(contextRef) {
         describe('Death Trooper\'s When Played ability', function() {
             beforeEach(function () {
@@ -12,11 +12,12 @@ describe('Death Trooper', function() {
                     player2: {
                         groundArena: ['wampa', 'superlaser-technician'],
                         spaceArena: ['tieln-fighter']
-                    }
+                    },
+                    testUndo: true
                 });
             });
 
-            it('can only target ground units & can damage itself', function () {
+            contextRef.undoIt('can only target ground units & can damage itself', function () {
                 const { context } = contextRef;
 
                 // Play Death Trooper
@@ -35,7 +36,7 @@ describe('Death Trooper', function() {
                 expect(context.wampa.damage).toEqual(2);
             });
 
-            it('works when no enemy ground units', function () {
+            contextRef.undoIt('works when no enemy ground units', function () {
                 const { context } = contextRef;
 
                 // Play Death Trooper

--- a/test/server/core/gameSteps/AbilityResolver.spec.ts
+++ b/test/server/core/gameSteps/AbilityResolver.spec.ts
@@ -1,14 +1,16 @@
 describe('Ability resolver', function() {
     integration(function(contextRef) {
-        it('Triggers during an "if you do" sub-step for an event ability should go in the same resolution window as triggers from the beginning of the ability', async function() {
-            await contextRef.setupTestAsync({
+        beforeEach(function () {
+            return contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
                     hand: ['selfdestruct'],
                     spaceArena: ['star-wing-scout', 'rhokai-gunship']
                 }
             });
+        });
 
+        it('Triggers during an "if you do" sub-step for an event ability should go in the same resolution window as triggers from the beginning of the ability', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.selfdestruct);

--- a/test/server/core/gameSteps/AbilityResolver.spec.ts
+++ b/test/server/core/gameSteps/AbilityResolver.spec.ts
@@ -1,16 +1,14 @@
 describe('Ability resolver', function() {
     integration(function(contextRef) {
-        beforeEach(function () {
-            return contextRef.setupTestAsync({
+        it('Triggers during an "if you do" sub-step for an event ability should go in the same resolution window as triggers from the beginning of the ability', async function() {
+            await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
                     hand: ['selfdestruct'],
                     spaceArena: ['star-wing-scout', 'rhokai-gunship']
                 }
             });
-        });
 
-        it('Triggers during an "if you do" sub-step for an event ability should go in the same resolution window as triggers from the beginning of the ability', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.selfdestruct);


### PR DESCRIPTION
### Highlights
* A number of Game.js fields moved into a state object
* Player Decklist converted to use GameObjectRef and moved into state
* Card.parentCard converted to GameObjectRef and moved into state
* Fixed, then disabled the "filter card from list" in Game.js, it wasn't doing anything before so it's disabled for now.
* Converted undo test to a custom global uit function
* Added a JS private #experimental object in the Game for flagging the system to use undo logic. That way I can enable it in tests now and in the future for local builds only.

### Code I'm Not So Proud Of
Soooo I made some methods public in ActionPhase to make clearing the ActionPhase possible. It's a little horrifying but it did work for tests. And the way I clear the pipeline also was quick and dirty.

### Testing Notes
the new uit function only works with tests that do the setup in a beforeEach. In part because the rollback only is working for the ActionPhase, but also because if the setup is within an _it_ call, it'll bump into the rollback which happens before the test runs and can cause complications. So, the uit method will simply treat the test as a normal test if the setup call hasn't happened yet.

To manually run all tests in undo, simply put `global.it = global.uit;` after the uit definition. uit will have false positives, but the failures we do run into will help us hunt down more issues with undo.