### PR TITLE
Added screen resolution and viewport to the bug report entries

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -327,6 +327,8 @@ export interface ISerializedReportState {
     lobbyId: string;
     timestamp: string;
     gameId?: string;
+    screenResolution?: { width: number; height: number } | null;
+    viewport?: { width: number; height: number } | null;
 }
 
 // ********************************************** INTERNAL TYPES **********************************************

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -928,27 +928,25 @@ export class Lobby {
             let parsedDescription = '';
             let screenResolution = null;
             let viewport = null;
-        
             if (bugReportMessage && typeof bugReportMessage === 'object') {
                 parsedDescription = bugReportMessage.description || '';
                 screenResolution = bugReportMessage.screenResolution || null;
                 viewport = bugReportMessage.viewport || null;
-            }
-            else {
+            } else {
                 // Take this as a string (backward compatibility)
                 parsedDescription = bugReportMessage;
-            }          
+            }
 
             if (!parsedDescription || parsedDescription.trim().length === 0) {
                 throw new Error('description is invalid');
             }
-            
+
             // Create game state snapshot
             const gameState = this.game
                 ? this.game.captureGameState(socket.user.id)
                 : { phase: 'action', player1: {}, player2: {} };
 
-            // Create bug report 
+            // Create bug report
             const bugReport = this.server.bugReportHandler.createBugReport(
                 parsedDescription,
                 gameState,
@@ -958,17 +956,17 @@ export class Lobby {
                 screenResolution,
                 viewport
             );
-            
+
             // Send to Discord
             const success = await this.server.bugReportHandler.sendBugReportToDiscord(bugReport);
             if (!success) {
                 throw new Error('Bug report failed to send to discord. No webhook configured');
             }
-            
+
             // we find the user
             const existingUser = this.users.find((u) => u.id === socket.user.id);
             existingUser.reportedBugs += success ? 1 : 0;
-            
+
             // Send success message to client
             socket.send('bugReportResult', {
                 id: uuid(),

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -922,34 +922,53 @@ export class Lobby {
     }
 
     // Report bug method
-    private async reportBug(socket: Socket, description: string): Promise<void> {
+    private async reportBug(socket: Socket, bugReportMessage: any): Promise<void> {
         try {
-            // Validate description
-            if (!description || description.trim().length === 0) {
+            // Parse description as JSON if it's in JSON format
+            let parsedDescription = '';
+            let screenResolution = null;
+            let viewport = null;
+        
+            if (bugReportMessage && typeof bugReportMessage === 'object') {
+                parsedDescription = bugReportMessage.description || '';
+                screenResolution = bugReportMessage.screenResolution || null;
+                viewport = bugReportMessage.viewport || null;
+            }
+            else {
+                // Take this as a string (backward compatibility)
+                parsedDescription = bugReportMessage;
+            }          
+
+            if (!parsedDescription || parsedDescription.trim().length === 0) {
                 throw new Error('description is invalid');
             }
-
+            
             // Create game state snapshot
             const gameState = this.game
                 ? this.game.captureGameState(socket.user.id)
                 : { phase: 'action', player1: {}, player2: {} };
 
-            // Create bug report
+            // Create bug report 
             const bugReport = this.server.bugReportHandler.createBugReport(
-                description,
+                parsedDescription,
                 gameState,
                 socket.user,
                 this.id,
-                this.game?.id
+                this.game?.id,
+                screenResolution,
+                viewport
             );
+            
             // Send to Discord
             const success = await this.server.bugReportHandler.sendBugReportToDiscord(bugReport);
             if (!success) {
                 throw new Error('Bug report failed to send to discord. No webhook configured');
             }
+            
             // we find the user
             const existingUser = this.users.find((u) => u.id === socket.user.id);
             existingUser.reportedBugs += success ? 1 : 0;
+            
             // Send success message to client
             socket.send('bugReportResult', {
                 id: uuid(),

--- a/server/utils/bugreport/BugReportHandler.ts
+++ b/server/utils/bugreport/BugReportHandler.ts
@@ -26,12 +26,23 @@ export class BugReportHandler {
     public async sendBugReportToDiscord(bugReport: ISerializedReportState): Promise<boolean> {
         try {
             // Always log the bug report
-            logger.info(`Bug report received from user ${bugReport.reporter.username}`, {
+            const logData = {
                 lobbyId: bugReport.lobbyId,
                 reporterId: bugReport.reporter.id,
                 description: bugReport.description,
                 gameStateJson: JSON.stringify(bugReport.gameState, null, 0)
-            });
+            };
+            
+            // Only add screen resolution and viewport to log if they exist
+            if (bugReport.screenResolution) {
+                Object.assign(logData, { screenResolution: bugReport.screenResolution });
+            }
+            
+            if (bugReport.viewport) {
+                Object.assign(logData, { viewport: bugReport.viewport });
+            }
+            
+            logger.info(`Bug report received from user ${bugReport.reporter.username}`, logData);
 
             // If no webhook URL is configured, just log it
             if (!this.discordWebhookUrl) {
@@ -103,6 +114,55 @@ export class BugReportHandler {
             ? bugReport.description.substring(0, 1021) + '...'
             : bugReport.description;
 
+        // Prepare fields for embed
+        const fields = [
+            {
+                name: 'Reporter',
+                value: `${bugReport.reporter.username} (player1)`,
+                inline: true,
+            },
+            {
+                name: 'Lobby ID',
+                value: bugReport.lobbyId,
+                inline: true
+            },
+            {
+                name: 'Game ID',
+                value: bugReport.gameId || 'N/A',
+                inline: true
+            },
+            {
+                name: 'Timestamp',
+                value: bugReport.timestamp,
+                inline: true
+            }
+        ];
+
+        // Add screen resolution if available
+        if (bugReport.screenResolution) {
+            fields.push({
+                name: 'Screen Resolution',
+                value: `${bugReport.screenResolution.width}x${bugReport.screenResolution.height}`,
+                inline: true
+            });
+        }
+        
+        // Add viewport information if available
+        if (bugReport.viewport) {
+            fields.push({
+                name: 'Viewport',
+                value: `${bugReport.viewport.width}x${bugReport.viewport.height}`,
+                inline: true
+            });
+        }
+
+        // Add game state field
+        fields.push({
+            name: 'Game State',
+            value: 'See attached JSON file for complete game state',
+            inline: false
+        });
+
         return {
             content: `New bug report from **${bugReport.reporter.username}**!`,
             embeds: [
@@ -110,32 +170,7 @@ export class BugReportHandler {
                     title: 'Bug Report',
                     color: 0xFF0000, // Red color
                     description: embedDescription,
-                    fields: [
-                        {
-                            name: 'Reporter',
-                            value: `${bugReport.reporter.username} (player1)`,
-                            inline: true,
-                        },
-                        {
-                            name: 'Lobby ID',
-                            value: bugReport.lobbyId,
-                            inline: true
-                        },
-                        {
-                            name: 'Game ID',
-                            value: bugReport.gameId || 'N/A',
-                            inline: true
-                        },
-                        {
-                            name: 'Timestamp',
-                            value: bugReport.timestamp,
-                            inline: true
-                        },
-                        {
-                            name: 'Game State',
-                            value: 'See attached JSON file for complete game state'
-                        }
-                    ],
+                    fields,
                     timestamp: new Date().toISOString()
                 }
             ]
@@ -149,6 +184,7 @@ export class BugReportHandler {
      * @param user User reporting the bug
      * @param lobbyId ID of the lobby where the bug occurred
      * @param gameId Optional ID of the game where the bug occurred
+     * @param screenResolution Optional screen resolution information
      * @returns Formatted bug report object
      */
     public createBugReport(
@@ -156,7 +192,9 @@ export class BugReportHandler {
         gameState: ISerializedGameState,
         user: User,
         lobbyId: string,
-        gameId?: string
+        gameId?: string,
+        screenResolution?: { width: number; height: number } | null,
+        viewport?: { width: number; height: number } | null
     ): ISerializedReportState {
         return {
             description: this.sanitizeForJson(description),
@@ -168,7 +206,9 @@ export class BugReportHandler {
             },
             lobbyId,
             gameId,
-            timestamp: new Date().toISOString()
+            timestamp: new Date().toISOString(),
+            screenResolution: screenResolution,
+            viewport: viewport
         };
     }
 }

--- a/server/utils/bugreport/BugReportHandler.ts
+++ b/server/utils/bugreport/BugReportHandler.ts
@@ -185,6 +185,7 @@ export class BugReportHandler {
      * @param lobbyId ID of the lobby where the bug occurred
      * @param gameId Optional ID of the game where the bug occurred
      * @param screenResolution Optional screen resolution information
+     * @param viewport Optional viewport information
      * @returns Formatted bug report object
      */
     public createBugReport(

--- a/server/utils/bugreport/BugReportHandler.ts
+++ b/server/utils/bugreport/BugReportHandler.ts
@@ -32,16 +32,16 @@ export class BugReportHandler {
                 description: bugReport.description,
                 gameStateJson: JSON.stringify(bugReport.gameState, null, 0)
             };
-            
+
             // Only add screen resolution and viewport to log if they exist
             if (bugReport.screenResolution) {
                 Object.assign(logData, { screenResolution: bugReport.screenResolution });
             }
-            
+
             if (bugReport.viewport) {
                 Object.assign(logData, { viewport: bugReport.viewport });
             }
-            
+
             logger.info(`Bug report received from user ${bugReport.reporter.username}`, logData);
 
             // If no webhook URL is configured, just log it
@@ -146,7 +146,7 @@ export class BugReportHandler {
                 inline: true
             });
         }
-        
+
         // Add viewport information if available
         if (bugReport.viewport) {
             fields.push({


### PR DESCRIPTION
Updated the bug report to take in the screen resolution and viewport for helping debug  FE issues.  Helpful to see what sort of device "roughly" they are using when complaining about UI features.  Strictly captures the physical screen resolution and then viewport of the game within the browser 

Here is a new bug report from an iphone in landscape
![image](https://github.com/user-attachments/assets/35d0a8a5-835a-4022-bd5c-3b51b6ca0f04)

Here it is in portrait mode
![image](https://github.com/user-attachments/assets/9b54b77f-f6b0-4af2-bafd-08317a57f0bc)

Here is the FE sending the old message w/o screen resolution and viewport set -- proving its still backward compatible and can read the old messages
![image](https://github.com/user-attachments/assets/36354322-b68d-4cc4-89e8-8e4f9857db42)
