### PR TITLE
Connection improvements during matchmaking countdown

### DIFF
--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -1235,7 +1235,7 @@ export class GameServer {
 
                     // Check if the user is still disconnected after the timer
                     if (lobby?.isDisconnected(id, socket.id)) {
-                        logger.info(`GameServer: User ${id} on socket id ${socket.id} is disconnected from lobby ${lobby.id} for more than 20s, removing from lobby`, { userId: id, lobbyId: lobby.id });
+                        logger.info(`GameServer: User ${id} on socket id ${socket.id} is disconnected from lobby ${lobby.id} for more than ${timeoutSeconds}s, removing from lobby`, { userId: id, lobbyId: lobby.id });
 
                         this.userLobbyMap.delete(id);
 

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -879,8 +879,8 @@ export class Lobby {
      */
     private async endGameUpdateStatsAsync(game: Game): Promise<void> {
         try {
-            // Only update stats if the game has a winner
-            if (!game.winner || !game.finishedAt) {
+            // Only update stats if the game has a winner and made it into the second round at least
+            if (!game.winner || !game.finishedAt || this.game.roundNumber <= 1) {
                 return;
             }
 
@@ -924,10 +924,9 @@ export class Lobby {
                 logger.error(`Lobby ${this.id}: Missing information (${player2User.deckID}) for player2 ${player2.id}`);
                 return;
             }
-            if (this.game.roundNumber > 1) {
-                await this.updatePlayerStatsAsync(player1User, player2User, player1Score);
-                await this.updatePlayerStatsAsync(player2User, player1User, player2Score);
-            }
+
+            await this.updatePlayerStatsAsync(player1User, player2User, player1Score);
+            await this.updatePlayerStatsAsync(player2User, player1User, player2Score);
 
             logger.info(`Lobby ${this.id}: Successfully updated deck stats for game ${game.id}`);
         } catch (error) {


### PR DESCRIPTION
Few small tweaks to patch over some potential problems that might be causing the queueing issues for people on unstable internet connections.

I suspect that what's going on is that if any disconnects happen during the handoff from the queue to the lobby, our user connection flag gets messed up and erroneously marks the user as disconnected. Then, they don't receive lobby state updates, so the FE never updates and the server thinks they left.

The changes I made to try and smooth this over are:
- Changed the state-send methods to check the underlying socketio connection flag, as that is much more reliable. If this seems to work better then we can plan to move off of our manual connection flag completely.
- Added a callback on the state-send function that will mark the user's status as connected if the gamestate or lobbystate message is acknowledged by the FE
- During the match countdown, lobby state updates will be forced to send even if we think the user is disconnected. This should increase the likelihood of the FE actually receiving an update in time.
- Added logic to mark the user as connected if any message is received from the FE, in case there are other scenarios where the user is incorrectly getting marked as disconnected and staying that way