### PR TITLE
Fix cards similar to Timely Intervention

### DIFF
--- a/server/game/abilities/EpicActionAbility.ts
+++ b/server/game/abilities/EpicActionAbility.ts
@@ -1,0 +1,15 @@
+import { EpicActionLimit } from '../core/ability/AbilityLimit';
+import { ActionAbility } from '../core/ability/ActionAbility';
+import type { Card } from '../core/card/Card';
+import type Game from '../core/Game';
+import type { IEpicActionProps } from '../Interfaces';
+
+export class EpicActionAbility extends ActionAbility {
+    public constructor(game: Game, card: Card, properties: IEpicActionProps) {
+        super(game, card, { ...properties, limit: new EpicActionLimit() });
+    }
+
+    public override isEpicAction(): this is EpicActionAbility {
+        return true;
+    }
+}

--- a/server/game/abilities/EpicActionAbility.ts
+++ b/server/game/abilities/EpicActionAbility.ts
@@ -1,3 +1,4 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
 import { EpicActionLimit } from '../core/ability/AbilityLimit';
 import { ActionAbility } from '../core/ability/ActionAbility';
 import type { Card } from '../core/card/Card';
@@ -7,9 +8,15 @@ import type { IEpicActionProps } from '../Interfaces';
 export class EpicActionAbility extends ActionAbility {
     public constructor(game: Game, card: Card, properties: IEpicActionProps) {
         super(game, card, { ...properties, limit: new EpicActionLimit() });
+
+        this.canResolveWithoutLegalTargets = true;
     }
 
     public override isEpicAction(): this is EpicActionAbility {
         return true;
+    }
+
+    public override meetsRequirements(context: AbilityContext, ignoredRequirements: string[] = [], thisStepOnly: boolean = false): string {
+        return super.meetsRequirements(context, [...ignoredRequirements, 'gameStateChange'], thisStepOnly);
     }
 }

--- a/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
+++ b/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
@@ -1,7 +1,7 @@
 import { BaseCard } from '../../../core/card/BaseCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { KeywordName, CardType, ZoneName, RelativePlayer } from '../../../core/Constants';
-import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
+import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class EnergyConversionLab extends BaseCard {
     protected override getImplementationId () {
@@ -24,7 +24,7 @@ export default class EnergyConversionLab extends BaseCard {
                         AbilityHelper.immediateEffects.playCardFromHand(),
                         AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush) }),
                     ],
-                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll
+                    targetingEnforcement: TargetingEnforcement.EnforceAll
                 })
             }
         });

--- a/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
+++ b/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
@@ -1,7 +1,7 @@
 import { BaseCard } from '../../../core/card/BaseCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { KeywordName, CardType, ZoneName, RelativePlayer } from '../../../core/Constants';
-import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class EnergyConversionLab extends BaseCard {
     protected override getImplementationId () {
@@ -24,7 +24,7 @@ export default class EnergyConversionLab extends BaseCard {
                         AbilityHelper.immediateEffects.playCardFromHand(),
                         AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush) }),
                     ],
-                    targetingEnforcement: TargetingEnforcement.EnforceAll
+                    resolutionMode: ResolutionMode.AllGameSystemsMustBeLegal,
                 })
             }
         });

--- a/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
+++ b/server/game/cards/01_SOR/bases/EnergyConversionLab.ts
@@ -1,6 +1,7 @@
 import { BaseCard } from '../../../core/card/BaseCard';
 import AbilityHelper from '../../../AbilityHelper';
 import { KeywordName, CardType, ZoneName, RelativePlayer } from '../../../core/Constants';
+import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
 
 export default class EnergyConversionLab extends BaseCard {
     protected override getImplementationId () {
@@ -18,14 +19,13 @@ export default class EnergyConversionLab extends BaseCard {
                 cardTypeFilter: CardType.BasicUnit,
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous(
-                    [
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    gameSystems: [
                         AbilityHelper.immediateEffects.playCardFromHand(),
                         AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush) }),
                     ],
-                    false, // We do not ignore targeting requirements
-                    true // All effect must have a legal target
-                )
+                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll
+                })
             }
         });
     }

--- a/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
+++ b/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
-import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
+import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -24,7 +24,7 @@ export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
                         AbilityHelper.immediateEffects.playCardFromHand(),
                         AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel) })
                     ],
-                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                    targetingEnforcement: TargetingEnforcement.EnforceAll,
                 }),
             }
         });

--- a/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
+++ b/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
@@ -21,7 +21,7 @@ export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
                 immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                     AbilityHelper.immediateEffects.playCardFromHand(),
                     AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel) })
-                ])
+                ], false, true),
             }
         });
     }

--- a/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
+++ b/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
+import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
 
 export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -18,10 +19,13 @@ export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
                 cardCondition: (card) => card.isUnit() && card.cost <= 3,
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.playCardFromHand(),
-                    AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel) })
-                ], false, true),
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    gameSystems: [
+                        AbilityHelper.immediateEffects.playCardFromHand(),
+                        AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel) })
+                    ],
+                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                }),
             }
         });
     }

--- a/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
+++ b/server/game/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
-import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -24,7 +24,7 @@ export default class ChewbaccaWalkingCarpet extends LeaderUnitCard {
                         AbilityHelper.immediateEffects.playCardFromHand(),
                         AbilityHelper.immediateEffects.forThisPhaseCardEffect({ effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel) })
                     ],
-                    targetingEnforcement: TargetingEnforcement.EnforceAll,
+                    resolutionMode: ResolutionMode.AllGameSystemsMustBeLegal,
                 }),
             }
         });

--- a/server/game/cards/02_SHD/events/TimelyIntervention.ts
+++ b/server/game/cards/02_SHD/events/TimelyIntervention.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { CardType, KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
 import { EventCard } from '../../../core/card/EventCard';
-import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
+import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class TimelyIntervention extends EventCard {
     protected override getImplementationId() {
@@ -26,7 +26,7 @@ export default class TimelyIntervention extends EventCard {
                             effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                         }),
                     ],
-                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                    targetingEnforcement: TargetingEnforcement.EnforceAll,
                 })
             }
         });

--- a/server/game/cards/02_SHD/events/TimelyIntervention.ts
+++ b/server/game/cards/02_SHD/events/TimelyIntervention.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { CardType, KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
 import { EventCard } from '../../../core/card/EventCard';
+import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
 
 export default class TimelyIntervention extends EventCard {
     protected override getImplementationId() {
@@ -18,12 +19,15 @@ export default class TimelyIntervention extends EventCard {
                 cardTypeFilter: CardType.BasicUnit,
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.playCardFromHand(),
-                    AbilityHelper.immediateEffects.forThisPhaseCardEffect({
-                        effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
-                    }),
-                ], false, true)
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    gameSystems: [
+                        AbilityHelper.immediateEffects.playCardFromHand(),
+                        AbilityHelper.immediateEffects.forThisPhaseCardEffect({
+                            effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
+                        }),
+                    ],
+                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                })
             }
         });
     }

--- a/server/game/cards/02_SHD/events/TimelyIntervention.ts
+++ b/server/game/cards/02_SHD/events/TimelyIntervention.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { CardType, KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
 import { EventCard } from '../../../core/card/EventCard';
-import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class TimelyIntervention extends EventCard {
     protected override getImplementationId() {
@@ -26,7 +26,7 @@ export default class TimelyIntervention extends EventCard {
                             effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                         }),
                     ],
-                    targetingEnforcement: TargetingEnforcement.EnforceAll,
+                    resolutionMode: ResolutionMode.AllGameSystemsMustBeLegal,
                 })
             }
         });

--- a/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
+++ b/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
@@ -14,6 +14,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
         this.addActionAbility({
             title: 'Play a unit that costs 4 or less from your hand. Give it ambush for this phase',
             cost: [AbilityHelper.costs.abilityActivationResourceCost(1), AbilityHelper.costs.exhaustSelf()],
+            cannotTargetFirst: true,
             targetResolver: {
                 cardCondition: (card) => card.isUnit() && card.cost <= 4,
                 cardTypeFilter: CardType.BasicUnit,
@@ -24,7 +25,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                     AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                         effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                     }),
-                ])
+                ], false, true),
             }
         });
     }
@@ -42,7 +43,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                     AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                         effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                     }),
-                ])
+                ], false, true),
             }
         });
     }

--- a/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
+++ b/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { CardType, KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
-import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -28,7 +28,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                             effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                         }),
                     ],
-                    targetingEnforcement: TargetingEnforcement.EnforceAll,
+                    resolutionMode: ResolutionMode.AllGameSystemsMustBeLegal,
                 }),
             }
         });
@@ -49,7 +49,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                             effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                         }),
                     ],
-                    targetingEnforcement: TargetingEnforcement.EnforceAll,
+                    resolutionMode: ResolutionMode.AllGameSystemsMustBeLegal,
                 }),
             }
         });

--- a/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
+++ b/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { CardType, KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
+import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
 
 export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -20,12 +21,15 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                 cardTypeFilter: CardType.BasicUnit,
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.playCardFromHand(),
-                    AbilityHelper.immediateEffects.forThisPhaseCardEffect({
-                        effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
-                    }),
-                ], false, true),
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    gameSystems: [
+                        AbilityHelper.immediateEffects.playCardFromHand(),
+                        AbilityHelper.immediateEffects.forThisPhaseCardEffect({
+                            effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
+                        }),
+                    ],
+                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                }),
             }
         });
     }
@@ -38,12 +42,15 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                 cardTypeFilter: CardType.BasicUnit,
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.playCardFromHand(),
-                    AbilityHelper.immediateEffects.forThisPhaseCardEffect({
-                        effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
-                    }),
-                ], false, true),
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    gameSystems: [
+                        AbilityHelper.immediateEffects.playCardFromHand(),
+                        AbilityHelper.immediateEffects.forThisPhaseCardEffect({
+                            effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
+                        }),
+                    ],
+                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                }),
             }
         });
     }

--- a/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
+++ b/server/game/cards/02_SHD/leaders/FennecShandHonoringTheDeal.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { CardType, KeywordName, RelativePlayer, ZoneName } from '../../../core/Constants';
-import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
+import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -28,7 +28,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                             effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                         }),
                     ],
-                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                    targetingEnforcement: TargetingEnforcement.EnforceAll,
                 }),
             }
         });
@@ -49,7 +49,7 @@ export default class FennecShandHonoringTheDeal extends LeaderUnitCard {
                             effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
                         }),
                     ],
-                    targetingEnforcement: AggregateSystemTargetingEnforcement.EnforceAll,
+                    targetingEnforcement: TargetingEnforcement.EnforceAll,
                 }),
             }
         });

--- a/server/game/cards/02_SHD/units/IG-11ICannotBeCaptured.ts
+++ b/server/game/cards/02_SHD/units/IG-11ICannotBeCaptured.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName } from '../../../core/Constants';
-import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class IG11ICannotBeCaptured extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -29,7 +29,7 @@ export default class IG11ICannotBeCaptured extends NonLeaderUnitCard {
                             };
                         })
                     ],
-                    targetingEnforcement: TargetingEnforcement.IgnoreAll,
+                    resolutionMode: ResolutionMode.AlwaysResolve,
                 })
             },
             effect: 'defeat him and deal 3 damage to each enemy ground unit instead',

--- a/server/game/cards/02_SHD/units/IG-11ICannotBeCaptured.ts
+++ b/server/game/cards/02_SHD/units/IG-11ICannotBeCaptured.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName } from '../../../core/Constants';
-import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
+import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class IG11ICannotBeCaptured extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -29,7 +29,7 @@ export default class IG11ICannotBeCaptured extends NonLeaderUnitCard {
                             };
                         })
                     ],
-                    targetingEnforcement: AggregateSystemTargetingEnforcement.IgnoreAll,
+                    targetingEnforcement: TargetingEnforcement.IgnoreAll,
                 })
             },
             effect: 'defeat him and deal 3 damage to each enemy ground unit instead',

--- a/server/game/cards/02_SHD/units/IG-11ICannotBeCaptured.ts
+++ b/server/game/cards/02_SHD/units/IG-11ICannotBeCaptured.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName } from '../../../core/Constants';
+import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
 
 export default class IG11ICannotBeCaptured extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -18,15 +19,18 @@ export default class IG11ICannotBeCaptured extends NonLeaderUnitCard {
             },
             replaceWith: {
                 target: this,
-                replacementImmediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.defeat(),
-                    AbilityHelper.immediateEffects.damage((context) => {
-                        return {
-                            amount: 3,
-                            target: context.game.getOtherPlayer(context.player).getArenaUnits({ arena: ZoneName.GroundArena })
-                        };
-                    })
-                ], true)
+                replacementImmediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    gameSystems: [
+                        AbilityHelper.immediateEffects.defeat(),
+                        AbilityHelper.immediateEffects.damage((context) => {
+                            return {
+                                amount: 3,
+                                target: context.game.getOtherPlayer(context.player).getArenaUnits({ arena: ZoneName.GroundArena })
+                            };
+                        })
+                    ],
+                    targetingEnforcement: AggregateSystemTargetingEnforcement.IgnoreAll,
+                })
             },
             effect: 'defeat him and deal 3 damage to each enemy ground unit instead',
             effectArgs: (context) => [context.source],

--- a/server/game/cards/05_LOF/events/AsIHaveForeseen.ts
+++ b/server/game/cards/05_LOF/events/AsIHaveForeseen.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
-import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
+import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class AsIHaveForeseen extends EventCard {
     protected override getImplementationId() {
@@ -32,7 +32,7 @@ export default class AsIHaveForeseen extends EventCard {
                                             adjustCost: { costAdjustType: CostAdjustType.Decrease, amount: 4 }
                                         })
                                     ],
-                                    targetingEnforcement: AggregateSystemTargetingEnforcement.IgnoreAll,
+                                    targetingEnforcement: TargetingEnforcement.IgnoreAll,
                                 }),
                             },
                             {

--- a/server/game/cards/05_LOF/events/AsIHaveForeseen.ts
+++ b/server/game/cards/05_LOF/events/AsIHaveForeseen.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
+import { AggregateSystemTargetingEnforcement } from '../../../core/gameSystem/AggregateSystem';
 
 export default class AsIHaveForeseen extends EventCard {
     protected override getImplementationId() {
@@ -23,13 +24,16 @@ export default class AsIHaveForeseen extends EventCard {
                             {
                                 text: 'Use the Force and play for 4 less',
                                 arg: 'play-discount',
-                                immediateEffect: AbilityHelper.immediateEffects.sequential([
-                                    AbilityHelper.immediateEffects.useTheForce({ target: context.player }),
-                                    AbilityHelper.immediateEffects.playCardFromOutOfPlay({
-                                        target: topCardOfDeck,
-                                        adjustCost: { costAdjustType: CostAdjustType.Decrease, amount: 4 }
-                                    })
-                                ], true),
+                                immediateEffect: AbilityHelper.immediateEffects.sequential({
+                                    gameSystems: [
+                                        AbilityHelper.immediateEffects.useTheForce({ target: context.player }),
+                                        AbilityHelper.immediateEffects.playCardFromOutOfPlay({
+                                            target: topCardOfDeck,
+                                            adjustCost: { costAdjustType: CostAdjustType.Decrease, amount: 4 }
+                                        })
+                                    ],
+                                    targetingEnforcement: AggregateSystemTargetingEnforcement.IgnoreAll,
+                                }),
                             },
                             {
                                 text: 'Leave on top',

--- a/server/game/cards/05_LOF/events/AsIHaveForeseen.ts
+++ b/server/game/cards/05_LOF/events/AsIHaveForeseen.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
-import { TargetingEnforcement } from '../../../gameSystems/SimultaneousOrSequentialSystem';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class AsIHaveForeseen extends EventCard {
     protected override getImplementationId() {
@@ -32,7 +32,7 @@ export default class AsIHaveForeseen extends EventCard {
                                             adjustCost: { costAdjustType: CostAdjustType.Decrease, amount: 4 }
                                         })
                                     ],
-                                    targetingEnforcement: TargetingEnforcement.IgnoreAll,
+                                    resolutionMode: ResolutionMode.AlwaysResolve,
                                 }),
                             },
                             {

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -137,7 +137,9 @@ class PlayerOrCardAbility {
     }
 
     /**
-     * @param {*} context
+     * @param {AbilityContext} context
+     * @param {String[]} ignoredRequirements
+     * @param {Boolean} thisStepOnly
      * @returns {String}
      */
     meetsRequirements(context, ignoredRequirements = [], thisStepOnly = false) {

--- a/server/game/core/ability/PlayerOrCardAbility.js
+++ b/server/game/core/ability/PlayerOrCardAbility.js
@@ -358,6 +358,11 @@ class PlayerOrCardAbility {
         return false;
     }
 
+    /** @returns {this is import('../../abilities/EpicActionAbility.js').EpicActionAbility} */
+    isEpicAction() {
+        return false;
+    }
+
     /** Return the controller of ability, can be different from card's controller (with bounty for exemple)
      * @returns {import('../Player.js').Player} */
     get controller() {

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -84,8 +84,7 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
 
     public override hasLegalTarget(context: AbilityContext) {
         const player = this.getChoosingPlayer(context);
-        return this.selector.hasEnoughTargets(context, player) ||
-          (context.ability?.isEpicAction() && this.isChoosingFromHidden(this.selector.getAllLegalTargets(context, player), context));
+        return this.selector.hasEnoughTargets(context, player);
     }
 
     public getAllLegalTargets(context: AbilityContext): Card[] {

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -83,7 +83,9 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
     }
 
     public override hasLegalTarget(context: AbilityContext) {
-        return this.selector.hasEnoughTargets(context, this.getChoosingPlayer(context));
+        const player = this.getChoosingPlayer(context);
+        return this.selector.hasEnoughTargets(context, player) ||
+          (context.ability?.isEpicAction() && this.isChoosingFromHidden(this.selector.getAllLegalTargets(context, player), context));
     }
 
     public getAllLegalTargets(context: AbilityContext): Card[] {
@@ -104,14 +106,11 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
         // A player can always choose not to pick a card from a zone that is hidden from their opponents
         // if doing so would reveal hidden information(i.e. that there are one or more valid cards in that zone) (SWU Comp Rules 2.0 1.17.4)
         // TODO: test if picking a card from an opponent's usually hidden zone(e.g. opponent's hand) works as expected(the if block here should be skipped)
-        let choosingFromHidden = false;
-        const choosingPlayer = typeof this.properties.choosingPlayer === 'function' ? this.properties.choosingPlayer(context) : this.properties.choosingPlayer;
-        const zones = new Set<ZoneName>(legalTargets.map((card) => card.zoneName));
-        if (!(this.properties.ignoreHiddenZoneRule ?? false) && (!!this.properties.cardTypeFilter || !!this.properties.cardCondition) && CardTargetResolver.allZonesAreHidden([...zones], choosingPlayer)) {
+        const choosingFromHidden = this.isChoosingFromHidden(legalTargets, context);
+        if (choosingFromHidden) {
             this.properties.optional = true;
             this.selector.optional = true;
             this.selector.appendToDefaultTitle = CardTargetResolver.choosingFromHiddenPrompt;
-            choosingFromHidden = true;
         }
 
         // if there are legal targets but this wouldn't have a gamestate-changing effect on any of them, we can just shortcut and skip selection
@@ -285,5 +284,16 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
         }
 
         Contract.fail(`Target zone filters '${properties.zoneFilter}' for ability has no overlap with legal zones for target card types '${properties.cardTypeFilter}', so target resolution is guaranteed to find no legal targets`);
+    }
+
+    private isChoosingFromHidden(legalTargets: Card[], context: AbilityContext): boolean {
+        const choosingPlayer = typeof this.properties.choosingPlayer === 'function' ? this.properties.choosingPlayer(context) : this.properties.choosingPlayer;
+        const zones = new Set<ZoneName>(legalTargets.map((card) => card.zoneName));
+        return !(this.properties.ignoreHiddenZoneRule ?? false) &&
+          (!!this.properties.cardTypeFilter || !!this.properties.cardCondition) &&
+          (
+              (zones.size === 0 && !!this.properties.zoneFilter && CardTargetResolver.allZonesAreHidden(this.properties.zoneFilter, choosingPlayer)) ||
+              CardTargetResolver.allZonesAreHidden([...zones], choosingPlayer)
+          );
     }
 }

--- a/server/game/core/ability/abilityTargets/TargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/TargetResolver.ts
@@ -57,7 +57,7 @@ export abstract class TargetResolver<TProps extends ITargetResolverBase<AbilityC
             return;
         }
 
-        const player = context.choosingPlayerOverride || this.getChoosingPlayer(context);
+        const player = this.getChoosingPlayer(context);
         if (player === context.player.opponent && context.stage === Stage.PreTarget) {
             targetResults.delayTargeting = this;
             return;
@@ -100,7 +100,11 @@ export abstract class TargetResolver<TProps extends ITargetResolverBase<AbilityC
         return this.hasTargetsChosenByPlayerInternal(context, player);
     }
 
-    public getChoosingPlayer(context) {
+    public getChoosingPlayer(context: AbilityContext) {
+        if (context.choosingPlayerOverride) {
+            return context.choosingPlayerOverride;
+        }
+
         let playerProp = this.properties.choosingPlayer;
         if (typeof playerProp === 'function') {
             playerProp = playerProp(context);

--- a/server/game/core/card/BaseCard.ts
+++ b/server/game/core/card/BaseCard.ts
@@ -4,10 +4,9 @@ import { CardType } from '../Constants';
 import * as Contract from '../utils/Contract';
 import type { ICardWithDamageProperty } from './propertyMixins/Damage';
 import { WithDamage } from './propertyMixins/Damage';
-import { ActionAbility } from '../ability/ActionAbility';
-import type { IActionAbilityProps, IConstantAbilityProps, IEpicActionProps, ITriggeredAbilityProps } from '../../Interfaces';
+import type { ActionAbility } from '../ability/ActionAbility';
+import type { IConstantAbilityProps, IEpicActionProps, ITriggeredAbilityProps } from '../../Interfaces';
 import { WithStandardAbilitySetup } from './propertyMixins/StandardAbilitySetup';
-import { EpicActionLimit } from '../ability/AbilityLimit';
 import { WithTriggeredAbilities, type ICardWithTriggeredAbilities } from './propertyMixins/TriggeredAbilityRegistration';
 import { WithConstantAbilities } from './propertyMixins/ConstantAbilityRegistration';
 import type { IConstantAbility } from '../ongoingEffect/IConstantAbility';
@@ -15,6 +14,7 @@ import type TriggeredAbility from '../ability/TriggeredAbility';
 import type { ICardWithActionAbilities } from './propertyMixins/ActionAbilityRegistration';
 import { WithActionAbilities } from './propertyMixins/ActionAbilityRegistration';
 import type { ICardDataJson } from '../../../utils/cardData/CardDataInterfaces';
+import { EpicActionAbility } from '../../abilities/EpicActionAbility';
 
 const BaseCardParent = WithActionAbilities(WithConstantAbilities(WithTriggeredAbilities(WithDamage(WithStandardAbilitySetup(Card)))));
 
@@ -24,7 +24,7 @@ export interface IBaseCard extends ICardWithDamageProperty, ICardWithActionAbili
 
 /** A Base card (as in, the card you put in your base zone) */
 export class BaseCard extends BaseCardParent implements IBaseCard {
-    private _epicActionAbility: ActionAbility;
+    private _epicActionAbility?: EpicActionAbility;
 
     public get epicActionSpent() {
         Contract.assertNotNullLike(this._epicActionAbility, `Attempting to check if epic action for card ${this.internalName} is spent, but no epic action ability is set`);
@@ -74,11 +74,7 @@ export class BaseCard extends BaseCardParent implements IBaseCard {
     protected setEpicActionAbility(properties: IEpicActionProps<this>): void {
         Contract.assertIsNullLike(this._epicActionAbility, 'Epic action ability already set');
 
-        const propertiesWithLimit: IActionAbilityProps<this> = Object.assign(properties, {
-            limit: new EpicActionLimit()
-        });
-
-        this._epicActionAbility = new ActionAbility(this.game, this, propertiesWithLimit);
+        this._epicActionAbility = new EpicActionAbility(this.game, this, properties);
     }
 
     private epicActionSpentInternal(): boolean {

--- a/server/game/core/gameSystem/AggregateSystem.ts
+++ b/server/game/core/gameSystem/AggregateSystem.ts
@@ -7,15 +7,6 @@ import { GameSystem } from './GameSystem';
 // helper type useful for some extensions of this class
 export type ISystemArrayOrFactory<TContext extends AbilityContext> = (GameSystem<TContext>)[] | ((context: TContext) => (GameSystem<TContext>)[]);
 
-export enum AggregateSystemTargetingEnforcement {
-    Default = 'default',
-    // Assume all systems have a legal target.
-    // Needed for situations where there currently isn't a target but an earlier system in the chain will create one.
-    IgnoreAll = 'ignoreAll',
-    // Enforce all systems to have a legal target.
-    EnforceAll = 'enforceAll',
-}
-
 /**
  * Meta-system used for executing a set of other systems together.
  *

--- a/server/game/core/gameSystem/AggregateSystem.ts
+++ b/server/game/core/gameSystem/AggregateSystem.ts
@@ -7,6 +7,15 @@ import { GameSystem } from './GameSystem';
 // helper type useful for some extensions of this class
 export type ISystemArrayOrFactory<TContext extends AbilityContext> = (GameSystem<TContext>)[] | ((context: TContext) => (GameSystem<TContext>)[]);
 
+export enum AggregateSystemTargetingEnforcement {
+    Default = 'default',
+    // Assume all systems have a legal target.
+    // Needed for situations where there currently isn't a target but an earlier system in the chain will create one.
+    IgnoreAll = 'ignoreAll',
+    // Enforce all systems to have a legal target.
+    EnforceAll = 'enforceAll',
+}
+
 /**
  * Meta-system used for executing a set of other systems together.
  *

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -112,6 +112,7 @@ import { SelectCardSystem } from './SelectCardSystem';
 import { SequentialSystem } from './SequentialSystem';
 import type { IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { ShuffleDeckSystem } from './ShuffleDeckSystem';
+import type { ISimultaneousSystemProperties } from './SimultaneousSystem';
 import { SimultaneousGameSystem } from './SimultaneousSystem';
 import type { ITakeControlOfResourceProperties } from './TakeControlOfResourceSystem';
 import { TakeControlOfResourceSystem } from './TakeControlOfResourceSystem';
@@ -658,9 +659,14 @@ export function selectPlayer<TContext extends AbilityContext = AbilityContext>(p
 // }
 export function sequential<TContext extends AbilityContext = AbilityContext>(gameSystems: ISystemArrayOrFactory<TContext>, everyGameSystemMustBeLegal: boolean = false) {
     return new SequentialSystem<TContext>(gameSystems, everyGameSystemMustBeLegal);
-} // takes an array of gameActions, not a propertyFactory
-export function simultaneous<TContext extends AbilityContext = AbilityContext>(gameSystems: ISystemArrayOrFactory<TContext>, ignoreTargetingRequirements = null, everyGameSystemMustBeLegal: boolean = false) {
-    return new SimultaneousGameSystem<TContext>(gameSystems, ignoreTargetingRequirements, everyGameSystemMustBeLegal);
+}
+export function simultaneous<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISimultaneousSystemProperties<TContext> | GameSystem<TContext>[], TContext>) {
+    return new SimultaneousGameSystem<TContext>((context: TContext) => {
+        const props = typeof propertyFactory === 'function' ? propertyFactory(context) : propertyFactory;
+        return !Array.isArray(props) ? props : {
+            gameSystems: props,
+        };
+    });
 }
 
 export function shuffleDeck<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IShuffleDeckProperties, TContext> = {}) {

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -3,7 +3,6 @@ import type { AbilityContext } from '../core/ability/AbilityContext';
 import { ZoneName, DeckZoneDestination, PlayType, RelativePlayer, DamageType } from '../core/Constants';
 import type { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
 
-import type { ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
 import type { IAttachUpgradeProperties } from './AttachUpgradeSystem';
 import { AttachUpgradeSystem } from './AttachUpgradeSystem';
 import type { ICaptureProperties } from './CaptureSystem';
@@ -109,6 +108,7 @@ import type { ISearchDeckProperties } from './SearchDeckSystem';
 import { SearchDeckSystem } from './SearchDeckSystem';
 import type { ISelectCardProperties } from './SelectCardSystem';
 import { SelectCardSystem } from './SelectCardSystem';
+import type { ISequentialSystemProperties } from './SequentialSystem';
 import { SequentialSystem } from './SequentialSystem';
 import type { IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { ShuffleDeckSystem } from './ShuffleDeckSystem';
@@ -657,8 +657,13 @@ export function selectPlayer<TContext extends AbilityContext = AbilityContext>(p
 // export function selectToken(propertyFactory: PropsFactory<SelectTokenProperties>) {
 //     return new SelectTokenAction(propertyFactory);
 // }
-export function sequential<TContext extends AbilityContext = AbilityContext>(gameSystems: ISystemArrayOrFactory<TContext>, everyGameSystemMustBeLegal: boolean = false) {
-    return new SequentialSystem<TContext>(gameSystems, everyGameSystemMustBeLegal);
+export function sequential<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISequentialSystemProperties<TContext> | GameSystem<TContext>[], TContext>) {
+    return new SequentialSystem<TContext>((context: TContext) => {
+        const props = typeof propertyFactory === 'function' ? propertyFactory(context) : propertyFactory;
+        return !Array.isArray(props) ? props : {
+            gameSystems: props,
+        };
+    });
 }
 export function simultaneous<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISimultaneousSystemProperties<TContext> | GameSystem<TContext>[], TContext>) {
     return new SimultaneousGameSystem<TContext>((context: TContext) => {

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -113,7 +113,7 @@ import { SequentialSystem } from './SequentialSystem';
 import type { IShuffleDeckProperties } from './ShuffleDeckSystem';
 import { ShuffleDeckSystem } from './ShuffleDeckSystem';
 import type { ISimultaneousSystemProperties } from './SimultaneousSystem';
-import { SimultaneousGameSystem } from './SimultaneousSystem';
+import { SimultaneousSystem } from './SimultaneousSystem';
 import type { ITakeControlOfResourceProperties } from './TakeControlOfResourceSystem';
 import { TakeControlOfResourceSystem } from './TakeControlOfResourceSystem';
 import type { ITakeControlOfUnitProperties } from './TakeControlOfUnitSystem';
@@ -666,7 +666,7 @@ export function sequential<TContext extends AbilityContext = AbilityContext>(pro
     });
 }
 export function simultaneous<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISimultaneousSystemProperties<TContext> | GameSystem<TContext>[], TContext>) {
-    return new SimultaneousGameSystem<TContext>((context: TContext) => {
+    return new SimultaneousSystem<TContext>((context: TContext) => {
         const props = typeof propertyFactory === 'function' ? propertyFactory(context) : propertyFactory;
         return !Array.isArray(props) ? props : {
             gameSystems: props,

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -658,20 +658,12 @@ export function selectPlayer<TContext extends AbilityContext = AbilityContext>(p
 //     return new SelectTokenAction(propertyFactory);
 // }
 export function sequential<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISequentialSystemProperties<TContext> | GameSystem<TContext>[], TContext>) {
-    return new SequentialSystem<TContext>((context: TContext) => {
-        const props = typeof propertyFactory === 'function' ? propertyFactory(context) : propertyFactory;
-        return !Array.isArray(props) ? props : {
-            gameSystems: props,
-        };
-    });
+    const makeProps = (props: ISequentialSystemProperties<TContext> | GameSystem<TContext>[]) => (!Array.isArray(props) ? props : { gameSystems: props });
+    return new SequentialSystem<TContext>(typeof propertyFactory !== 'function' ? makeProps(propertyFactory) : (context: TContext) => makeProps(propertyFactory(context)));
 }
 export function simultaneous<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISimultaneousSystemProperties<TContext> | GameSystem<TContext>[], TContext>) {
-    return new SimultaneousSystem<TContext>((context: TContext) => {
-        const props = typeof propertyFactory === 'function' ? propertyFactory(context) : propertyFactory;
-        return !Array.isArray(props) ? props : {
-            gameSystems: props,
-        };
-    });
+    const makeProps = (props: ISimultaneousSystemProperties<TContext> | GameSystem<TContext>[]) => (!Array.isArray(props) ? props : { gameSystems: props });
+    return new SimultaneousSystem<TContext>(typeof propertyFactory !== 'function' ? makeProps(propertyFactory) : (context: TContext) => makeProps(propertyFactory(context)));
 }
 
 export function shuffleDeck<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IShuffleDeckProperties, TContext> = {}) {

--- a/server/game/gameSystems/SequentialSystem.ts
+++ b/server/game/gameSystems/SequentialSystem.ts
@@ -1,18 +1,18 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import type { MetaEventName } from '../core/Constants';
+import { GameStateChangeRequired, type MetaEventName } from '../core/Constants';
 import type { GameEvent } from '../core/event/GameEvent';
 import type { GameObject } from '../core/GameObject';
 import type { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
-import type { ISystemArrayOrFactory } from '../core/gameSystem/AggregateSystem';
+import { AggregateSystemTargetingEnforcement } from '../core/gameSystem/AggregateSystem';
 import { AggregateSystem } from '../core/gameSystem/AggregateSystem';
 import type { Player } from '../core/Player';
-
+import * as Contract from '../core/utils/Contract';
+import * as Helpers from '../core/utils/Helpers';
 
 export interface ISequentialSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
     gameSystems: GameSystem<TContext>[];
 
-    // If true, all game systems must be legal for the entire sequence to be legal
-    everyGameSystemMustBeLegal?: boolean;
+    targetingEnforcement?: AggregateSystemTargetingEnforcement;
 }
 
 // TODO: add a variant of this (or a configuration option) for repeating the same action a variable number of times
@@ -25,35 +25,49 @@ export interface ISequentialSystemProperties<TContext extends AbilityContext = A
  */
 export class SequentialSystem<TContext extends AbilityContext = AbilityContext> extends AggregateSystem<TContext, ISequentialSystemProperties<TContext>> {
     protected override readonly eventName: MetaEventName.Sequential;
-    protected readonly everyGameSystemMustBeLegal: boolean;
-    public constructor(gameSystems: ISystemArrayOrFactory<TContext>, everyGameSystemMustBeLegal: boolean = false) {
-        if (typeof gameSystems === 'function') {
-            super((context: TContext) => ({ gameSystems: gameSystems(context) }));
-        } else {
-            super({ gameSystems });
-        }
-        this.everyGameSystemMustBeLegal = everyGameSystemMustBeLegal;
-    }
+    protected override readonly defaultProperties: ISequentialSystemProperties<TContext> = {
+        gameSystems: [],
+        targetingEnforcement: AggregateSystemTargetingEnforcement.Default,
+    };
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     public override eventHandler() {}
 
-    private allGameSystemsAreLegal(context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}): boolean {
-        const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        return properties.gameSystems.every((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
-    }
-
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        if (this.everyGameSystemMustBeLegal && !this.allGameSystemsAreLegal(context, additionalProperties)) {
-            return;
+
+        let queueGenerateEventGameStepsFn: (gameSystem: GameSystem<TContext>, events: GameEvent[]) => () => boolean;
+        let generateStepName: (gameSystem: GameSystem<TContext>) => string;
+
+        if (properties.targetingEnforcement === AggregateSystemTargetingEnforcement.IgnoreAll) {
+            queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>, eventsForThisAction: GameEvent[]) => () => {
+                gameSystem.queueGenerateEventGameSteps(eventsForThisAction, context, additionalProperties);
+                return true;
+            };
+            generateStepName = (gameSystem: GameSystem<TContext>) => `add events for sequential system  ${gameSystem.name}`;
+        } else {
+            // Exit early if we are enforcing targeting and there are no targets (e.g. when the user picks "Choose nothing")
+            if (properties.targetingEnforcement === AggregateSystemTargetingEnforcement.EnforceAll && !this.allTargetsLegal(context, additionalProperties) && Helpers.asArray(properties.target).length === 0) {
+                return;
+            }
+            Contract.assertFalse(
+                properties.targetingEnforcement === AggregateSystemTargetingEnforcement.EnforceAll && !this.allTargetsLegal(context, additionalProperties),
+                `Attempting to trigger sequential system with enforceTargeting set to true, but not all game systems are legal. Systems: ${properties.gameSystems.map((gameSystem) => gameSystem.name).join(', ')}`
+            );
+            queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>, eventsForThisAction: GameEvent[]) => () => {
+                if (gameSystem.hasLegalTarget(context, additionalProperties)) {
+                    gameSystem.queueGenerateEventGameSteps(eventsForThisAction, context, additionalProperties);
+                    return true;
+                }
+                return false;
+            };
+            generateStepName = (gameSystem: GameSystem<TContext>) => `check targets and add events for sequential system ${gameSystem.name}`;
         }
 
         for (const gameSystem of properties.gameSystems) {
             context.game.queueSimpleStep(() => {
-                if (gameSystem.hasLegalTarget(context, additionalProperties)) {
-                    const eventsForThisAction = [];
-                    gameSystem.queueGenerateEventGameSteps(eventsForThisAction, context, additionalProperties);
+                const eventsForThisAction = [];
+                if (queueGenerateEventGameStepsFn(gameSystem, eventsForThisAction)()) {
                     context.game.queueSimpleStep(() => {
                         for (const event of eventsForThisAction) {
                             events.push(event);
@@ -63,7 +77,7 @@ export class SequentialSystem<TContext extends AbilityContext = AbilityContext> 
                         }
                     }, `open event window for sequential system ${gameSystem.name}`);
                 }
-            }, `check and add events for sequential system ${gameSystem.name}`);
+            }, generateStepName(gameSystem));
         }
     }
 
@@ -76,13 +90,36 @@ export class SequentialSystem<TContext extends AbilityContext = AbilityContext> 
         return properties.gameSystems[0].getEffectMessage(context);
     }
 
-    public override hasLegalTarget(context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}): boolean {
-        const { gameSystems } = this.generatePropertiesFromContext(context, additionalProperties);
-        return gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context));
+    public override hasLegalTarget(context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        if (properties.targetingEnforcement === AggregateSystemTargetingEnforcement.EnforceAll) {
+            for (const candidateTarget of this.targets(context, additionalProperties)) {
+                if (this.canAffect(candidateTarget, context, additionalProperties, mustChangeGameState)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context));
     }
 
-    public override canAffectInternal(target: GameObject, context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}): boolean {
+    public override allTargetsLegal(context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        if (properties.targetingEnforcement === AggregateSystemTargetingEnforcement.EnforceAll) {
+            return properties.gameSystems.every((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+        }
+        return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+    }
+
+    public override canAffectInternal(target: GameObject, context: TContext, additionalProperties: Partial<ISequentialSystemProperties<TContext>> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        if (properties.targetingEnforcement === AggregateSystemTargetingEnforcement.EnforceAll) {
+            return properties.gameSystems.every((gameSystem) => gameSystem.canAffect(target, context, additionalProperties, mustChangeGameState));
+        }
+
         return properties.gameSystems.some((gameSystem) => gameSystem.canAffect(target, context));
     }
 

--- a/server/game/gameSystems/SequentialSystem.ts
+++ b/server/game/gameSystems/SequentialSystem.ts
@@ -5,7 +5,7 @@ import type { GameSystem } from '../core/gameSystem/GameSystem';
 import * as Contract from '../core/utils/Contract';
 import * as Helpers from '../core/utils/Helpers';
 import type { ISimultaneousOrSequentialSystemProperties } from './SimultaneousOrSequentialSystem';
-import { SimultaneousOrSequentialSystem, TargetingEnforcement } from './SimultaneousOrSequentialSystem';
+import { ResolutionMode, SimultaneousOrSequentialSystem } from './SimultaneousOrSequentialSystem';
 
 export type ISequentialSystemProperties<TContext extends AbilityContext = AbilityContext> = ISimultaneousOrSequentialSystemProperties<TContext>;
 
@@ -32,7 +32,7 @@ export class SequentialSystem<TContext extends AbilityContext = AbilityContext> 
         let queueGenerateEventGameStepsFn: (gameSystem: GameSystem<TContext>, events: GameEvent[]) => () => boolean;
         let generateStepName: (gameSystem: GameSystem<TContext>) => string;
 
-        if (properties.targetingEnforcement === TargetingEnforcement.IgnoreAll) {
+        if (properties.resolutionMode === ResolutionMode.AlwaysResolve) {
             queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>, eventsForThisAction: GameEvent[]) => () => {
                 gameSystem.queueGenerateEventGameSteps(eventsForThisAction, context, additionalProperties);
                 return true;
@@ -40,11 +40,11 @@ export class SequentialSystem<TContext extends AbilityContext = AbilityContext> 
             generateStepName = (gameSystem: GameSystem<TContext>) => `add events for sequential system  ${gameSystem.name}`;
         } else {
             // Exit early if we are enforcing targeting and there are no targets (e.g. when the user picks "Choose nothing")
-            if (properties.targetingEnforcement === TargetingEnforcement.EnforceAll && !this.allTargetsLegal(context, additionalProperties) && Helpers.asArray(properties.target).length === 0) {
+            if (properties.resolutionMode === ResolutionMode.AllGameSystemsMustBeLegal && !this.allTargetsLegal(context, additionalProperties) && Helpers.asArray(properties.target).length === 0) {
                 return;
             }
             Contract.assertFalse(
-                properties.targetingEnforcement === TargetingEnforcement.EnforceAll && !this.allTargetsLegal(context, additionalProperties),
+                properties.resolutionMode === ResolutionMode.AllGameSystemsMustBeLegal && !this.allTargetsLegal(context, additionalProperties),
                 `Attempting to trigger sequential system with enforceTargeting set to true, but not all game systems are legal. Systems: ${properties.gameSystems.map((gameSystem) => gameSystem.name).join(', ')}`
             );
             queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>, eventsForThisAction: GameEvent[]) => () => {

--- a/server/game/gameSystems/SimultaneousOrSequentialSystem.ts
+++ b/server/game/gameSystems/SimultaneousOrSequentialSystem.ts
@@ -1,0 +1,75 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import { GameStateChangeRequired } from '../core/Constants';
+import type { GameObject } from '../core/GameObject';
+import type { GameSystem, IGameSystemProperties } from '../core/gameSystem/GameSystem';
+import { AggregateSystem } from '../core/gameSystem/AggregateSystem';
+import type { Player } from '../core/Player';
+
+export interface ISimultaneousOrSequentialSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
+    gameSystems: GameSystem<TContext>[];
+
+    targetingEnforcement?: TargetingEnforcement;
+}
+
+export enum TargetingEnforcement {
+    Default = 'default',
+    // Assume all systems have a legal target.
+    // Needed for situations where there currently isn't a target but an earlier system in the chain will create one.
+    IgnoreAll = 'ignoreAll',
+    // Enforce all systems to have a legal target.
+    EnforceAll = 'enforceAll',
+}
+
+export abstract class SimultaneousOrSequentialSystem<TProps extends ISimultaneousOrSequentialSystemProperties<TContext>, TContext extends AbilityContext = AbilityContext> extends AggregateSystem<TContext, TProps> {
+    protected override readonly defaultProperties: ISimultaneousOrSequentialSystemProperties<TContext> = {
+        gameSystems: [],
+        targetingEnforcement: TargetingEnforcement.Default,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override eventHandler() {}
+
+    public override getInnerSystems(properties: TProps) {
+        return properties.gameSystems;
+    }
+
+    public override hasLegalTarget(context: TContext, additionalProperties: Partial<TProps> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        if (properties.targetingEnforcement === TargetingEnforcement.EnforceAll) {
+            for (const candidateTarget of this.targets(context, additionalProperties)) {
+                if (this.canAffect(candidateTarget, context, additionalProperties, mustChangeGameState)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+    }
+
+    public override canAffectInternal(target: GameObject, context: TContext, additionalProperties: Partial<TProps> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        if (properties.targetingEnforcement === TargetingEnforcement.EnforceAll) {
+            return properties.gameSystems.every((gameSystem) => gameSystem.canAffect(target, context, additionalProperties, mustChangeGameState));
+        }
+
+        return properties.gameSystems.some((gameSystem) => gameSystem.canAffect(target, context, additionalProperties, mustChangeGameState));
+    }
+
+    public override allTargetsLegal(context: TContext, additionalProperties: Partial<TProps> = {}): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        if (properties.targetingEnforcement === TargetingEnforcement.EnforceAll) {
+            return properties.gameSystems.every((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+        }
+        return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+    }
+
+    public override hasTargetsChosenByPlayer(context: TContext, player: Player = context.player, additionalProperties: Partial<TProps> = {}) {
+        const properties = this.generatePropertiesFromContext(context);
+        return properties.gameSystems.some((gameSystem) =>
+            gameSystem.hasTargetsChosenByPlayer(context, player, additionalProperties)
+        );
+    }
+}

--- a/server/game/gameSystems/SimultaneousOrSequentialSystem.ts
+++ b/server/game/gameSystems/SimultaneousOrSequentialSystem.ts
@@ -61,9 +61,9 @@ export abstract class SimultaneousOrSequentialSystem<TProps extends ISimultaneou
     public override allTargetsLegal(context: TContext, additionalProperties: Partial<TProps> = {}): boolean {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
         if (properties.targetingEnforcement === TargetingEnforcement.EnforceAll) {
-            return properties.gameSystems.every((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+            return properties.gameSystems.every((gameSystem) => gameSystem.allTargetsLegal(context, additionalProperties));
         }
-        return properties.gameSystems.some((gameSystem) => gameSystem.hasLegalTarget(context, additionalProperties));
+        return properties.gameSystems.some((gameSystem) => gameSystem.allTargetsLegal(context, additionalProperties));
     }
 
     public override hasTargetsChosenByPlayer(context: TContext, player: Player = context.player, additionalProperties: Partial<TProps> = {}) {

--- a/server/game/gameSystems/SimultaneousSystem.ts
+++ b/server/game/gameSystems/SimultaneousSystem.ts
@@ -4,7 +4,7 @@ import * as Contract from '../core/utils/Contract';
 import * as Helpers from '../core/utils/Helpers';
 import type { GameSystem } from '../core/gameSystem/GameSystem';
 import type { ISimultaneousOrSequentialSystemProperties } from './SimultaneousOrSequentialSystem';
-import { SimultaneousOrSequentialSystem, TargetingEnforcement } from './SimultaneousOrSequentialSystem';
+import { ResolutionMode, SimultaneousOrSequentialSystem } from './SimultaneousOrSequentialSystem';
 import type { GameEvent } from '../core/event/GameEvent';
 
 export type ISimultaneousSystemProperties<TContext extends AbilityContext = AbilityContext> = ISimultaneousOrSequentialSystemProperties<TContext>;
@@ -29,18 +29,18 @@ export class SimultaneousSystem<TContext extends AbilityContext = AbilityContext
         let queueGenerateEventGameStepsFn: (gameSystem: GameSystem<TContext>) => () => void;
         let generateStepName: (gameSystem: GameSystem<TContext>) => string;
 
-        if (properties.targetingEnforcement === TargetingEnforcement.IgnoreAll) {
+        if (properties.resolutionMode === ResolutionMode.AlwaysResolve) {
             queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>) => () => {
                 gameSystem.queueGenerateEventGameSteps(events, context, additionalProperties);
             };
             generateStepName = (gameSystem: GameSystem<TContext>) => `queue generate event game steps for ${gameSystem.name}`;
         } else {
             // Exit early if we are enforcing targeting and there are no targets (e.g. when the user picks "Choose nothing")
-            if (properties.targetingEnforcement === TargetingEnforcement.EnforceAll && !this.allTargetsLegal(context, additionalProperties) && Helpers.asArray(properties.target).length === 0) {
+            if (properties.resolutionMode === ResolutionMode.AllGameSystemsMustBeLegal && !this.allTargetsLegal(context, additionalProperties) && Helpers.asArray(properties.target).length === 0) {
                 return;
             }
             Contract.assertFalse(
-                properties.targetingEnforcement === TargetingEnforcement.EnforceAll && !this.allTargetsLegal(context, additionalProperties),
+                properties.resolutionMode === ResolutionMode.AllGameSystemsMustBeLegal && !this.allTargetsLegal(context, additionalProperties),
                 `Attempting to trigger simultaneous system with enforceTargeting set to true, but not all game systems are legal. Systems: ${properties.gameSystems.map((gameSystem) => gameSystem.name).join(', ')}`
             );
             queueGenerateEventGameStepsFn = (gameSystem: GameSystem<TContext>) => () => {

--- a/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
+++ b/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
@@ -79,6 +79,28 @@ describe('Energy Conversion Lab', function() {
 
                 context.ignoreUnresolvedActionPhasePrompts = true;
             });
+
+            it('should do nothing when choosing nothing', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['poe-dameron#quick-to-improvise'],
+                        base: 'energy-conversion-lab',
+                        leader: 'han-solo#worth-the-risk',
+                    },
+                    player2: {
+                        groundArena: ['rugged-survivors']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.energyConversionLab);
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.poeDameron).toBeInZone('hand');
+                expect(context.poeDameron.hasSomeKeyword('ambush')).toBeFalse();
+            });
         });
     });
 });

--- a/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
+++ b/test/server/cards/01_SOR/bases/EnergyConversionLab.spec.ts
@@ -52,8 +52,9 @@ describe('Energy Conversion Lab', function() {
 
                 const { context } = contextRef;
 
-                expect(context.energyConversionLab).not.toHaveAvailableActionWhenClickedBy(context.player1);
-                expect(context.energyConversionLab.epicActionSpent).toBeFalse();
+                context.player1.clickCard(context.energyConversionLab);
+
+                expect(context.player2).toBeActivePlayer();
             });
 
             // Cf issue: https://github.com/SWU-Karabast/forceteki/issues/1005:
@@ -100,6 +101,27 @@ describe('Energy Conversion Lab', function() {
 
                 expect(context.poeDameron).toBeInZone('hand');
                 expect(context.poeDameron.hasSomeKeyword('ambush')).toBeFalse();
+            });
+
+            it('can be used to soft pass if there are no legal targets in hand', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['vanquish'],
+                        base: 'energy-conversion-lab',
+                        leader: 'han-solo#worth-the-risk',
+                    },
+                    player2: {
+                        groundArena: ['rugged-survivors']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.energyConversionLab);
+
+                expect(context.energyConversionLab.epicActionSpent).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.spec.ts
+++ b/test/server/cards/01_SOR/leaders/ChewbaccaWalkingCarpet.spec.ts
@@ -15,9 +15,6 @@ describe('Chewbacca, Walking Carpet', function() {
                         groundArena: ['wampa'],
                         spaceArena: ['tieln-fighter']
                     },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
                 });
             });
 
@@ -29,15 +26,21 @@ describe('Chewbacca, Walking Carpet', function() {
 
                 context.player1.clickCard(context.liberatedSlaves);
                 expect(context.player1.exhaustedResourceCount).toBe(3);
+                expect(context.liberatedSlaves.hasSomeKeyword('sentinel')).toBeTrue();
 
                 // player 2 attacks, liberated slaves automatically selected due to sentinel
                 context.player2.clickCard(context.wampa);
+                expect(context.player2).toBeAbleToSelectExactly([context.liberatedSlaves]);
+
+                context.player2.clickCard(context.liberatedSlaves);
                 expect(context.player1).toBeActivePlayer();
                 expect(context.liberatedSlaves.damage).toBe(4);
                 expect(context.wampa.damage).toBe(3);
 
                 // next round, liberated slaves should no longer have sentinel
                 context.moveToNextActionPhase();
+                expect(context.liberatedSlaves.hasSomeKeyword('sentinel')).toBeFalse();
+
                 context.player1.passAction();
                 context.player2.clickCard(context.wampa);
                 expect(context.player2).toBeAbleToSelectExactly([context.p1Base, context.liberatedSlaves]);
@@ -53,7 +56,38 @@ describe('Chewbacca, Walking Carpet', function() {
 
                 // test sentinel gain again for good measure
                 context.player2.clickCard(context.tielnFighter);
+                expect(context.player2).toBeAbleToSelectExactly([context.seventhFleetDefender]);
+
+                context.player2.clickCard(context.seventhFleetDefender);
                 expect(context.tielnFighter).toBeInZone('discard');
+            });
+
+            it('should not allow the player to select a unit that cannot be played', function () {
+                const { context } = contextRef;
+
+                context.player1.exhaustResources(context.player1.readyResourceCount - 2);
+
+                context.player1.clickCard(context.chewbacca);
+                expect(context.player1).toBeAbleToSelectExactly([context.allianceXwing]);
+                expect(context.liberatedSlaves).not.toHaveAvailableActionWhenClickedBy(context.player1);
+                expect(context.seventhFleetDefender).not.toHaveAvailableActionWhenClickedBy(context.player1);
+
+                context.player1.clickCard(context.allianceXwing);
+                expect(context.allianceXwing.hasSomeKeyword('sentinel')).toBeTrue();
+            });
+
+            it('should not give sentinel when choosing nothing', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chewbacca);
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.allianceXwing).toBeInZone('hand');
+                expect(context.allianceXwing.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.liberatedSlaves).toBeInZone('hand');
+                expect(context.liberatedSlaves.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.seventhFleetDefender).toBeInZone('hand');
+                expect(context.seventhFleetDefender.hasSomeKeyword('sentinel')).toBeFalse();
             });
         });
     }); // No tests for the unit side because it's only text is keywords.

--- a/test/server/cards/02_SHD/events/TimelyIntervention.spec.ts
+++ b/test/server/cards/02_SHD/events/TimelyIntervention.spec.ts
@@ -116,5 +116,30 @@ describe('Timely Intervention', function () {
 
             context.ignoreUnresolvedActionPhasePrompts = true;
         });
+
+        it('should do nothing when choosing nothing', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['poe-dameron#quick-to-improvise', 'wampa', 'timely-intervention'],
+                    leader: 'han-solo#worth-the-risk',
+                    base: 'command-center',
+                    resources: 5
+                },
+                player2: {
+                    groundArena: ['rugged-survivors']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.timelyIntervention);
+            context.player1.clickPrompt('Choose nothing');
+
+            expect(context.poeDameron).toBeInZone('hand');
+            expect(context.poeDameron.hasSomeKeyword('ambush')).toBeFalse();
+            expect(context.wampa).toBeInZone('hand');
+            expect(context.wampa.hasSomeKeyword('ambush')).toBeFalse();
+        });
     });
 });

--- a/test/server/cards/02_SHD/leaders/FennecShandHonoringTheDeal.spec.ts
+++ b/test/server/cards/02_SHD/leaders/FennecShandHonoringTheDeal.spec.ts
@@ -7,15 +7,12 @@ describe('Fennec Shand, Honoring the Deal', function () {
                     player1: {
                         base: 'echo-base',
                         leader: 'fennec-shand#honoring-the-deal',
-                        hand: ['reinforcement-walker', 'rebel-pathfinder', 'alliance-xwing', 'wampa'],
-                        resources: 4
+                        hand: ['reinforcement-walker', 'rebel-pathfinder', 'alliance-xwing', 'clone-combat-squadron'],
+                        resources: 5
                     },
                     player2: {
                         groundArena: ['isb-agent'],
                     },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
                 });
             });
 
@@ -23,7 +20,8 @@ describe('Fennec Shand, Honoring the Deal', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.fennecShand);
-                expect(context.player1).toBeAbleToSelectExactly([context.rebelPathfinder, context.allianceXwing, context.wampa]);
+                context.player1.clickPrompt('Play a unit that costs 4 or less from your hand. Give it ambush for this phase');
+                expect(context.player1).toBeAbleToSelectExactly([context.rebelPathfinder, context.allianceXwing, context.cloneCombatSquadron]);
 
                 context.player1.clickCard(context.rebelPathfinder);
                 expect(context.fennecShand.exhausted).toBeTrue();
@@ -32,9 +30,39 @@ describe('Fennec Shand, Honoring the Deal', function () {
                 expect(context.player1).toHavePassAbilityPrompt('Ambush');
 
                 context.player1.clickPrompt('Trigger');
+                context.player1.clickCard(context.isbAgent);
                 expect(context.rebelPathfinder.exhausted).toBeTrue();
                 expect(context.rebelPathfinder.damage).toBe(1);
                 expect(context.isbAgent.damage).toBe(2);
+            });
+
+            it('should not allow the player to select a unit that cannot be played', function () {
+                const { context } = contextRef;
+
+                context.player1.exhaustResources(context.player1.readyResourceCount - 4);
+
+                context.player1.clickCard(context.fennecShand);
+                context.player1.clickPrompt('Play a unit that costs 4 or less from your hand. Give it ambush for this phase');
+                expect(context.player1).toBeAbleToSelectExactly([context.rebelPathfinder, context.allianceXwing]);
+                expect(context.cloneCombatSquadron).not.toHaveAvailableActionWhenClickedBy(context.player1);
+
+                context.player1.clickCard(context.allianceXwing);
+                expect(context.allianceXwing.hasSomeKeyword('ambush')).toBeTrue();
+            });
+
+            it('should not give ambush when choosing nothing', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.fennecShand);
+                context.player1.clickPrompt('Play a unit that costs 4 or less from your hand. Give it ambush for this phase');
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.rebelPathfinder).toBeInZone('hand');
+                expect(context.rebelPathfinder.hasSomeKeyword('ambush')).toBeFalse();
+                expect(context.allianceXwing).toBeInZone('hand');
+                expect(context.allianceXwing.hasSomeKeyword('ambush')).toBeFalse();
+                expect(context.cloneCombatSquadron).toBeInZone('hand');
+                expect(context.cloneCombatSquadron.hasSomeKeyword('ambush')).toBeFalse();
             });
         });
 
@@ -116,28 +144,69 @@ describe('Fennec Shand, Honoring the Deal', function () {
         });
 
         describe('Fennec Shand\'s deployed ability', function () {
-            beforeEach(function () {
-                return contextRef.setupTestAsync({
+            it('should not allow the player to play a unit with cost 4 or less when he does not have any targetable units in hand', async function () {
+                await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         leader: { card: 'fennec-shand#honoring-the-deal', deployed: true },
                         hand: ['reinforcement-walker'],
                         resources: 8
                     },
-
-                    // IMPORTANT: this is here for backwards compatibility of older tests, don't use in new code
-                    autoSingleTarget: true
                 });
-            });
 
-            it('should not allow the player to play a unit with cost 4 or less when he does not have any targetable units in hand', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.fennecShand);
-                context.player2.passAction();
+                context.player1.clickCard(context.p2Base);
+
                 expect(context.fennecShand.exhausted).toBeTrue();
                 expect(context.fennecShand).not.toHaveAvailableActionWhenClickedBy(context.player1);
                 expect(context.p2Base.damage).toBe(4);
+            });
+
+            it('should not allow the player to select a unit that cannot be played', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'fennec-shand#honoring-the-deal', deployed: true },
+                        hand: ['reinforcement-walker', 'rebel-pathfinder', 'alliance-xwing', 'clone-combat-squadron'],
+                        resources: 3
+                    },
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.fennecShand);
+                context.player1.clickPrompt('Play a unit that costs 4 or less from your hand. Give it ambush for this phase');
+                expect(context.player1).toBeAbleToSelectExactly([context.rebelPathfinder, context.allianceXwing]);
+                expect(context.cloneCombatSquadron).not.toHaveAvailableActionWhenClickedBy(context.player1);
+
+                context.player1.clickCard(context.allianceXwing);
+                expect(context.allianceXwing.hasSomeKeyword('ambush')).toBeTrue();
+            });
+
+            it('should not give ambush when choosing nothing', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'fennec-shand#honoring-the-deal', deployed: true },
+                        hand: ['reinforcement-walker', 'rebel-pathfinder', 'alliance-xwing', 'clone-combat-squadron'],
+                        resources: 8
+                    },
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.fennecShand);
+                context.player1.clickPrompt('Play a unit that costs 4 or less from your hand. Give it ambush for this phase');
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.rebelPathfinder).toBeInZone('hand');
+                expect(context.rebelPathfinder.hasSomeKeyword('ambush')).toBeFalse();
+                expect(context.allianceXwing).toBeInZone('hand');
+                expect(context.allianceXwing.hasSomeKeyword('ambush')).toBeFalse();
+                expect(context.cloneCombatSquadron).toBeInZone('hand');
+                expect(context.cloneCombatSquadron.hasSomeKeyword('ambush')).toBeFalse();
             });
         });
     });


### PR DESCRIPTION
Apply a fix similar to #1160 to other cards like Timely Intervention. It also fixes a contract assertion that was happening if you selected `Choose nothing` when using one of these abilities.

Fixes #1086