### PR TITLE
Bugfix: Hello There targets cards that entered play

### DIFF
--- a/server/game/cards/03_TWI/events/HelloThere.ts
+++ b/server/game/cards/03_TWI/events/HelloThere.ts
@@ -2,10 +2,10 @@ import { EventCard } from '../../../core/card/EventCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
+import type { CardsEnteredPlayThisPhaseWatcher } from '../../../stateWatchers/CardsEnteredPlayThisPhaseWatcher';
 
 export default class HelloThere extends EventCard {
-    private cardsPlayedThisPhaseWatcher: CardsPlayedThisPhaseWatcher;
+    private enteredPlayWatcher: CardsEnteredPlayThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -15,7 +15,7 @@ export default class HelloThere extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar): void {
-        this.cardsPlayedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsPlayedThisPhase(registrar, this);
+        this.enteredPlayWatcher = AbilityHelper.stateWatchers.cardsEnteredPlayThisPhase(registrar, this);
     }
 
     public override setupCardAbilities() {
@@ -23,7 +23,7 @@ export default class HelloThere extends EventCard {
             title: 'Choose a unit that entered play this phase. It gets -4/-4 for this phase.',
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
-                cardCondition: (card) => this.cardsPlayedThisPhaseWatcher.someCardPlayed((entry) => entry.card === card),
+                cardCondition: (card) => this.enteredPlayWatcher.someCardPlayed((entry) => entry.card === card),
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.modifyStats({ power: -4, hp: -4 })
                 })

--- a/server/game/stateWatchers/CardsEnteredPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsEnteredPlayThisPhaseWatcher.ts
@@ -36,6 +36,11 @@ export class CardsEnteredPlayThisPhaseWatcher extends StateWatcher<EnteredCardEn
             .map((entry) => entry.card);
     }
 
+    /** Check the list of cards that entered play in the state if we found cards that match filters */
+    public someCardPlayed(filter: (entry: EnteredCardEntry) => boolean): boolean {
+        return this.getCardsPlayed(filter).length > 0;
+    }
+
     protected override setupWatcher() {
         // on card entered play, add the card to the player's list of cards entered play this phase
         this.addUpdater({

--- a/test/server/cards/03_TWI/events/HelloThere.spec.ts
+++ b/test/server/cards/03_TWI/events/HelloThere.spec.ts
@@ -6,9 +6,16 @@ describe('Hello There', function() {
                     phase: 'action',
                     player1: {
                         hand: ['hello-there', 'green-squadron-awing', 'pyke-sentinel'],
+                        groundArena: [
+                            {
+                                card: 'discerning-veteran',
+                                capturedUnits: ['village-protectors']
+                            }
+                        ]
                     },
                     player2: {
-                        hand: ['atst', 'consular-security-force'],
+                        leader: 'captain-rex#fighting-for-his-brothers',
+                        hand: ['atst', 'consular-security-force', 'takedown']
                     }
                 });
             });
@@ -38,6 +45,103 @@ describe('Hello There', function() {
                 context.moveToNextActionPhase();
                 expect(context.atst.getPower()).toBe(6);
                 expect(context.atst.getHp()).toBe(7);
+            });
+
+            it('should work on leader units deployed this phase', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                // Player 2 deploys Captain Rex
+                context.player2.clickCard(context.captainRex);
+                context.player2.clickPrompt('Deploy Captain Rex');
+
+                const cloneTrooper = context.player2.findCardByName('clone-trooper', 'groundArena');
+
+                // Player 1 plays Hello There, targeting Captain Rex
+                context.player1.clickCard(context.helloThere);
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.captainRex,
+                    cloneTrooper,
+                ]);
+                context.player1.clickCard(context.captainRex);
+
+                // Captain Rex should be 0/2
+                expect(context.captainRex.getPower()).toBe(0);
+                expect(context.captainRex.getHp()).toBe(2);
+
+                // On next phase -4/-4 should be gone
+                context.moveToNextActionPhase();
+                expect(context.captainRex.getPower()).toBe(2);
+                expect(context.captainRex.getHp()).toBe(6);
+            });
+
+            it('should work on token units that entered play this phase', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                // Player 2 deploys Captain Rex to create a Clone Trooper token
+                context.player2.clickCard(context.captainRex);
+                context.player2.clickPrompt('Deploy Captain Rex');
+
+                const cloneTrooper = context.player2.findCardByName('clone-trooper', 'groundArena');
+
+                // Player 1 plays Hello There, targeting Clone Trooper
+                context.player1.clickCard(context.helloThere);
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.captainRex,
+                    cloneTrooper,
+                ]);
+                context.player1.clickCard(cloneTrooper);
+
+                // Clone Trooper should be defeated by the -4/-4 stat modifier
+                expect(cloneTrooper).toBeInZone('outsideTheGame');
+            });
+
+            it('should be able to target units that were rescued from capture this phase', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                // Player 2 plays Takedown to defeat Discerning Veteran
+                context.player2.clickCard(context.takedown);
+                context.player2.clickCard(context.discerningVeteran);
+
+                // Village Protectors are rescued from capture
+                expect(context.villageProtectors).toBeInZone('groundArena');
+
+                // Player 1 plays Hello There, targeting Village Protectors
+                context.player1.clickCard(context.helloThere);
+                expect(context.player1).toBeAbleToSelectExactly([context.villageProtectors]);
+                context.player1.clickCard(context.villageProtectors);
+
+                // Village Protectors should be defeated by the -4/-4 stat modifier
+                expect(context.villageProtectors).toBeInZone('discard');
+            });
+
+            it('should not be able to target units, leaders, or tokens that entered play in the previous phase', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                // Player 2 deploys Captain Rex
+                context.player2.clickCard(context.captainRex);
+                context.player2.clickPrompt('Deploy Captain Rex');
+
+                context.player1.passAction();
+
+                // Player 2 plays Consular Security Force
+                context.player2.clickCard(context.consularSecurityForce);
+
+                // Move to the next action phase
+                context.moveToNextActionPhase();
+
+                // Player 1 plays Hello There, but there are no valid targets
+                context.player1.clickCard(context.helloThere);
+
+                // Event resolves immediately due to no valid targets
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });


### PR DESCRIPTION
Fixes #1088

### Testing Notes

Added the following test cases:
 - ✅  It can target a leader deployed this phase
 - ✅ It can target a token unit that entered play this phase
 - ✅ It can target a unit that was rescued from capture this phase
 - ✅ It cannot target leaders, tokens, or units that entered play the previous phase