### PR TITLE
DRAFT: Convert detached effects to a value instead of an impl

### DIFF
--- a/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectBuilder.ts
@@ -5,12 +5,12 @@ import type { IOngoingCardEffectProps, IOngoingPlayerEffectProps, IOngoingCardEf
 // import type { StatusToken } from '../StatusToken';
 import { OngoingCardEffect } from './OngoingCardEffect';
 // import ConflictEffect from './ConflictEffect';
-import DetachedOngoingEffectImpl from './effectImpl/DetachedOngoingEffectImpl';
 import type { CalculateOngoingEffect } from './effectImpl/DynamicOngoingEffectImpl';
 import DynamicOngoingEffectImpl from './effectImpl/DynamicOngoingEffectImpl';
 import { OngoingPlayerEffect } from './OngoingPlayerEffect';
 import StaticOngoingEffectImpl from './effectImpl/StaticOngoingEffectImpl';
 import type { OngoingEffectValueWrapper } from './effectImpl/OngoingEffectValueWrapper';
+import DetachedOngoingEffectValueWrapper from './effectImpl/DetachedOngoingEffectValueWrapper';
 
 /* Types of effect
     1. Static effects - do something for a period
@@ -25,7 +25,7 @@ export const OngoingEffectBuilder = {
         dynamic: <TValue>(type: EffectName, value: CalculateOngoingEffect<TValue>): IOngoingCardEffectGenerator => (game: Game, source: Card, props: IOngoingCardEffectProps) =>
             new OngoingCardEffect(game, source, props, new DynamicOngoingEffectImpl(type, value)),
         detached: (type: EffectName, value): IOngoingCardEffectGenerator => (game: Game, source: Card, props: IOngoingCardEffectProps) =>
-            new OngoingCardEffect(game, source, props, new DetachedOngoingEffectImpl(type, value.apply, value.unapply)),
+            new OngoingCardEffect(game, source, props, new StaticOngoingEffectImpl(type, new DetachedOngoingEffectValueWrapper(value.apply, value.unapply))),
         flexible: <TValue>(type: EffectName, value?: CalculateOngoingEffect<TValue> | OngoingEffectValueWrapper<TValue> | TValue): IOngoingCardEffectGenerator =>
             (typeof value === 'function'
                 ? OngoingEffectBuilder.card.dynamic(type, value as CalculateOngoingEffect<TValue>)
@@ -37,7 +37,7 @@ export const OngoingEffectBuilder = {
         dynamic: <TValue>(type: EffectName, value: CalculateOngoingEffect<TValue>): IOngoingPlayerEffectGenerator => (game: Game, source: Card, props: IOngoingPlayerEffectProps) =>
             new OngoingPlayerEffect(game, source, props, new DynamicOngoingEffectImpl(type, value)),
         detached: (type: EffectName, value): IOngoingPlayerEffectGenerator => (game: Game, source: Card, props: IOngoingPlayerEffectProps) =>
-            new OngoingPlayerEffect(game, source, props, new DetachedOngoingEffectImpl(type, value.apply, value.unapply)),
+            new OngoingPlayerEffect(game, source, props, new StaticOngoingEffectImpl(type, new DetachedOngoingEffectValueWrapper(value.apply, value.unapply))),
         flexible: <TValue>(type: EffectName, value?: CalculateOngoingEffect<TValue> | OngoingEffectValueWrapper<TValue> | TValue): IOngoingPlayerEffectGenerator =>
             (typeof value === 'function'
                 ? OngoingEffectBuilder.player.dynamic(type, value as CalculateOngoingEffect<TValue>)

--- a/server/game/core/ongoingEffect/effectImpl/DetachedOngoingEffectValueWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/DetachedOngoingEffectValueWrapper.ts
@@ -1,37 +1,28 @@
 import type { AbilityContext } from '../../ability/AbilityContext';
-import type { EffectName } from '../../Constants';
-import { OngoingEffectImpl } from './OngoingEffectImpl';
+import { OngoingEffectValueWrapper } from './OngoingEffectValueWrapper';
 
-export default class DetachedOngoingEffectImpl<TValue> extends OngoingEffectImpl<TValue> {
+export default class DetachedOngoingEffectValueWrapper<TValue> extends OngoingEffectValueWrapper<TValue> {
     private state: Record<string, any> = {};
 
-    public constructor(type: EffectName,
+    public constructor(
         public applyFunc,
         public unapplyFunc
     ) {
-        super(type);
+        super(null);
         this.applyFunc = applyFunc;
         this.unapplyFunc = unapplyFunc;
     }
 
-    public apply(target: any) {
+    public override apply(target: any) {
         this.state[target.uuid] = this.applyFunc(target, this.context, this.state[target.uuid]);
     }
 
-    public unapply(target: any) {
+    public override unapply(target: any) {
         this.state[target.uuid] = this.unapplyFunc(target, this.context, this.state[target.uuid]);
         if (this.state[target.uuid] === undefined) {
             // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
             delete this.state[target.uuid];
         }
-    }
-
-    public getValue(target: any) {
-        return null;
-    }
-
-    public recalculate(target: any): boolean {
-        return false;
     }
 
     public override setContext(context: AbilityContext) {

--- a/server/game/core/ongoingEffect/effectImpl/GainKeyword.ts
+++ b/server/game/core/ongoingEffect/effectImpl/GainKeyword.ts
@@ -24,14 +24,10 @@ export class GainKeyword extends OngoingEffectValueWrapper<IKeywordProperties | 
     }
 
     public override apply(target: Card): void {
-        super.apply(target);
-
         this.refreshWhileInPlayKeywordAbilityEffects(target);
     }
 
     public override unapply(target: Card): void {
-        super.unapply(target);
-
         this.refreshWhileInPlayKeywordAbilityEffects(target);
     }
 


### PR DESCRIPTION
The current implementation of detached ongoing effects was creating problems for undo. Refactored it into a ValueWrapper instead of an EffectImpl so that it can inherit from GameObject and be easier to backup / restore for undo purposes.