### PR TITLE
Call out damage amount and exploited unit's title in TWI Count Dooku's ability prompt

### DIFF
--- a/server/game/cards/03_TWI/units/CountDookuFallenJedi.ts
+++ b/server/game/cards/03_TWI/units/CountDookuFallenJedi.ts
@@ -18,6 +18,7 @@ export default class CountDookuFallenJedi extends NonLeaderUnitCard {
                 // TODO: correct implementation of the rules for multiple instances of damage in the same ability
                 (context) => Helpers.asArray(context.event.costs.exploitedUnitsInformation).map((exploitedUnitInformation) =>
                     AbilityHelper.immediateEffects.selectCard({
+                        activePromptTitle: `Deal ${exploitedUnitInformation.power} damage to an enemy unit (for exploiting ${exploitedUnitInformation.title})`,
                         cardTypeFilter: WildcardCardType.Unit,
                         controller: RelativePlayer.Opponent,
                         optional: true,

--- a/test/server/cards/03_TWI/units/CountDookuFallenJedi.spec.ts
+++ b/test/server/cards/03_TWI/units/CountDookuFallenJedi.spec.ts
@@ -30,13 +30,14 @@ describe('Count Dooku, Fallen Jedi', function() {
                 // choose first damage target (from wampa)
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.cartelSpacer]);
                 expect(context.player1).toHaveChooseNothingButton();
-                // click needs to be non-checking b/c prompt remains unchanged
-                context.player1.clickCardNonChecking(context.atst);
+                expect(context.player1).toHavePrompt('Deal 5 damage to an enemy unit (for exploiting Wampa)');
+                context.player1.clickCard(context.atst);
                 expect(context.atst.damage).toBe(5);
 
                 // choose second damage target (from battle droid)
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.cartelSpacer]);
                 expect(context.player1).toHaveChooseNothingButton();
+                expect(context.player1).toHavePrompt('Deal 1 damage to an enemy unit (for exploiting Battle Droid)');
                 context.player1.clickCard(context.cartelSpacer);
                 expect(context.cartelSpacer.damage).toBe(1);
                 expect(context.getChatLogs(1)[0]).toContain('player1 uses Count Dooku to deal 1 damage to Cartel Spacer');
@@ -56,6 +57,7 @@ describe('Count Dooku, Fallen Jedi', function() {
 
                 // choose first damage target (from wampa)
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.cartelSpacer]);
+                expect(context.player1).toHavePrompt('Deal 5 damage to an enemy unit (for exploiting Wampa)');
                 context.player1.clickPrompt('Choose nothing');
                 expect(context.atst.damage).toBe(0);
                 expect(context.cartelSpacer.damage).toBe(0);
@@ -63,6 +65,7 @@ describe('Count Dooku, Fallen Jedi', function() {
                 // choose second damage target (from battle droid)
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.cartelSpacer]);
                 expect(context.player1).toHaveChooseNothingButton();
+                expect(context.player1).toHavePrompt('Deal 1 damage to an enemy unit (for exploiting Battle Droid)');
                 context.player1.clickCard(context.cartelSpacer);
                 expect(context.cartelSpacer.damage).toBe(1);
             });


### PR DESCRIPTION
Per user request: 
> When exploiting 2 units with Dooku, there is no way to know which unit's power is being used
> I reallllly wish it said "Deal X damage" when I'm choosing my targets

### Screenshots

<img width="500" alt="Screenshot 2025-06-23 at 12 42 46 PM" src="https://github.com/user-attachments/assets/3139c8c6-ea9d-42c6-b589-f10fed78d919" />

--------

<img width="500" alt="Screenshot 2025-06-23 at 12 42 54 PM" src="https://github.com/user-attachments/assets/9483184d-d5a3-4942-8aab-c5c96879f4f1" />