### PR TITLE
Fix controller issue with Flight of the Inquisitor

### DIFF
--- a/server/game/cards/05_LOF/events/FlightOfTheInquisitor.ts
+++ b/server/game/cards/05_LOF/events/FlightOfTheInquisitor.ts
@@ -1,6 +1,6 @@
 import AbilityHelper from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
-import { Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
 
 export default class FlightOfTheInquisitor extends EventCard {
     protected override getImplementationId() {
@@ -18,12 +18,14 @@ export default class FlightOfTheInquisitor extends EventCard {
                 [
                     AbilityHelper.immediateEffects.selectCard({
                         zoneFilter: ZoneName.Discard,
+                        controller: RelativePlayer.Self,
                         cardTypeFilter: WildcardCardType.Unit,
                         cardCondition: (card) => card.hasSomeTrait(Trait.Force),
                         immediateEffect: AbilityHelper.immediateEffects.returnToHand()
                     }),
                     AbilityHelper.immediateEffects.selectCard({
                         zoneFilter: ZoneName.Discard,
+                        controller: RelativePlayer.Self,
                         cardTypeFilter: WildcardCardType.Upgrade,
                         cardCondition: (card) => card.hasSomeTrait(Trait.Lightsaber),
                         immediateEffect: AbilityHelper.immediateEffects.returnToHand()

--- a/test/server/cards/05_LOF/events/FlightOfTheInquisitor.spec.ts
+++ b/test/server/cards/05_LOF/events/FlightOfTheInquisitor.spec.ts
@@ -11,6 +11,10 @@ describe('Flight of the Inquisitor', function () {
                     },
                     player2: {
                         groundArena: ['steadfast-battalion'],
+                        discard: [
+                            'vernestra-rwoh#precocious-knight',
+                            'youngling-padawan'
+                        ]
                     },
                 });
             });
@@ -54,7 +58,11 @@ describe('Flight of the Inquisitor', function () {
                     discard: ['timely-intervention', 'fallen-lightsaber', 'jedi-lightsaber'],
                 },
                 player2: {
-                    groundArena: ['rugged-survivors']
+                    groundArena: ['rugged-survivors'],
+                    discard: [
+                        'vernestra-rwoh#precocious-knight',
+                        'youngling-padawan'
+                    ]
                 }
             });
 
@@ -79,7 +87,11 @@ describe('Flight of the Inquisitor', function () {
                     deck: ['rebel-pathfinder']
                 },
                 player2: {
-                    groundArena: ['rugged-survivors']
+                    groundArena: ['rugged-survivors'],
+                    discard: [
+                        'vernestra-rwoh#precocious-knight',
+                        'youngling-padawan'
+                    ]
                 }
             });
 
@@ -107,7 +119,11 @@ describe('Flight of the Inquisitor', function () {
                     deck: ['rebel-pathfinder']
                 },
                 player2: {
-                    hand: ['timely-intervention']
+                    hand: ['timely-intervention'],
+                    discard: [
+                        'vernestra-rwoh#precocious-knight',
+                        'youngling-padawan'
+                    ]
                 }
             });
 


### PR DESCRIPTION
Flight of the Inquisitor would only let the player choose from the opponent's discard if it was non-empty