### PR TITLE
Sullustan Spacer fix

### DIFF
--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -208,7 +208,7 @@ function getRegexForKeyword(keyword: KeywordName) {
         case KeywordName.Shielded:
             return /(?:^|(?:\n))Shielded/g;
         case KeywordName.Smuggle:
-            return /(?:\n)?Smuggle\s\[\s*(\d+)\s+resource(?:s)?\s*([\w\s]*)\]/g;
+            return /(?:\n)?Smuggle\s\[\s*(\d+)\s+resources(?:,\s*|\s+)([\w\s]+)(,.*)?\]/g;
         default:
             throw new Error(`Keyword '${keyword}' is not implemented yet`);
     }

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -164,7 +164,12 @@ function parseKeywordWithCostValuesIfEnabled(keyword: KeywordName, cardText: str
 
     const cost = Number(match.value[1]);
     const aspectString = match.value[2];
-    const aspects = EnumHelpers.checkConvertToEnum(aspectString.toLowerCase().split(' '), Aspect);
+
+    let aspects: Aspect[] = [];
+    if (aspectString && aspectString.length > 0) {
+        aspects = EnumHelpers.checkConvertToEnum(aspectString.toLowerCase().split(' '), Aspect);
+    }
+
     const additionalCosts = match.value[3] !== undefined;
 
     // regex capture group will be keyword value with costs
@@ -191,7 +196,7 @@ function getRegexForKeyword(keyword: KeywordName) {
         case KeywordName.Overwhelm:
             return /(?:^|(?:\n))Overwhelm/g;
         case KeywordName.Piloting:
-            return /Piloting\s\[\s*(\d+)\s+resource(?:s)?(?:,\s*|\s+)([\w\s]+)\]/g;
+            return /Piloting\s\[\s*(\d+)\s+resource(?:s)?\s*([\w\s]*)\]/g;
         case KeywordName.Raid:
             return /(?:^|(?:\n))Raid ([\d]+)/g;
         case KeywordName.Restore:
@@ -203,7 +208,7 @@ function getRegexForKeyword(keyword: KeywordName) {
         case KeywordName.Shielded:
             return /(?:^|(?:\n))Shielded/g;
         case KeywordName.Smuggle:
-            return /(?:\n)?Smuggle\s\[\s*(\d+)\s+resources(?:,\s*|\s+)([\w\s]+)(,.*)?\]/g;
+            return /(?:\n)?Smuggle\s\[\s*(\d+)\s+resource(?:s)?\s*([\w\s]*)\]/g;
         default:
             throw new Error(`Keyword '${keyword}' is not implemented yet`);
     }

--- a/test/server/core/abilities/keyword/Piloting.spec.ts
+++ b/test/server/core/abilities/keyword/Piloting.spec.ts
@@ -371,5 +371,25 @@ describe('Piloting keyword', function() {
             expect(context.greenSquadronAwing.getPower()).toBe(2);
             expect(context.greenSquadronAwing.getHp()).toBe(4);
         });
+
+        it('Piloting respects aspect costs', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'darth-vader#dark-lord-of-the-sith',
+                    hand: ['dagger-squadron-pilot'],
+                    spaceArena: ['concord-dawn-interceptors'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            const p1Resources = context.player1.readyResourceCount;
+            context.player1.clickCard(context.daggerSquadronPilot);
+            expect(context.player1).toHaveExactPromptButtons(['Cancel', 'Play Dagger Squadron Pilot', 'Play Dagger Squadron Pilot with Piloting']);
+            context.player1.clickPrompt('Play Dagger Squadron Pilot');
+            expect(context.player1.readyResourceCount).toBe(p1Resources - 5);
+            expect(context.daggerSquadronPilot).toBeInZone('groundArena');
+        });
     });
 });

--- a/test/server/core/abilities/keyword/Piloting.spec.ts
+++ b/test/server/core/abilities/keyword/Piloting.spec.ts
@@ -348,5 +348,28 @@ describe('Piloting keyword', function() {
             context.player1.clickCard(context.ruthlessRaider);
             expect(context.ruthlessRaider.damage).toBe(4);
         });
+
+        it('Piloting works when the ability has no aspect costs', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['sullustan-spacer'],
+                    spaceArena: ['green-squadron-awing']
+                }
+            });
+
+            const { context } = contextRef;
+
+            // no error should happen in this test
+            context.player1.clickCard(context.sullustanSpacer);
+            expect(context.player1).toHaveExactPromptButtons(['Cancel', 'Play Sullustan Spacer', 'Play Sullustan Spacer with Piloting']);
+
+            context.player1.clickPrompt('Play Sullustan Spacer with Piloting');
+            expect(context.player1).toBeAbleToSelectExactly([context.greenSquadronAwing]);
+            context.player1.clickCard(context.greenSquadronAwing);
+            expect(context.sullustanSpacer).toBeAttachedTo(context.greenSquadronAwing);
+            expect(context.greenSquadronAwing.getPower()).toBe(2);
+            expect(context.greenSquadronAwing.getHp()).toBe(4);
+        });
     });
 });


### PR DESCRIPTION
The parser for piloting abilities was requiring aspect costs to be present, but for "neutral" cards there might not be aspect costs. This was causing Sullustan Spacer to not read as having a piloting ability.