### PR TITLE
Add GH actions for tags & releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,39 @@
+name: Create Release
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'The tag used to create the release'
+        type: string
+        required: true
+      release_title:
+        description: 'The title of the release'
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The tag used to create the release'
+        type: string
+        required: true
+      release_title:
+        description: 'The title of the release'
+        type: string
+        required: true
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        run: |
+          gh release create "${{ inputs.tag_name }}" \
+            --title "${{ inputs.release_title }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,50 @@
+name: Create Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The name of the tag'
+        type: string
+        required: true
+      ref:
+        description: 'The ref to create the tag from (default: the commit that triggered the workflow)'
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'The name of the tag'
+        type: string
+        required: true
+      ref:
+        description: 'The ref to create the tag from (default: the commit that triggered the workflow)'
+        type: string
+        required: false
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create tag
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+          REF: ${{ inputs.ref }}
+        with:
+          script: |
+            const ref = process.env.REF || context.sha;
+            const tag_object = await github.rest.git.createTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: process.env.TAG_NAME
+                object: ref,
+                type: 'commit'
+            });
+
+            await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${tag_object.data.tag}`,
+                sha: tag_object.data.sha
+            });

--- a/.github/workflows/generate-tag-release.yml
+++ b/.github/workflows/generate-tag-release.yml
@@ -1,0 +1,34 @@
+name: Generate Tag and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The ref to create the tag from (default: the commit that triggered the workflow)'
+        type: string
+        required: false
+
+jobs:
+  generate_tag_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+    
+      - name: Generate Version Number
+        id: generate_version
+        run: |
+            chmod +x ./scripts/shell/gen-ver.sh
+            echo "version=$(./scripts/shell/gen-ver.sh)" >> "$GITHUB_OUTPUT"
+    
+      - name: Create Tag
+        uses: ./.github/workflows/create-tag.yml
+        with:
+          tag_name: ${{ steps.generate_version.outputs.version }}
+          ref: ${{ inputs.ref }}
+    
+      - name: Create Release
+        uses: ./.github/workflows/create-release.yml
+        with:
+          tag_name: ${{ steps.generate_version.outputs.version }}
+          release_title: "${{ steps.generate_version.outputs.version }}"

--- a/scripts/shell/gen-ver.sh
+++ b/scripts/shell/gen-ver.sh
@@ -1,0 +1,16 @@
+# Get the date in YY.MM.DD format
+current_date=$(date +%y.%m.%d)
+
+ # Get the latest release tag
+ latest_release=$(git tag --sort=-creatordate | grep -E "^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$" | head -n 1)
+ 
+ # If latest release was today
+ if [[ "$latest_release" == "v$current_date"* ]]; then
+    # Increment the patch version number using the inc-patch-ver.sh script
+    new_version="$("$(dirname "$0")/inc-patch-ver.sh" "$latest_release")"
+ else
+     # Otherwise use the current date as the version
+     new_version="v$current_date"
+ fi
+ 
+ echo $new_version

--- a/scripts/shell/inc-patch-ver.sh
+++ b/scripts/shell/inc-patch-ver.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+increment_version() {
+    local version=$1
+    
+    # Remove the 'v' prefix
+    version=${version#v}
+    
+    # Split the version into components
+    IFS='.' read -ra version_parts <<< "$version"
+    
+    # If there's no patch number, add it
+    if [ ${#version_parts[@]} -eq 3 ]; then
+        version_parts+=("1")
+    else
+        # Increment the last part (patch number)
+        last_index=$((${#version_parts[@]} - 1))
+        version_parts[$last_index]=$((version_parts[last_index] + 1))
+    fi
+    
+    # Join the parts back together and add 'v' prefix
+    local new_version="v$(IFS='.'; echo "${version_parts[*]}")"
+    echo "$new_version"
+}
+
+# Check if version argument is provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+# Validate version format
+if ! [[ $1 =~ ^v[0-9]{2}\.[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$ ]]; then
+    echo "Error: Version must be in format vYY.MM.DD or vYY.MM.DD.patch"
+    exit 1
+fi
+
+new_version=$(increment_version "$1")
+echo "$new_version"


### PR DESCRIPTION
## Description

This PR introduces 3 GitHub Actions workflows:

1. `create-tag.yml` - A reusable workflow that can be invoked directly via dispatch (uncommon, usually for testing in isolation), or called by another workflow (common). This creates a tag on a specific git ref.
2. `create-release.yml` - A reusable workflow that can be invoked directly via dispatch (uncommon, usually for testing in isolation), or called by another workflow (common). This creates a release based on a given tag.
3. `generate-tag-release.yml` - A workflow that can be manually invoked to generate a version number, create a tag with the version number, and publish a [release](https://github.com/SWU-Karabast/forceteki/releases). In the future, this could be triggered via workflow call during deployments.

This PR also introduces 2 shell scripts to help with versioning:

1. `gen-ver.sh` - Generates a calendar version number (e.g. `v25.05.21`) based on the current date and any existing tags
2. `inc-patch-ver.sh` - Called within `gen-ver.sh` to either increment or add a patch version (in case there are multiple releases on the same calendar day).

### Calendar Versioning

The versioning scheme introduced here uses zero-padded two-digit calendar versioning. For example, the first release on August 9, 2025 would be version `v25.08.09`.

To disambiguate multiple releases on the same calendar day, we add a patch version to the end. Versions without the patch component have an implicit `.0` patch version. For example, the second release on August 9, 2025 would be version `v25.08.09.1`.