### PR TITLE
Generalize hidden icon for 'cannot be attacked' restriction

### DIFF
--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -1101,7 +1101,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
         public override getSummary(activePlayer: Player) {
             if (this.isInPlay()) {
                 const hasSentinel = this.hasSomeKeyword(KeywordName.Sentinel);
-                const isHidden = !hasSentinel && this.hasSomeKeyword(KeywordName.Hidden) && this.wasPlayedThisPhase();
+                const cannotBeAttacked = (this.hasRestriction(AbilityRestriction.BeAttacked) && !hasSentinel);
                 const clonedCardSetId = this.hasOngoingEffect(EffectName.CloneUnit) ? this.getOngoingEffectValues<Card>(EffectName.CloneUnit)[0].setId : null;
 
                 return {
@@ -1109,7 +1109,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
                     power: this.getPower(),
                     hp: this.getHp(),
                     sentinel: hasSentinel,
-                    hidden: isHidden,
+                    hidden: cannotBeAttacked,
                     isAttacker: this.isInPlay() && this.isUnit() && (this.isAttacking() || this.controller.getAttackerHighlightingState(this)),
                     isDefender: this.isInPlay() && this.isUnit() && this.isDefending(),
                     clonedCardId: clonedCardSetId,


### PR DESCRIPTION
| Effect active | Effect not active |
| :---: | :---: |
| <img width="800" height="1056" alt="Screenshot 2025-07-17 at 10 40 37 AM" src="https://github.com/user-attachments/assets/7c689faa-4f5c-4e86-9b70-33f03f114ba5" /> | <img width="800" height="1056" alt="Screenshot 2025-07-17 at 10 41 11 AM" src="https://github.com/user-attachments/assets/dc3f3e6f-3e68-4f89-b969-b66a1e2d5fab" /> |
