### PR TITLE
Update Shatterpoint to use ChooseModalEffectsSystem

### DIFF
--- a/server/game/cards/05_LOF/events/Shatterpoint.ts
+++ b/server/game/cards/05_LOF/events/Shatterpoint.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
-import { RelativePlayer, TargetMode, WildcardCardType } from '../../../core/Constants';
+import { WildcardCardType } from '../../../core/Constants';
 
 export default class Shatterpoint extends EventCard {
     protected override getImplementationId() {
@@ -13,21 +13,19 @@ export default class Shatterpoint extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Choose one: Defeat a non-leader unit with 3 or less remaining HP or Use the Force. If you do, defeat a non-leader unit',
-            targetResolver: {
-                mode: TargetMode.Select,
-                choosingPlayer: RelativePlayer.Self,
-                showUnresolvable: true,
+            immediateEffect: AbilityHelper.immediateEffects.chooseModalEffects({
+                amountOfChoices: 1,
                 choices: () => ({
-                    ['Defeat a non-leader unit with 3 or less remaining HP']:
-                        AbilityHelper.immediateEffects.selectCard({
+                    ['Defeat a non-leader unit with 3 or less remaining HP']: AbilityHelper.immediateEffects
+                        .selectCard({
                             cardTypeFilter: WildcardCardType.NonLeaderUnit,
                             cardCondition: (card) => card.isUnit() && card.remainingHp <= 3,
                             innerSystem: AbilityHelper.immediateEffects.defeat(),
                         }),
-                    ['Use the Force. If you do, defeat a non-leader unit']:
-                        AbilityHelper.immediateEffects.useTheForce()
+                    ['Use the Force. If you do, defeat a non-leader unit']: AbilityHelper.immediateEffects
+                        .useTheForce()
                 }),
-            },
+            }),
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Defeat a non-leader unit',
                 ifYouDoCondition: () => {

--- a/test/server/cards/05_LOF/events/Shatterpoint.spec.ts
+++ b/test/server/cards/05_LOF/events/Shatterpoint.spec.ts
@@ -26,9 +26,11 @@ describe('Shatterpoint', function() {
                     'Use the Force. If you do, defeat a non-leader unit',
                 ]);
                 context.player1.clickPrompt('Use the Force. If you do, defeat a non-leader unit');
+                expect(context.getChatLogs(1)).toContain('player1 chooses "Use the Force. If you do, defeat a non-leader unit"');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.atst, context.greenSquadronAwing]);
                 context.player1.clickCard(context.atst);
+
 
                 expect(context.player2).toBeActivePlayer();
                 expect(context.player1.hasTheForce).toBeFalse();
@@ -60,6 +62,7 @@ describe('Shatterpoint', function() {
                     'Use the Force. If you do, defeat a non-leader unit',
                 ]);
                 context.player1.clickPrompt('Defeat a non-leader unit with 3 or less remaining HP');
+                expect(context.getChatLogs(1)).toContain('player1 chooses "Defeat a non-leader unit with 3 or less remaining HP"');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.greenSquadronAwing]);
                 context.player1.clickCard(context.greenSquadronAwing);


### PR DESCRIPTION
Using the `ChooseModalEffectsSystem` means we get the player's choice in the chat logs:

<img width="260" alt="Screenshot 2025-06-12 at 9 30 19 AM" src="https://github.com/user-attachments/assets/5ad3a47b-c021-4530-af28-5741481cf0ef" />