### PR TITLE
Fix cards that search entire deck

### DIFF
--- a/server/game/TargetInterfaces.ts
+++ b/server/game/TargetInterfaces.ts
@@ -59,6 +59,7 @@ export interface IDropdownListTargetResolver<TContext extends AbilityContext> ex
     mode: TargetMode.DropdownList;
     options: string[] | ((context: TContext) => string[]);
     condition?: (context: AbilityContext) => boolean;
+    logSelection?: boolean;
 }
 
 export interface ITargetResolverBase<TContext extends AbilityContext> {

--- a/server/game/cards/01_SOR/events/SearchYourFeelings.ts
+++ b/server/game/cards/01_SOR/events/SearchYourFeelings.ts
@@ -14,6 +14,7 @@ export default class SearchYourFeelings extends EventCard {
 
     // TODO: since the card display prompt can't handle showing the full deck currently, we instead use a dropdown list of card names
     // once the prompt is fixed, we can go back to using that for deck search like other cards do
+    // TODO: the dropdown list prompt doesn't have support for "optional" currently, so the player will be forced to choose a card
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Choose the name of a card from your deck to draw',

--- a/server/game/cards/01_SOR/events/SearchYourFeelings.ts
+++ b/server/game/cards/01_SOR/events/SearchYourFeelings.ts
@@ -1,5 +1,8 @@
 import AbilityHelper from '../../../AbilityHelper';
+import type { AbilityContext } from '../../../core/ability/AbilityContext';
+import type { Card } from '../../../core/card/Card';
 import { EventCard } from '../../../core/card/EventCard';
+import { TargetMode } from '../../../core/Constants';
 
 export default class SearchYourFeelings extends EventCard {
     protected override getImplementationId() {
@@ -9,14 +12,34 @@ export default class SearchYourFeelings extends EventCard {
         };
     }
 
+    // TODO: since the card display prompt can't handle showing the full deck currently, we instead use a dropdown list of card names
+    // once the prompt is fixed, we can go back to using that for deck search like other cards do
     public override setupCardAbilities() {
         this.setEventAbility({
-            title: 'Search your deck for a card, draw it, then shuffle',
-            immediateEffect: AbilityHelper.immediateEffects.entireDeckSearch({
-                shuffleWhenDone: true,
-                revealSelected: false,
-                selectedCardsImmediateEffect: AbilityHelper.immediateEffects.drawSpecificCard()
-            })
+            title: 'Choose the name of a card from your deck to draw',
+            targetResolver: {
+                mode: TargetMode.DropdownList,
+                options: (context) => this.getDistinctCardNamesInDeck(context),
+                logSelection: false,
+                condition: (context) => context.player.drawDeck.length > 0,
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
+                    AbilityHelper.immediateEffects.drawSpecificCard((context) => ({
+                        target: context.player.drawDeck.find((card) => this.buildCardName(card) === context.select)
+                    })),
+                    AbilityHelper.immediateEffects.shuffleDeck((context) => ({
+                        target: context.player
+                    }))
+                ])
+            },
         });
+    }
+
+    private getDistinctCardNamesInDeck(context: AbilityContext): string[] {
+        const cardNamesInDeck = context.player.drawDeck.map((card) => this.buildCardName(card));
+        return [...new Set(cardNamesInDeck)];
+    }
+
+    private buildCardName(card: Card): string {
+        return `${card.title}${card.subtitle ? ', ' + card.subtitle : ''}`;
     }
 }

--- a/server/game/cards/01_SOR/events/SearchYourFeelings.ts
+++ b/server/game/cards/01_SOR/events/SearchYourFeelings.ts
@@ -12,7 +12,7 @@ export default class SearchYourFeelings extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Search your deck for a card, draw it, then shuffle',
-            immediateEffect: AbilityHelper.immediateEffects.deckSearch({
+            immediateEffect: AbilityHelper.immediateEffects.entireDeckSearch({
                 shuffleWhenDone: true,
                 revealSelected: false,
                 selectedCardsImmediateEffect: AbilityHelper.immediateEffects.drawSpecificCard()

--- a/server/game/cards/02_SHD/events/BountyPosting.ts
+++ b/server/game/cards/02_SHD/events/BountyPosting.ts
@@ -14,7 +14,7 @@ export default class BountyPosting extends EventCard {
     public override setupCardAbilities() {
         this.setEventAbility({
             title: 'Search your deck for a Bounty upgrade, reveal it, and draw it (shuffle your deck)',
-            immediateEffect: AbilityHelper.immediateEffects.deckSearch({
+            immediateEffect: AbilityHelper.immediateEffects.entireDeckSearch({
                 cardCondition: (card) => card.isUpgrade() && card.hasSomeTrait(Trait.Bounty),
                 selectedCardsImmediateEffect: AbilityHelper.immediateEffects.drawSpecificCard(),
                 shuffleWhenDone: true

--- a/server/game/cards/04_JTL/units/AnnihilatorTaggesFlagship.ts
+++ b/server/game/cards/04_JTL/units/AnnihilatorTaggesFlagship.ts
@@ -1,7 +1,7 @@
 import AbilityHelper from '../../../AbilityHelper';
 import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { EventName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { EventName, RelativePlayer, TargetMode, WildcardCardType } from '../../../core/Constants';
 
 export default class AnnihilatorTaggesFlagship extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -46,19 +46,14 @@ export default class AnnihilatorTaggesFlagship extends NonLeaderUnitCard {
                             ];
                         }),
                     }),
-                    AbilityHelper.immediateEffects.conditional((context) => {
-                        const opponentDeck = context.player.opponent.drawDeck;
-                        return {
-                            condition: opponentDeck.length > 0,
-                            onTrue: AbilityHelper.immediateEffects.simultaneous(() => {
-                                const matchingCardNames = opponentDeck.filter((card) => card.title === this.getTargetTitle(ifYouDoContext));
-                                return matchingCardNames.map((target) =>
-                                    AbilityHelper.immediateEffects.discardSpecificCard({
-                                        target: target
-                                    })
-                                );
-                            }),
-                        };
+                    AbilityHelper.immediateEffects.entireDeckSearch({
+                        cardCondition: (card) => card.title === this.getTargetTitle(ifYouDoContext),
+                        selectedCardsImmediateEffect: AbilityHelper.immediateEffects.discardSpecificCard(),
+                        shuffleWhenDone: true,
+                        targetMode: TargetMode.Unlimited,
+                        activePromptTitle: `Select which cards named ${this.getTargetTitle(ifYouDoContext)} to discard from the opponent's deck`,
+                        player: ifYouDoContext.player.opponent,
+                        choosingPlayer: ifYouDoContext.player
                     })
                 ])
             })

--- a/server/game/core/ability/abilityTargets/DropdownListTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/DropdownListTargetResolver.ts
@@ -44,7 +44,10 @@ export class DropdownListTargetResolver extends TargetResolver<IDropdownListTarg
             context.select = choice;
         }
         const abilitySource = context.ability.gainAbilitySource != null ? context.ability.gainAbilitySource : context.source;
-        context.game.addMessage('{0} names {1} using {2}', context.player, choice, abilitySource.title);
+
+        if (this.properties.logSelection ?? true) {
+            context.game.addMessage('{0} names {1} using {2}', context.player, choice, abilitySource.title);
+        }
     }
 
     public override checkTarget(context: AbilityContext): boolean {

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -149,6 +149,8 @@ import type { IUseWhenPlayedProperties } from './UseWhenPlayedSystem';
 import { UseWhenPlayedSystem } from './UseWhenPlayedSystem';
 import type { IRandomSelectionSystemProperties } from './RandomSelectionSystem';
 import { RandomSelectionSystem } from './RandomSelectionSystem';
+import type { ISearchEntireDeckProperties } from './SearchEntireDeckSystem';
+import { SearchEntireDeckSystem } from './SearchEntireDeckSystem';
 
 type PropsFactory<Props, TContext extends AbilityContext = AbilityContext> = Props | ((context: TContext) => Props);
 
@@ -596,6 +598,9 @@ export function delayedPlayerEffect<TContext extends AbilityContext = AbilityCon
             propertyFactory,
             { delayedEffectType: DelayedEffectType.Player }
         ));
+}
+export function entireDeckSearch<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ISearchEntireDeckProperties<TContext>, TContext>) {
+    return new SearchEntireDeckSystem<TContext>(propertyFactory);
 }
 export function loseGame<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<ILoseGameProperties, TContext>) {
     return new LoseGameSystem<TContext>(propertyFactory);

--- a/server/game/gameSystems/PlayMultipleCardsFromDeckSystem.ts
+++ b/server/game/gameSystems/PlayMultipleCardsFromDeckSystem.ts
@@ -43,7 +43,7 @@ export class PlayMultipleCardsFromDeckSystem<TContext extends AbilityContext = A
         selectAmount: number,
         event: any,
         additionalProperties: Partial<IPlayMultipleCardsFromDeckProperties<TContext>>
-    ): IDisplayCardsSelectProperties {
+    ): IDisplayCardsSelectProperties | null {
         return {
             ...super.buildPromptProperties(cards, properties, context, title, selectAmount, event, additionalProperties),
             multiSelectCondition: (card: Card, currentlySelectedCards: Card[]) =>

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -22,8 +22,12 @@ export interface ISearchDeckProperties<TContext extends AbilityContext = Ability
     targetMode?: TargetMode.UpTo | TargetMode.Single | TargetMode.UpToVariable | TargetMode.Unlimited;
     activePromptTitle?: string;
 
-    /** The number of cards from the top of the deck to search, or a function to determine how many cards to search. Default is -1, which indicates the whole deck. */
-    searchCount?: number | ((context: TContext) => number);
+    /**
+     * The number of cards from the top of the deck to search, or a function to determine how many cards to search. Default is -1, which indicates the whole deck.
+     *
+     * This is currently required while SearchEntireDeckSystem exists, but once the prompt UI issue is fixed we can remove that system and make this optional again.
+     */
+    searchCount: number | ((context: TContext) => number);
     canChooseFewer?: boolean;
 
     /** The number of cards to select from the search, or a function to determine how many cards to select. Default is 1. The targetMode will interact with this to determine the min/max number of cards to retrieve. */
@@ -166,18 +170,22 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
             }
         }
 
-        context.game.promptDisplayCardsForSelection(
-            choosingPlayer,
-            this.buildPromptProperties(
-                cards,
-                properties,
-                context,
-                title,
-                selectAmount,
-                event,
-                additionalProperties
-            )
+        const promptProperties = this.buildPromptProperties(
+            cards,
+            properties,
+            context,
+            title,
+            selectAmount,
+            event,
+            additionalProperties
         );
+
+        if (promptProperties) {
+            context.game.promptDisplayCardsForSelection(
+                choosingPlayer,
+                promptProperties
+            );
+        }
     }
 
     protected buildPromptProperties(
@@ -188,7 +196,7 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
         selectAmount: number,
         event: any,
         additionalProperties: Partial<TProperties>
-    ): IDisplayCardsSelectProperties {
+    ): IDisplayCardsSelectProperties | null {
         return {
             activePromptTitle: title,
             source: context.source,
@@ -205,7 +213,7 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
         };
     }
 
-    private onSearchComplete(properties: ISearchDeckProperties, context: TContext, event: any, selectedCards: Card[], allCards: Card[]): void {
+    protected onSearchComplete(properties: ISearchDeckProperties, context: TContext, event: any, selectedCards: Card[], allCards: Card[]): void {
         event.selectedCards = selectedCards;
         context.selectedPromptCards = Array.from(selectedCards);
 

--- a/server/game/gameSystems/SearchEntireDeckSystem.ts
+++ b/server/game/gameSystems/SearchEntireDeckSystem.ts
@@ -1,0 +1,56 @@
+// allow block comments without spaces so we can have compact jsdoc descriptions in this file
+/* eslint @stylistic/lines-around-comment: off */
+
+import type { AbilityContext } from '../core/ability/AbilityContext.js';
+import type { Card } from '../core/card/Card.js';
+import type { TargetMode } from '../core/Constants.js';
+import type { IDisplayCardsSelectProperties } from '../core/gameSteps/PromptInterfaces.js';
+import { GameSystem } from '../core/gameSystem/GameSystem.js';
+import { SearchDeckSystem, type ISearchDeckProperties } from './SearchDeckSystem.js';
+
+export type ISearchEntireDeckProperties<TContext extends AbilityContext = AbilityContext> = Omit<ISearchDeckProperties<TContext>, 'searchCount' | 'multiSelectCondition' | 'remainingCardsHandler'> & {
+    targetMode?: TargetMode.UpTo | TargetMode.Single;
+};
+
+/**
+ * This system is a hack to address the fact that our display prompt doesn't have scroll and can't show the entire deck at once.
+ * Instead, it will only show the selectable cards from the deck, or pass completely if there are none.
+ *
+ * Once we have fixed the prompt issue, this system can be removed completely.
+ */
+export class SearchEntireDeckSystem<TContext extends AbilityContext = AbilityContext> extends SearchDeckSystem<TContext, ISearchDeckProperties<TContext>> {
+    // constructor needs to do some extra work to ensure that the passed props object ends up as valid for the parent class
+    public constructor(propertiesOrPropertyFactory: ISearchEntireDeckProperties<TContext> | ((context?: AbilityContext) => ISearchEntireDeckProperties<TContext>)) {
+        const propertyWithSearchCount = GameSystem.appendToPropertiesOrPropertyFactory<ISearchDeckProperties<TContext>, 'searchCount'>(propertiesOrPropertyFactory, { searchCount: -1 });
+        super(propertyWithSearchCount);
+    }
+
+    protected override buildPromptProperties(
+        cards: Card[],
+        properties: ISearchDeckProperties<TContext>,
+        context: TContext,
+        title: string,
+        selectAmount: number,
+        event: any,
+        additionalProperties: Partial<ISearchDeckProperties<TContext>>
+    ): IDisplayCardsSelectProperties | null {
+        const selectableCards = cards.filter((card) => properties.cardCondition(card, context));
+
+        if (selectableCards.length === 0) {
+            return null;
+        }
+
+        return {
+            activePromptTitle: title,
+            source: context.source,
+            displayCards: selectableCards,
+            maxCards: selectAmount,
+            canChooseFewer: properties.canChooseFewer || true,
+            validCardCondition: (card: Card) =>
+                properties.cardCondition(card, context) &&
+                (!properties.selectedCardsImmediateEffect || properties.selectedCardsImmediateEffect.canAffect(card, context, additionalProperties)),
+            selectedCardsHandler: (selectedCards: Card[]) =>
+                this.onSearchComplete(properties, context, event, selectedCards, cards)
+        };
+    }
+}

--- a/server/game/gameSystems/SearchEntireDeckSystem.ts
+++ b/server/game/gameSystems/SearchEntireDeckSystem.ts
@@ -9,7 +9,7 @@ import { GameSystem } from '../core/gameSystem/GameSystem.js';
 import { SearchDeckSystem, type ISearchDeckProperties } from './SearchDeckSystem.js';
 
 export type ISearchEntireDeckProperties<TContext extends AbilityContext = AbilityContext> = Omit<ISearchDeckProperties<TContext>, 'searchCount' | 'multiSelectCondition' | 'remainingCardsHandler'> & {
-    targetMode?: TargetMode.UpTo | TargetMode.Single;
+    targetMode?: TargetMode.UpTo | TargetMode.Single | TargetMode.Unlimited;
 };
 
 /**

--- a/test/server/cards/01_SOR/events/SearchYourFeelings.spec.ts
+++ b/test/server/cards/01_SOR/events/SearchYourFeelings.spec.ts
@@ -6,49 +6,120 @@ describe('Search Your Feelings', function() {
                     phase: 'action',
                     player1: {
                         hand: ['search-your-feelings'],
-                        deck: ['battlefield-marine', 'cartel-spacer', 'cell-block-guard', 'pyke-sentinel', 'volunteer-soldier']
+                        deck: ['battlefield-marine', 'han-solo#has-his-moments', 'cell-block-guard', 'pyke-sentinel', 'volunteer-soldier']
                     }
                 });
             });
+
+            const buildCardName = (card) => `${card.title}${card.subtitle ? ', ' + card.subtitle : ''}`;
+
+            // TODO: uncomment these when we revert back to using the full display prompt for deck search
+            // it('should be able to retrieve ANY card from the deck', function () {
+            //     const { context } = contextRef;
+
+            //     // Play card
+            //     context.player1.clickCard(context.searchYourFeelings);
+            //     expect(context.searchYourFeelings).toBeInZone('discard');
+
+            //     expect(context.player1).toHaveExactDisplayPromptCards({
+            //         selectable: [context.battlefieldMarine, context.cartelSpacer, context.cellBlockGuard,
+            //             context.pykeSentinel, context.volunteerSoldier],
+            //     });
+            //     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+
+            //     // Choose card
+            //     context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
+            //     expect(context.player2).toBeActivePlayer();
+            //     expect(context.battlefieldMarine).toBeInZone('hand');
+            //     expect(context.player1.deck.length).toBe(4);
+            // });
+
+            // it('should be able to choose no cards', function () {
+            //     const { context } = contextRef;
+
+            //     // Play card
+            //     context.player1.clickCard(context.searchYourFeelings);
+            //     expect(context.searchYourFeelings).toBeInZone('discard');
+
+            //     expect(context.player1).toHaveExactDisplayPromptCards({
+            //         selectable: [context.battlefieldMarine, context.cartelSpacer, context.cellBlockGuard,
+            //             context.pykeSentinel, context.volunteerSoldier],
+            //     });
+            //     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+
+            //     // Choose card
+            //     context.player1.clickPrompt('Take nothing');
+            //     expect(context.player2).toBeActivePlayer();
+            //     expect(context.player1.deck.length).toBe(5);
+            // });
+
+            // it('works with just one card in deck', function () {
+            //     const { context } = contextRef;
+
+            //     // Set up deck
+            //     context.player1.setDeck([context.battlefieldMarine]);
+
+            //     // Play card
+            //     context.player1.clickCard(context.searchYourFeelings);
+            //     expect(context.searchYourFeelings).toBeInZone('discard');
+            //     expect(context.player1).toHaveExactDisplayPromptCards({
+            //         selectable: [context.battlefieldMarine],
+            //     });
+            //     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+
+            //     // Choose card
+            //     context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
+            //     expect(context.player2).toBeActivePlayer();
+            // });
 
             it('should be able to retrieve ANY card from the deck', function () {
                 const { context } = contextRef;
 
                 // Play card
                 context.player1.clickCard(context.searchYourFeelings);
-                expect(context.searchYourFeelings).toBeInZone('discard');
 
-                expect(context.player1).toHaveExactDisplayPromptCards({
-                    selectable: [context.battlefieldMarine, context.cartelSpacer, context.cellBlockGuard,
-                        context.pykeSentinel, context.volunteerSoldier],
-                });
-                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+                expect(context.player1).toHaveExactDropdownListOptions([
+                    context.battlefieldMarine,
+                    context.hanSolo,
+                    context.cellBlockGuard,
+                    context.pykeSentinel,
+                    context.volunteerSoldier
+                ].map((card) => buildCardName(card)));
+                // expect(context.player1).toHaveEnabledPromptButton('Take nothing');   // TODO: uncomment when this works again
 
                 // Choose card
-                context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
+                context.player1.chooseListOption('Battlefield Marine');
+                expect(context.getChatLogs(3).join('\n')).not.toContain('Battlefield Marine');
                 expect(context.player2).toBeActivePlayer();
+                expect(context.searchYourFeelings).toBeInZone('discard');
                 expect(context.battlefieldMarine).toBeInZone('hand');
                 expect(context.player1.deck.length).toBe(4);
             });
 
-            it('should be able to choose no cards', function () {
-                const { context } = contextRef;
+            // TODO: uncomment this when we either (a) add the ability to choose no cards in the dropdown list prompt,
+            // or (b) revert back to using the full display prompt for deck search
 
-                // Play card
-                context.player1.clickCard(context.searchYourFeelings);
-                expect(context.searchYourFeelings).toBeInZone('discard');
+            // it('should be able to choose no cards', function () {
+            //     const { context } = contextRef;
 
-                expect(context.player1).toHaveExactDisplayPromptCards({
-                    selectable: [context.battlefieldMarine, context.cartelSpacer, context.cellBlockGuard,
-                        context.pykeSentinel, context.volunteerSoldier],
-                });
-                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+            //     // Play card
+            //     context.player1.clickCard(context.searchYourFeelings);
 
-                // Choose card
-                context.player1.clickPrompt('Take nothing');
-                expect(context.player2).toBeActivePlayer();
-                expect(context.player1.deck.length).toBe(5);
-            });
+            //     expect(context.player1).toHaveExactDropdownListOptions([
+            //         context.battlefieldMarine,
+            //         context.cartelSpacer,
+            //         context.cellBlockGuard,
+            //         context.pykeSentinel,
+            //         context.volunteerSoldier
+            //     ].map((card) => buildCardName(card)));
+            //     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+
+            //     // Choose card
+            //     context.player1.clickPrompt('Take nothing');
+            //     expect(context.player2).toBeActivePlayer();
+            //     expect(context.player1.deck.length).toBe(5);
+            //     expect(context.searchYourFeelings).toBeInZone('discard');
+            // });
 
             it('works with just one card in deck', function () {
                 const { context } = contextRef;
@@ -58,14 +129,10 @@ describe('Search Your Feelings', function() {
 
                 // Play card
                 context.player1.clickCard(context.searchYourFeelings);
-                expect(context.searchYourFeelings).toBeInZone('discard');
-                expect(context.player1).toHaveExactDisplayPromptCards({
-                    selectable: [context.battlefieldMarine],
-                });
-                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
-                // Choose card
-                context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
+                // Battlefield Marine is automatically selected since it's the only card
+                expect(context.getChatLogs(3).join('\n')).not.toContain('Battlefield Marine');
+                expect(context.battlefieldMarine).toBeInZone('hand');
                 expect(context.player2).toBeActivePlayer();
             });
 
@@ -106,7 +173,7 @@ describe('Search Your Feelings', function() {
 
                 // Take nothing (deck will still shuffle)
                 context.player1.clickCard(context.searchYourFeelings);
-                context.player1.clickPrompt('Take nothing');
+                // expect(context.player1).toHaveEnabledPromptButton('Take nothing');   // TODO: uncomment when this works again
 
                 expect(preShuffleDeck).not.toEqual(context.player1.deck);
             });

--- a/test/server/cards/02_SHD/events/BountyPosting.spec.ts
+++ b/test/server/cards/02_SHD/events/BountyPosting.spec.ts
@@ -21,7 +21,7 @@ describe('Bounty Posting', function() {
                 context.player1.clickCard(context.bountyPosting);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.deathMark, context.topTarget],
-                    invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
+                    // invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]   // TODO: uncomment when we re-enable full deck search
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -62,7 +62,7 @@ describe('Bounty Posting', function() {
                 context.player1.clickCard(context.bountyPosting);
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [context.deathMark, context.topTarget],
-                    invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
+                    // invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]   // TODO: uncomment when we re-enable full deck search
                 });
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
@@ -88,12 +88,14 @@ describe('Bounty Posting', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.bountyPosting);
-                expect(context.player1).toHaveExactDisplayPromptCards({
-                    invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
-                });
-                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
 
-                context.player1.clickPrompt('Take nothing');
+                // TODO: uncomment when we re-enable full deck search
+                // expect(context.player1).toHaveExactDisplayPromptCards({
+                //     invalid: [context.tielnFighter, context.cellBlockGuard, context.pykeSentinel, context.hylobonEnforcer]
+                // });
+                // expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+                // context.player1.clickPrompt('Take nothing');
+
                 expect(context.player2).toBeActivePlayer();
             });
         });

--- a/test/server/cards/03_TWI/leaders/PreVizslaPursuingTheThrone.spec.ts
+++ b/test/server/cards/03_TWI/leaders/PreVizslaPursuingTheThrone.spec.ts
@@ -28,7 +28,6 @@ describe('Pre Vizsla, Pursuing the Throne', function () {
 
             // draw a specific cards
             context.player1.clickCard(context.searchYourFeelings);
-            context.player1.clickCardInDisplayCardPrompt(context.avenger);
             context.player2.passAction();
 
             const exhaustedResourceCount = context.player1.exhaustedResourceCount;

--- a/test/server/cards/03_TWI/units/Clone.spec.ts
+++ b/test/server/cards/03_TWI/units/Clone.spec.ts
@@ -913,6 +913,8 @@ describe('Clone', function() {
                 context.player2.clickCard(context.annihilator);
                 context.player2.clickCard(context.clone);
                 context.player2.clickPrompt('Done');
+                context.player2.clickCardInDisplayCardPrompt(inDeckWampa);
+                context.player2.clickPrompt('Done');
                 expect(context.clone).toBeInZone('discard');
                 expect(context.clone).toBeVanillaClone();
                 expect(inHandWampa).toBeInZone('discard');

--- a/test/server/cards/04_JTL/units/AnnihilatorTaggesFlagship.spec.ts
+++ b/test/server/cards/04_JTL/units/AnnihilatorTaggesFlagship.spec.ts
@@ -162,7 +162,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 // Player sees the opponent's deck
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [inDeckBoba, inDeckPilotBoba],
-                    // invalid: [context.cartelSpacer]
+                    // invalid: [context.cartelSpacer]      // TODO: uncomment when we re-enable full deck search
                 });
 
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -224,7 +224,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 // Player sees the opponent's deck
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [inDeckBoba, inDeckPilotBoba],
-                    // invalid: [context.cartelSpacer]
+                    // invalid: [context.cartelSpacer]      // TODO: uncomment when we re-enable full deck search
                 });
 
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -284,7 +284,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
             //     // Player sees the opponent's deck
             //     expect(context.player1).toHaveExactDisplayPromptCards({
             //         selectable: [inDeckLurkingTIE],
-            //         invalid: [context.cartelSpacer]
+            //         invalid: [context.cartelSpacer]      // TODO: uncomment when we re-enable full deck search
             //     });
 
             //     expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -332,7 +332,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 // Player sees the opponent's deck
                 expect(context.player1).toHaveExactDisplayPromptCards({
                     selectable: [inDeckBoba, inDeckPilotBoba],
-                    // invalid: [context.cartelSpacer]
+                    // invalid: [context.cartelSpacer]      // TODO: uncomment when we re-enable full deck search
                 });
 
                 context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
@@ -394,7 +394,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
             // Search deck for Bobas
             expect(context.player1).toHaveExactDisplayPromptCards({
                 selectable: [inDeckBoba, inDeckPilotBoba],
-                // invalid: [context.cartelSpacer]
+                // invalid: [context.cartelSpacer]      // TODO: uncomment when we re-enable full deck search
             });
 
             context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
@@ -446,7 +446,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
             // Search deck for L3's
             expect(context.player1).toHaveExactDisplayPromptCards({
                 selectable: [inDeckL337, inDeckL337Pilot],
-                // invalid: [context.cartelSpacer]
+                // invalid: [context.cartelSpacer]      // TODO: uncomment when we re-enable full deck search
             });
 
             context.player1.clickCardInDisplayCardPrompt(inDeckL337);

--- a/test/server/cards/04_JTL/units/AnnihilatorTaggesFlagship.spec.ts
+++ b/test/server/cards/04_JTL/units/AnnihilatorTaggesFlagship.spec.ts
@@ -159,21 +159,20 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 context.player1.clickCard(inPlayBoba);
                 expect(inPlayBoba).toBeInZone('discard');
 
-                // TODO: these are commented out pending some fixes for the FE prompt for this
-                // // Player sees the opponent's deck
-                // expect(context.player1).toHaveExactDisplayPromptCards({
-                //     selectable: [inDeckBoba, inDeckPilotBoba],
-                //     invalid: [context.cartelSpacer]
-                // });
+                // Player sees the opponent's deck
+                expect(context.player1).toHaveExactDisplayPromptCards({
+                    selectable: [inDeckBoba, inDeckPilotBoba],
+                    // invalid: [context.cartelSpacer]
+                });
 
-                // expect(context.player1).toHaveEnabledPromptButton('Take nothing');
-                // expect(context.player2).toHavePrompt('Waiting for opponent to use Annihilator');
+                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+                expect(context.player2).toHavePrompt('Waiting for opponent to use Annihilator');
 
-                // context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
-                // expect(context.player1).toHaveEnabledPromptButton('Done');
+                context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
+                expect(context.player1).toHaveEnabledPromptButton('Done');
 
-                // context.player1.clickCardInDisplayCardPrompt(inDeckPilotBoba);
-                // context.player1.clickPrompt('Done');
+                context.player1.clickCardInDisplayCardPrompt(inDeckPilotBoba);
+                context.player1.clickPrompt('Done');
 
                 expect(inDeckBoba).toBeInZone('discard');
                 expect(inDeckPilotBoba).toBeInZone('discard');
@@ -222,21 +221,20 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 expect(inHandBoba).toBeInZone('discard');
                 expect(inHandPilotBoba).toBeInZone('discard');
 
-                // TODO: these are commented out pending some fixes for the FE prompt for this
-                // // Player sees the opponent's deck
-                // expect(context.player1).toHaveExactDisplayPromptCards({
-                //     selectable: [inDeckBoba, inDeckPilotBoba],
-                //     invalid: [context.cartelSpacer]
-                // });
+                // Player sees the opponent's deck
+                expect(context.player1).toHaveExactDisplayPromptCards({
+                    selectable: [inDeckBoba, inDeckPilotBoba],
+                    // invalid: [context.cartelSpacer]
+                });
 
-                // expect(context.player1).toHaveEnabledPromptButton('Take nothing');
-                // expect(context.player2).toHavePrompt('Waiting for opponent to use Annihilator');
+                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+                expect(context.player2).toHavePrompt('Waiting for opponent to use Annihilator');
 
-                // context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
-                // expect(context.player1).toHaveEnabledPromptButton('Done');
+                context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
+                expect(context.player1).toHaveEnabledPromptButton('Done');
 
-                // context.player1.clickCardInDisplayCardPrompt(inDeckPilotBoba);
-                // context.player1.clickPrompt('Done');
+                context.player1.clickCardInDisplayCardPrompt(inDeckPilotBoba);
+                context.player1.clickPrompt('Done');
 
                 expect(inDeckBoba).toBeInZone('discard');
                 expect(inDeckPilotBoba).toBeInZone('discard');
@@ -321,7 +319,7 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 const inHandBoba = context.player2.findCardByName('boba-fett#disintegrator', 'hand');
                 const inHandPilotBoba = context.player2.findCardByName('boba-fett#feared-bounty-hunter', 'hand');
                 const inDeckBoba = context.player2.findCardByName('boba-fett#disintegrator', 'deck');
-                // const inDeckPilotBoba = context.player2.findCardByName('boba-fett#feared-bounty-hunter', 'deck'); see below TODO
+                const inDeckPilotBoba = context.player2.findCardByName('boba-fett#feared-bounty-hunter', 'deck');
 
                 context.player1.clickCard(context.annihilator);
                 context.player1.clickCard(player2LeaderBoba);
@@ -331,19 +329,18 @@ describe('Annihilator, Tagge\'s Flagship', function() {
                 expect(inHandBoba).toBeInZone('discard');
                 expect(inHandPilotBoba).toBeInZone('discard');
 
-                // TODO: these are commented out pending some fixes for the FE prompt for this
-                // // Player sees the opponent's deck
-                // expect(context.player1).toHaveExactDisplayPromptCards({
-                //     selectable: [inDeckBoba, inDeckPilotBoba],
-                //     invalid: [context.cartelSpacer]
-                // });
+                // Player sees the opponent's deck
+                expect(context.player1).toHaveExactDisplayPromptCards({
+                    selectable: [inDeckBoba, inDeckPilotBoba],
+                    // invalid: [context.cartelSpacer]
+                });
 
-                // context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
-                // expect(context.player1).toHaveEnabledPromptButton('Done');
-                // context.player1.clickPrompt('Done');
+                context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
+                expect(context.player1).toHaveEnabledPromptButton('Done');
+                context.player1.clickPrompt('Done');
 
                 expect(inDeckBoba).toBeInZone('discard');
-                // expect(inDeckPilotBoba).toBeInZone('deck'); see above TODO
+                expect(inDeckPilotBoba).toBeInZone('deck');
                 expect(context.player2).toBeActivePlayer();
             });
         });
@@ -394,18 +391,17 @@ describe('Annihilator, Tagge\'s Flagship', function() {
             expect(inHandBoba).toBeInZone('discard');
             expect(inHandPilotBoba).toBeInZone('discard');
 
-            // TODO: these are commented out pending some fixes for the FE prompt for this
-            // // Search deck for Bobas
-            // expect(context.player1).toHaveExactDisplayPromptCards({
-            //     selectable: [inDeckBoba, inDeckPilotBoba],
-            //     invalid: [context.cartelSpacer]
-            // });
+            // Search deck for Bobas
+            expect(context.player1).toHaveExactDisplayPromptCards({
+                selectable: [inDeckBoba, inDeckPilotBoba],
+                // invalid: [context.cartelSpacer]
+            });
 
-            // context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
-            // expect(context.player1).toHaveEnabledPromptButton('Done');
+            context.player1.clickCardInDisplayCardPrompt(inDeckBoba);
+            expect(context.player1).toHaveEnabledPromptButton('Done');
 
-            // context.player1.clickCardInDisplayCardPrompt(inDeckPilotBoba);
-            // context.player1.clickPrompt('Done');
+            context.player1.clickCardInDisplayCardPrompt(inDeckPilotBoba);
+            context.player1.clickPrompt('Done');
 
             expect(inDeckBoba).toBeInZone('discard');
             expect(inDeckPilotBoba).toBeInZone('discard');
@@ -440,6 +436,23 @@ describe('Annihilator, Tagge\'s Flagship', function() {
             context.player1.clickCard(inPlayL337);
             context.player2.clickPrompt('Trigger');
             context.player2.clickCard(context.atst);
+
+            // click "Done" for hand display prompt and discard L3's from hand
+            context.player1.clickPrompt('Done');
+
+            expect(inHandL337).toBeInZone('discard');
+            expect(inHandL337Pilot).toBeInZone('discard');
+
+            // Search deck for L3's
+            expect(context.player1).toHaveExactDisplayPromptCards({
+                selectable: [inDeckL337, inDeckL337Pilot],
+                // invalid: [context.cartelSpacer]
+            });
+
+            context.player1.clickCardInDisplayCardPrompt(inDeckL337);
+            expect(context.player1).toHaveEnabledPromptButton('Done');
+
+            context.player1.clickCardInDisplayCardPrompt(inDeckL337Pilot);
             context.player1.clickPrompt('Done');
 
             expect(context.atst).toHaveExactUpgradeNames(['l337#get-out-of-my-seat']);


### PR DESCRIPTION
We have a UI issue currently where the card display prompt can't show the entire deck since it doesn't have a scroll option, so it can overwhelm the screen.

Made some adjustments to the cards that need to search the whole deck to make them at least playable for now:

- Bounty Posting: now will only show the selectable cards from the deck instead of the whole deck
- Annihilator: already had a similar workaround to Bounty Posting, just made it _slightly_ less incorrect in that the player can now choose how many copies to remove from the deck
- Search Your Feelings: now uses a dropdown list of card names instead the card display. there's a little bit of a rules issue where right now we can't offer the option to choose no card, since the dropdown UI doesn't have support for extra buttons. Will work on this