### PR TITLE
Update Shadowed Intentions to use replacement effects

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -172,6 +172,7 @@ export type IConstantAbilityPropsWithGainCondition<TSource extends IUpgradeCard,
 export type ITriggeredAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityProps<TTarget> & IGainCondition<TSource>;
 export type ITriggeredAbilityBasePropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = ITriggeredAbilityBaseProps<TTarget> & IGainCondition<TSource>;
 export type IActionAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = IActionAbilityProps<TTarget> & IGainCondition<TSource>;
+export type IReplacementEffectAbilityPropsWithGainCondition<TSource extends IUpgradeCard, TTarget extends Card> = IReplacementEffectAbilityProps<TTarget> & IGainCondition<TSource>;
 
 export type IAbilityPropsWithType<TSource extends Card = Card> =
   ITriggeredAbilityPropsWithType<TSource> |

--- a/server/game/cards/02_SHD/units/LurkingTIEPhantom.ts
+++ b/server/game/cards/02_SHD/units/LurkingTIEPhantom.ts
@@ -1,6 +1,7 @@
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { AbilityRestriction } from '../../../core/Constants';
+import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 
 export default class LurkingTIEPhantom extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -11,22 +12,26 @@ export default class LurkingTIEPhantom extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities() {
+        this.addReplacementEffectAbility({
+            title: 'This unit can\'t be captured, damaged, or defeated by enemy card abilities',
+            when: {
+                onCardCaptured: (event, context) =>
+                    event.card === context.source &&
+                    event.context.player !== context.player,
+                onCardDefeated: (event, context) =>
+                    event.card === context.source &&
+                    event.defeatSource.type === DefeatSourceType.Ability &&
+                    event.defeatSource.player !== context.player,
+            }
+        });
+
+        // TODO: Update damage prevention using replacement effects
         this.addConstantAbility({
             title: 'This unit can\'t be captured, damaged, or defeated by enemy card abilities',
-            ongoingEffect: [
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.ReceiveDamage,
-                    restrictedActionCondition: (context) => !context.ability.isAttackAction() && context.ability.controller !== this.controller,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeCaptured,
-                    restrictedActionCondition: (context) => context.ability.controller !== this.controller,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeDefeated,
-                    restrictedActionCondition: (context) => context.ability.controller !== this.controller,
-                })
-            ]
+            ongoingEffect: AbilityHelper.ongoingEffects.cardCannot({
+                cannot: AbilityRestriction.ReceiveDamage,
+                restrictedActionCondition: (context) => !context.ability.isAttackAction() && context.ability.controller !== this.controller,
+            })
         });
     }
 }

--- a/server/game/cards/03_TWI/upgrades/ShadowedIntentions.ts
+++ b/server/game/cards/03_TWI/upgrades/ShadowedIntentions.ts
@@ -1,6 +1,6 @@
-import AbilityHelper from '../../../AbilityHelper';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
-import { AbilityRestriction } from '../../../core/Constants';
+import { ZoneName } from '../../../core/Constants';
+import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 
 export default class ShadowedIntentions extends UpgradeCard {
     protected override getImplementationId() {
@@ -11,22 +11,21 @@ export default class ShadowedIntentions extends UpgradeCard {
     }
 
     protected override setupCardAbilities() {
-        this.addGainConstantAbilityTargetingAttached({
+        this.addReplacementEffectAbilityTargetingAttached({
             title: 'This unit can\'t be captured, defeated, or returned to its owner\'s hand by enemy card abilities',
-            ongoingEffect: [
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeCaptured,
-                    restrictedActionCondition: (context) => context.ability.controller !== this.controller,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.BeDefeated,
-                    restrictedActionCondition: (context) => context.ability.controller !== this.controller,
-                }),
-                AbilityHelper.ongoingEffects.cardCannot({
-                    cannot: AbilityRestriction.ReturnToHand,
-                    restrictedActionCondition: (context) => context.ability.controller !== this.controller,
-                }),
-            ]
+            when: {
+                onCardCaptured: (event, context) =>
+                    event.card === context.source &&
+                    event.context.player !== context.player,
+                onCardDefeated: (event, context) =>
+                    event.card === context.source &&
+                    event.defeatSource.type === DefeatSourceType.Ability &&
+                    event.defeatSource.player !== context.player,
+                onCardMoved: (event, context) =>
+                    event.card === context.source &&
+                    event.destination === ZoneName.Hand &&
+                    event.context.player !== context.player
+            }
         });
     }
 }

--- a/server/game/core/card/UpgradeCard.ts
+++ b/server/game/core/card/UpgradeCard.ts
@@ -6,7 +6,7 @@ import * as Contract from '../utils/Contract';
 import type { MoveZoneDestination } from '../Constants';
 import { AbilityType, CardType, ZoneName, WildcardRelativePlayer, StandardTriggeredAbilityType } from '../Constants';
 import { PlayUpgradeAction } from '../../actions/PlayUpgradeAction';
-import type { IActionAbilityPropsWithGainCondition, IConstantAbilityProps, IConstantAbilityPropsWithGainCondition, IKeywordPropertiesWithGainCondition, ITriggeredAbilityBasePropsWithGainCondition, ITriggeredAbilityPropsWithGainCondition, WhenTypeOrStandard } from '../../Interfaces';
+import type { IActionAbilityPropsWithGainCondition, IConstantAbilityProps, IConstantAbilityPropsWithGainCondition, IKeywordPropertiesWithGainCondition, IReplacementEffectAbilityPropsWithGainCondition, ITriggeredAbilityBasePropsWithGainCondition, ITriggeredAbilityPropsWithGainCondition, WhenTypeOrStandard } from '../../Interfaces';
 import type { Card } from './Card';
 import OngoingEffectLibrary from '../../ongoingEffects/OngoingEffectLibrary';
 import { WithStandardAbilitySetup } from './propertyMixins/StandardAbilitySetup';
@@ -102,6 +102,16 @@ export class UpgradeCard extends UpgradeCardParent implements IUpgradeCard, IPla
             title: 'Give ability to the attached card',
             condition: this.addZoneCheckToGainCondition(gainCondition),
             ongoingEffect: OngoingEffectLibrary.gainAbility({ type: AbilityType.Triggered, ...gainedAbilityProperties })
+        });
+    }
+
+    protected addReplacementEffectAbilityTargetingAttached(properties: IReplacementEffectAbilityPropsWithGainCondition<this, IUnitCard>) {
+        const { gainCondition, ...gainedAbilityProperties } = properties;
+
+        this.addConstantAbilityTargetingAttached({
+            title: 'Give ability to the attached card',
+            condition: this.addZoneCheckToGainCondition(gainCondition),
+            ongoingEffect: OngoingEffectLibrary.gainAbility({ type: AbilityType.ReplacementEffect, ...gainedAbilityProperties })
         });
     }
 

--- a/test/server/cards/02_SHD/units/LurkingTIEPhantom.spec.ts
+++ b/test/server/cards/02_SHD/units/LurkingTIEPhantom.spec.ts
@@ -176,5 +176,27 @@ describe('Lurking TIE Phantom', function() {
             expect(context.lurkingTiePhantom.damage).toBe(0);
             expect(context.player2).toBeActivePlayer();
         });
+
+        it('Lurking TIE Phantom can be defeated by an oppontent\'s No Glory, Only Results', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['no-glory-only-results']
+                },
+                player2: {
+                    spaceArena: ['lurking-tie-phantom']
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Player 1 plays No Glory, Only Results
+            context.player1.clickCard(context.noGloryOnlyResults);
+            expect(context.player1).toBeAbleToSelectExactly([context.lurkingTiePhantom]);
+
+            // Choose Lurking TIE Phantom and defeat it
+            context.player1.clickCard(context.lurkingTiePhantom);
+            expect(context.lurkingTiePhantom).toBeInZone('discard', context.player2);
+        });
     });
 });

--- a/test/server/cards/03_TWI/upgrades/ShadowedIntentions.spec.ts
+++ b/test/server/cards/03_TWI/upgrades/ShadowedIntentions.spec.ts
@@ -68,5 +68,34 @@ describe('Shadowed Intentions', function() {
             expect(context.battlefieldMarine).toBeInZone('discard');
             expect(context.shadowedIntentions).toBeInZone('discard');
         });
+
+        it('Shadowed Intentions\' ability does not prevent defeat from an opponent\'s No Glory, Only Results', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['no-glory-only-results']
+                },
+                player2: {
+                    groundArena: [
+                        {
+                            card: 'director-krennic#on-the-verge-of-greatness',
+                            upgrades: ['shield', 'shadowed-intentions']
+                        }
+                    ]
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Player 1 plays No Glory, Only Results
+            context.player1.clickCard(context.noGloryOnlyResults);
+            expect(context.player1).toBeAbleToSelectExactly([context.directorKrennic]);
+
+            // Choose Director Krennic to take control and defeat it
+            context.player1.clickCard(context.directorKrennic);
+
+            expect(context.directorKrennic).toBeInZone('discard', context.player2);
+            expect(context.shadowedIntentions).toBeInZone('discard', context.player2);
+        });
     });
 });

--- a/test/server/cards/04_JTL/events/NoGloryOnlyResults.spec.ts
+++ b/test/server/cards/04_JTL/events/NoGloryOnlyResults.spec.ts
@@ -93,56 +93,5 @@ describe('No Glory, Only Results', function() {
             expect(context.blackSunStarfighter).toBeInZone('discard');
             expect(context.superlaserTechnician).toBeInZone('resource');
         });
-
-        it('No Glory, Only Results should defeat an enemy unit with Shadowed Intentions attached', async function() {
-            await contextRef.setupTestAsync({
-                phase: 'action',
-                player1: {
-                    hand: ['no-glory-only-results']
-                },
-                player2: {
-                    groundArena: [
-                        {
-                            card: 'director-krennic#on-the-verge-of-greatness',
-                            upgrades: ['shield', 'shadowed-intentions']
-                        }
-                    ]
-                }
-            });
-
-            const { context } = contextRef;
-
-            // Player 1 plays No Glory, Only Results
-            context.player1.clickCard(context.noGloryOnlyResults);
-            expect(context.player1).toBeAbleToSelectExactly([context.directorKrennic]);
-
-            // Choose Director Krennic to take control and defeat it
-            context.player1.clickCard(context.directorKrennic);
-
-            expect(context.directorKrennic).toBeInZone('discard', context.player2);
-            expect(context.shadowedIntentions).toBeInZone('discard', context.player2);
-        });
-
-        it('No Glory, Only Results should be able to defeat an enemy Lurking TIE Phantom', async function() {
-            await contextRef.setupTestAsync({
-                phase: 'action',
-                player1: {
-                    hand: ['no-glory-only-results']
-                },
-                player2: {
-                    spaceArena: ['lurking-tie-phantom']
-                }
-            });
-
-            const { context } = contextRef;
-
-            // Player 1 plays No Glory, Only Results
-            context.player1.clickCard(context.noGloryOnlyResults);
-            expect(context.player1).toBeAbleToSelectExactly([context.lurkingTiePhantom]);
-
-            // Choose Lurking TIE Phantom and defeat it
-            context.player1.clickCard(context.lurkingTiePhantom);
-            expect(context.lurkingTiePhantom).toBeInZone('discard');
-        });
     });
 });

--- a/test/server/cards/04_JTL/events/NoGloryOnlyResults.spec.ts
+++ b/test/server/cards/04_JTL/events/NoGloryOnlyResults.spec.ts
@@ -93,5 +93,56 @@ describe('No Glory, Only Results', function() {
             expect(context.blackSunStarfighter).toBeInZone('discard');
             expect(context.superlaserTechnician).toBeInZone('resource');
         });
+
+        it('No Glory, Only Results should defeat an enemy unit with Shadowed Intentions attached', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['no-glory-only-results']
+                },
+                player2: {
+                    groundArena: [
+                        {
+                            card: 'director-krennic#on-the-verge-of-greatness',
+                            upgrades: ['shield', 'shadowed-intentions']
+                        }
+                    ]
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Player 1 plays No Glory, Only Results
+            context.player1.clickCard(context.noGloryOnlyResults);
+            expect(context.player1).toBeAbleToSelectExactly([context.directorKrennic]);
+
+            // Choose Director Krennic to take control and defeat it
+            context.player1.clickCard(context.directorKrennic);
+
+            expect(context.directorKrennic).toBeInZone('discard', context.player2);
+            expect(context.shadowedIntentions).toBeInZone('discard', context.player2);
+        });
+
+        it('No Glory, Only Results should be able to defeat an enemy Lurking TIE Phantom', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['no-glory-only-results']
+                },
+                player2: {
+                    spaceArena: ['lurking-tie-phantom']
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Player 1 plays No Glory, Only Results
+            context.player1.clickCard(context.noGloryOnlyResults);
+            expect(context.player1).toBeAbleToSelectExactly([context.lurkingTiePhantom]);
+
+            // Choose Lurking TIE Phantom and defeat it
+            context.player1.clickCard(context.lurkingTiePhantom);
+            expect(context.lurkingTiePhantom).toBeInZone('discard');
+        });
     });
 });


### PR DESCRIPTION
Also partially updates Lurking TIE Phantom to use replacement effects to prevent defeat and capture by enemy card abilities. The damage prevention is still using ongoing effects because more work is needed to update replacement effects to work with damage prevention (#820).

Fixes #1131