### PR TITLE
Add a RandomSelectionSystem for reliable randomization during ability resolution

### DIFF
--- a/server/game/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.ts
+++ b/server/game/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.ts
@@ -1,5 +1,4 @@
 import AbilityHelper from '../../../AbilityHelper';
-import * as Helpers from '../../../core/utils/Helpers';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { PhaseName, RelativePlayer, TargetMode, ZoneName } from '../../../core/Constants';
 
@@ -44,9 +43,11 @@ export default class DoctorAphraRapaciousArchaeologist extends LeaderUnitCard {
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Discard,
                 multiSelectCardCondition: (card, selectedCards) => selectedCards.every((selectedCard) => selectedCard.title !== card.title),
-                immediateEffect: AbilityHelper.immediateEffects.returnToHand((context) => ({
-                    target: Helpers.randomItem(Helpers.asArray(context.target), context.game.randomGenerator),
-                })),
+                immediateEffect: AbilityHelper.immediateEffects.randomSelection({
+                    title: 'Return 1 at random to your hand',
+                    count: 1,
+                    innerSystem: AbilityHelper.immediateEffects.returnToHand(),
+                })
             },
         });
     }

--- a/server/game/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.ts
+++ b/server/game/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.ts
@@ -44,7 +44,6 @@ export default class DoctorAphraRapaciousArchaeologist extends LeaderUnitCard {
                 zoneFilter: ZoneName.Discard,
                 multiSelectCardCondition: (card, selectedCards) => selectedCards.every((selectedCard) => selectedCard.title !== card.title),
                 immediateEffect: AbilityHelper.immediateEffects.randomSelection({
-                    title: 'Return 1 at random to your hand',
                     count: 1,
                     innerSystem: AbilityHelper.immediateEffects.returnToHand(),
                 })

--- a/server/game/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.ts
+++ b/server/game/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.ts
@@ -44,7 +44,6 @@ export default class DoctorAphraRapaciousArchaeologist extends LeaderUnitCard {
                 zoneFilter: ZoneName.Discard,
                 multiSelectCardCondition: (card, selectedCards) => selectedCards.every((selectedCard) => selectedCard.title !== card.title),
                 immediateEffect: AbilityHelper.immediateEffects.randomSelection({
-                    count: 1,
                     innerSystem: AbilityHelper.immediateEffects.returnToHand(),
                 })
             },

--- a/server/game/cards/03_TWI/units/JarJarBinksFoolishGungan.ts
+++ b/server/game/cards/03_TWI/units/JarJarBinksFoolishGungan.ts
@@ -15,9 +15,7 @@ export default class JarJarBinksFoolishGungan extends NonLeaderUnitCard {
         this.addOnAttackAbility({
             title: 'Deal 2 damage to a random unit or base',
             immediateEffect: AbilityHelper.immediateEffects.randomSelection((context) => ({
-                title: 'Deal 2 damage to a random unit or base',
                 target: this.getAllTargets(context),
-                count: 1,
                 innerSystem: AbilityHelper.immediateEffects.damage({
                     amount: 2
                 })

--- a/server/game/cards/03_TWI/units/JarJarBinksFoolishGungan.ts
+++ b/server/game/cards/03_TWI/units/JarJarBinksFoolishGungan.ts
@@ -1,6 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
-import * as Helpers from '../../../core/utils/Helpers';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import type { AbilityContext } from '../../../core/ability/AbilityContext';
+import type { Card } from '../../../core/card/Card';
 
 export default class JarJarBinksFoolishGungan extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,14 +14,20 @@ export default class JarJarBinksFoolishGungan extends NonLeaderUnitCard {
     public override setupCardAbilities () {
         this.addOnAttackAbility({
             title: 'Deal 2 damage to a random unit or base',
-            immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({ amount: 2, target: this.chooseRandomTarget(context) })),
+            immediateEffect: AbilityHelper.immediateEffects.randomSelection((context) => ({
+                title: 'Deal 2 damage to a random unit or base',
+                target: this.getAllTargets(context),
+                count: 1,
+                innerSystem: AbilityHelper.immediateEffects.damage({
+                    amount: 2
+                })
+            }))
         });
     }
 
-    private chooseRandomTarget(context) {
+    private getAllTargets(context: AbilityContext): Card[] {
         const controllerUnits = context.player.getArenaUnits();
         const opponentUnits = context.player.opponent.getArenaUnits();
-        const allTargets = [...controllerUnits, ...opponentUnits, context.player.opponent.base, context.player.base]; // All units and bases
-        return Helpers.randomItem(allTargets, context.game.randomGenerator);
+        return [...controllerUnits, ...opponentUnits, context.player.opponent.base, context.player.base]; // All units and bases
     }
 }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -318,6 +318,7 @@ export enum MetaEventName {
     Optional = 'optional',
     PayCardPrintedCost = 'payCardPrintedCost',
     PlayCard = 'playCard',
+    RandomSelection = 'randomSelection',
     ReplacementEffect = 'replacementEffect',
     SelectCard = 'selectCard',
     SelectPlayer = 'selectPlayer',

--- a/server/game/core/gameSystem/GameSystem.ts
+++ b/server/game/core/gameSystem/GameSystem.ts
@@ -10,7 +10,7 @@ import * as Contract from '../utils/Contract';
 import type { GameObject } from '../GameObject';
 import type { ILastKnownInformation } from '../../gameSystems/DefeatCardSystem';
 
-type PlayerOrCard = Player | Card;
+export type PlayerOrCard = Player | Card;
 
 export interface IGameSystemProperties {
     target?: PlayerOrCard | PlayerOrCard[];

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -147,6 +147,8 @@ import type { IPlayerTargetSystemProperties } from '../core/gameSystem/PlayerTar
 import { OptionalSystem, type IOptionalSystemProperties } from './OptionalSystem';
 import type { IUseWhenPlayedProperties } from './UseWhenPlayedSystem';
 import { UseWhenPlayedSystem } from './UseWhenPlayedSystem';
+import type { IRandomSelectionSystemProperties } from './RandomSelectionSystem';
+import { RandomSelectionSystem } from './RandomSelectionSystem';
 
 type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
 
@@ -631,6 +633,9 @@ export function conditional<TContext extends AbilityContext = AbilityContext>(pr
 }
 export function optional<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IOptionalSystemProperties<TContext>, TContext>) {
     return new OptionalSystem<TContext>(propertyFactory);
+}
+export function randomSelection<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IRandomSelectionSystemProperties<TContext>, TContext>) {
+    return new RandomSelectionSystem<TContext>(propertyFactory);
 }
 // export function onAffinity(propertyFactory: PropsFactory<AffinityActionProperties>) {
 //     return new AffinityAction(propertyFactory);

--- a/server/game/gameSystems/RandomSelectionSystem.ts
+++ b/server/game/gameSystems/RandomSelectionSystem.ts
@@ -81,9 +81,7 @@ export class RandomSelectionSystem<TContext extends AbilityContext = AbilityCont
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<IRandomSelectionSystemProperties<TContext>> = {}): void {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
-        context.target = context.targets.randomTarget;
-
-        properties.innerSystem.queueGenerateEventGameSteps(events, context, { ...additionalProperties, target: context.targets.randomTarget });
+        properties.innerSystem.queueGenerateEventGameSteps(events, context, additionalProperties);
     }
 
     private generateFormatString(args: any[]): string {

--- a/server/game/gameSystems/RandomSelectionSystem.ts
+++ b/server/game/gameSystems/RandomSelectionSystem.ts
@@ -1,0 +1,75 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import type { Card } from '../core/card/Card';
+import { GameStateChangeRequired, MetaEventName } from '../core/Constants';
+import type { GameEvent } from '../core/event/GameEvent';
+import { AggregateSystem } from '../core/gameSystem/AggregateSystem';
+import type { GameSystem, IGameSystemProperties, PlayerOrCard } from '../core/gameSystem/GameSystem';
+import type { Player } from '../core/Player';
+import * as Contract from '../core/utils/Contract';
+import * as Helpers from '../core/utils/Helpers';
+import * as ChatHelpers from '../core/chat/ChatHelpers';
+import type { FormatMessage } from '../core/chat/GameChat';
+
+export interface IRandomSelectionSystemProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties {
+    title: string;
+    count: number;
+    innerSystem: GameSystem<TContext>;
+}
+
+export class RandomSelectionSystem<TContext extends AbilityContext = AbilityContext> extends AggregateSystem<TContext, IRandomSelectionSystemProperties<TContext>> {
+    protected override readonly eventName = MetaEventName.RandomSelection;
+
+    public override getInnerSystems(properties: IRandomSelectionSystemProperties<TContext>) {
+        return [properties.innerSystem];
+    }
+
+    public override getEffectMessage(context: TContext, additionalProperties: Partial<IRandomSelectionSystemProperties<TContext>> = {}): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        const target: PlayerOrCard | PlayerOrCard[] | string | FormatMessage = properties.target;
+        return [`randomly ${ChatHelpers.verb(properties, 'select', 'selecting')} {0} of {1}`, [properties.count, target]];
+    }
+
+    public override canAffectInternal(target: Player | Card, context: TContext, additionalProperties: Partial<IRandomSelectionSystemProperties<TContext>> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        return properties.innerSystem.canAffect(target, context, additionalProperties, mustChangeGameState);
+    }
+
+    public override hasLegalTarget(context: TContext, additionalProperties: Partial<IRandomSelectionSystemProperties<TContext>> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        return properties.innerSystem.hasLegalTarget(context, additionalProperties, mustChangeGameState);
+    }
+
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<IRandomSelectionSystemProperties<TContext>> = {}): void {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        const targets = Helpers.asArray(properties.target);
+
+        if (targets.length < properties.count) {
+            Contract.fail(`Cannot select ${properties.count} targets from a list of ${targets.length}`);
+        }
+
+        const selectedTargets = Helpers.getRandomArrayElements(targets, properties.count, context.game.randomGenerator);
+
+        if (selectedTargets.length === 1) {
+            context.target = selectedTargets[0];
+        } else {
+            context.target = selectedTargets;
+        }
+
+        const finalAdditionalProperties = { ...additionalProperties, target: selectedTargets };
+
+        this.addSelectionMessage(context, properties, finalAdditionalProperties);
+        properties.innerSystem.queueGenerateEventGameSteps(events, context, finalAdditionalProperties);
+    }
+
+    private addSelectionMessage(
+        context: TContext,
+        properties: IRandomSelectionSystemProperties<TContext>,
+        additionalProperties: Partial<IRandomSelectionSystemProperties<TContext>> = {}
+    ): void {
+        const messageArgs = [context.player, ' uses ', context.source, ' to '];
+        const [effectMessage, effectArgs] = properties.innerSystem.getEffectMessage(context, additionalProperties);
+        context.game.addMessage('{0}{1}{2}{3}{4}{5}{6}{7}{8}', ...messageArgs, { message: context.game.gameChat.formatMessage(effectMessage, effectArgs) });
+    }
+}

--- a/test/server/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.spec.ts
+++ b/test/server/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.spec.ts
@@ -55,12 +55,10 @@ describe('Doctor Aphra, Rapacious Archaeologist', function () {
                 // After the selection, one "random" card is returned to the hand and Doctor Aphra loses the +3/+0 bonus because there are no longer 5 different cost cards in the discard
                 context.player1.clickPrompt('Done');
 
-                expect(context.getChatLogs(3)).toContain('player1 uses Doctor Aphra to randomly select 1 from: Millennium Falcon, Warzone Lieutenant, and Devotion');
-                expect(context.getChatLogs(3)).toContain('Devotion was randomly selected using Doctor Aphra\'s ability');
-                expect(context.getChatLogs(3)).toContain('player1 uses Doctor Aphra to return Devotion to their hand');
-                expect(context.devotion).toBeInZone('hand', context.player1);
+                expect(context.getChatLogs(1)).toContain('player1 uses Doctor Aphra to randomly select Millennium Falcon from Millennium Falcon, Warzone Lieutenant, and Devotion, and to return Millennium Falcon to their hand');
+                expect(milleniumFalconPieceOfJunk).toBeInZone('hand', context.player1);
+                expect(context.devotion).toBeInZone('discard', context.player1);
                 expect(context.warzoneLieutenant).toBeInZone('discard', context.player1);
-                expect(milleniumFalconPieceOfJunk).toBeInZone('discard', context.player1);
                 expect(context.doctorAphraRapaciousArchaeologist.getPower()).toBe(2);
                 expect(context.doctorAphraRapaciousArchaeologist.getHp()).toBe(5);
             });

--- a/test/server/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.spec.ts
+++ b/test/server/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.spec.ts
@@ -55,8 +55,9 @@ describe('Doctor Aphra, Rapacious Archaeologist', function () {
                 // After the selection, one "random" card is returned to the hand and Doctor Aphra loses the +3/+0 bonus because there are no longer 5 different cost cards in the discard
                 context.player1.clickPrompt('Done');
 
-                expect(context.getChatLogs(2)).toContain('player1 uses Doctor Aphra to randomly select 1 of Millennium Falcon, Warzone Lieutenant, and Devotion');
-                expect(context.getChatLogs(2)).toContain('player1 uses Doctor Aphra to return Devotion to their hand');
+                expect(context.getChatLogs(3)).toContain('player1 uses Doctor Aphra to randomly select 1 from: Millennium Falcon, Warzone Lieutenant, and Devotion');
+                expect(context.getChatLogs(3)).toContain('Devotion was randomly selected using Doctor Aphra\'s ability');
+                expect(context.getChatLogs(3)).toContain('player1 uses Doctor Aphra to return Devotion to their hand');
                 expect(context.devotion).toBeInZone('hand', context.player1);
                 expect(context.warzoneLieutenant).toBeInZone('discard', context.player1);
                 expect(milleniumFalconPieceOfJunk).toBeInZone('discard', context.player1);

--- a/test/server/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.spec.ts
+++ b/test/server/cards/02_SHD/leaders/DoctorAphraRapaciousArchaeologist.spec.ts
@@ -55,6 +55,8 @@ describe('Doctor Aphra, Rapacious Archaeologist', function () {
                 // After the selection, one "random" card is returned to the hand and Doctor Aphra loses the +3/+0 bonus because there are no longer 5 different cost cards in the discard
                 context.player1.clickPrompt('Done');
 
+                expect(context.getChatLogs(2)).toContain('player1 uses Doctor Aphra to randomly select 1 of Millennium Falcon, Warzone Lieutenant, and Devotion');
+                expect(context.getChatLogs(2)).toContain('player1 uses Doctor Aphra to return Devotion to their hand');
                 expect(context.devotion).toBeInZone('hand', context.player1);
                 expect(context.warzoneLieutenant).toBeInZone('discard', context.player1);
                 expect(milleniumFalconPieceOfJunk).toBeInZone('discard', context.player1);

--- a/test/server/cards/03_TWI/units/JarJarBinksFoolishGungan.spec.ts
+++ b/test/server/cards/03_TWI/units/JarJarBinksFoolishGungan.spec.ts
@@ -15,23 +15,33 @@ describe('Jar Jar Binks, Foolish Gungan', function () {
 
             const { context } = contextRef;
 
-            context.game.setRandomSeed('356244');
+            context.game.setRandomSeed('12345');
 
             context.player1.clickCard(context.jarJarBinks);
             context.player1.clickCard(context.p2Base);
+
+            // Ability hits Republic ARC-170
+            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Republic ARC-170');
+            expect(context.republicArc170.damage).toBe(2);
+            expect(context.p2Base.damage).toBe(2);
 
             context.moveToNextActionPhase();
             context.player1.clickCard(context.jarJarBinks);
             context.player1.clickCard(context.p2Base);
 
+            // Ability hits Restored ARC-170
+            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Restored ARC-170');
+            expect(context.restoredArc170.damage).toBe(2);
+            expect(context.p2Base.damage).toBe(4);
+
             context.moveToNextActionPhase();
             context.player1.clickCard(context.jarJarBinks);
             context.player1.clickCard(context.p2Base);
 
-            expect(context.p1Base.damage).toBe(2); // Jar Jar's ability deals damage to a base
-            expect(context.p2Base.damage).toBe(6); // Jar Jar's attacks
-            expect(context.jarJarBinks.damage).toBe(2); // Jar Jar's ability deals damage to a friendly unit
-            expect(context.restoredArc170.damage).toBe(2); // Jar Jar's ability deals damage to an enemy unit
+            // Ability hits AT-ST
+            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to deal 2 damage to AT-ST');
+            expect(context.atst.damage).toBe(2);
+            expect(context.p2Base.damage).toBe(6);
         });
     });
 });

--- a/test/server/cards/03_TWI/units/JarJarBinksFoolishGungan.spec.ts
+++ b/test/server/cards/03_TWI/units/JarJarBinksFoolishGungan.spec.ts
@@ -21,7 +21,8 @@ describe('Jar Jar Binks, Foolish Gungan', function () {
             context.player1.clickCard(context.p2Base);
 
             // Ability hits Republic ARC-170
-            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Republic ARC-170');
+            expect(context.getChatLogs(2)).toContain('Republic ARC-170 was randomly selected using Jar Jar Binks\'s ability');
+            expect(context.getChatLogs(2)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Republic ARC-170');
             expect(context.republicArc170.damage).toBe(2);
             expect(context.p2Base.damage).toBe(2);
 
@@ -30,7 +31,8 @@ describe('Jar Jar Binks, Foolish Gungan', function () {
             context.player1.clickCard(context.p2Base);
 
             // Ability hits Restored ARC-170
-            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Restored ARC-170');
+            expect(context.getChatLogs(2)).toContain('Restored ARC-170 was randomly selected using Jar Jar Binks\'s ability');
+            expect(context.getChatLogs(2)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Restored ARC-170');
             expect(context.restoredArc170.damage).toBe(2);
             expect(context.p2Base.damage).toBe(4);
 
@@ -39,7 +41,8 @@ describe('Jar Jar Binks, Foolish Gungan', function () {
             context.player1.clickCard(context.p2Base);
 
             // Ability hits AT-ST
-            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to deal 2 damage to AT-ST');
+            expect(context.getChatLogs(2)).toContain('AT-ST was randomly selected using Jar Jar Binks\'s ability');
+            expect(context.getChatLogs(2)).toContain('player1 uses Jar Jar Binks to deal 2 damage to AT-ST');
             expect(context.atst.damage).toBe(2);
             expect(context.p2Base.damage).toBe(6);
         });

--- a/test/server/cards/03_TWI/units/JarJarBinksFoolishGungan.spec.ts
+++ b/test/server/cards/03_TWI/units/JarJarBinksFoolishGungan.spec.ts
@@ -15,35 +15,32 @@ describe('Jar Jar Binks, Foolish Gungan', function () {
 
             const { context } = contextRef;
 
-            context.game.setRandomSeed('12345');
+            context.game.setRandomSeed('khgfk');
 
             context.player1.clickCard(context.jarJarBinks);
             context.player1.clickCard(context.p2Base);
 
-            // Ability hits Republic ARC-170
-            expect(context.getChatLogs(2)).toContain('Republic ARC-170 was randomly selected using Jar Jar Binks\'s ability');
-            expect(context.getChatLogs(2)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Republic ARC-170');
-            expect(context.republicArc170.damage).toBe(2);
+            // Ability hits own base
+            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to randomly select Kestro City from Jar Jar Binks, Republic ARC-170, Wampa, AT-ST, Restored ARC-170, Administrator\'s Tower, and Kestro City, and to deal 2 damage to Kestro City');
+            expect(context.p1Base.damage).toBe(2);
             expect(context.p2Base.damage).toBe(2);
 
             context.moveToNextActionPhase();
             context.player1.clickCard(context.jarJarBinks);
             context.player1.clickCard(context.p2Base);
 
-            // Ability hits Restored ARC-170
-            expect(context.getChatLogs(2)).toContain('Restored ARC-170 was randomly selected using Jar Jar Binks\'s ability');
-            expect(context.getChatLogs(2)).toContain('player1 uses Jar Jar Binks to deal 2 damage to Restored ARC-170');
-            expect(context.restoredArc170.damage).toBe(2);
+            // Ability hits Republic ARC-170 (friendly unit)
+            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to randomly select Republic ARC-170 from Jar Jar Binks, Republic ARC-170, Wampa, AT-ST, Restored ARC-170, Administrator\'s Tower, and Kestro City, and to deal 2 damage to Republic ARC-170');
+            expect(context.republicArc170.damage).toBe(2);
             expect(context.p2Base.damage).toBe(4);
 
             context.moveToNextActionPhase();
             context.player1.clickCard(context.jarJarBinks);
             context.player1.clickCard(context.p2Base);
 
-            // Ability hits AT-ST
-            expect(context.getChatLogs(2)).toContain('AT-ST was randomly selected using Jar Jar Binks\'s ability');
-            expect(context.getChatLogs(2)).toContain('player1 uses Jar Jar Binks to deal 2 damage to AT-ST');
-            expect(context.atst.damage).toBe(2);
+            // Ability hits Wampa (enemy unit)
+            expect(context.getChatLogs(1)).toContain('player1 uses Jar Jar Binks to randomly select Wampa from Jar Jar Binks, Republic ARC-170, Wampa, AT-ST, Restored ARC-170, Administrator\'s Tower, and Kestro City, and to deal 2 damage to Wampa');
+            expect(context.wampa.damage).toBe(2);
             expect(context.p2Base.damage).toBe(6);
         });
     });


### PR DESCRIPTION
Card abilities are evaluated many times throughout the steps of the ability resolution. For example, they could be evaluated separately while resolving the ability and generating an effect message for the ability. This created issues where there was a discrepancy between game state and the game logs.

This PR adds a `RandomSelectionSystem` so card abilities can reliably produce a random result that is only evaluated once during ability resolution. This system can take an array of targets from its surrounding context and will randomly select `count` targets for its inner system.

Fixes #1329 

### Chat Log examples

| Doctor Aphra | Jar Jar Binks |
| :---: | :---: |
| <img width="259" alt="Screenshot 2025-06-04 at 5 07 19 PM" src="https://github.com/user-attachments/assets/7c30324b-0792-452e-b6d4-4a8fa61d21be" /> | <img width="254" alt="Screenshot 2025-06-04 at 5 07 54 PM" src="https://github.com/user-attachments/assets/ec3e029b-050c-43ef-a0c1-06a3ae891bd7" /> |

