### PR TITLE
Improve game chat logs for Game Rule effects

### DIFF
--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -581,13 +581,6 @@ export class Player extends GameObject<IPlayerState> {
      * @param {number} numCards
      */
     public drawCardsToHand(numCards: number) {
-        if (numCards > this.drawDeck.length) {
-            // TODO: move log message into the DrawSystem
-            // Game log message about empty deck damage(the damage itself is handled in DrawSystem.updateEvent()).
-            this.game.addMessage('{0} attempts to draw {1} cards from their empty deck and takes {2} damage instead ',
-                this.name, numCards - this.drawDeck.length, 3 * (numCards - this.drawDeck.length)
-            );
-        }
         for (const card of this.drawDeck.slice(0, numCards)) {
             card.moveTo(ZoneName.Hand);
         }

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -392,9 +392,17 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
                         Contract.assertTrue(card.canBeInPlay(), `Card ${card.title} is not a IInPlayCard`);
                         this.resolveUniqueDefeat(card);
                     }
+                    this.game.addMessage(
+                        '{0} defeats {1} {2} of {3} due to the uniquenes rule.',
+                        this.controller, cardOrCards.length, cardOrCards.length > 1 ? 'copies' : 'copy', this
+                    );
                     return true;
                 }
                 Contract.assertTrue(cardOrCards.canBeInPlay(), `Card ${cardOrCards.title} is not a IInPlayCard`);
+                this.game.addMessage(
+                    '{0} defeats 1 copy of {1} due to the uniquenes rule.',
+                    this.controller, this
+                );
                 return this.resolveUniqueDefeat(cardOrCards);
             }
         };

--- a/server/game/core/card/baseClasses/InPlayCard.ts
+++ b/server/game/core/card/baseClasses/InPlayCard.ts
@@ -393,14 +393,14 @@ export class InPlayCard<T extends IInPlayCardState = IInPlayCardState> extends I
                         this.resolveUniqueDefeat(card);
                     }
                     this.game.addMessage(
-                        '{0} defeats {1} {2} of {3} due to the uniquenes rule.',
+                        '{0} defeats {1} {2} of {3} due to the uniquenes rule',
                         this.controller, cardOrCards.length, cardOrCards.length > 1 ? 'copies' : 'copy', this
                     );
                     return true;
                 }
                 Contract.assertTrue(cardOrCards.canBeInPlay(), `Card ${cardOrCards.title} is not a IInPlayCard`);
                 this.game.addMessage(
-                    '{0} defeats 1 copy of {1} due to the uniquenes rule.',
+                    '{0} defeats 1 copy of {1} due to the uniquenes rule',
                     this.controller, this
                 );
                 return this.resolveUniqueDefeat(cardOrCards);

--- a/server/game/gameSystems/DrawSystem.ts
+++ b/server/game/gameSystems/DrawSystem.ts
@@ -51,7 +51,12 @@ export class DrawSystem<TContext extends AbilityContext = AbilityContext> extend
             // Add a contingent event to deal damage for any cards the player fails to draw due to not having enough left in their deck.
             const contingentEvents = [];
             if (event.amount > event.player.drawDeck.length) {
-                const damageAmount = 3 * (event.amount - event.player.drawDeck.length);
+                const cannotDrawCount = event.amount - event.player.drawDeck.length;
+                const damageAmount = 3 * cannotDrawCount;
+
+                context.game.addMessage('{0} attempts to draw {1} cards from their empty deck and takes {2} damage instead',
+                    event.player, cannotDrawCount, damageAmount
+                );
 
                 // Here we generate a damage event with a new context that contains just the player,
                 // this way the damage is attributed to the player and not the card that triggered the draw (or its controller).

--- a/server/game/gameSystems/TakeControlOfUnitSystem.ts
+++ b/server/game/gameSystems/TakeControlOfUnitSystem.ts
@@ -69,16 +69,22 @@ export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityCo
         super.updateEvent(event, player, context, additionalProperties);
 
         // By rule, leader units are always defeated instead of changing control (CR 3.4.6)
-        event.setReplacementEventsGenerator((event) => (
-            event.card.isLeader() && event.newController !== event.card.controller
-                ? [
+        event.setReplacementEventsGenerator((event) => {
+            if (event.card.isLeader() && event.newController !== event.card.controller) {
+                context.game.addMessage(
+                    '{0} would take control of {1}, but it is a leader unit so it is defeated instead',
+                    event.newController, event.card
+                );
+
+                return [
                     new FrameworkDefeatCardSystem({
                         defeatSource: DefeatSourceType.FrameworkEffect,
                         target: event.card
                     }).generateEvent(context.game.getFrameworkContext(event.player))
-                ]
-                : []
-        ));
+                ];
+            }
+            return [];
+        });
     }
 
     public override generatePropertiesFromContext(context: TContext, additionalProperties?: Partial<ITakeControlOfUnitProperties>): ITakeControlOfUnitProperties {

--- a/test/server/cards/01_SOR/events/ChangeOfHeart.spec.ts
+++ b/test/server/cards/01_SOR/events/ChangeOfHeart.spec.ts
@@ -137,6 +137,7 @@ describe('Change of Heart', function() {
                 context.moveToRegroupPhase();
 
                 // Millennium Falcon is defeated, Darth Vader is returned to leader position
+                expect(context.getChatLogs(1)).toContain('player2 would take control of Millennium Falcon, but it is a leader unit so it is defeated instead');
                 expect(context.millenniumFalcon).toBeInZone('discard', context.player2);
                 expect(context.darthVader).toBeInZone('base', context.player1);
                 expect(context.darthVader.exhausted).toBeTrue();

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -453,6 +453,7 @@ describe('Uniqueness rule', function() {
 
                 context.player1.clickCard(kuiil2);
 
+                expect(context.getChatLogs(1)).toContain('player1 defeats 1 copy of Kuiil due to the uniquenes rule');
                 expect(kuiil1).toBeInZone('groundArena');
                 expect(kuiil2).toBeInZone('discard');
 
@@ -507,6 +508,7 @@ describe('Uniqueness rule', function() {
 
                 context.player1.clickPrompt('Done');
 
+                expect(context.getChatLogs(1)).toContain('player1 defeats 2 copies of Obi-Wan Kenobi due to the uniquenes rule');
                 expect(obi1).toBeInZone('discard');
                 expect(obi2).toBeInZone('discard');
                 expect(obi3).toBeInZone('groundArena');

--- a/test/server/gameSystems/DrawSystem.spec.ts
+++ b/test/server/gameSystems/DrawSystem.spec.ts
@@ -47,6 +47,7 @@ describe('Draw system', function() {
 
                 context.player1.clickCard(context.missionBriefing);
                 context.player1.clickPrompt('You');
+                expect(context.getChatLogs(1)).toContain('player1 attempts to draw 2 cards from their empty deck and takes 6 damage instead');
                 expect(context.player1.base.damage).toBe(6);
                 expect(context.player1.hand.length).toBe(1);
                 expect(context.player1.deck.length).toBe(0);


### PR DESCRIPTION
Fixes #1284

| Uniqueness Rule | Leader Change Control | Draw from empty deck |
| :---: | :---: | :---: |
|<img width="265" alt="Screenshot 2025-05-24 at 9 34 57 AM" src="https://github.com/user-attachments/assets/69c09fc4-b69e-4ede-9f49-992e589e83b6" /> | <img width="254" alt="Screenshot 2025-05-24 at 9 50 17 AM" src="https://github.com/user-attachments/assets/204ba851-a015-4e42-af91-0cd9eb54990d" /> | <img width="243" alt="Screenshot 2025-05-24 at 9 50 40 AM" src="https://github.com/user-attachments/assets/c0fefc11-d28f-4ee8-ad35-6f2a9d9e3882" /> |
| <img width="279" alt="Screenshot 2025-05-24 at 9 30 16 AM" src="https://github.com/user-attachments/assets/e9476f6e-57d5-4d10-b980-0f78625d3116" /> | | |


