### PR TITLE
Extend turn timer during distribution prompt

### DIFF
--- a/server/game/core/actionTimer/IActionTimer.ts
+++ b/server/game/core/actionTimer/IActionTimer.ts
@@ -2,9 +2,9 @@ export interface IActionTimer {
     get isPaused(): boolean;
     get isRunning(): boolean;
     addSpecificTimeHandler(timeSeconds: number, handler: () => void);
-    start();
-    restartIfRunning();
-    pause();
-    resume();
-    stop();
+    start(overrideTimeLimitSeconds?: number): void;
+    restartIfRunning(): void;
+    pause(): void;
+    resume(): void;
+    stop(): void;
 }

--- a/server/game/core/gameSteps/prompts/DistributeAmongTargetsPrompt.ts
+++ b/server/game/core/gameSteps/prompts/DistributeAmongTargetsPrompt.ts
@@ -78,6 +78,11 @@ export class DistributeAmongTargetsPrompt extends UiPrompt {
         };
     }
 
+    protected override startActionTimer(player: Player): void {
+        // due to a bug that clears the prompts when the timer message appears, we're extending the timer during this prompt for now
+        player.actionTimer.start(120);
+    }
+
     protected override highlightSelectableCards(): void {
         this.player.setSelectableCards(this.properties.legalTargets);
         this.player.opponent.setSelectableCards([]);

--- a/server/game/core/gameSteps/prompts/UiPrompt.ts
+++ b/server/game/core/gameSteps/prompts/UiPrompt.ts
@@ -67,7 +67,7 @@ export abstract class UiPrompt extends BaseStep {
                 player.setPrompt(this.addButtonDefaultsToPrompt(this.activePrompt(player)));
 
                 if (this.firstContinue) {
-                    player.actionTimer.start();
+                    this.startActionTimer(player);
                 }
             } else {
                 player.setPrompt(this.waitingPrompt());
@@ -76,6 +76,10 @@ export abstract class UiPrompt extends BaseStep {
         }
 
         this.highlightSelectableCards();
+    }
+
+    protected startActionTimer(player: Player) {
+        player.actionTimer.start();
     }
 
     protected highlightSelectableCards() {


### PR DESCRIPTION
Temporarily extending turn timer during distribution prompt to 2min to get around the issue where the messages are resetting the prompt