### PR TITLE
[Bugfix] Shien Flurry prevents damage only once

### DIFF
--- a/server/game/abilities/keyword/exploit/ExploitCostAdjuster.ts
+++ b/server/game/abilities/keyword/exploit/ExploitCostAdjuster.ts
@@ -1,5 +1,5 @@
 import type { AbilityContext } from '../../../core/ability/AbilityContext';
-import { PerGameAbilityLimit } from '../../../core/ability/AbilityLimit';
+import { PerPlayerPerGameAbilityLimit } from '../../../core/ability/AbilityLimit';
 import { CardTargetResolver } from '../../../core/ability/abilityTargets/CardTargetResolver';
 import type { Card } from '../../../core/card/Card';
 import type { ICardWithCostProperty } from '../../../core/card/propertyMixins/Cost';
@@ -42,7 +42,7 @@ export class ExploitCostAdjuster extends ExploitCostAdjusterBase {
                 // if we haven't yet resolved the exploit targets, just return the maximum possible discount amount
                 amount: (_card, _player, context) =>
                     (this.numExploitedCards != null ? this.numExploitedCards * 2 : this.getMaxExploitCount(context) * 2),
-                limit: new PerGameAbilityLimit(1)
+                limit: new PerPlayerPerGameAbilityLimit(1)
             }
         );
 

--- a/server/game/cards/01_SOR/units/BenduTheOneInTheMiddle.ts
+++ b/server/game/cards/01_SOR/units/BenduTheOneInTheMiddle.ts
@@ -18,7 +18,7 @@ export default class BenduTheOneInTheMiddle extends NonLeaderUnitCard {
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Playable,
                     match: (card) => !card.hasSomeAspect(Aspect.Heroism) && !card.hasSomeAspect(Aspect.Villainy),
-                    limit: AbilityLimit.perGame(1),
+                    limit: AbilityLimit.perPlayerPerGame(1),
                     amount: 2
                 })
             })

--- a/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
+++ b/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
@@ -25,7 +25,7 @@ export default class JabbaTheHuttHisHighExaltedness extends LeaderUnitCard {
                             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                                     cardTypeFilter: WildcardCardType.Unit,
-                                    limit: AbilityLimit.perGame(1),
+                                    limit: AbilityLimit.perPlayerPerGame(1),
                                     amount: 1
                                 })
                             })
@@ -70,7 +70,7 @@ export default class JabbaTheHuttHisHighExaltedness extends LeaderUnitCard {
                             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                                     cardTypeFilter: WildcardCardType.Unit,
-                                    limit: AbilityLimit.perGame(1),
+                                    limit: AbilityLimit.perPlayerPerGame(1),
                                     amount: 2
                                 })
                             })

--- a/server/game/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.ts
+++ b/server/game/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.ts
@@ -32,7 +32,7 @@ export default class CountDookuFaceOfTheConfederacy extends LeaderUnitCard {
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.addExploit({
                     match: (card) => card.hasSomeTrait(Trait.Separatist),
-                    limit: AbilityHelper.limit.perGame(1),
+                    limit: AbilityHelper.limit.perPlayerPerGame(1),
                     exploitKeywordAmount: 3
                 })
             })

--- a/server/game/cards/03_TWI/units/TranquilityInspiringFlagship.ts
+++ b/server/game/cards/03_TWI/units/TranquilityInspiringFlagship.ts
@@ -28,7 +28,7 @@ export default class TranquilityInspiringFlagship extends NonLeaderUnitCard {
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     match: (card) => card.hasSomeTrait(Trait.Republic),
-                    limit: AbilityLimit.perGame(3),
+                    limit: AbilityLimit.perPlayerPerGame(3),
                     amount: 1
                 })
             })

--- a/server/game/cards/03_TWI/upgrades/GeneralsBlade.ts
+++ b/server/game/cards/03_TWI/upgrades/GeneralsBlade.ts
@@ -23,7 +23,7 @@ export default class GeneralsBlade extends UpgradeCard {
                 ongoingEffectTargetDescription: 'them',
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Unit,
-                    limit: AbilityLimit.perGame(1),
+                    limit: AbilityLimit.perPlayerPerGame(1),
                     amount: 2
                 })
             }),

--- a/server/game/cards/04_JTL/events/JumpToLightspeed.ts
+++ b/server/game/cards/04_JTL/events/JumpToLightspeed.ts
@@ -45,7 +45,7 @@ export default class JumpToLightspeed extends EventCard {
                             const selectedCard = Helper.asArray(ifYouDoContext.targets.friendlySpaceUnit)[0];
                             return selectedCard.title === card.title && selectedCard.subtitle === card.subtitle;
                         },
-                        limit: AbilityHelper.limit.perGame(1)
+                        limit: AbilityHelper.limit.perPlayerPerGame(1)
                     })
                 })
             })

--- a/server/game/cards/04_JTL/leaders/WedgeAntillesLeaderOfRedSquadron.ts
+++ b/server/game/cards/04_JTL/leaders/WedgeAntillesLeaderOfRedSquadron.ts
@@ -48,7 +48,7 @@ export default class WedgeAntillesLeaderOfRedSquadron extends LeaderUnitCard {
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     match: (card) => card.hasSomeTrait(Trait.Pilot),
-                    limit: AbilityHelper.limit.perGame(1),
+                    limit: AbilityHelper.limit.perPlayerPerGame(1),
                     amount: 1
                 })
             })

--- a/server/game/cards/04_JTL/units/SnapWexleyResistanceReconFlier.ts
+++ b/server/game/cards/04_JTL/units/SnapWexleyResistanceReconFlier.ts
@@ -22,7 +22,7 @@ export default class SnapWexleyResistanceReconFlier extends NonLeaderUnitCard {
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     match: (card) => card.hasSomeTrait(Trait.Resistance),
                     cardTypeFilter: WildcardCardType.Playable,
-                    limit: AbilityLimit.perGame(1),
+                    limit: AbilityLimit.perPlayerPerGame(1),
                     amount: 1
                 })
             })

--- a/server/game/cards/05_LOF/bases/MysticMonastery.ts
+++ b/server/game/cards/05_LOF/bases/MysticMonastery.ts
@@ -11,7 +11,7 @@ export default class MysticMonastery extends BaseCard {
     }
 
     public override setupCardAbilities () {
-        const limit = AbilityHelper.limit.perGame(3);
+        const limit = AbilityHelper.limit.perPlayerPerGame(3);
 
         this.addActionAbility({
             title: 'The Force is with you',

--- a/server/game/cards/05_LOF/leaders/MorganElsbethFollowingTheCall.ts
+++ b/server/game/cards/05_LOF/leaders/MorganElsbethFollowingTheCall.ts
@@ -60,7 +60,7 @@ export default class MorganElsbethFollowingTheCall extends LeaderUnitCard {
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Unit,
-                    limit: AbilityLimit.perGame(1),
+                    limit: AbilityLimit.perPlayerPerGame(1),
                     amount: (card, player) => {
                         const cardKeywords = new Set(card.keywords.map((keyword) => keyword.name));
                         const inPlayKeywords = player.getArenaUnits()

--- a/server/game/gameSystems/DelayedEffectSystem.ts
+++ b/server/game/gameSystems/DelayedEffectSystem.ts
@@ -1,5 +1,5 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import { PerGameAbilityLimit, type IAbilityLimit } from '../core/ability/AbilityLimit';
+import { PerPlayerPerGameAbilityLimit, type IAbilityLimit } from '../core/ability/AbilityLimit';
 import type { TriggeredAbilityContext } from '../core/ability/TriggeredAbilityContext';
 import { Duration, EventName, GameStateChangeRequired } from '../core/Constants';
 import type { GameEvent } from '../core/event/GameEvent';
@@ -94,7 +94,7 @@ export class DelayedEffectSystem<TContext extends AbilityContext = AbilityContex
                 title,
                 when,
                 immediateEffect,
-                limit: limit ?? new PerGameAbilityLimit(1),
+                limit: limit ?? new PerPlayerPerGameAbilityLimit(1),
             })
         };
 

--- a/test/server/cards/05_LOF/events/ShienFlurry.spec.ts
+++ b/test/server/cards/05_LOF/events/ShienFlurry.spec.ts
@@ -132,5 +132,46 @@ describe('Shien Flurry', function() {
             expect(context.getChatLogs(3)).toContain('player1 uses Obi-Wan Kenobi\'s gained ability from Shien Flurry to prevent 2 damage to Obi-Wan Kenobi');
             expect(context.getChatLogs(3)).toContain('player2 uses The Legacy Run to deal 4 damage to Obi-Wan Kenobi');
         });
+
+        it('Shien Flurry\'s ability should prevent damage only once, even if the unit changes control', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: [
+                        'shien-flurry',
+                        'obiwan-kenobi#following-fate'
+                    ],
+                    groundArena: ['battlefield-marine']
+                },
+                player2: {
+                    leader: 'emperor-palpatine#galactic-ruler',
+                    groundArena: ['fallen-jedi']
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Play Shien Flurry to ambush with Obi-Wan Kenobi and prevent 2 damage
+            context.player1.clickCard(context.shienFlurry);
+            context.player1.clickCard(context.obiwanKenobi);
+
+            context.player1.clickPrompt('Trigger');
+            context.player1.clickCard(context.fallenJedi); // 3 power
+
+            expect(context.obiwanKenobi.damage).toBe(1);
+
+            // Deploy Emperor Palpatine to take control of Obi-Wan Kenobi
+            context.player2.clickCard(context.emperorPalpatine);
+            context.player2.clickPrompt('Deploy Emperor Palpatine');
+            context.player2.clickCard(context.obiwanKenobi);
+
+            expect(context.obiwanKenobi).toBeInZone('groundArena', context.player2);
+
+            // Battlefield Marine attacks Obi-Wan Kenobi, and no damage should be prevented
+            context.player1.clickCard(context.battlefieldMarine);
+            context.player1.clickCard(context.obiwanKenobi);
+
+            expect(context.obiwanKenobi.damage).toBe(4);
+        });
     });
 });


### PR DESCRIPTION
Fixes #1481 

Previously, we had a `perGame` ability limit, which tracked usages per-player. This has been renamed to `perPlayerPerGame`, and a new `perGame` ability limit has been introduced, which is agnostic of player.