### PR TITLE
Better cancel handling for floating cost adjusters

### DIFF
--- a/server/game/abilities/keyword/exploit/ExploitCostAdjuster.ts
+++ b/server/game/abilities/keyword/exploit/ExploitCostAdjuster.ts
@@ -119,6 +119,7 @@ export class ExploitCostAdjuster extends ExploitCostAdjusterBase {
             choices.push('Cancel');
             handlers.push(() => {
                 result.cancelled = true;
+                this.resetForCancel();
             });
         }
 
@@ -135,6 +136,12 @@ export class ExploitCostAdjuster extends ExploitCostAdjusterBase {
             choices,
             handlers
         });
+    }
+
+    public resetForCancel() {
+        // reset the cost adjuster so it can be used again after a cancel
+        this.minimumExploitCount = null;
+        this.numExploitedCards = null;
     }
 
     private resolveExploit(events: any[], context: AbilityContext, result: ICostResult) {

--- a/server/game/abilities/keyword/exploit/MergedExploitCostAdjuster.ts
+++ b/server/game/abilities/keyword/exploit/MergedExploitCostAdjuster.ts
@@ -40,6 +40,13 @@ export class MergedExploitCostAdjuster extends ExploitCostAdjuster {
         this.addMergedAdjusters(adjusters);
     }
 
+    public override resetForCancel(): void {
+        super.resetForCancel();
+        for (const adjuster of this.mergedAdjusters) {
+            adjuster.resetForCancel();
+        }
+    }
+
     private distributeExploitedCardsAmount(numExploitedCards: number) {
         let remainingExploitedCards = numExploitedCards;
         for (const adjuster of this.mergedAdjusters) {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -43,6 +43,7 @@ const { GameStateManager } = require('./GameStateManager.js');
 const { ActionWindow } = require('./gameSteps/ActionWindow.js');
 const { GameObjectBase } = require('./GameObjectBase.js');
 const Helpers = require('./utils/Helpers.js');
+const { CostAdjuster } = require('./cost/CostAdjuster.js');
 
 class Game extends EventEmitter {
     #debug;
@@ -1308,6 +1309,13 @@ class Game extends EventEmitter {
         player.disconnected = false;
 
         this.addMessage('{0} has reconnected', player);
+    }
+
+    /** @param {CostAdjuster} costAdjuster */
+    removeCostAdjusterFromAll(costAdjuster) {
+        for (const player of this.getPlayers()) {
+            player.removeCostAdjuster(costAdjuster);
+        }
     }
 
     /** Goes through the list of cards moved during event resolution and does a uniqueness rule check for each */

--- a/server/game/core/cost/CostAdjuster.ts
+++ b/server/game/core/cost/CostAdjuster.ts
@@ -106,7 +106,7 @@ export class CostAdjuster {
     private readonly matchAbilityCosts: boolean;
 
     public constructor(
-        private game: Game,
+        protected game: Game,
         protected source: Card,
         properties: ICostAdjusterProperties
     ) {

--- a/test/server/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.spec.ts
@@ -178,6 +178,49 @@ describe('Count Dooku, Face of the Confederacy', function () {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('should give the next Separatist unit played this phase Exploit 3 if it does not already have Exploit, and allow cancelling', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.countDooku);
+                context.player1.clickCard(context.p2Base);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.theInvisibleHand);
+                expect(context.player1).toHaveExactPromptButtons(['Play without Exploit', 'Trigger Exploit', 'Cancel']);
+                context.player1.clickPrompt('Cancel');
+
+                expect(context.player1).toBeActivePlayer();
+                expect(context.theInvisibleHand).toBeInZone('hand');
+                expect(context.player1.exhaustedResourceCount).toBe(0);
+                expect(context.player1).toBeAbleToSelect(context.theInvisibleHand);
+
+                context.player1.clickCard(context.theInvisibleHand);
+                expect(context.player1).toHaveExactPromptButtons(['Play without Exploit', 'Trigger Exploit', 'Cancel']);
+
+                context.player1.clickPrompt('Trigger Exploit');
+                expect(context.player1).toBeAbleToSelectExactly([context.battleDroid, context.atst, context.snowspeeder, context.cartelSpacer, context.countDooku]);
+                expect(context.player1).not.toHaveEnabledPromptButton('Done');
+
+                context.player1.clickCard(context.battleDroid);
+                context.player1.clickCard(context.atst);
+                context.player1.clickCard(context.snowspeeder);
+                context.player1.clickCardNonChecking(context.cartelSpacer);
+                context.player1.clickPrompt('Done');
+
+                // confirm Exploit results
+                expect(context.snowspeeder).toBeInZone('discard');
+                expect(context.cartelSpacer).toBeInZone('spaceArena');
+                expect(context.atst).toBeInZone('discard');
+                expect(context.battleDroid).toBeInZone('outsideTheGame');
+                expect(context.player1.exhaustedResourceCount).toBe(2);
+
+                // next Separatist card played should not gain Exploit
+                context.player2.passAction();
+                context.player1.clickCard(context.dwarfSpiderDroid);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('effect should expire at the end of the phase', function () {
                 const { context } = contextRef;
 


### PR DESCRIPTION
Fixes a bug discovered with Count Dooku where hitting the "cancel" button at the exploit trigger stage would cause the cost adjuster to break _if_ the unit didn't already have its own exploit