### PR TITLE
Add source ip to chat logging so if abuse is reported we can ip ban

### DIFF
--- a/docs/ip-logging.md
+++ b/docs/ip-logging.md
@@ -1,0 +1,45 @@
+# IP Logging for Chat Messages
+
+This feature adds IP address logging to chat messages to help identify and ban abusive users.
+
+## Implementation Details
+
+When a user sends a chat message, their IP address is now logged along with the message content, user ID, username, and lobby ID. This information is included in the server logs.
+
+## How to Use
+
+1. Run the server as normal
+2. When a user sends a chat message, their IP address will be included in the logs
+3. To find abusive messages, search the logs for the timestamp or message content
+4. Once found, you can see the IP address in the log entry and ban it if needed
+
+## Testing the Feature
+
+A test script is included to verify that IP logging is working correctly:
+
+1. Start the server
+2. Create a lobby through the normal client interface
+3. Run the test script:
+   ```
+   node test/ip-logging-test.js
+   ```
+4. When prompted, enter the lobby ID
+5. The script will send a test message
+6. Check the server logs for an entry like:
+   ```
+   [info]: Lobby: user <username> sent chat message: This is a test message for IP logging { lobbyId: '<id>', userName: '<username>', userId: '<id>', ipAddress: '<ip>' }
+   ```
+
+## Log Format
+
+The IP address is included in the log message metadata with the key `ipAddress`. When looking at the logs, you'll see entries like:
+
+```
+[timestamp] [info]: Lobby: user UserName sent chat message: Message content { lobbyId: 'abc123', userName: 'UserName', userId: 'user123', ipAddress: '192.168.1.1' }
+```
+
+## Implementation Notes
+
+- IP addresses are extracted from the socket connection's handshake data
+- If the IP address cannot be determined, it will be logged as "unknown"
+- This feature only affects chat message logging and does not modify any game mechanics or user-facing functionality

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -364,7 +364,15 @@ export class Lobby {
             return;
         }
 
-        logger.info(`Lobby: user ${existingUser.username} sent chat message: ${args[0]}`, { lobbyId: this.id, userName: existingUser.username, userId: existingUser.id });
+        // Get IP address from socket 
+        const ipAddress = socket.ip || 'unknown';
+        
+        logger.info(`Lobby: user ${existingUser.username} sent chat message: ${args[0]}`, { 
+            lobbyId: this.id, 
+            userName: existingUser.username, 
+            userId: existingUser.id,
+            ipAddress: ipAddress
+        });
         this.gameChat.addChatMessage(existingUser, args[0]);
         this.sendLobbyState();
     }

--- a/server/socket.js
+++ b/server/socket.js
@@ -15,6 +15,10 @@ class Socket extends EventEmitter {
         socket.on('authenticate', this.onAuthenticate.bind(this));
         socket.on('disconnect', this.onDisconnect.bind(this));
     }
+    
+    get ip() {
+        return this.socket.handshake.address;
+    }
 
     get id() {
         return this.socket.id;

--- a/test/ip-logging-test.js
+++ b/test/ip-logging-test.js
@@ -1,0 +1,78 @@
+const io = require('socket.io-client');
+const readline = require('readline');
+
+// Create readline interface for user input
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+// Connect to the socket server
+console.log('Connecting to server...');
+const socket = io('http://localhost:10000', {
+  path: '/ws',
+  reconnection: true,
+  reconnectionAttempts: 10,
+  reconnectionDelay: 1000
+});
+
+// Handle connection events
+socket.on('connect', () => {
+  console.log('Connected to server with socket ID:', socket.id);
+  console.log('IP logging test - sending test chat message');
+  
+  // Join a lobby or create one (this depends on your server implementation)
+  // For this test, we're assuming you'll create a lobby manually first
+  
+  // Ask for the lobby ID
+  rl.question('Enter lobby ID (or press enter to skip): ', (lobbyId) => {
+    if (lobbyId) {
+      // Join the specified lobby
+      socket.emit('joingame', lobbyId);
+      console.log('Joining lobby:', lobbyId);
+      
+      // Send a test chat message after a short delay
+      setTimeout(() => {
+        console.log('Sending test chat message...');
+        socket.emit('chat', 'This is a test message for IP logging');
+        console.log('Test message sent. Check server logs for IP address.');
+        
+        // Close the connection after another short delay
+        setTimeout(() => {
+          socket.disconnect();
+          rl.close();
+        }, 2000);
+      }, 2000);
+    } else {
+      console.log('No lobby ID provided. Test canceled.');
+      socket.disconnect();
+      rl.close();
+    }
+  });
+});
+
+// Handle errors
+socket.on('error', (error) => {
+  console.error('Socket error:', error);
+});
+
+// Handle disconnection
+socket.on('disconnect', () => {
+  console.log('Disconnected from server');
+});
+
+// Handle connection errors
+socket.on('connect_error', (error) => {
+  console.error('Connection error:', error);
+});
+
+// Handle server messages
+socket.on('gamestate', (data) => {
+  console.log('Received game state update');
+});
+
+// Exit handler
+rl.on('close', () => {
+  console.log('Test complete. Check server logs for IP address in chat message logs.');
+  process.exit(0);
+});


### PR DESCRIPTION
  1. Added IP address extraction in the sendChatMessage method in Lobby.ts
  2. Added an ip getter to the Socket class for easier access to the IP address
  3. Updated the chat message logging to include the IP address in the log data
  4. Created a test script at /test/ip-logging-test.js to verify the functionality
  5. Added documentation at /docs/ip-logging.md explaining how to use and test the feature

  When a user sends a chat message, their IP address will now be included in the server logs along
  with their user ID, username, and the message content. This will make it easier to identify and ban
   abusive users by checking the logs for specific messages and seeing the associated IP address.
