### PR TITLE
Fix issue with stolen units and direct overwhelm damage

### DIFF
--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -16,6 +16,7 @@ export class Attack {
 
     private unitControllersChanged = new Set<IAttackableCard>();
     private targets: IAttackableCard[];
+    private defendingPlayer: Player;
 
     public previousAttack: Attack;
 
@@ -29,6 +30,7 @@ export class Attack {
         this.attacker = attacker;
         this.attackingPlayer = attacker.controller;
         this.targets = targets;
+        this.defendingPlayer = targets[0].controller;
         this.targetInPlayMap = new Map(targets.filter((target) => target.isUnit()).map((target) => [target, target.inPlayId]));
 
         // we grab the in-play IDs of the attacker and defender cards in case other abilities need to refer back to them later.
@@ -51,8 +53,7 @@ export class Attack {
     }
 
     public getDefendingPlayer(): Player {
-        Contract.assertTrue(this.targets.length > 0, 'Expected at least one target but there are none');
-        return this.targets[0].controller;
+        return this.defendingPlayer;
     }
 
     public getSingleTarget(): IAttackableCard {

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -79,7 +79,7 @@ export class AttackFlow extends BaseStepWithPipeline {
         const damageEvents = [];
 
         // TSTODO: This will need to be updated to account for attacking units owned by different opponents
-        const targetControllerBase = legalTargets[0].controller.base;
+        const targetControllerBase = this.attack.getDefendingPlayer().base;
 
         if (directOverwhelmDamage > 0) {
             damageEvents.push(new DamageSystem({

--- a/test/server/core/abilities/keyword/Overwhelm.spec.ts
+++ b/test/server/core/abilities/keyword/Overwhelm.spec.ts
@@ -93,9 +93,16 @@ describe('Overwhelm keyword', function() {
                 return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        groundArena: [{ card: 'emperor-palpatine#master-of-the-dark-side', upgrades: ['fallen-lightsaber'] }]
+                        groundArena: [
+                            {
+                                card: 'emperor-palpatine#master-of-the-dark-side',
+                                upgrades: ['fallen-lightsaber']
+                            },
+                            'cloudrider'
+                        ]
                     },
                     player2: {
+                        hand: ['traitorous'],
                         groundArena: ['death-star-stormtrooper']
                     }
                 });
@@ -106,6 +113,24 @@ describe('Overwhelm keyword', function() {
 
                 context.player1.clickCard(context.emperorPalpatine);
                 context.player1.clickCard(context.deathStarStormtrooper);
+                expect(context.p2Base.damage).toBe(9);
+            });
+
+            it('a stolen unit, and the unit is defeated before damage is resolved, all damage goes to the opponent\'s base', function () {
+                const { context } = contextRef;
+                context.player1.passAction();
+
+                // Player 2 takes control of Cloud-Rider with Traitorous
+                context.player2.clickCard(context.traitorous);
+                context.player2.clickCard(context.cloudrider);
+                expect(context.cloudrider).toBeInZone('groundArena', context.player2);
+
+                // Emperor Palpatine attacks Cloud-Rider
+                context.player1.clickCard(context.emperorPalpatine);
+                context.player1.clickCard(context.cloudrider);
+
+                expect(context.cloudrider).toBeInZone('discard', context.player1);
+                expect(context.p1Base.damage).toBe(0);
                 expect(context.p2Base.damage).toBe(9);
             });
         });


### PR DESCRIPTION
Fixes #1320 

Maybe there is a better way to solve this. I was hoping to use `lastKnownInformation`, but in the `AttackFlow`, I was unable to find a way to reference the defeat event for the unit that gets defeated before combat damage is resolved.

Open to feedback if there's a better way to do this!