### PR TITLE
"When played" standard triggered ability

### DIFF
--- a/server/game/cards/01_SOR/units/AvengerHuntingStarDestroyer.ts
+++ b/server/game/cards/01_SOR/units/AvengerHuntingStarDestroyer.ts
@@ -15,7 +15,7 @@ export default class AvengerHuntingStarDestroyer extends NonLeaderUnitCard {
             title: 'Opponent chooses a non-leader unit they control to defeat',
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 activePromptTitle: 'Choose a non-leader unit to defeat',

--- a/server/game/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.ts
+++ b/server/game/cards/01_SOR/units/BlackOneScourgeOfStarkillerBase.ts
@@ -13,7 +13,7 @@ export default class BlackOneScourgeOfStarkillerBase extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Discard your hand',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true
             },
             optional: true,

--- a/server/game/cards/01_SOR/units/C-3POProtocolDroid.ts
+++ b/server/game/cards/01_SOR/units/C-3POProtocolDroid.ts
@@ -15,7 +15,7 @@ export default class C3POProtocolDroid extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Choose a number',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             targetResolver: {

--- a/server/game/cards/01_SOR/units/InfernoFourUnforgetting.ts
+++ b/server/game/cards/01_SOR/units/InfernoFourUnforgetting.ts
@@ -14,7 +14,7 @@ export default class InfernoFourUnforgetting extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Look at the top 2 cards of your deck. Put any number of them on the bottom of your deck and the rest on top in any order.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.lookMoveDeckCardsTopOrBottom({ amount: 2 })

--- a/server/game/cards/01_SOR/units/R2D2IgnoringProtocol.ts
+++ b/server/game/cards/01_SOR/units/R2D2IgnoringProtocol.ts
@@ -14,7 +14,7 @@ export default class R2D2IgnoringProtocol extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Look at the top 2 cards of your deck. Put any number of them on the bottom of your deck and the rest on top in any order.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.lookMoveDeckCardsTopOrBottom({ amount: 1 })

--- a/server/game/cards/01_SOR/units/ReinforcementWalker.ts
+++ b/server/game/cards/01_SOR/units/ReinforcementWalker.ts
@@ -14,7 +14,7 @@ export default class ReinforcementWalker extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Look at the top card of your deck. Draw it or discard it and heal 3 damage from your base.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.lookAtAndChooseOption(

--- a/server/game/cards/01_SOR/units/RuthlessRaider.ts
+++ b/server/game/cards/01_SOR/units/RuthlessRaider.ts
@@ -14,7 +14,7 @@ export default class RuthlessRaider extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 2 damage to an enemy base and 2 damage to an enemy unit',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true
             },
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([

--- a/server/game/cards/01_SOR/units/TheGhostSpectreHomeBase.ts
+++ b/server/game/cards/01_SOR/units/TheGhostSpectreHomeBase.ts
@@ -15,7 +15,7 @@ export default class TheGhostSpectreHomeBase extends NonLeaderUnitCard {
             title: 'Give a shield token to another Spectre unit',
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             optional: true,
             targetResolver: {

--- a/server/game/cards/01_SOR/units/WolffeSuspiciousVeteran.ts
+++ b/server/game/cards/01_SOR/units/WolffeSuspiciousVeteran.ts
@@ -14,7 +14,7 @@ export default class WolffeSuspiciousVeteran extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Bases can\'t be healed',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({

--- a/server/game/cards/02_SHD/units/CassianAndorRebellionsAreBuiltOnHope.ts
+++ b/server/game/cards/02_SHD/units/CassianAndorRebellionsAreBuiltOnHope.ts
@@ -1,6 +1,5 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { PlayType } from '../../../core/Constants';
 
 export default class CassianAndorRebellionsAreBuiltOnHope extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -11,12 +10,12 @@ export default class CassianAndorRebellionsAreBuiltOnHope extends NonLeaderUnitC
     }
 
     public override setupCardAbilities () {
-        this.addWhenPlayedAbility({
-            title: 'Ready this unit.',
-            immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => context.event.playType === PlayType.Smuggle,
-                onTrue: AbilityHelper.immediateEffects.ready(),
-            })
+        this.addTriggeredAbility({
+            title: 'Ready this unit',
+            when: {
+                whenPlayedUsingSmuggle: true,
+            },
+            immediateEffect: AbilityHelper.immediateEffects.ready(),
         });
     }
 }

--- a/server/game/cards/02_SHD/units/CovetousRivals.ts
+++ b/server/game/cards/02_SHD/units/CovetousRivals.ts
@@ -15,7 +15,7 @@ export default class CovetousRivals extends NonLeaderUnitCard {
             title: 'Deal 2 damage to a unit with a Bounty',
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/units/DjBlatantThief.ts
+++ b/server/game/cards/02_SHD/units/DjBlatantThief.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { PlayType, RelativePlayer } from '../../../core/Constants';
+import { RelativePlayer } from '../../../core/Constants';
 
 export default class DjBlatantThief extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,9 +14,7 @@ export default class DjBlatantThief extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Take control of an enemy resource. When this unit leaves play, that resource\'s owner takes control of it.',
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Smuggle
+                whenPlayedUsingSmuggle: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.sequential((sequentialContext) => [
                 AbilityHelper.immediateEffects.takeControlOfResource((context) => ({ target: context.player })),

--- a/server/game/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.ts
+++ b/server/game/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.ts
@@ -15,7 +15,7 @@ export default class GeneralRieekanDefensiveStrategist extends NonLeaderUnitCard
             title: 'Choose a friendly unit. If it has Sentinel, give an Experience token to it. Otherwise, it gains Sentinel for this phase',
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/units/JabbasRancorPateesa.ts
+++ b/server/game/cards/02_SHD/units/JabbasRancorPateesa.ts
@@ -20,7 +20,7 @@ export default class JabbasRancorPateesa extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 3 damage to another friendly ground unit and 3 damage to an enemy ground unit',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             targetResolvers: {

--- a/server/game/cards/02_SHD/units/PreVizslaPowerHungry.ts
+++ b/server/game/cards/02_SHD/units/PreVizslaPowerHungry.ts
@@ -14,7 +14,7 @@ export default class PreVizslaPowerHungry extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Pay the cost of an upgrade attached to another non-Vehicle unit',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             optional: true,

--- a/server/game/cards/02_SHD/units/PrivateerCrew.ts
+++ b/server/game/cards/02_SHD/units/PrivateerCrew.ts
@@ -1,6 +1,5 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { PlayType } from '../../../core/Constants';
 
 export default class PrivateerCrew extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -11,15 +10,15 @@ export default class PrivateerCrew extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities() {
-        this.addWhenPlayedAbility({
+        this.addTriggeredAbility({
             title: 'Give 3 experience tokens to this unit',
-            immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => context.event.playType === PlayType.Smuggle,
-                onTrue: AbilityHelper.immediateEffects.giveExperience((context) => ({
-                    amount: 3,
-                    target: context.source
-                })),
-            })
+            when: {
+                whenPlayedUsingSmuggle: true,
+            },
+            immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => ({
+                amount: 3,
+                target: context.source
+            })),
         });
     }
 }

--- a/server/game/cards/02_SHD/units/StolenLandspeeder.ts
+++ b/server/game/cards/02_SHD/units/StolenLandspeeder.ts
@@ -15,11 +15,14 @@ export default class StolenLandspeeder extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'An opponent takes control of it',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source && event.playType === PlayType.PlayFromHand
+                whenPlayed: true,
             },
-            immediateEffect: AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
-                newController: context.player.opponent
-            }))
+            immediateEffect: AbilityHelper.immediateEffects.conditional({
+                condition: (context) => context.event.playType === PlayType.PlayFromHand,
+                onTrue: AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
+                    newController: context.player.opponent
+                })),
+            })
         });
 
         this.addBountyAbility({

--- a/server/game/cards/02_SHD/units/SurvivorsGauntlet.ts
+++ b/server/game/cards/02_SHD/units/SurvivorsGauntlet.ts
@@ -16,7 +16,7 @@ export default class SurvivorsGauntlet extends NonLeaderUnitCard {
             title: 'Attach an upgrade on a unit to another eligible unit controlled by the same player',
             optional: true,
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             targetResolvers: {

--- a/server/game/cards/02_SHD/units/XanaduBloodCadBanesReward.ts
+++ b/server/game/cards/02_SHD/units/XanaduBloodCadBanesReward.ts
@@ -14,7 +14,7 @@ export default class XanaduBloodCadBanesReward extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Return another friendly non-leader Underworld unit to its owner’s hand',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             optional: true,

--- a/server/game/cards/02_SHD/upgrades/HotshotDL44Blaster.ts
+++ b/server/game/cards/02_SHD/upgrades/HotshotDL44Blaster.ts
@@ -14,8 +14,11 @@ export default class HotshotDL44Blaster extends UpgradeCard {
     public override setupCardAbilities() {
         this.setAttachCondition((card: Card) => !card.hasSomeTrait(Trait.Vehicle));
 
-        this.addWhenPlayedAbility({
+        this.addTriggeredAbility({
             title: 'When Smuggled, attack with attached unit',
+            when: {
+                whenPlayedUsingSmuggle: true,
+            },
             immediateEffect: AbilityHelper.immediateEffects.conditional((context) => ({
                 target: context.source.parentCard,
                 condition: context.event.playType === PlayType.Smuggle,

--- a/server/game/cards/03_TWI/units/BattleDroidEscort.ts
+++ b/server/game/cards/03_TWI/units/BattleDroidEscort.ts
@@ -13,7 +13,7 @@ export default class BattleDroidEscort extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Create a Battle Droid token.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createBattleDroid()

--- a/server/game/cards/03_TWI/units/CalculatingMagnaGuard.ts
+++ b/server/game/cards/03_TWI/units/CalculatingMagnaGuard.ts
@@ -14,7 +14,7 @@ export default class CalculatingMagnaGuard extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'This unit gains Sentinel for this phase',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onCardDefeated: (event, context) => event.card.isUnit() && event.card.controller === context.player && event.card !== context.source,
             },
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({

--- a/server/game/cards/03_TWI/units/CaptainTyphoProtectingTheSenator.ts
+++ b/server/game/cards/03_TWI/units/CaptainTyphoProtectingTheSenator.ts
@@ -16,7 +16,7 @@ export default class CaptainTyphoProtectingTheSenator extends NonLeaderUnitCard 
             optional: false,
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/03_TWI/units/EliteP38Starfighter.ts
+++ b/server/game/cards/03_TWI/units/EliteP38Starfighter.ts
@@ -14,7 +14,7 @@ export default class EliteP38Starfighter extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 1 damage to a unit',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true
             },
             optional: true,

--- a/server/game/cards/03_TWI/units/EnfysNestChampionOfJustice.ts
+++ b/server/game/cards/03_TWI/units/EnfysNestChampionOfJustice.ts
@@ -14,7 +14,7 @@ export default class EnfysNestChampionOfJustice extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Return an enemy non-leader unit with less power than this unit to its owner\'s hand',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             optional: true,

--- a/server/game/cards/03_TWI/units/ObiWansAetherspriteThisIsWhyIHateFlying.ts
+++ b/server/game/cards/03_TWI/units/ObiWansAetherspriteThisIsWhyIHateFlying.ts
@@ -16,7 +16,7 @@ export default class ObiWansAetherspriteThisIsWhyIHateFlying extends NonLeaderUn
             optional: true,
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.damage({ amount: 1 }),

--- a/server/game/cards/03_TWI/units/PeltaSupplyFrigate.ts
+++ b/server/game/cards/03_TWI/units/PeltaSupplyFrigate.ts
@@ -15,7 +15,7 @@ export default class PeltaSupplyFrigate extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Create a Clone Trooper token',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createCloneTrooper()
         });

--- a/server/game/cards/03_TWI/units/RecklessTorrent.ts
+++ b/server/game/cards/03_TWI/units/RecklessTorrent.ts
@@ -15,7 +15,7 @@ export default class RecklessTorrent extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Deal 2 damage to a friendly unit and 2 damage to an enemy unit in the same arena',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolvers: {
                 friendlyUnit: {

--- a/server/game/cards/03_TWI/units/ResoluteUnderAnakinsCommand.ts
+++ b/server/game/cards/03_TWI/units/ResoluteUnderAnakinsCommand.ts
@@ -19,7 +19,7 @@ export default class ResoluteUnderAnakinsCommand extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 2 damage to an enemy unit and each other enemy unit with the same name as that unit',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             targetResolver: {

--- a/server/game/cards/03_TWI/units/SanctionersShuttle.ts
+++ b/server/game/cards/03_TWI/units/SanctionersShuttle.ts
@@ -15,7 +15,7 @@ export default class SanctionersShuttle extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'This unit captures an enemy non-leader unit that costs 3 or less. ',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 cardCondition: (card) => card.isNonLeaderUnit() && card.cost <= 3,

--- a/server/game/cards/03_TWI/units/SteelaGerreraBelovedTactician.ts
+++ b/server/game/cards/03_TWI/units/SteelaGerreraBelovedTactician.ts
@@ -14,7 +14,7 @@ export default class SteelaGerreraBelovedTactician extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 2 damage to your base',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true
             },
             optional: true,

--- a/server/game/cards/03_TWI/units/SubjugatingStarfighter.ts
+++ b/server/game/cards/03_TWI/units/SubjugatingStarfighter.ts
@@ -10,12 +10,12 @@ export default class SubjugatingStarfighter extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities () {
-        this.addTriggeredAbility({
-            title: 'Create a Battle Droid token.',
-            when: {
-                onCardPlayed: (event, context) => event.card === context.source && context.player.hasInitiative(),
-            },
-            immediateEffect: AbilityHelper.immediateEffects.createBattleDroid()
+        this.addWhenPlayedAbility({
+            title: 'Create a Battle Droid token',
+            immediateEffect: AbilityHelper.immediateEffects.conditional({
+                condition: (context) => context.player.hasInitiative(),
+                onTrue: AbilityHelper.immediateEffects.createBattleDroid(),
+            })
         });
     }
 }

--- a/server/game/cards/04_JTL/units/AnnihilatorTaggesFlagship.ts
+++ b/server/game/cards/04_JTL/units/AnnihilatorTaggesFlagship.ts
@@ -16,7 +16,7 @@ export default class AnnihilatorTaggesFlagship extends NonLeaderUnitCard {
             title: 'Defeat an enemy unit',
             optional: true,
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true
             },
             targetResolver: {

--- a/server/game/cards/04_JTL/units/AstromechPilot.ts
+++ b/server/game/cards/04_JTL/units/AstromechPilot.ts
@@ -1,5 +1,5 @@
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, WildcardCardType } from '../../../core/Constants';
+import { AbilityType, WildcardCardType } from '../../../core/Constants';
 import AbilityHelper from '../../../AbilityHelper';
 
 export default class AstromechPilot extends NonLeaderUnitCard {
@@ -15,9 +15,7 @@ export default class AstromechPilot extends NonLeaderUnitCard {
             title: 'Heal 2 damage from a unit',
             type: AbilityType.Triggered,
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             optional: true,
             targetResolver: {

--- a/server/game/cards/04_JTL/units/BB8HappyBeeps.ts
+++ b/server/game/cards/04_JTL/units/BB8HappyBeeps.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, Trait } from '../../../core/Constants';
+import { AbilityType, Trait } from '../../../core/Constants';
 
 export default class BB8HappyBeeps extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,9 +14,7 @@ export default class BB8HappyBeeps extends NonLeaderUnitCard {
         this.addPilotingAbility({
             type: AbilityType.Triggered,
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             title: 'Pay 2 resources',
             optional: true,

--- a/server/game/cards/04_JTL/units/BoShekCharismaticSmuggler.ts
+++ b/server/game/cards/04_JTL/units/BoShekCharismaticSmuggler.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, EventName, PlayType } from '../../../core/Constants';
+import { AbilityType, EventName } from '../../../core/Constants';
 
 export default class BoShekCharismaticSmuggler extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -15,9 +15,7 @@ export default class BoShekCharismaticSmuggler extends NonLeaderUnitCard {
             title: 'Discard 2 cards from your deck',
             type: AbilityType.Triggered,
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.discardFromDeck((context) => ({
                 amount: 2,

--- a/server/game/cards/04_JTL/units/BobaFettFearedBountyHunter.ts
+++ b/server/game/cards/04_JTL/units/BobaFettFearedBountyHunter.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { AbilityType, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class BobaFettFearedBountyHunter extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -15,9 +15,7 @@ export default class BobaFettFearedBountyHunter extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Deal 1 damage to a unit. If attached unit is a Transport, deal 2 damage instead.',
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             optional: true,
             targetResolver: {

--- a/server/game/cards/04_JTL/units/CaptainPhasmaOnMyCommand.ts
+++ b/server/game/cards/04_JTL/units/CaptainPhasmaOnMyCommand.ts
@@ -16,7 +16,7 @@ export default class CaptainPhasmaOnMyCommand extends NonLeaderUnitCard {
             optional: true,
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/04_JTL/units/ExecutorMightOfTheEmpire.ts
+++ b/server/game/cards/04_JTL/units/ExecutorMightOfTheEmpire.ts
@@ -14,7 +14,7 @@ export default class ExecutorMightOfTheEmpire extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Create 3 TIE Fighter tokens.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true,
                 onAttack: true,
             },

--- a/server/game/cards/04_JTL/units/FettsFiresprayFearedSilhouette.ts
+++ b/server/game/cards/04_JTL/units/FettsFiresprayFearedSilhouette.ts
@@ -15,7 +15,7 @@ export default class FettsFiresprayFearedSilhouette extends NonLeaderUnitCard {
             title: 'Deal 1 indirect damage to a player. If you control Boba Fett, deal 2 indirect damage instead',
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             targetResolver: {
                 mode: TargetMode.Player,

--- a/server/game/cards/04_JTL/units/FriskVanguardLoudmouth.ts
+++ b/server/game/cards/04_JTL/units/FriskVanguardLoudmouth.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { AbilityType, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class FriskVanguardLoudmouth extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -15,9 +15,7 @@ export default class FriskVanguardLoudmouth extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Defeat an upgrade that costs 2 or less',
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             optional: true,
             targetResolver: {

--- a/server/game/cards/04_JTL/units/GeneralDravenDoingWhatMustBeDone.ts
+++ b/server/game/cards/04_JTL/units/GeneralDravenDoingWhatMustBeDone.ts
@@ -14,7 +14,7 @@ export default class GeneralDravenDoingWhatMustBeDone extends NonLeaderUnitCard 
             title: 'Create an X-Wing token',
             when: {
                 onAttack: true,
-                onCardPlayed: (event, context) => event.card === context.source
+                whenPlayed: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createXWing()
         });

--- a/server/game/cards/04_JTL/units/HanSoloHasHisMoments.ts
+++ b/server/game/cards/04_JTL/units/HanSoloHasHisMoments.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import type { Attack } from '../../../core/attack/Attack';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType } from '../../../core/Constants';
+import { AbilityType } from '../../../core/Constants';
 
 export default class HanSoloHasHisMoments extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -16,7 +16,7 @@ export default class HanSoloHasHisMoments extends NonLeaderUnitCard {
             title: 'Attack with attached unit. If it\'s the Millennium Falcon, it deals its combat damage before the defender.',
             type: AbilityType.Triggered,
             when: {
-                onCardPlayed: (event, context) => event.card === context.source && event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.attack((context) => ({

--- a/server/game/cards/04_JTL/units/KimogilaHeavyFighter.ts
+++ b/server/game/cards/04_JTL/units/KimogilaHeavyFighter.ts
@@ -21,7 +21,7 @@ export default class KimogilaHeavyFighter extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 3 indirect damage to a player',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
             },
             targetResolver: {
                 mode: TargetMode.Player,

--- a/server/game/cards/04_JTL/units/ProfundityWeFight.ts
+++ b/server/game/cards/04_JTL/units/ProfundityWeFight.ts
@@ -14,7 +14,7 @@ export default class ProfundityWeFight extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Make a player discard a card from their hand',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true,
             },
             targetResolver: {

--- a/server/game/cards/04_JTL/units/RafaMartezShrewdSister.ts
+++ b/server/game/cards/04_JTL/units/RafaMartezShrewdSister.ts
@@ -15,7 +15,7 @@ export default class RafaMartezShrewdSister extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Deal 1 damage to a friendly unit and ready a resource',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttack: true,
             },
             targetResolver: {

--- a/server/game/cards/04_JTL/units/ShuttleST149UnderKrennicsAuthority.ts
+++ b/server/game/cards/04_JTL/units/ShuttleST149UnderKrennicsAuthority.ts
@@ -15,7 +15,7 @@ export default class ShuttleST149UnderKrennicsAuthority extends NonLeaderUnitCar
             title: 'Take control of a token upgrade on a unit and attach it to a different eligible unit.',
             optional: true,
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true,
             },
             targetResolvers: {

--- a/server/game/cards/04_JTL/units/SnapWexleyResistanceReconFlier.ts
+++ b/server/game/cards/04_JTL/units/SnapWexleyResistanceReconFlier.ts
@@ -1,5 +1,5 @@
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, Trait } from '../../../core/Constants';
+import { AbilityType, Trait } from '../../../core/Constants';
 import AbilityHelper from '../../../AbilityHelper';
 import * as AbilityLimit from '../../../core/ability/AbilityLimit';
 
@@ -15,7 +15,7 @@ export default class SnapWexleyResistanceReconFlier extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'The next Resistance card you play this phase costs 1 resource less',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source && event.playType !== PlayType.Piloting,
+                whenPlayed: true,
                 onAttack: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
@@ -31,9 +31,7 @@ export default class SnapWexleyResistanceReconFlier extends NonLeaderUnitCard {
             title: 'Search the top 5 cards of your deck for a Resistance card, reveal it, and draw it',
             type: AbilityType.Triggered,
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,

--- a/server/game/cards/04_JTL/units/TIEAmbushSquadron.ts
+++ b/server/game/cards/04_JTL/units/TIEAmbushSquadron.ts
@@ -13,7 +13,7 @@ export default class TIEAmbushSquadron extends NonLeaderUnitCard {
         this.addTriggeredAbility({
             title: 'Create a TIE Fighter token.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 whenDefeated: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createTieFighter()

--- a/server/game/cards/04_JTL/units/TheInvisibleHandCrawlingWithVultures.ts
+++ b/server/game/cards/04_JTL/units/TheInvisibleHandCrawlingWithVultures.ts
@@ -16,7 +16,7 @@ export default class TheInvisibleHandCrawlingWithVultures extends NonLeaderUnitC
         this.addTriggeredAbility({
             title: 'Search the top 8 cards of your deck for a Droid unit, reveal it, and draw it. If it costs 2 or less, you may play it for free.',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source,
+                whenPlayed: true,
                 onAttackCompleted: (event, context) => event.attack.attacker === context.source
             },
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({

--- a/server/game/cards/04_JTL/units/TheMandalorianWeatheredPilot.ts
+++ b/server/game/cards/04_JTL/units/TheMandalorianWeatheredPilot.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, RelativePlayer, TargetMode, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { AbilityType, RelativePlayer, TargetMode, WildcardCardType, ZoneName } from '../../../core/Constants';
 
 export default class TheMandalorianWeatheredPilot extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -27,7 +27,7 @@ export default class TheMandalorianWeatheredPilot extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Exhaust an enemy unit in this arena',
             when: {
-                onCardPlayed: (event, context) => event.card === context.source && event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             targetResolver: {
                 mode: TargetMode.Single,

--- a/server/game/cards/04_JTL/units/WingmanVictorThreeBackstabber.ts
+++ b/server/game/cards/04_JTL/units/WingmanVictorThreeBackstabber.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType, WildcardRelativePlayer } from '../../../core/Constants';
+import { AbilityType, WildcardRelativePlayer } from '../../../core/Constants';
 
 export default class WingmanVictorThreeBackstabber extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -15,9 +15,7 @@ export default class WingmanVictorThreeBackstabber extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Give an Experience token to another unit',
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             optional: true,
             targetResolver: {

--- a/server/game/cards/04_JTL/units/WingmanVictorTwoMaulerMithel.ts
+++ b/server/game/cards/04_JTL/units/WingmanVictorTwoMaulerMithel.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { AbilityType, PlayType } from '../../../core/Constants';
+import { AbilityType } from '../../../core/Constants';
 
 export default class WingmanVictorTwoMaulerMithel extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -15,9 +15,7 @@ export default class WingmanVictorTwoMaulerMithel extends NonLeaderUnitCard {
             type: AbilityType.Triggered,
             title: 'Create a TIE Fighter',
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card === context.source &&
-                    event.playType === PlayType.Piloting
+                whenPlayed: true,
             },
             immediateEffect: AbilityHelper.immediateEffects.createTieFighter((context) => ({
                 target: context.player

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -147,8 +147,10 @@ export enum WildcardRelativePlayer {
 export type RelativePlayerFilter = RelativePlayer | WildcardRelativePlayer;
 
 export enum StandardTriggeredAbilityType {
+    OnAttack = 'onAttack',
     WhenDefeated = 'whenDefeated',
-    OnAttack = 'onAttack'
+    WhenPlayed = 'whenPlayed',
+    WhenPlayedUsingSmuggle = 'whenPlayedUsingSmuggle',
 }
 
 export enum TargetMode {

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -1,6 +1,6 @@
 import { CardAbility } from './CardAbility';
 import { TriggeredAbilityContext } from './TriggeredAbilityContext';
-import { EventName, StandardTriggeredAbilityType } from '../Constants';
+import { EventName, PlayType, StandardTriggeredAbilityType } from '../Constants';
 import { AbilityType, GameStateChangeRequired, RelativePlayer, Stage } from '../Constants';
 import type { ITriggeredAbilityProps, WhenType, WhenTypeOrStandard } from '../../Interfaces';
 import type { GameEvent } from '../event/GameEvent';
@@ -64,6 +64,17 @@ export default class TriggeredAbility extends CardAbility {
         return this.standardTriggerTypes.includes(StandardTriggeredAbilityType.WhenDefeated);
     }
 
+    public get isWhenPlayed() {
+        return this.standardTriggerTypes.some((trigger) =>
+            trigger === StandardTriggeredAbilityType.WhenPlayed ||
+            trigger === StandardTriggeredAbilityType.WhenPlayedUsingSmuggle
+        );
+    }
+
+    public get isWhenPlayedUsingSmuggle() {
+        return this.standardTriggerTypes.includes(StandardTriggeredAbilityType.WhenPlayedUsingSmuggle);
+    }
+
     public constructor(
         game: Game,
         card: Card,
@@ -125,6 +136,12 @@ export default class TriggeredAbility extends CardAbility {
                         break;
                     case StandardTriggeredAbilityType.OnAttack:
                         updatedWhen[EventName.OnAttackDeclared] = (event, context) => event.attack.attacker === context.source;
+                        break;
+                    case StandardTriggeredAbilityType.WhenPlayed:
+                        updatedWhen[EventName.OnCardPlayed] = (event, context) => event.card === context.source;
+                        break;
+                    case StandardTriggeredAbilityType.WhenPlayedUsingSmuggle:
+                        updatedWhen[EventName.OnCardPlayed] = (event, context) => event.card === context.source && event.playType === PlayType.Smuggle;
                         break;
                     default:
                         Contract.fail(`Unexpected standard trigger type: ${trigger}`);

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -405,7 +405,7 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    protected validateCardAbilities(cardText: string) {
+    protected validateCardAbilities(abilities: TriggeredAbility[], cardText?: string) {
     }
 
     // ******************************************* ABILITY HELPERS *******************************************

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -122,6 +122,8 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     protected constantAbilities: IConstantAbility[] = [];
     protected disableWhenDefeatedCheck = false;
     protected disableOnAttackCheck = false;
+    protected disableWhenPlayedCheck = false;
+    protected disableWhenPlayedUsingSmuggleCheck = false;
     protected triggeredAbilities: TriggeredAbility[] = [];
 
     protected get hiddenForController() {

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -59,7 +59,7 @@ export class LeaderUnitCardInternal extends LeaderUnitCardParent implements IDep
 
         this.setupLeaderUnitSide = true;
         this.setupLeaderUnitSideAbilities(this);
-        this.validateCardAbilities(cardData.deployBox);
+        this.validateCardAbilities(this.triggeredAbilities, cardData.deployBox);
     }
 
     protected override setupDefaultState() {

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -324,33 +324,33 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
         }
     }
 
-    protected override validateCardAbilities(cardText?: string) {
+    protected override validateCardAbilities(abilities: TriggeredAbility[], cardText?: string) {
         if (!this.hasImplementationFile || cardText == null) {
             return;
         }
 
         Contract.assertFalse(
             !this.disableWhenDefeatedCheck &&
-            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Defeated/g) &&
-            !this.triggeredAbilities.some((ability) => ability.isWhenDefeated),
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Defeated/gi) &&
+            !abilities.some((ability) => ability.isWhenDefeated),
             `Card ${this.internalName} has one or more 'When Defeated' keywords in its text but no corresponding ability definition or set property 'disableWhenDefeatedCheck' to true on card implementation`
         );
         Contract.assertFalse(
             !this.disableOnAttackCheck &&
-            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))On Attack\b/g) &&
-            !this.triggeredAbilities.some((ability) => ability.isOnAttackAbility),
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))On Attack\b/gi) &&
+            !abilities.some((ability) => ability.isOnAttackAbility),
             `Card ${this.internalName} has one or more 'On Attack' keywords in its text but no corresponding ability definition or set property 'disableOnAttackCheck' to true on card implementation`
         );
         Contract.assertFalse(
             !this.disableWhenPlayedCheck &&
-            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Played\b/g) &&
-            !this.triggeredAbilities.some((ability) => ability.isWhenPlayed),
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Played\b/gi) &&
+            !abilities.some((ability) => ability.isWhenPlayed),
             `Card ${this.internalName} has one or more 'When Played' keywords in its text but no corresponding ability definition or set property 'disableWhenPlayedCheck' to true on card implementation`
         );
         Contract.assertFalse(
             !this.disableWhenPlayedUsingSmuggleCheck &&
-            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Played using Smuggle\b/g) &&
-            !this.triggeredAbilities.some((ability) => ability.isWhenPlayedUsingSmuggle),
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Played using Smuggle\b/gi) &&
+            !abilities.some((ability) => ability.isWhenPlayedUsingSmuggle),
             `Card ${this.internalName} has one or more 'When Played using Smuggle' keywords in its text but no corresponding ability definition or set property 'disableWhenPlayedUsingSmuggleCheck' to true on card implementation`
         );
     }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -273,8 +273,8 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
     }
 
     protected addWhenPlayedAbility(properties: ITriggeredAbilityBaseProps<this>): TriggeredAbility {
-        const triggeredProperties = Object.assign(properties, { when: { onCardPlayed: (event, context) => event.card === context.source } });
-        return this.addTriggeredAbility(triggeredProperties);
+        const when: WhenTypeOrStandard = { [StandardTriggeredAbilityType.WhenPlayed]: true };
+        return this.addTriggeredAbility({ ...properties, when });
     }
 
     protected addWhenDefeatedAbility(properties: ITriggeredAbilityBaseProps<this>): TriggeredAbility {
@@ -340,6 +340,18 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
             cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))On Attack\b/g) &&
             !this.triggeredAbilities.some((ability) => ability.isOnAttackAbility),
             `Card ${this.internalName} has one or more 'On Attack' keywords in its text but no corresponding ability definition or set property 'disableOnAttackCheck' to true on card implementation`
+        );
+        Contract.assertFalse(
+            !this.disableWhenPlayedCheck &&
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Played\b/g) &&
+            !this.triggeredAbilities.some((ability) => ability.isWhenPlayed),
+            `Card ${this.internalName} has one or more 'When Played' keywords in its text but no corresponding ability definition or set property 'disableWhenPlayedCheck' to true on card implementation`
+        );
+        Contract.assertFalse(
+            !this.disableWhenPlayedUsingSmuggleCheck &&
+            cardText && Helpers.hasSomeMatch(cardText, /(?:^|(?:[\n/]))When Played using Smuggle\b/g) &&
+            !this.triggeredAbilities.some((ability) => ability.isWhenPlayedUsingSmuggle),
+            `Card ${this.internalName} has one or more 'When Played using Smuggle' keywords in its text but no corresponding ability definition or set property 'disableWhenPlayedUsingSmuggleCheck' to true on card implementation`
         );
     }
 

--- a/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
+++ b/server/game/core/card/propertyMixins/StandardAbilitySetup.ts
@@ -11,7 +11,7 @@ export function WithStandardAbilitySetup<TBaseClass extends CardConstructor<TSta
             const [Player, cardData] = this.unpackConstructorArgs(...args);
 
             this.setupCardAbilities(this);
-            this.validateCardAbilities(cardData.text);
+            this.validateCardAbilities(this.triggeredAbilities, cardData.text);
 
             // if an implementation file is provided, enforce that all keywords requiring explicit setup have been set up
             if (this.hasImplementationFile) {

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -225,6 +225,8 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
             if (this.hasSomeKeyword(KeywordName.Piloting)) {
                 Contract.assertNotNullLike(cardData.upgradeHp, `Card ${this.internalName} is missing upgradeHp`);
                 Contract.assertNotNullLike(cardData.upgradePower, `Card ${this.internalName} is missing upgradePower`);
+
+                this.validateCardAbilities(this.pilotingTriggeredAbilities, cardData.pilotText);
             }
 
             this.attackAction = new InitiateAttackAction(this.game, this);

--- a/test/server/cards/02_SHD/units/KraytDragon.spec.ts
+++ b/test/server/cards/02_SHD/units/KraytDragon.spec.ts
@@ -38,7 +38,6 @@ describe('Krayt Dragon', function () {
                 context.player2.clickCard(context.privateerCrew);
 
                 // should choose which player resolve their triggers first
-                context.player2.clickPrompt('You');
                 expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.wampa, context.privateerCrew]);
                 context.player1.clickCard(context.p2Base);
                 expect(context.p2Base.damage).toBe(2);

--- a/test/server/cards/02_SHD/upgrades/HotshotDL44Blaster.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/HotshotDL44Blaster.spec.ts
@@ -10,9 +10,6 @@ describe('Hotshot DL-44 Blaster', function() {
                         hand: ['hotshot-dl44-blaster'],
                         base: 'tarkintown'
                     },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
                 });
             });
 
@@ -20,6 +17,7 @@ describe('Hotshot DL-44 Blaster', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.hotshotDl44Blaster);
+                context.player1.clickCard(context.battlefieldMarine);
                 expect(context.player2).toBeActivePlayer();
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['hotshot-dl44-blaster']);
                 expect(context.battlefieldMarine.exhausted).toBe(false);
@@ -38,9 +36,6 @@ describe('Hotshot DL-44 Blaster', function() {
                         resources: ['hotshot-dl44-blaster', 'atst', 'atst', 'atst', 'atst', 'atst'],
                         base: 'administrators-tower'
                     },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
                 });
             });
 
@@ -48,6 +43,8 @@ describe('Hotshot DL-44 Blaster', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.hotshotDl44Blaster);
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.p2Base);
                 expect(context.player2).toBeActivePlayer();
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['hotshot-dl44-blaster']);
                 expect(context.battlefieldMarine.exhausted).toBe(true);

--- a/test/server/cards/03_TWI/units/SubjugatingStarfighter.spec.ts
+++ b/test/server/cards/03_TWI/units/SubjugatingStarfighter.spec.ts
@@ -22,7 +22,7 @@ describe('Subjugating Starfighter', function() {
                 context.player1.clickCard(context.subjugatingStarfighter);
 
                 // Check if the Battle Droid token was created if the player has initiative.'
-                context.player1.clickPrompt('Create a Battle Droid token.');
+                context.player1.clickPrompt('Create a Battle Droid token');
                 expect(context.player1.findCardsByName('battle-droid').length).toBe(1);
                 expect(context.player1.findCardsByName('battle-droid')).toAllBeInZone('groundArena', context.player1);
                 expect(context.player1.findCardsByName('battle-droid').every((battleDroid) => battleDroid.exhausted)).toBeTrue();
@@ -43,7 +43,7 @@ describe('Subjugating Starfighter', function() {
                 context.player1.clickCard(context.subjugatingStarfighter);
 
                 // Check if the Battle Droid token was created if the player has initiative.'
-                context.player1.clickPrompt('Create a Battle Droid token.');
+                context.player1.clickPrompt('Create a Battle Droid token');
                 expect(context.player1.findCardsByName('battle-droid').length).toBe(1);
                 expect(context.player1.findCardsByName('battle-droid')).toAllBeInZone('groundArena', context.player1);
                 expect(context.player1.findCardsByName('battle-droid').every((battleDroid) => battleDroid.exhausted)).toBeTrue();

--- a/test/server/cards/04_JTL/units/SnapWexleyResistanceReconFlier.spec.ts
+++ b/test/server/cards/04_JTL/units/SnapWexleyResistanceReconFlier.spec.ts
@@ -5,7 +5,7 @@ describe('Snap Wexley, Resistance Recon Flier', function() {
                 return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        hand: ['snap-wexley#resistance-recon-flier', 'poe-dameron#quick-to-improvise', 'black-one#straight-at-them', 'battlefield-marine'],
+                        hand: ['snap-wexley#resistance-recon-flier', 'poe-dameron#quick-to-improvise', 'black-one#straight-at-them', 'battlefield-marine', 'dilapidated-ski-speeder', 'resistance-xwing', 'desperate-commando'],
                         spaceArena: ['green-squadron-awing'],
                         deck: ['atst', 'wampa', 'protector', 'fireball#an-explosion-with-wings', 'determined-recruit', 'bb8#happy-beeps'],
                         base: 'echo-base',
@@ -68,6 +68,36 @@ describe('Snap Wexley, Resistance Recon Flier', function() {
 
                 context.player1.clickCard(context.blackOne);
 
+                expect(context.player1.exhaustedResourceCount - resourceCount).toBe(1);
+
+                context.player2.passAction();
+
+                resourceCount = context.player1.exhaustedResourceCount;
+                context.player1.clickCard(context.dilapidatedSkiSpeeder);
+                expect(context.player1.exhaustedResourceCount - resourceCount).toBe(3);
+
+                context.player2.passAction();
+
+                context.readyCard(context.snapWexley);
+                context.player1.clickCard(context.snapWexley);
+                context.player1.clickCard(context.p2Base);
+
+                // Esnsure that the discount is not applied in the next phase
+                context.moveToNextActionPhase();
+
+                resourceCount = context.player1.exhaustedResourceCount;
+                context.player1.clickCard(context.desperateCommando);
+                expect(context.player1.exhaustedResourceCount - resourceCount).toBe(4);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.snapWexley);
+                context.player1.clickCard(context.p2Base);
+
+                context.player2.passAction();
+
+                resourceCount = context.player1.exhaustedResourceCount;
+                context.player1.clickCard(context.resistanceXwing);
                 expect(context.player1.exhaustedResourceCount - resourceCount).toBe(1);
             });
         });


### PR DESCRIPTION
Adds a "when played" standard triggered ability similar to what already exists for "when defeated" and "on attack". This should simplify the implementation of the new `Qui-Gon Jinn’s Aethersprite` once it becomes available.

I've also updated `validateCardAbilities` to run using the pilot text and abilities for pilots.