### PR TITLE
Add chat message for player ready / unready

### DIFF
--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -515,4 +515,5 @@ export enum AlertType {
     Notification = 'notification',
     Warning = 'warning',
     Danger = 'danger',
+    ReadyStatus = 'readyStatus',
 }

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -353,6 +353,7 @@ export class Lobby {
         }
         currentUser.ready = args[0];
         logger.info(`Lobby: user ${currentUser.username} set ready status: ${args[0]}`, { lobbyId: this.id, userName: currentUser.username, userId: currentUser.id });
+        this.gameChat.addAlert(AlertType.ReadyStatus, `${currentUser.username} is ${args[0] ? 'ready to start' : 'not ready to start'}`);
         this.updateUserLastActivity(currentUser.id);
     }
 


### PR DESCRIPTION
I've noticed that it's hard to catch when a player readies or unreadies in the lobby if you're not paying close attention. Re-adding the chat message notifications when it happens.

Corresponding FE PR adds the styling for the new notification type: 