### PR TITLE
Undo: fix event listener cleanup for rolled-back objects

### DIFF
--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -73,6 +73,15 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     protected afterSetState(oldState: T) { }
 
+    /**
+     * A function for game to call on all objects if they are being removed from the GameObject list (typically after a rollback to before the object was created).
+     * This is intended to be used for cleanup of any state that the object has that is not part of the state object.
+     *
+     * The most common example is removing event handlers that have been registered on Game.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public cleanupOnRemove(oldState: T) { }
+
     /** Creates a Ref to this GO that can be used to do a lookup to the object. This should be the *only* way a Ref is ever created. */
     public getRef<T extends GameObjectBase = this>(): GameObjectRef<T> {
         const ref = { isRef: true, uuid: this.state.uuid };

--- a/server/game/core/ability/AbilityLimit.ts
+++ b/server/game/core/ability/AbilityLimit.ts
@@ -49,6 +49,12 @@ export abstract class AbilityLimit<TState extends IAbilityLimitState = IAbilityL
         }
     }
 
+    public override cleanupOnRemove(oldState: TState): void {
+        if (oldState.isRegistered) {
+            this.unregisterEvents();
+        }
+    }
+
     public registerEvents(): void {
         this.state.isRegistered = true;
     }

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -272,4 +272,10 @@ export default class TriggeredAbility extends CardAbility<ITriggeredAbillityStat
             }
         }
     }
+
+    public override cleanupOnRemove(oldState: ITriggeredAbillityState): void {
+        if (oldState.isRegistered) {
+            this.unregisterEvents();
+        }
+    }
 }

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -265,6 +265,7 @@ export class OngoingEffectEngine extends GameObjectBase<IOngoingEffectState> {
         return this.effects.map((effect) => effect.getDebugInfo());
     }
 
+    // TODO THIS PR: what do we need to do with this?
     public override afterSetAllState(prevState: IOngoingEffectState) {
         for (const currEffect of this.state.effects) {
             if (!prevState.effects.some((x) => x.uuid === currEffect.uuid)) {

--- a/server/game/core/snapshot/GameStateManager.ts
+++ b/server/game/core/snapshot/GameStateManager.ts
@@ -62,12 +62,13 @@ export class GameStateManager implements IGameObjectRegistrar {
         const removals: { index: number; go: GameObjectBase; oldState: IGameObjectBaseState }[] = [];
         const updates: { go: GameObjectBase; oldState: IGameObjectBaseState }[] = [];
 
+        const snapshotStatesByUuid = new Map<string, IGameObjectBaseState>(snapshot.states.map((x) => [x.uuid, x]));
+
         // Indexes in last to first for the purpose of removal.
         for (let i = this.allGameObjects.length - 1; i >= 0; i--) {
             const go = this.allGameObjects[i];
 
-            // NOTE: We aren't removing GameObjects, but this makes room for it.
-            const updatedState = snapshot.states.find((x) => x.uuid === go.uuid);
+            const updatedState = snapshotStatesByUuid.get(go.uuid);
             if (!updatedState) {
                 removals.push({ index: i, go, oldState: go.getState() });
                 continue;


### PR DESCRIPTION
GameObjects that registered event listeners might leave state hanging if they are removed from the GameObject list completely instead of being rolled back to an "unregistered" state. Fixed this by adding a cleanup method that is called when GOs are removed completely, which handles unregistration.

Also cleaned up a couple N^2 `find()` operations which improved undo test time by 3x.