### PR TITLE
Automatically clean up GameObjects that aren't referenced

### DIFF
--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -29,12 +29,20 @@ export interface GameObjectRef<T extends GameObjectBase = GameObjectBase> {
 /** GameObjectBase simply defines this as an object with state, and with a unique identifier. */
 @registerState()
 export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjectBaseState> implements IGameObjectBase<T> {
+    public readonly game: Game;
+
     protected state: T;
 
     private _hasRef = false;
 
     public get hasRef() {
-        return this._hasRef;
+        return this._hasRef || this.alwaysTrackState;
+    }
+
+    /** Subclasses can override this to force the state manager to keep track of this object, even if refs aren't created for it */
+    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+    protected get alwaysTrackState() {
+        return false;
     }
 
     /** ID given by the game engine. */
@@ -47,9 +55,8 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
         this.state.uuid = value;
     }
 
-    public constructor(
-        public readonly game: Game
-    ) {
+    public constructor(game: Game) {
+        this.game = game;
         // @ts-expect-error state is a generic object that is defined by the deriving classes, it's essentially w/e the children want it to be.
         this.state = {};
         // All state defaults *must* happen before registration, so we can't rely on the derived constructor to set the defaults as register will already be called.

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -31,6 +31,12 @@ export interface GameObjectRef<T extends GameObjectBase = GameObjectBase> {
 export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjectBaseState> implements IGameObjectBase<T> {
     protected state: T;
 
+    private _hasRef = false;
+
+    public get hasRef() {
+        return this._hasRef;
+    }
+
     /** ID given by the game engine. */
     public get uuid() {
         return this.state.uuid;
@@ -87,6 +93,8 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
 
     /** Creates a Ref to this GO that can be used to do a lookup to the object. This should be the *only* way a Ref is ever created. */
     public getRef<T extends GameObjectBase = this>(): GameObjectRef<T> {
+        this._hasRef = true;
+
         const ref = { isRef: true, uuid: this.state.uuid };
 
         if (Helpers.isDevelopment()) {

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -48,7 +48,7 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     }
 
     public constructor(
-        public game: Game
+        public readonly game: Game
     ) {
         // @ts-expect-error state is a generic object that is defined by the deriving classes, it's essentially w/e the children want it to be.
         this.state = {};

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -75,6 +75,11 @@ export class Player extends GameObject<IPlayerState> {
     public disconnected: boolean;
     public left: boolean;
 
+    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+    public override get hasRef(): boolean {
+        return true;
+    }
+
     // TODO: Convert all Zones to Refs and let the GameStateManager keep them there alone?
     public get handZone(): HandZone {
         return this.game.gameObjectManager.get(this.state.handZone);

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -76,7 +76,7 @@ export class Player extends GameObject<IPlayerState> {
     public left: boolean;
 
     // eslint-disable-next-line @typescript-eslint/class-literal-property-style
-    public override get hasRef(): boolean {
+    public override get alwaysTrackState(): boolean {
         return true;
     }
 

--- a/server/game/core/ability/AbilityLimit.ts
+++ b/server/game/core/ability/AbilityLimit.ts
@@ -33,6 +33,12 @@ export abstract class AbilityLimit<TState extends IAbilityLimitState = IAbilityL
         this.state.ability = value.getRef();
     }
 
+    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+    public override get hasRef(): boolean {
+        return true;
+    }
+
+
     protected override setupDefaultState(): void {
         super.setupDefaultState();
 

--- a/server/game/core/ability/AbilityLimit.ts
+++ b/server/game/core/ability/AbilityLimit.ts
@@ -34,7 +34,7 @@ export abstract class AbilityLimit<TState extends IAbilityLimitState = IAbilityL
     }
 
     // eslint-disable-next-line @typescript-eslint/class-literal-property-style
-    public override get hasRef(): boolean {
+    public override get alwaysTrackState(): boolean {
         return true;
     }
 

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -214,6 +214,11 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
         return this.state.facedown;
     }
 
+    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+    public override get hasRef(): boolean {
+        return true;
+    }
+
     public get internalName(): string {
         return this._internalName;
     }

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -215,7 +215,7 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     }
 
     // eslint-disable-next-line @typescript-eslint/class-literal-property-style
-    public override get hasRef(): boolean {
+    public override get alwaysTrackState(): boolean {
         return true;
     }
 

--- a/server/game/core/ongoingEffect/OngoingEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingEffect.ts
@@ -80,6 +80,9 @@ export abstract class OngoingEffect<TTarget extends GameObject = GameObject, TSt
 
         this.impl.duration = this.duration;
         this.impl.isConditional = !!properties.condition;
+
+        // bit of a hack to keep the impl object added to the game state
+        this.impl.getRef();
     }
 
     protected override setupDefaultState() {

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -67,6 +67,11 @@ export class OngoingEffectEngine extends GameObjectBase<IOngoingEffectState> {
     public events: EventRegistrar;
     public effectsChangedSinceLastCheck = false;
 
+    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+    public override get hasRef(): boolean {
+        return true;
+    }
+
     @undoArray()
     public accessor effects: readonly OngoingEffect[] = [];
 

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -68,7 +68,7 @@ export class OngoingEffectEngine extends GameObjectBase<IOngoingEffectState> {
     public effectsChangedSinceLastCheck = false;
 
     // eslint-disable-next-line @typescript-eslint/class-literal-property-style
-    public override get hasRef(): boolean {
+    public override get alwaysTrackState(): boolean {
         return true;
     }
 

--- a/server/game/core/snapshot/GameStateManager.ts
+++ b/server/game/core/snapshot/GameStateManager.ts
@@ -10,9 +10,10 @@ export interface IGameObjectRegistrar {
 }
 
 export class GameStateManager implements IGameObjectRegistrar {
-    private readonly allGameObjects: GameObjectBase[] = [];
     private readonly game: Game;
     private readonly gameObjectMapping = new Map<string, GameObjectBase>();
+
+    private allGameObjects: GameObjectBase[] = [];
 
     private _lastGameObjectId = -1;
 
@@ -50,7 +51,28 @@ export class GameStateManager implements IGameObjectRegistrar {
         }
     }
 
-    public getAllGameStates(): IGameObjectBaseState[] {
+    public buildGameStateForSnapshot(): IGameObjectBaseState[] {
+        const removalUuids = new Set<string>();
+        const removalIndexes = new Set<number>();
+
+        // Indexes in last to first for the purpose of removal.
+        for (let i = this.allGameObjects.length - 1; i >= 0; i--) {
+            const go = this.allGameObjects[i];
+
+            if (!go.hasRef) {
+                // If the GameObjectBase doesn't have a ref, it means it was never used in the game, so we can skip it.
+                removalIndexes.add(i);
+                removalUuids.add(go.uuid);
+            }
+        }
+
+        this.allGameObjects = this.allGameObjects.filter((_, index) => !removalIndexes.has(index));
+
+        for (const removeUuid of removalUuids) {
+            this.gameObjectMapping.delete(removeUuid);
+        }
+
+        // Return the state of all game objects that are still in the game.
         return this.allGameObjects.map((go) => go.getState());
     }
 

--- a/server/game/core/snapshot/SnapshotFactory.ts
+++ b/server/game/core/snapshot/SnapshotFactory.ts
@@ -130,7 +130,7 @@ export class SnapshotFactory {
             timepoint,
             phase: this.game.currentPhase,
             gameState: structuredClone(this.game.state),
-            states: this.gameStateManager.getAllGameStates(),
+            states: this.gameStateManager.buildGameStateForSnapshot(),
             rngState: this.game.randomGenerator.rngState
         };
 

--- a/server/game/core/zone/ZoneAbstract.ts
+++ b/server/game/core/zone/ZoneAbstract.ts
@@ -47,6 +47,11 @@ export abstract class ZoneAbstract<TCard extends Card = Card, TState extends IGa
         return this.getCards();
     }
 
+    // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+    public override get hasRef(): boolean {
+        return true;
+    }
+
     public constructor(game: Game, owner?: Player) {
         super(game);
         this.owner = owner ?? game;

--- a/server/game/core/zone/ZoneAbstract.ts
+++ b/server/game/core/zone/ZoneAbstract.ts
@@ -48,7 +48,7 @@ export abstract class ZoneAbstract<TCard extends Card = Card, TState extends IGa
     }
 
     // eslint-disable-next-line @typescript-eslint/class-literal-property-style
-    public override get hasRef(): boolean {
+    public override get alwaysTrackState(): boolean {
         return true;
     }
 


### PR DESCRIPTION
I caught that we were holding thousands of PlayerAction game objects that were generated as part of evaluating potential available actions for cards. To alleviate this, I added a way to determine whether a GameObject has ever had a ref created for it. Any GO for which this is _not_ true at snapshot time will be removed from the list so it can be GCd.

Special provision had to be made for certain types of objects that are typically held as "real" references and a `GameObjectRef` is never created for them. In this case, there is an `alwaysTrackState` property getter that can be overridden. It's not the most elegant solution but it will get us by until we can finish the decorator work.

All regular (non-undo) tests are passing but it is possible this introduced some regressions in the undo work. I will continue investigating and do a fast-follow PR if so.