### PR TITLE
Fix server error with Calculated Lethality

### DIFF
--- a/server/game/cards/02_SHD/events/CalculatedLethality.ts
+++ b/server/game/cards/02_SHD/events/CalculatedLethality.ts
@@ -18,16 +18,21 @@ export default class CalculatedLethality extends EventCard {
                 cardCondition: (card) => card.isNonLeaderUnit() && card.cost <= 3,
                 immediateEffect: AbilityHelper.immediateEffects.defeat(),
             },
-            then: (thenContext) => ({
-                title: 'For each upgrade that was on that unit, give an Experience token to a friendly unit.',
-                thenCondition: () => thenContext.events?.length > 0,
-                immediateEffect: AbilityHelper.immediateEffects.distributeExperienceAmong({
-                    amountToDistribute: thenContext.events[0].lastKnownInformation.upgrades.length,
-                    cardTypeFilter: WildcardCardType.Unit,
-                    controller: RelativePlayer.Self,
-                    canChooseNoTargets: false,
-                })
-            })
+            ifYouDo: (ifYouDoContext) => {
+                const upgradeCount = ifYouDoContext.target.isInPlay()
+                    ? ifYouDoContext.target.upgrades.length
+                    : ifYouDoContext.events[0].lastKnownInformation.upgrades.length;
+
+                return {
+                    title: 'For each upgrade that was on that unit, give an Experience token to a friendly unit.',
+                    immediateEffect: AbilityHelper.immediateEffects.distributeExperienceAmong({
+                        amountToDistribute: upgradeCount,
+                        cardTypeFilter: WildcardCardType.Unit,
+                        controller: RelativePlayer.Self,
+                        canChooseNoTargets: false,
+                    })
+                };
+            }
         });
     }
 }

--- a/server/game/cards/02_SHD/events/CalculatedLethality.ts
+++ b/server/game/cards/02_SHD/events/CalculatedLethality.ts
@@ -18,13 +18,16 @@ export default class CalculatedLethality extends EventCard {
                 cardCondition: (card) => card.isNonLeaderUnit() && card.cost <= 3,
                 immediateEffect: AbilityHelper.immediateEffects.defeat(),
             },
-            ifYouDo: (ifYouDoContext) => {
-                const upgradeCount = ifYouDoContext.target.isInPlay()
-                    ? ifYouDoContext.target.upgrades.length
-                    : ifYouDoContext.events[0].lastKnownInformation.upgrades.length;
+            then: (thenContext) => {
+                const upgradeCount = thenContext.target
+                    ? (thenContext.target.isInPlay()
+                        ? thenContext.target.upgrades.length
+                        : thenContext.events[0].lastKnownInformation.upgrades.length)
+                    : 0;
 
                 return {
                     title: 'For each upgrade that was on that unit, give an Experience token to a friendly unit.',
+                    thenCondition: () => thenContext.target,
                     immediateEffect: AbilityHelper.immediateEffects.distributeExperienceAmong({
                         amountToDistribute: upgradeCount,
                         cardTypeFilter: WildcardCardType.Unit,

--- a/test/server/cards/02_SHD/events/CalculatedLethality.spec.ts
+++ b/test/server/cards/02_SHD/events/CalculatedLethality.spec.ts
@@ -72,7 +72,76 @@ describe('Calculated Lethality', function () {
                 expect(context.fifthBrother).toBeInZone('discard');
                 expect(context.corellianFreighter).toHaveExactUpgradeNames(['experience', 'experience', 'experience']);
             });
-            // TODO ADD A TEST WITH LURKIN TIE PHANTOM
+
+            it('does not defeat Lurking TIE Phantom, but does still distribute experience', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['calculated-lethality'],
+                        groundArena: [
+                            'pyke-sentinel'
+                        ]
+                    },
+                    player2: {
+                        spaceArena: [
+                            { card: 'lurking-tie-phantom', upgrades: ['experience', 'experience'] }
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.calculatedLethality);
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.pykeSentinel,
+                    context.lurkingTiePhantom
+                ]);
+                context.player1.clickCard(context.lurkingTiePhantom);
+
+                expect(context.lurkingTiePhantom).toBeInZone('spaceArena');
+
+                // TODO: Experience should still be distributed since the defeat effect was replaced
+
+                // context.player1.setDistributeExperiencePromptState(new Map([
+                //     [context.pykeSentinel, 2]
+                // ]));
+
+                // expect(context.pykeSentinel).toHaveExactUpgradeNames(['experience', 'experience']);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should do nothing if no unit can be targeted', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['calculated-lethality']
+                    },
+                    player2: {
+                        groundArena: [
+                            {
+                                card: 'iden-versio#adapt-or-die',
+                                damage: 0,
+                                exhausted: true,
+                                upgrades: [
+                                    'shield',
+                                    'legal-authority'
+                                ],
+                                capturedUnits: [
+                                    'resupply-carrier'
+                                ]
+                            }
+                        ],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.calculatedLethality);
+                expect(context.player1).toHavePrompt('Playing Calculated Lethality will have no effect. Are you sure you want to play it?');
+
+                context.player1.clickPrompt('Play anyway');
+                expect(context.player2).toBeActivePlayer();
+            });
         });
     });
 });

--- a/test/server/cards/02_SHD/events/CalculatedLethality.spec.ts
+++ b/test/server/cards/02_SHD/events/CalculatedLethality.spec.ts
@@ -100,13 +100,7 @@ describe('Calculated Lethality', function () {
 
                 expect(context.lurkingTiePhantom).toBeInZone('spaceArena');
 
-                // TODO: Experience should still be distributed since the defeat effect was replaced
-
-                // context.player1.setDistributeExperiencePromptState(new Map([
-                //     [context.pykeSentinel, 2]
-                // ]));
-
-                // expect(context.pykeSentinel).toHaveExactUpgradeNames(['experience', 'experience']);
+                expect(context.pykeSentinel).toHaveExactUpgradeNames(['experience', 'experience']);
                 expect(context.player2).toBeActivePlayer();
             });
 


### PR DESCRIPTION
Fixes #1534

Calculated Lethality was causing a server error when there were no units to target because the `lastKnownInformation` was undefined.