### PR TITLE
Bug fixes in FE state related to resourcing

### DIFF
--- a/server/game/core/PlayerPromptState.ts
+++ b/server/game/core/PlayerPromptState.ts
@@ -106,16 +106,18 @@ export class PlayerPromptState {
     public getCardSelectionState(card: Card): ICardSelectionState {
         const selectable = this._selectableCards.includes(card);
 
+        const index = this._selectedCards?.indexOf(card) ?? -1;
+        const selected = index !== -1;
+
         if (!selectable) {
-            return { selectable };
+            return { selectable, selected: selected ? true : undefined };
         }
 
-        const index = this._selectedCards?.indexOf(card) ?? -1;
         const order = index !== -1 && this.selectOrder ? index + 1 : undefined;
 
         const result = {
             selectable,
-            selected: index !== -1,
+            selected,
             unselectable: this.selectCardMode && !selectable,
             order
         };

--- a/server/game/core/gameSteps/prompts/ResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/ResourcePrompt.ts
@@ -92,7 +92,8 @@ export class ResourcePrompt extends AllPlayerPrompt {
 
     public override waitingPrompt() {
         return {
-            menuTitle: 'Waiting for opponent to choose cards to resource'
+            menuTitle: 'Waiting for opponent to choose cards to resource',
+            promptType: PromptType.Resource,
         };
     }
 


### PR DESCRIPTION
The gamestate changes made it so that when you click "Done" while resourcing, the chosen cards appear as unselected. Fixed things so that (a) we always send "selected: true" even if selectable is false, and (b) we now send promptType: resource for the player who is waiting on the opponent