### PR TITLE
Fix uniqueness check when multiple unique units enter play

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1235,24 +1235,20 @@ class Game extends EventEmitter {
 
     /** Goes through the list of cards moved during event resolution and does a uniqueness rule check for each */
     checkUniqueRule() {
-        const dedupedMovedCards = this.movedCards.reduce((acc, card) => {
-            // Only prompt once per copy of a unique card controlled by the same player
-            const existingCard = acc.find((otherCard) =>
-                otherCard.title === card.title &&
-                otherCard.subtitle === card.subtitle &&
-                otherCard.controller === card.controller
-            );
+        const checkedCards = new Array();
 
-            if (!existingCard) {
-                acc.push(card);
-            }
-
-            return acc;
-        }, []);
-
-        for (const movedCard of dedupedMovedCards) {
+        for (const movedCard of this.movedCards) {
             if (EnumHelpers.isArena(movedCard.zoneName) && movedCard.unique) {
-                movedCard.checkUnique();
+                const existingCard = checkedCards.find((otherCard) =>
+                    otherCard.title === movedCard.title &&
+                    otherCard.subtitle === movedCard.subtitle &&
+                    otherCard.controller === movedCard.controller
+                );
+
+                if (!existingCard) {
+                    checkedCards.push(movedCard);
+                    movedCard.checkUnique();
+                }
             }
         }
     }

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1235,7 +1235,22 @@ class Game extends EventEmitter {
 
     /** Goes through the list of cards moved during event resolution and does a uniqueness rule check for each */
     checkUniqueRule() {
-        for (const movedCard of this.movedCards) {
+        const dedupedMovedCards = this.movedCards.reduce((acc, card) => {
+            // Only prompt once per copy of a unique card controlled by the same player
+            const existingCard = acc.find((otherCard) =>
+                otherCard.title === card.title &&
+                otherCard.subtitle === card.subtitle &&
+                otherCard.controller === card.controller
+            );
+
+            if (!existingCard) {
+                acc.push(card);
+            }
+
+            return acc;
+        }, []);
+
+        for (const movedCard of dedupedMovedCards) {
             if (EnumHelpers.isArena(movedCard.zoneName) && movedCard.unique) {
                 movedCard.checkUnique();
             }

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -421,6 +421,44 @@ describe('Uniqueness rule', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('works the same as above if the player chooses the other copy', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: [
+                            'fell-the-dragon'
+                        ]
+                    },
+                    player2: {
+                        groundArena: [
+                            {
+                                card: 'cad-bane#hostage-taker',
+                                capturedUnits: [
+                                    'kuiil#i-have-spoken',
+                                    'kuiil#i-have-spoken'
+                                ]
+                            }
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+                const kuiil1 = context.cadBane.capturedUnits[0];
+                const kuiil2 = context.cadBane.capturedUnits[1];
+
+                context.player1.clickCard(context.fellTheDragon);
+                context.player1.clickCard(context.cadBane);
+
+                expect(context.player1).toHavePrompt('Choose which copy of Kuiil, I Have Spoken to defeat');
+
+                context.player1.clickCard(kuiil2);
+
+                expect(kuiil1).toBeInZone('groundArena');
+                expect(kuiil2).toBeInZone('discard');
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('and one copy was already in play, the player is prompted to defeat two copies', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
@@ -488,6 +526,76 @@ describe('Uniqueness rule', function() {
                 context.player1.clickCard(obi3);
 
                 expect(obi3).toHaveExactUpgradeNames(['experience', 'experience', 'experience', 'experience']);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('works the same as above if the player chooses the other copy', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: [
+                            'fell-the-dragon'
+                        ],
+                        groundArena: [
+                            'obiwan-kenobi#following-fate'
+                        ]
+                    },
+                    player2: {
+                        groundArena: [
+                            {
+                                card: 'cad-bane#hostage-taker',
+                                capturedUnits: [
+                                    'obiwan-kenobi#following-fate',
+                                    'obiwan-kenobi#following-fate'
+                                ]
+                            }
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+                const obi1 = context.cadBane.capturedUnits[0];
+                const obi2 = context.cadBane.capturedUnits[1];
+                const obi3 = context.player1.findCardByName('obiwan-kenobi#following-fate', 'groundArena');
+
+                context.player1.clickCard(context.fellTheDragon);
+                context.player1.clickCard(context.cadBane);
+
+                expect(context.player1).toHavePrompt('Choose which copies of Obi-Wan Kenobi, Following Fate to defeat');
+                expect(context.player1).not.toHaveExactPromptButtons(['Done']);
+                expect(context.player1).toBeAbleToSelectExactly([obi1, obi2, obi3]);
+
+                context.player1.clickCard(obi2);
+
+                expect(context.player1).toHavePrompt('Choose which copies of Obi-Wan Kenobi, Following Fate to defeat');
+                expect(context.player1).not.toHaveExactPromptButtons(['Done']);
+
+                context.player1.clickCard(obi3);
+
+                expect(context.player1).toHavePrompt('Choose which copies of Obi-Wan Kenobi, Following Fate to defeat');
+                expect(context.player1).toHaveExactPromptButtons(['Done']);
+
+                context.player1.clickPrompt('Done');
+
+                expect(obi1).toBeInZone('groundArena');
+                expect(obi2).toBeInZone('discard');
+                expect(obi3).toBeInZone('discard');
+
+                // Once both are defeated, the player can resolve the When Defeated abilities
+                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
+                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.'
+                ]);
+
+                context.player1.clickPrompt('Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.');
+
+                expect(context.player1).toBeAbleToSelectExactly([obi1]);
+
+                context.player1.clickCardNonChecking(obi1);
+                context.player1.clickCard(obi1);
+
+                expect(obi1).toHaveExactUpgradeNames(['experience', 'experience', 'experience', 'experience']);
                 expect(context.player2).toBeActivePlayer();
             });
         });

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -381,5 +381,115 @@ describe('Uniqueness rule', function() {
                 expect(context.cellBlockGuard).toBeInZone('groundArena');
             });
         });
+
+        describe('When multiple copies of a unique unit are rescued simultaneously,', function() {
+            it('the player is prompted to choose which copy to defeat', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: [
+                            'fell-the-dragon'
+                        ]
+                    },
+                    player2: {
+                        groundArena: [
+                            {
+                                card: 'cad-bane#hostage-taker',
+                                capturedUnits: [
+                                    'kuiil#i-have-spoken',
+                                    'kuiil#i-have-spoken'
+                                ]
+                            }
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+                const kuiil1 = context.cadBane.capturedUnits[0];
+                const kuiil2 = context.cadBane.capturedUnits[1];
+
+                context.player1.clickCard(context.fellTheDragon);
+                context.player1.clickCard(context.cadBane);
+
+                expect(context.player1).toHavePrompt('Choose which copy of Kuiil, I Have Spoken to defeat');
+
+                context.player1.clickCard(kuiil1);
+
+                expect(kuiil1).toBeInZone('discard');
+                expect(kuiil2).toBeInZone('groundArena');
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('and one copy was already in play, the player is prompted to defeat two copies', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: [
+                            'fell-the-dragon'
+                        ],
+                        groundArena: [
+                            'obiwan-kenobi#following-fate'
+                        ]
+                    },
+                    player2: {
+                        groundArena: [
+                            {
+                                card: 'cad-bane#hostage-taker',
+                                capturedUnits: [
+                                    'obiwan-kenobi#following-fate',
+                                    'obiwan-kenobi#following-fate'
+                                ]
+                            }
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+                const obi1 = context.cadBane.capturedUnits[0];
+                const obi2 = context.cadBane.capturedUnits[1];
+                const obi3 = context.player1.findCardByName('obiwan-kenobi#following-fate', 'groundArena');
+
+                context.player1.clickCard(context.fellTheDragon);
+                context.player1.clickCard(context.cadBane);
+
+                expect(context.player1).toHavePrompt('Choose which copies of Obi-Wan Kenobi, Following Fate to defeat');
+                expect(context.player1).not.toHaveExactPromptButtons(['Done']);
+                expect(context.player1).toBeAbleToSelectExactly([obi1, obi2, obi3]);
+
+                context.player1.clickCard(obi1);
+
+                expect(context.player1).toHavePrompt('Choose which copies of Obi-Wan Kenobi, Following Fate to defeat');
+                expect(context.player1).not.toHaveExactPromptButtons(['Done']);
+
+                context.player1.clickCard(obi2);
+
+                expect(context.player1).toHavePrompt('Choose which copies of Obi-Wan Kenobi, Following Fate to defeat');
+                expect(context.player1).toHaveExactPromptButtons(['Done']);
+
+                context.player1.clickPrompt('Done');
+
+                expect(obi1).toBeInZone('discard');
+                expect(obi2).toBeInZone('discard');
+                expect(obi3).toBeInZone('groundArena');
+
+                // Once both are defeated, the player can resolve the When Defeated abilities
+                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
+                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.'
+                ]);
+
+                context.player1.clickPrompt('Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.');
+
+                expect(context.player1).toBeAbleToSelectExactly([obi3]);
+
+                context.player1.clickCardNonChecking(obi3);
+                context.player1.clickCard(obi3);
+
+                expect(obi3).toHaveExactUpgradeNames(['experience', 'experience', 'experience', 'experience']);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes #1029 

#### Prompt to defeat multiple copies
<img width="750" alt="Screenshot 2025-04-02 at 9 32 17 PM" src="https://github.com/user-attachments/assets/e82ea7dd-9ca2-46e2-b64e-28f6dd6200cf" />

#### Prompt state when 2 copies are selected
<img width="750" alt="Screenshot 2025-04-02 at 9 32 30 PM" src="https://github.com/user-attachments/assets/100cd609-90da-4abd-aece-115fedb3c87f" />
