### PR TITLE
Fix issues with Impropriety Among Thieves

### DIFF
--- a/server/game/cards/03_TWI/events/ImproprietyAmongThieves.ts
+++ b/server/game/cards/03_TWI/events/ImproprietyAmongThieves.ts
@@ -20,9 +20,22 @@ export default class ImproprietyAmongThieves extends EventCard {
                     cardTypeFilter: WildcardCardType.NonLeaderUnit,
                     zoneFilter: WildcardZoneName.AnyArena,
                     cardCondition: (card) => card.canBeExhausted() && !card.exhausted,
+                    immediateEffect: AbilityHelper.immediateEffects.simultaneous([
+                        AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
+                            newController: context.player.opponent,
+                        })),
+                        AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
+                            title: 'Owner takes control',
+                            when: {
+                                onPhaseStarted: (context) => context.phase === PhaseName.Regroup
+                            },
+                            immediateEffect: AbilityHelper.immediateEffects.takeControlOfUnit({
+                                newController: context.targets.friendlyUnit.owner
+                            })
+                        }))
+                    ])
                 },
                 enemyUnit: {
-                    dependsOn: 'friendlyUnit',
                     activePromptTitle: 'Choose an enemy ready non-leader unit',
                     controller: RelativePlayer.Opponent,
                     cardTypeFilter: WildcardCardType.NonLeaderUnit,
@@ -30,11 +43,6 @@ export default class ImproprietyAmongThieves extends EventCard {
                     cardCondition: (card) => card.canBeExhausted() && !card.exhausted,
                     immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                         AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
-                            target: context.targets.friendlyUnit,
-                            newController: context.player.opponent,
-                        })),
-                        AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
-                            target: context.targets.enemyUnit,
                             newController: context.player,
                         })),
                         AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
@@ -43,21 +51,10 @@ export default class ImproprietyAmongThieves extends EventCard {
                                 onPhaseStarted: (context) => context.phase === PhaseName.Regroup
                             },
                             immediateEffect: AbilityHelper.immediateEffects.takeControlOfUnit({
-                                target: context.targets.friendlyUnit,
-                                newController: context.targets.friendlyUnit.owner,
-                            }),
-                        })),
-                        AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
-                            title: 'Owner takes control',
-                            when: {
-                                onPhaseStarted: (context) => context.phase === PhaseName.Regroup
-                            },
-                            immediateEffect: AbilityHelper.immediateEffects.takeControlOfUnit({
-                                target: context.targets.enemyUnit,
-                                newController: context.targets.enemyUnit.owner,
-                            }),
+                                newController: context.targets.enemyUnit.owner
+                            })
                         }))
-                    ]),
+                    ])
                 }
             },
         });

--- a/server/game/cards/03_TWI/events/ImproprietyAmongThieves.ts
+++ b/server/game/cards/03_TWI/events/ImproprietyAmongThieves.ts
@@ -19,23 +19,10 @@ export default class ImproprietyAmongThieves extends EventCard {
                     controller: RelativePlayer.Self,
                     cardTypeFilter: WildcardCardType.NonLeaderUnit,
                     zoneFilter: WildcardZoneName.AnyArena,
-                    cardCondition: (card) => card.canBeExhausted() && !card.exhausted,
-                    immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                        AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
-                            newController: context.player.opponent,
-                        })),
-                        AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
-                            title: 'Owner takes control',
-                            when: {
-                                onPhaseStarted: (context) => context.phase === PhaseName.Regroup
-                            },
-                            immediateEffect: AbilityHelper.immediateEffects.takeControlOfUnit({
-                                newController: context.targets.friendlyUnit.owner
-                            })
-                        }))
-                    ])
+                    cardCondition: (card) => card.canBeExhausted() && !card.exhausted
                 },
                 enemyUnit: {
+                    dependsOn: 'friendlyUnit',
                     activePromptTitle: 'Choose an enemy ready non-leader unit',
                     controller: RelativePlayer.Opponent,
                     cardTypeFilter: WildcardCardType.NonLeaderUnit,
@@ -43,10 +30,26 @@ export default class ImproprietyAmongThieves extends EventCard {
                     cardCondition: (card) => card.canBeExhausted() && !card.exhausted,
                     immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                         AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
+                            target: context.targets.friendlyUnit,
+                            newController: context.player.opponent,
+                        })),
+                        AbilityHelper.immediateEffects.takeControlOfUnit((context) => ({
+                            target: context.targets.enemyUnit,
                             newController: context.player,
                         })),
                         AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
                             title: 'Owner takes control',
+                            target: context.targets.friendlyUnit,
+                            when: {
+                                onPhaseStarted: (context) => context.phase === PhaseName.Regroup
+                            },
+                            immediateEffect: AbilityHelper.immediateEffects.takeControlOfUnit({
+                                newController: context.targets.friendlyUnit.owner
+                            })
+                        })),
+                        AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
+                            title: 'Owner takes control',
+                            target: context.targets.enemyUnit,
                             when: {
                                 onPhaseStarted: (context) => context.phase === PhaseName.Regroup
                             },
@@ -54,7 +57,7 @@ export default class ImproprietyAmongThieves extends EventCard {
                                 newController: context.targets.enemyUnit.owner
                             })
                         }))
-                    ])
+                    ]),
                 }
             },
         });

--- a/test/server/cards/03_TWI/events/ImproprietyAmongThieves.spec.ts
+++ b/test/server/cards/03_TWI/events/ImproprietyAmongThieves.spec.ts
@@ -38,6 +38,7 @@ describe('Impropriety Among Thieves', function () {
                             leader: { card: 'boba-fett#daimyo', deployed: true },
                         },
                         player2: {
+                            hand: ['waylay', 'vanquish', 'change-of-heart', 'superlaser-blast', 'evacuate'],
                             groundArena: ['seasoned-shoretrooper', { card: 'scanning-officer', exhausted: true }],
                             leader: { card: 'sabine-wren#galvanized-revolutionary', deployed: true },
                         }
@@ -48,16 +49,17 @@ describe('Impropriety Among Thieves', function () {
                     const { context } = contextRef;
 
                     context.player1.clickCard(context.improprietyAmongThieves);
+
                     expect(context.player1).toHavePrompt('Choose a friendly ready non-leader unit');
                     expect(context.player1).toBeAbleToSelectExactly(context.superlaserTechnician);
-
                     context.player1.clickCard(context.superlaserTechnician);
+
                     expect(context.player1).toHavePrompt('Choose an enemy ready non-leader unit');
                     expect(context.player1).toBeAbleToSelectExactly(context.seasonedShoretrooper);
-
                     context.player1.clickCard(context.seasonedShoretrooper);
 
                     expect(context.player2).toBeActivePlayer();
+
                     expect(context.superlaserTechnician).toBeInZone('groundArena', context.player2);
                     expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player1);
 
@@ -65,6 +67,175 @@ describe('Impropriety Among Thieves', function () {
 
                     expect(context.superlaserTechnician).toBeInZone('groundArena', context.player1);
                     expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player2);
+                });
+
+                it('works if one of the units gets defeated', () => {
+                    const { context } = contextRef;
+
+                    // Player 1 plays Impropriety Among Thieves
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    // Player 1 chooses to give Player 2 Superlaser Technician
+                    expect(context.player1).toHavePrompt('Choose a friendly ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.superlaserTechnician);
+                    context.player1.clickCard(context.superlaserTechnician);
+
+                    // Player 1 chooses to take Seasoned Shoretrooper
+                    expect(context.player1).toHavePrompt('Choose an enemy ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.seasonedShoretrooper);
+                    context.player1.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player1);
+
+                    // Player 2 plays Vanquish to defeat Seasoned Shoretrooper
+                    context.player2.clickCard(context.vanquish);
+                    context.player2.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.seasonedShoretrooper).toBeInZone('discard', context.player2);
+
+                    context.moveToRegroupPhase();
+
+                    // Superlaser Technician returns to Player 1, but Seasoned Shoretrooper remains in the discard pile
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player1);
+                    expect(context.seasonedShoretrooper).toBeInZone('discard', context.player2);
+                });
+
+                it('works if one of the units is returned to its owner\'s hand', () => {
+                    const { context } = contextRef;
+
+                    // Player 1 plays Impropriety Among Thieves
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    // Player 1 chooses to give Player 2 Superlaser Technician
+                    expect(context.player1).toHavePrompt('Choose a friendly ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.superlaserTechnician);
+                    context.player1.clickCard(context.superlaserTechnician);
+
+                    // Player 1 chooses to take Seasoned Shoretrooper
+                    expect(context.player1).toHavePrompt('Choose an enemy ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.seasonedShoretrooper);
+                    context.player1.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player1);
+
+                    // Player 2 plays Waylay to return Seasoned Shoretrooper to their hand
+                    context.player2.clickCard(context.waylay);
+                    context.player2.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.seasonedShoretrooper).toBeInZone('hand', context.player2);
+
+                    context.moveToRegroupPhase();
+
+                    // Superlaser Technician returns to Player 1, but Seasoned Shoretrooper remains in the hand
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player1);
+                    expect(context.seasonedShoretrooper).toBeInZone('hand', context.player2);
+                });
+
+                it('works if one of the units changes control again', () => {
+                    const { context } = contextRef;
+
+                    // Player 1 plays Impropriety Among Thieves
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    // Player 1 chooses to give Player 2 Superlaser Technician
+                    expect(context.player1).toHavePrompt('Choose a friendly ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.superlaserTechnician);
+                    context.player1.clickCard(context.superlaserTechnician);
+
+                    // Player 1 chooses to take Seasoned Shoretrooper
+                    expect(context.player1).toHavePrompt('Choose an enemy ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.seasonedShoretrooper);
+                    context.player1.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player1);
+
+                    // Player 2 plays Change of Heart to take control of Seasoned Shoretrooper
+                    context.player2.clickCard(context.changeOfHeart);
+                    context.player2.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player2);
+
+                    context.moveToRegroupPhase();
+
+                    // Superlaser Technician returns to Player 1, but Seasoned Shoretrooper remains with Player 2
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player1);
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player2);
+                });
+
+                it('nothing happens at the regroup phase if both units have been defeated', () => {
+                    const { context } = contextRef;
+
+                    // Player 1 plays Impropriety Among Thieves
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    // Player 1 chooses to give Player 2 Superlaser Technician
+                    expect(context.player1).toHavePrompt('Choose a friendly ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.superlaserTechnician);
+                    context.player1.clickCard(context.superlaserTechnician);
+
+                    // Player 1 chooses to take Seasoned Shoretrooper
+                    expect(context.player1).toHavePrompt('Choose an enemy ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.seasonedShoretrooper);
+                    context.player1.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player1);
+
+                    // Player 2 plays Superlaser Blast to defeat all units
+                    context.player2.clickCard(context.superlaserBlast);
+
+                    // Put Superlaser Technician into play as a resource
+                    expect(context.player2).toHavePassAbilityPrompt('Put Superlaser Technician into play as a resource and ready it');
+                    context.player2.clickPrompt('Trigger');
+
+                    expect(context.superlaserTechnician).toBeInZone('resource', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('discard', context.player2);
+
+                    context.moveToRegroupPhase();
+
+                    // Nothing changes
+                    expect(context.superlaserTechnician).toBeInZone('resource', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('discard', context.player2);
+                });
+
+                it('nothing happens at the regroup phase if both units have been returned to their owners\' hands', () => {
+                    const { context } = contextRef;
+
+                    // Player 1 plays Impropriety Among Thieves
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    // Player 1 chooses to give Player 2 Superlaser Technician
+                    expect(context.player1).toHavePrompt('Choose a friendly ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.superlaserTechnician);
+                    context.player1.clickCard(context.superlaserTechnician);
+
+                    // Player 1 chooses to take Seasoned Shoretrooper
+                    expect(context.player1).toHavePrompt('Choose an enemy ready non-leader unit');
+                    expect(context.player1).toBeAbleToSelectExactly(context.seasonedShoretrooper);
+                    context.player1.clickCard(context.seasonedShoretrooper);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.superlaserTechnician).toBeInZone('groundArena', context.player2);
+                    expect(context.seasonedShoretrooper).toBeInZone('groundArena', context.player1);
+
+                    // Player 2 plays Evacuate to return all units to their owners' hands
+                    context.player2.clickCard(context.evacuate);
+
+                    expect(context.superlaserTechnician).toBeInZone('hand', context.player1);
+                    expect(context.seasonedShoretrooper).toBeInZone('hand', context.player2);
+
+                    context.moveToRegroupPhase();
+
+                    // Nothing changes, both units are still in their owners' hands
+                    expect(context.superlaserTechnician).toBeInZone('hand', context.player1);
+                    expect(context.seasonedShoretrooper).toBeInZone('hand', context.player2);
                 });
             });
 

--- a/test/server/cards/03_TWI/events/ImproprietyAmongThieves.spec.ts
+++ b/test/server/cards/03_TWI/events/ImproprietyAmongThieves.spec.ts
@@ -28,6 +28,44 @@ describe('Impropriety Among Thieves', function () {
                 });
             });
 
+            describe('when there are too few ready non-leader units in play', function () {
+                it('does nothing when opponent has no ready non-leader units', async function() {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            hand: ['impropriety-among-thieves'],
+                            groundArena: ['battlefield-marine'],
+                        }
+                    });
+
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
+                });
+
+                it('does nothing when player has no ready non-leader units', async function() {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            hand: ['impropriety-among-thieves']
+                        },
+                        player2: {
+                            groundArena: ['battlefield-marine']
+                        }
+                    });
+
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.improprietyAmongThieves);
+
+                    expect(context.player2).toBeActivePlayer();
+                    expect(context.battlefieldMarine).toBeInZone('groundArena', context.player2);
+                });
+            });
+
             describe('when there are ready non-leader units in play', function () {
                 beforeEach(async function () {
                     await contextRef.setupTestAsync({


### PR DESCRIPTION
Fixes #1165

### Test Cases Added:

- Event fizzles if there is no ready friendly non-leader unit
- Event fizzles if there is no ready enemy non-leader unit
- A unit is defeated after exchange of control
- A unit is returned to hand after exchange of control
- A unit changes control again after initial exchange of control
- Both units are defeated, one of which moves to the resource zone
- Both units are returned to hand