### PR TITLE
[Bugfix] Bounty Hunter's Quarry can resolve during the regroup phase

### DIFF
--- a/server/game/cards/02_SHD/upgrades/BountyHuntersQuarry.ts
+++ b/server/game/cards/02_SHD/upgrades/BountyHuntersQuarry.ts
@@ -23,7 +23,8 @@ export default class BountyHuntersQuarry extends UpgradeCard {
                     searchCount: (context) => (context.source.unique ? 10 : 5),
                     cardCondition: (card) => card.isUnit() && card.cost <= 3,
                     selectedCardsImmediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay({
-                        adjustCost: { costAdjustType: CostAdjustType.Free }
+                        adjustCost: { costAdjustType: CostAdjustType.Free },
+                        ignoredRequirements: ['phase']
                     }),
                 }),
             }

--- a/server/game/cards/02_SHD/upgrades/BountyHuntersQuarry.ts
+++ b/server/game/cards/02_SHD/upgrades/BountyHuntersQuarry.ts
@@ -23,8 +23,7 @@ export default class BountyHuntersQuarry extends UpgradeCard {
                     searchCount: (context) => (context.source.unique ? 10 : 5),
                     cardCondition: (card) => card.isUnit() && card.cost <= 3,
                     selectedCardsImmediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay({
-                        adjustCost: { costAdjustType: CostAdjustType.Free },
-                        ignoredRequirements: ['phase']
+                        adjustCost: { costAdjustType: CostAdjustType.Free }
                     }),
                 }),
             }

--- a/server/game/core/ability/PlayerAction.js
+++ b/server/game/core/ability/PlayerAction.js
@@ -15,12 +15,12 @@ class PlayerAction extends PlayerOrCardAbility {
 
     /** @override */
     meetsRequirements(context, ignoredRequirements = []) {
-        if (
-            !ignoredRequirements.includes('phase') &&
-            context.game.currentPhase !== PhaseName.Action
-        ) {
-            return 'phase';
-        }
+        // if (
+        //     !ignoredRequirements.includes('phase') &&
+        //     context.game.currentPhase !== PhaseName.Action
+        // ) {
+        //     return 'phase';
+        // }
 
         return super.meetsRequirements(context, ignoredRequirements);
     }

--- a/server/game/core/ability/PlayerAction.js
+++ b/server/game/core/ability/PlayerAction.js
@@ -13,18 +13,6 @@ class PlayerAction extends PlayerOrCardAbility {
         this.cannotBeCancelled = true;
     }
 
-    /** @override */
-    meetsRequirements(context, ignoredRequirements = []) {
-        // if (
-        //     !ignoredRequirements.includes('phase') &&
-        //     context.game.currentPhase !== PhaseName.Action
-        // ) {
-        //     return 'phase';
-        // }
-
-        return super.meetsRequirements(context, ignoredRequirements);
-    }
-
     getAdjustedCost(context) {
         let resourceCost = this.getCosts(context).find((cost) => cost.getAdjustedCost);
         return resourceCost ? resourceCost.getAdjustedCost(context) : 0;

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -187,6 +187,10 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
             return this.upgrades.some((card) => card.isShield());
         }
 
+        public hasSentinel(): boolean {
+            return this.hasSomeKeyword(KeywordName.Sentinel);
+        }
+
         public override isLeader(): this is ILeaderCard {
             return this.isLeaderAttachedToThis();
         }

--- a/server/game/gameSystems/PlayCardSystem.ts
+++ b/server/game/gameSystems/PlayCardSystem.ts
@@ -39,7 +39,7 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
     public override readonly eventName = MetaEventName.PlayCard;
     protected override readonly targetTypeFilter = [CardType.BasicUnit, CardType.BasicUpgrade, CardType.Event];
     protected override readonly defaultProperties: IPlayCardProperties = {
-        ignoredRequirements: [],
+        ignoredRequirements: ['phase'],
         optional: false,
         entersReady: false,
         playType: PlayType.PlayFromHand,
@@ -67,7 +67,7 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
     private resolvePlayCardAbility(ability: PlayCardAction, event: any) {
         const newContext = ability.createContext(event.player);
 
-        event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional, false, null, this.properties?.ignoredRequirements ?? []));
+        event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional, false, null, ['phase']));
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/server/game/gameSystems/PlayCardSystem.ts
+++ b/server/game/gameSystems/PlayCardSystem.ts
@@ -67,7 +67,7 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
     private resolvePlayCardAbility(ability: PlayCardAction, event: any) {
         const newContext = ability.createContext(event.player);
 
-        event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional, false, null, ['phase']));
+        event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional, false, null, event.ignoredRequirements));
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {
@@ -82,6 +82,7 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
 
         event.playCardAbilities = this.generateLegalPlayCardAbilities(target, properties, context);
         event.optional = properties.optional ?? context.ability.optional;
+        event.ignoredRequirements = properties.ignoredRequirements ?? [];
     }
 
     public override canAffectInternal(card: Card, context: TContext, additionalProperties = {}): boolean {

--- a/server/game/gameSystems/PlayCardSystem.ts
+++ b/server/game/gameSystems/PlayCardSystem.ts
@@ -67,7 +67,7 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
     private resolvePlayCardAbility(ability: PlayCardAction, event: any) {
         const newContext = ability.createContext(event.player);
 
-        event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional, false));
+        event.context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional, false, null, this.properties?.ignoredRequirements ?? []));
     }
 
     public override getEffectMessage(context: TContext): [string, any[]] {

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -39,7 +39,8 @@ interface SwuTestContext {
     p2Leader: ILeaderCard;
     snapshotId?: number;
 
-    allowTestToEndWithOpenPrompt: boolean;
+    ignoreUnresolvedActionPhasePrompts: boolean;
+    requireResolvedRegroupPhasePrompts: boolean;
 
     advancePhases(endphase);
     allPlayersInInitiativeOrder(): PlayerInteractionWrapper[];

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -125,7 +125,7 @@ global.integration = function (definitions) {
                 let activePromptsText = playersWithUnresolvedPrompts.map((player) =>
                     `\n******* ${player.name.toUpperCase()} PROMPT *******\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}\n`
                 ).join('');
-
+                console.log(`** Unresolved prompt in ${context.game.currentPhase} phase`);
                 throw new TestSetupError(`The test ended with an unresolved prompt for one or both players. Unresolved prompts:\n${activePromptsText}`);
             }
             try {

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -125,8 +125,7 @@ global.integration = function (definitions) {
                 let activePromptsText = playersWithUnresolvedPrompts.map((player) =>
                     `\n******* ${player.name.toUpperCase()} PROMPT *******\n${formatPrompt(player.currentPrompt(), player.currentActionTargets)}\n`
                 ).join('');
-                console.log(`** Unresolved prompt in ${context.game.currentPhase} phase`);
-                throw new TestSetupError(`The test ended with an unresolved prompt for one or both players. Unresolved prompts:\n${activePromptsText}`);
+                throw new TestSetupError(`The test ended with an unresolved prompt in ${context.game.currentPhase} phase for one or both players. Unresolved prompts:\n${activePromptsText}`);
             }
             try {
                 context.game.captureGameState('testrun');

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -106,7 +106,11 @@ global.integration = function (definitions) {
                 return;
             }
 
-            if (context.game.currentPhase !== 'action' || context.allowTestToEndWithOpenPrompt) {
+            if (
+                context.game.currentPhase === 'action' && context.ignoreUnresolvedActionPhasePrompts ||
+                context.game.currentPhase === 'regroup' && !context.requireResolvedRegroupPhasePrompts ||
+                context.game.currentPhase === 'setup' // Unresolved setup phase prompts are always ignored
+            ) {
                 return;
             }
 

--- a/test/server/actions/UnitAttack.spec.ts
+++ b/test/server/actions/UnitAttack.spec.ts
@@ -120,7 +120,7 @@ describe('Basic attack', function() {
                 expect(context.player2).toHavePrompt('player1 has won the game!');
                 expect(context.player1).toBeActivePlayer();
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
 

--- a/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
+++ b/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
@@ -77,7 +77,7 @@ describe('Energy Conversion Lab', function() {
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
                 expect(context.poeDameron).not.toHaveAvailableActionWhenClickedBy(context.player1);
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
     });

--- a/test/server/cards/01_SOR/events/Command.spec.ts
+++ b/test/server/cards/01_SOR/events/Command.spec.ts
@@ -116,7 +116,7 @@ describe('Command', function() {
             ]);
 
             // since we only clicked one option
-            context.allowTestToEndWithOpenPrompt = true;
+            context.ignoreUnresolvedActionPhasePrompts = true;
         });
 
         it('Command\'s damage ability should fizzle if there is no legal friendly unit', async function() {
@@ -149,7 +149,7 @@ describe('Command', function() {
             ]);
 
             // since we only clicked one option
-            context.allowTestToEndWithOpenPrompt = true;
+            context.ignoreUnresolvedActionPhasePrompts = true;
         });
     });
 });

--- a/test/server/cards/01_SOR/events/ForACauseIBelieveIn.spec.ts
+++ b/test/server/cards/01_SOR/events/ForACauseIBelieveIn.spec.ts
@@ -184,7 +184,7 @@ describe('For A Cause I Believe In', function() {
 
             // The FACIBI reveal prompt is hiding under the Game Over prompt here
             // https://github.com/SWU-Karabast/forceteki/issues/586
-            context.allowTestToEndWithOpenPrompt = true;
+            context.ignoreUnresolvedActionPhasePrompts = true;
         });
 
         it('should end the game if it deals lethal damage to the opponent\'s base', async function() {

--- a/test/server/cards/01_SOR/events/SuperlaserBlast.spec.ts
+++ b/test/server/cards/01_SOR/events/SuperlaserBlast.spec.ts
@@ -1,37 +1,33 @@
 describe('Superlaser Blast', function() {
     integration(function(contextRef) {
-        describe('Superlaser Blast', function() {
-            integration(function(contextRef) {
-                describe('Superlaser Blast\' ability', function() {
-                    beforeEach(async function () {
-                        await contextRef.setupTestAsync({
-                            phase: 'action',
-                            player1: {
-                                hand: ['superlaser-blast'],
-                                groundArena: ['atst'],
-                                spaceArena: ['cartel-spacer'],
-                                leader: { card: 'boba-fett#daimyo', deployed: true }
-                            },
-                            player2: {
-                                groundArena: ['wampa'],
-                                spaceArena: ['alliance-xwing'],
-                                leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
-                            }
-                        });
-                    });
-
-                    it('should defeat all units', function () {
-                        const { context } = contextRef;
-
-                        context.player1.clickCard(context.superlaserBlast);
-                        expect(context.atst).toBeInZone('discard');
-                        expect(context.cartelSpacer).toBeInZone('discard');
-                        expect(context.wampa).toBeInZone('discard');
-                        expect(context.allianceXwing).toBeInZone('discard');
-                        expect(context.bobaFett).toBeInZone('base');
-                        expect(context.lukeSkywalker).toBeInZone('base');
-                    });
+        describe('Superlaser Blast\' ability', function() {
+            beforeEach(async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['superlaser-blast'],
+                        groundArena: ['atst'],
+                        spaceArena: ['cartel-spacer'],
+                        leader: { card: 'boba-fett#daimyo', deployed: true }
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['alliance-xwing'],
+                        leader: { card: 'luke-skywalker#faithful-friend', deployed: true }
+                    }
                 });
+            });
+
+            it('should defeat all units', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.superlaserBlast);
+                expect(context.atst).toBeInZone('discard');
+                expect(context.cartelSpacer).toBeInZone('discard');
+                expect(context.wampa).toBeInZone('discard');
+                expect(context.allianceXwing).toBeInZone('discard');
+                expect(context.bobaFett).toBeInZone('base');
+                expect(context.lukeSkywalker).toBeInZone('base');
             });
         });
     });

--- a/test/server/cards/01_SOR/leaders/SabineWrenGalvanizedRevolutionary.spec.ts
+++ b/test/server/cards/01_SOR/leaders/SabineWrenGalvanizedRevolutionary.spec.ts
@@ -57,7 +57,7 @@ describe('Sabine Wren, Galvanized Revolutionary', function() {
                 expect(context.rebelPathfinder.damage).toBe(0);
                 expect(context.player1).toBeActivePlayer();
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
     });

--- a/test/server/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.spec.ts
+++ b/test/server/cards/01_SOR/units/EmperorPalpatineMasterOfTheDarkSide.spec.ts
@@ -78,7 +78,7 @@ describe('Emperor Palpatine, Master of the Dark Side', function() {
                 expect(context.player2).toHaveExactPromptButtons(['Draw a card', 'Draw a card']);
 
                 // so we don't have to resolve the rest of the trigger flow
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
 

--- a/test/server/cards/02_SHD/events/MidnightRepairs.spec.ts
+++ b/test/server/cards/02_SHD/events/MidnightRepairs.spec.ts
@@ -89,7 +89,7 @@ describe('Midnight Repairs', function () {
                 context.player1.clickCard(context.midnightRepairs);
                 expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
     });

--- a/test/server/cards/02_SHD/units/OmegaPartOfTheSquad.spec.ts
+++ b/test/server/cards/02_SHD/units/OmegaPartOfTheSquad.spec.ts
@@ -48,7 +48,7 @@ describe('Omega, Part of the Squad', function() {
                 expect(context.player1.exhaustedResourceCount).toBe(2);
 
                 // so we don't need to go all the way through the Omega ability again
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
 

--- a/test/server/cards/02_SHD/upgrades/BountyHuntersQuarry.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/BountyHuntersQuarry.spec.ts
@@ -4,7 +4,7 @@ describe('Bounty Hunter\'s Quarry', function () {
         describe('Bounty Hunter\'s Quarry bounty ability', function () {
             const prompt = 'Collect Bounty: Search the top 5 cards of your deck, or 10 cards instead if this unit is unique, for a unit that costs 3 or less and play it for free.';
 
-            xit('should prompt to choose a unit with a cost of 3 or less from the top 5 cards or top 10 cards (if unit is unique) and play it for free', async function () {
+            it('should prompt to choose a unit with a cost of 3 or less from the top 5 cards or top 10 cards (if unit is unique) and play it for free', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -95,7 +95,8 @@ describe('Bounty Hunter\'s Quarry', function () {
                             'echo-base-defender',
                             'cloudrider',
                             'resupply',
-                            'superlaser-technician'
+                            'superlaser-technician',
+                            'takedown'
                         ],
                         resources: 3
                     },
@@ -106,9 +107,6 @@ describe('Bounty Hunter\'s Quarry', function () {
                                 damage: 2,
                                 upgrades: ['bounty-hunters-quarry']
                             }
-                        ],
-                        groundArena: [
-                            'liberated-slaves',
                         ]
                     }
                 });
@@ -139,23 +137,18 @@ describe('Bounty Hunter\'s Quarry', function () {
                     ]
                 });
 
-                // Play Cloud-Rider
-                context.player1.clickCardInDisplayCardPrompt(context.cloudrider);
-                expect(context.cloudrider).toBeInZone('groundArena');
+                // Play Echo Base Defender for free
+                context.player1.clickCardInDisplayCardPrompt(context.echoBaseDefender);
+                expect(context.echoBaseDefender).toBeInZone('groundArena');
+                expect(context.player1.exhaustedResourceCount).toBe(0);
 
-                // Resolve ambush ability
-                expect(context.player1).toHavePrompt('Trigger the ability \'Ambush\' or pass');
-                context.player1.clickPrompt('Trigger');
-
-                // Choose attack target
-                context.player1.clickCard(context.liberatedSlaves);
-
-                // Check the result of the ambush attack
-                expect(context.liberatedSlaves.damage).toBe(3);
-                expect(context.cloudrider).toBeInZone('discard');
-
+                // Pass on resourcing
                 context.player1.clickPrompt('Done');
                 context.player2.clickPrompt('Done');
+
+                // Check that the last two cards in the deck before collecting the bounty are now in hand
+                expect(context.superlaserTechnician).toBeInZone('hand');
+                expect(context.takedown).toBeInZone('hand');
             });
         });
     });

--- a/test/server/cards/03_TWI/leaders/AnakinSkywalkerWhatItTakesToWin.spec.ts
+++ b/test/server/cards/03_TWI/leaders/AnakinSkywalkerWhatItTakesToWin.spec.ts
@@ -59,7 +59,7 @@ describe('Anakin Skywalker, What It Takes To Win', function () {
                 context.player1.clickCard(context.moistureFarmer);
                 expect(context.player1).toHavePrompt('player2 has won the game!');
                 expect(context.player2).toHavePrompt('player2 has won the game!');
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
 
             it('should buff attack against both targets if attacker can attack multiple targets', async function () {

--- a/test/server/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.spec.ts
@@ -275,7 +275,7 @@ describe('Count Dooku, Face of the Confederacy', function () {
                 expect(context.player1.exhaustedResourceCount).toBe(0);
 
                 // bypass target selection for event
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
 
             it('does not affect Separatist units played by the opponent', function () {

--- a/test/server/cards/03_TWI/units/SubjugatingStarfighter.spec.ts
+++ b/test/server/cards/03_TWI/units/SubjugatingStarfighter.spec.ts
@@ -16,7 +16,7 @@ describe('Subjugating Starfighter', function() {
                 const { context } = contextRef;
 
                 // Allow the test to end with an open prompt.
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
 
                 // Play the card.
                 context.player1.clickCard(context.subjugatingStarfighter);
@@ -69,7 +69,7 @@ describe('Subjugating Starfighter', function() {
                 const { context } = contextRef;
 
                 // Allow the test to end with an open prompt.
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
 
                 // Have player 2 claim initiative
                 context.player2.claimInitiative();

--- a/test/server/cards/04_JTL/units/BlueLeaderScarifAirSupport.spec.ts
+++ b/test/server/cards/04_JTL/units/BlueLeaderScarifAirSupport.spec.ts
@@ -245,7 +245,7 @@ describe('Blue Leader, Scarif Air Support', function() {
                 // confirm that Blue Leader isn't targetable
                 context.player2.clickCard(context.shootDown);
                 expect(context.player2).toBeAbleToSelectExactly(context.supportingEta2);
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
 
             it('it should be explicitly targetable for \'choose a ground unit\' effects', function() {

--- a/test/server/cards/04_JTL/units/TheStarhawkPrototypeBattleship.spec.ts
+++ b/test/server/cards/04_JTL/units/TheStarhawkPrototypeBattleship.spec.ts
@@ -158,7 +158,7 @@ describe('The Starhawk, Prototype Battleship', function() {
                 context.player2.clickPrompt('Deploy Admiral Trench');
                 expect(context.player2.exhaustedResourceCount).toBe(3);
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
 
             it('should not affect opponent\'s unit ability costs', function() {

--- a/test/server/core/Game.spec.ts
+++ b/test/server/core/Game.spec.ts
@@ -25,7 +25,7 @@ describe('Overall game mechanics', function() {
                 expect(context.player1).toHavePrompt('The game ended in a draw!');
                 expect(context.player2).toHavePrompt('The game ended in a draw!');
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
 
@@ -53,7 +53,7 @@ describe('Overall game mechanics', function() {
                 expect(context.player2).toHavePrompt('player1 has won the game!');
                 expect(context.player1).toBeActivePlayer();
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
     });

--- a/test/server/gameSystems/DrawSystem.spec.ts
+++ b/test/server/gameSystems/DrawSystem.spec.ts
@@ -65,7 +65,7 @@ describe('Draw system', function() {
                 expect(context.player2.hand.length).toBe(1);
                 expect(context.player1).toBeActivePlayer();
 
-                context.allowTestToEndWithOpenPrompt = true;
+                context.ignoreUnresolvedActionPhasePrompts = true;
             });
         });
     });


### PR DESCRIPTION
Fixes #1067 

### Notes

- Removed phase check in `PlayerAction.js` because it was preventing certain actions from being executed off a triggered ability during the regroup phase
- Added a simple case of collecting Bounty Hunter's Quarry during the regroup phase to `BountyHuntersQuarry.spec.ts`
- Added several more complex cases of chains of triggered abilities (all stemming from BHQ) to `RegroupPhase.spec.ts`