### PR TITLE
[Bugfix] Cassian Andor leader & DamageDealtThisPhaseWatcher

### DIFF
--- a/server/game/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.ts
+++ b/server/game/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.ts
@@ -25,7 +25,9 @@ export default class CassionAndorDedicatedToTheRebellion extends LeaderUnitCard 
                 condition: (context) => {
                     const damageDealtToBase = this.damageDealtThisPhaseWatcher.getDamageDealtByPlayer(
                         context.player,
-                        (damage) => damage.target.isBase()
+                        (damage) =>
+                            damage.target.isBase() &&
+                            damage.target.controller !== context.player
                     ).reduce((sum, damage) => sum + damage.amount, 0);
 
                     return damageDealtToBase >= 3;
@@ -39,9 +41,11 @@ export default class CassionAndorDedicatedToTheRebellion extends LeaderUnitCard 
         this.addTriggeredAbility({
             title: 'Draw a card',
             collectiveTrigger: true,
+            optional: true,
             when: {
                 onDamageDealt: (event, context) =>
                     event.card.isBase() &&
+                    event.card.controller !== context.player &&
                     event.damageSource.player === context.player
             },
             immediateEffect: AbilityHelper.immediateEffects.draw((context) => ({ target: context.player })),

--- a/server/game/stateWatchers/DamageDealtThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/DamageDealtThisPhaseWatcher.ts
@@ -43,7 +43,7 @@ export class DamageDealtThisPhaseWatcher extends StateWatcher<IDamageDealtThisPh
                     damageType: event.type,
                     damageSource: event.damageSource,
                     target: event.card,
-                    amount: event.amount,
+                    amount: event.damageDealt,
                     isIndirect: event.isIndirect,
                 })
         });


### PR DESCRIPTION
### Description

This PR has a couple fixes related to the SOR Cassian Andor leader:

- The leader and unit side abilities should only count damage dealt to an _enemy_ base
- The unit side ability should be optional
- The `DamageDealtThisPhaseWatcher` now tracks the correct damage amount for overhwhelm damage (previously it was coming through as `undefined`)