### PR TITLE
Better fix for damage distribution with replacement effect

### DIFF
--- a/server/game/gameSystems/DistributeAmongTargetsSystem.ts
+++ b/server/game/gameSystems/DistributeAmongTargetsSystem.ts
@@ -63,7 +63,7 @@ export abstract class DistributeAmongTargetsSystem<
         const context: TContext = event.context;
         event.totalDistributed =
             (event.individualEvents as GameEvent[])
-                .flatMap((event) => event.resolvedEvents)
+                .flatMap((event) => event.resolvedEvents.filter((resolvedEvent) => resolvedEvent.name === event.name))
                 .reduce((total, individualEvent) => total + this.getDistributedAmountFromEvent(individualEvent), 0);
 
         context.game.addMessage(this.getChatMessage(), ...this.getChatMessageArgs(event, context, event.additionalProperties));
@@ -76,7 +76,7 @@ export abstract class DistributeAmongTargetsSystem<
     protected getChatMessageArgs(event: any, context: TContext, additionalProperties: Partial<TProperties>): any[] {
         const targets: FormatMessage[] = [];
         const individualEvents: any[] = event.individualEvents || [];
-        for (const individualEvent of individualEvents.flatMap((event) => event.resolvedEvents)) {
+        for (const individualEvent of individualEvents.flatMap((event) => event.resolvedEvents.filter((resolvedEvent: GameEvent) => resolvedEvent.name === event.name))) {
             const amount = this.getDistributedAmountFromEvent(individualEvent);
             if (amount !== 0) {
                 targets.push({

--- a/test/server/cards/01_SOR/events/OverwhelmingBarrage.spec.ts
+++ b/test/server/cards/01_SOR/events/OverwhelmingBarrage.spec.ts
@@ -11,7 +11,7 @@ describe('Overwhelming Barrage', function() {
                     },
                     player2: {
                         groundArena: ['atst'],
-                        spaceArena: ['tieln-fighter'],
+                        spaceArena: ['tieln-fighter', { card: 'first-order-tie-fighter', upgrades: ['shield'] }],
                         leader: { card: 'han-solo#audacious-smuggler', deployed: true }
                     },
 
@@ -26,10 +26,11 @@ describe('Overwhelming Barrage', function() {
                 context.player1.clickCard(context.overwhelmingBarrage);
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine, context.leiaOrgana]);
                 context.player1.clickCard(context.wampa);
-                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.leiaOrgana, context.atst, context.tielnFighter, context.hanSolo]);
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.leiaOrgana, context.atst, context.tielnFighter, context.hanSolo, context.firstOrderTieFighter]);
                 context.player1.setDistributeDamagePromptState(new Map([
                     [context.atst, 2],
-                    [context.battlefieldMarine, 2],
+                    [context.battlefieldMarine, 1],
+                    [context.firstOrderTieFighter, 1],
                     [context.tielnFighter, 1],
                     [context.hanSolo, 1]
                 ]));
@@ -37,12 +38,14 @@ describe('Overwhelming Barrage', function() {
                 expect(context.leiaOrgana.damage).toBe(0);
                 expect(context.wampa.damage).toBe(0);
                 expect(context.atst.damage).toBe(2);
-                expect(context.battlefieldMarine.damage).toBe(2);
+                expect(context.battlefieldMarine.damage).toBe(1);
+                expect(context.firstOrderTieFighter).toHaveExactUpgradeNames([]);
+                expect(context.firstOrderTieFighter.damage).toBe(0);
                 expect(context.tielnFighter).toBeInZone('discard');
                 expect(context.hanSolo.damage).toBe(1);
 
-                expect(context.getChatLogs(2)).toContain('player1 plays Overwhelming Barrage to give +2/+2 to Wampa for this phase');
-                expect(context.getChatLogs(2)).toContain('player1 uses Overwhelming Barrage to deal 2 damage to AT-ST, 2 damage to Battlefield Marine, 1 damage to TIE/ln Fighter, and 1 damage to Han Solo');
+                expect(context.getChatLogs(3)).toContain('player1 plays Overwhelming Barrage to give +2/+2 to Wampa for this phase');
+                expect(context.getChatLogs(3)).toContain('player1 uses Overwhelming Barrage to deal 2 damage to AT-ST, 1 damage to Battlefield Marine, 1 damage to TIE/ln Fighter, and 1 damage to Han Solo');
 
                 // attack into wampa to confirm stats buff
                 context.setDamage(context.atst, 0);
@@ -59,7 +62,7 @@ describe('Overwhelming Barrage', function() {
 
                 context.player1.clickCard(context.overwhelmingBarrage);
                 context.player1.clickCard(context.wampa);
-                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.leiaOrgana, context.atst, context.tielnFighter, context.hanSolo]);
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.leiaOrgana, context.atst, context.tielnFighter, context.hanSolo, context.firstOrderTieFighter]);
                 context.player1.setDistributeDamagePromptState(new Map([
                     [context.tielnFighter, 6]
                 ]));
@@ -77,7 +80,7 @@ describe('Overwhelming Barrage', function() {
 
                 context.player1.clickCard(context.overwhelmingBarrage);
                 context.player1.clickCard(context.wampa);
-                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.leiaOrgana, context.atst, context.tielnFighter, context.hanSolo]);
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.leiaOrgana, context.atst, context.tielnFighter, context.hanSolo, context.firstOrderTieFighter]);
                 context.player1.setDistributeDamagePromptState(new Map([]));
 
                 expect(context.leiaOrgana.damage).toBe(0);


### PR DESCRIPTION
The fix in #1420 wasn't working correctly with shields.