### PR TITLE
Fix issue with newly active prompt property coming up too much

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -184,6 +184,8 @@ class Game extends EventEmitter {
         this.currentAttack = null;
         this.currentPhase = null;
         this.currentActionWindow = null;
+
+        /** @type {import('./gameSteps/prompts/UiPrompt.js').UiPrompt} */
         this.currentOpenPrompt = null;
 
         /** @type { import('./snapshot/SnapshotInterfaces.js').IGameState } */

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -153,6 +153,8 @@ export class Player extends GameObject<IPlayerState> {
     private noTimer: boolean;
     private _lastActionId = 0;
 
+    public activeForPreviousPrompt = false;
+
     public constructor(id: string, user: IUser, game: Game, useTimer = false) {
         super(game, user.username);
 

--- a/server/game/core/gameSteps/prompts/GameOverPrompt.js
+++ b/server/game/core/gameSteps/prompts/GameOverPrompt.js
@@ -19,14 +19,16 @@ class GameOverPrompt extends AllPlayerPrompt {
                 promptTitle: 'Tie Game',
                 menuTitle: 'The game ended in a draw!',
                 buttons: [{ text: 'Continue Playing', arg: 'continue' }],
-                promptUuid: this.uuid
+                promptUuid: this.uuid,
+                playerIsNewlyActive: true
             };
         }
         return {
             promptTitle: 'Game Won',
             menuTitle: this.winner.name + ' has won the game!',
             buttons: [{ text: 'Continue Playing', arg: 'continue' }],
-            promptUuid: this.uuid
+            promptUuid: this.uuid,
+            playerIsNewlyActive: true
         };
     }
 

--- a/server/game/core/gameSteps/prompts/GameOverPrompt.js
+++ b/server/game/core/gameSteps/prompts/GameOverPrompt.js
@@ -19,16 +19,14 @@ class GameOverPrompt extends AllPlayerPrompt {
                 promptTitle: 'Tie Game',
                 menuTitle: 'The game ended in a draw!',
                 buttons: [{ text: 'Continue Playing', arg: 'continue' }],
-                promptUuid: this.uuid,
-                playerIsNewlyActive: true
+                promptUuid: this.uuid
             };
         }
         return {
             promptTitle: 'Game Won',
             menuTitle: this.winner.name + ' has won the game!',
             buttons: [{ text: 'Continue Playing', arg: 'continue' }],
-            promptUuid: this.uuid,
-            playerIsNewlyActive: true
+            promptUuid: this.uuid
         };
     }
 

--- a/server/game/core/gameSteps/prompts/UiPrompt.ts
+++ b/server/game/core/gameSteps/prompts/UiPrompt.ts
@@ -16,7 +16,7 @@ export abstract class UiPrompt extends BaseStep {
 
     // indicates that the player just became active for this prompt
     // this is passed to the FE for the sake of being able to inform the player by e.g. making a sound
-    private playerIsNewlyActive = false;
+    private playerIsNewlyActive = new Map<Player, boolean>();
 
     public constructor(game: Game) {
         super(game);
@@ -29,16 +29,24 @@ export abstract class UiPrompt extends BaseStep {
     public abstract activePromptInternal(player: Player): IPlayerPromptStateProperties;
 
     public activePrompt(player: Player): IPlayerPromptStateProperties {
-        return { ...this.activePromptInternal(player), playerIsNewlyActive: this.playerIsNewlyActive };
+        return {
+            playerIsNewlyActive: this.playerIsNewlyActive.get(player) || false,
+            ...this.activePromptInternal(player)
+        };
     }
 
     public override continue(): boolean {
         if (this.firstContinue) {
             this.previousPrompt = this.game.currentOpenPrompt;
             this.game.currentOpenPrompt = this;
-            this.playerIsNewlyActive = true;
+
+            for (const player of this.game.getPlayers()) {
+                this.playerIsNewlyActive.set(player, !this.previousPrompt || !this.previousPrompt.activeCondition(player));
+            }
         } else {
-            this.playerIsNewlyActive = false;
+            for (const player of this.game.getPlayers()) {
+                this.playerIsNewlyActive.set(player, false);
+            }
         }
 
         const completed = this.isComplete();

--- a/server/game/core/gameSteps/prompts/UiPrompt.ts
+++ b/server/game/core/gameSteps/prompts/UiPrompt.ts
@@ -41,7 +41,7 @@ export abstract class UiPrompt extends BaseStep {
             this.game.currentOpenPrompt = this;
 
             for (const player of this.game.getPlayers()) {
-                this.playerIsNewlyActive.set(player, !this.previousPrompt || !this.previousPrompt.activeCondition(player));
+                this.playerIsNewlyActive.set(player, !player.activeForPreviousPrompt);
             }
         } else {
             for (const player of this.game.getPlayers()) {
@@ -83,12 +83,14 @@ export abstract class UiPrompt extends BaseStep {
     public setPrompt(): void {
         for (const player of this.game.getPlayers()) {
             if (this.activeCondition(player)) {
+                player.activeForPreviousPrompt = true;
                 player.setPrompt(this.addButtonDefaultsToPrompt(this.activePrompt(player)));
 
                 if (this.firstContinue) {
                     this.startActionTimer(player);
                 }
             } else {
+                player.activeForPreviousPrompt = false;
                 player.setPrompt(this.waitingPrompt());
                 player.actionTimer.stop();
             }


### PR DESCRIPTION
The property indicating that the FE should play the "it's your action" sound was coming up too frequently because it would happen _any_ time the player was prompted. It now tracks whether the user was active for the most recent prompt and uses that to control the property, so they won't be prompted for multiple prompts in a row.