### PR TITLE
Logging and better disconnect management for sockets

### DIFF
--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -997,8 +997,8 @@ export class GameServer {
 
             const socket = new Socket(ioSocket);
 
+            // if there is an older socket, clean it up first
             if (queuedPlayer.socket && queuedPlayer.socket.id !== socket.id) {
-                // clean up disconnect handlers on the old socket before removing it
                 queuedPlayer.socket.removeEventsListeners(['disconnect']);
                 queuedPlayer.socket.disconnect();
             }

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -998,6 +998,8 @@ export class GameServer {
             const socket = new Socket(ioSocket);
 
             if (queuedPlayer.socket && queuedPlayer.socket.id !== socket.id) {
+                // clean up disconnect handlers on the old socket before removing it
+                queuedPlayer.socket.removeEventsListeners(['disconnect']);
                 queuedPlayer.socket.disconnect();
             }
             queuedPlayer.socket = socket;
@@ -1211,12 +1213,12 @@ export class GameServer {
 
             setTimeout(() => {
                 try {
-                    if (isMatchmaking && !this.queue.isConnected(id)) {
+                    if (isMatchmaking && !this.queue.isConnected(id, socket.id)) {
                         this.queue.removePlayer(id, `Timeout disconnect on socket id ${socket.id}`);
                     }
 
                     // Check if the user is still disconnected after the timer
-                    if (lobby?.getUserState(id) === 'disconnected') {
+                    if (lobby?.isDisconnected(id, socket.id)) {
                         logger.info(`GameServer: User ${id} on socket id ${socket.id} is disconnected from lobby ${lobby.id} for more than 20s, removing from lobby`, { userId: id, lobbyId: lobby.id });
 
                         this.userLobbyMap.delete(id);

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -1108,13 +1108,6 @@ export class GameServer {
 
         logger.info(`GameServer: Matched players ${p1.user.getUsername()} and ${p2.user.getUsername()} in lobby ${lobby.id}.`);
 
-        setTimeout(() => {
-            console.log('Closing socket after 10 seconds of inactivity');
-
-            // close the low-level connection and trigger a reconnection
-            this.io.engine.close();
-        }, 15000);
-
         return Promise.resolve();
     }
 

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -223,8 +223,8 @@ export class Lobby {
     }
 
     private checkUpdateSocket(user: LobbyUser | LobbySpectator, socket: Socket): void {
+        // clean up disconnect handlers on the old socket before removing it
         if (user.socket && user.socket.id !== socket.id) {
-            // clean up disconnect handlers on the old socket before removing it
             user.socket.removeEventsListeners(['disconnect']);
             user.socket.disconnect();
         }

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -211,7 +211,7 @@ export class Lobby {
             });
         } else {
             existingSpectator.state = 'connected';
-            existingSpectator.socket = socket;
+            this.checkUpdateSocket(existingSpectator, socket);
         }
         // If game is ongoing, send the current state to the spectator
         if (this.game) {
@@ -220,6 +220,13 @@ export class Lobby {
             this.sendLobbyStateToSpectator(socket);
         }
         logger.info(`Lobby: adding spectator: ${user.getUsername()}, id: ${user.getId()} (${this.spectators.length} spectator(s))`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
+    }
+
+    private checkUpdateSocket(user: LobbyUser | LobbySpectator, socket: Socket): void {
+        if (user.socket && user.socket.id !== socket.id) {
+            user.socket.disconnect();
+        }
+        user.socket = socket;
     }
 
     public removeSpectator(id: string): void {
@@ -256,8 +263,8 @@ export class Lobby {
 
         if (existingUser) {
             existingUser.state = 'connected';
-            existingUser.socket = socket;
-            logger.info(`Lobby: setting state to connected for existing user: ${user.getUsername()}`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
+            this.checkUpdateSocket(existingUser, socket);
+            logger.info(`Lobby: setting state to connected for existing user ${user.getUsername()} with socket id ${socket.id}`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
         } else {
             this.users.push({
                 id: user.getId(),
@@ -267,7 +274,7 @@ export class Lobby {
                 socket,
                 reportedBugs: 0
             });
-            logger.info(`Lobby: adding username: ${user.getUsername()}, id: ${user.getId()} to users list (${this.users.length} user(s))`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
+            logger.info(`Lobby: adding username: ${user.getUsername()}, id: ${user.getId()}, socket id: ${socket.id} to users list (${this.users.length} user(s))`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
             this.gameChat.addMessage(`${user.getUsername()} has joined the lobby`);
         }
 
@@ -463,17 +470,17 @@ export class Lobby {
         return user;
     }
 
-    public setUserDisconnected(id: string): void {
+    public setUserDisconnected(id: string, socketId: string): void {
         const user = this.users.find((u) => u.id === id);
         if (user) {
             user.state = 'disconnected';
-            logger.info(`Lobby: setting user ${user.username} to disconnected`, { lobbyId: this.id, userName: user.username, userId: user.id });
+            logger.info(`Lobby: setting user ${user.username} to disconnected on socket id ${socketId}`, { lobbyId: this.id, userName: user.username, userId: user.id });
         }
 
         const spectator = this.spectators.find((u) => u.id === id);
         if (spectator) {
             spectator.state = 'disconnected';
-            logger.info(`Lobby: setting spectator ${spectator.username} to disconnected`, { lobbyId: this.id, userName: spectator.username, userId: spectator.id });
+            logger.info(`Lobby: setting spectator ${spectator.username} to disconnected on socket id ${socketId}`, { lobbyId: this.id, userName: spectator.username, userId: spectator.id });
         }
     }
 

--- a/server/gamenode/QueueHandler.ts
+++ b/server/gamenode/QueueHandler.ts
@@ -96,14 +96,15 @@ export class QueueHandler {
     /** If the user exists in the queue and is connected, temporarily move them into a disconnected state while waiting for reconnection */
     public disconnectPlayer(userId: string, socketId: string) {
         const queueEntry = this.findPlayerInQueue(userId);
-        if (queueEntry) {
+        if (queueEntry && queueEntry.player?.socket?.id === socketId) {
             this.removePlayer(userId, `Temporarily disconnected on socket id ${socketId}`);
             this.addPlayer(queueEntry.format, { user: queueEntry.player.user, deck: queueEntry.player.deck });
         }
     }
 
-    public isConnected(userId: string): boolean {
-        return !!this.findPlayerInQueue(userId);
+    public isConnected(userId: string, socketId: string): boolean {
+        const player = this.findPlayerInQueue(userId);
+        return player && player.player.socket?.id === socketId;
     }
 
     public removePlayer(userId: string, reasonStr: string) {

--- a/server/gamenode/QueueHandler.ts
+++ b/server/gamenode/QueueHandler.ts
@@ -74,14 +74,14 @@ export class QueueHandler {
         if (queueEntry) {
             playerEntry = queueEntry;
 
-            logger.info(`User ${userId} is already in queue for format ${queueEntry.format}, rejoining into queue for format ${playerEntry.format}`);
+            logger.info(`User ${userId} with socket id ${socket.id} is already in queue for format ${queueEntry.format}, rejoining into queue for format ${playerEntry.format}`);
             this.removePlayer(userId, 'Rejoining into queue');
         } else {
             const notConnectedPlayer = this.findNotConnectedPlayer(userId);
             Contract.assertNotNullLike(notConnectedPlayer, `Player ${userId} is not in the queue`);
 
             playerEntry = notConnectedPlayer;
-            this.removePlayer(userId, 'Player connected');
+            this.removePlayer(userId, `Player connected with socket id ${socket.id}`);
         }
 
         Contract.assertNotNullLike(playerEntry.format);
@@ -90,14 +90,14 @@ export class QueueHandler {
         playerEntry.player.socket = socket;
 
         this.queues.get(playerEntry.format)?.push(playerEntry.player);
-        logger.info(`User ${userId} connected, added to queue for format ${playerEntry.format}`);
+        logger.info(`User ${userId} connected with socket id ${socket.id}, added to queue for format ${playerEntry.format}`);
     }
 
     /** If the user exists in the queue and is connected, temporarily move them into a disconnected state while waiting for reconnection */
-    public disconnectPlayer(userId: string) {
+    public disconnectPlayer(userId: string, socketId: string) {
         const queueEntry = this.findPlayerInQueue(userId);
         if (queueEntry) {
-            this.removePlayer(userId, 'Temporarily disconnected');
+            this.removePlayer(userId, `Temporarily disconnected on socket id ${socketId}`);
             this.addPlayer(queueEntry.format, { user: queueEntry.player.user, deck: queueEntry.player.deck });
         }
     }


### PR DESCRIPTION
Added logging for the socket id on connect / disconnect events to help catch potential issues related to multiple open connections for the same user.

If a user connects with a new socket, we now disconnect the previous one before attaching the new one to decrease the likelihood of having multiple open. Also added checks to make sure that disconnect events are ignored if they are for sockets other than the most recently connected one.