### PR TITLE
Enable current snapshot only for prod testing

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -46,7 +46,7 @@ const { GameObjectBase } = require('./GameObjectBase.js');
 const Helpers = require('./utils/Helpers.js');
 const { CostAdjuster } = require('./cost/CostAdjuster.js');
 const { logger } = require('../../logger.js');
-const { SnapshotManager } = require('./snapshot/SnapshotManager.js');
+const { SnapshotManager, UndoMode } = require('./snapshot/SnapshotManager.js');
 const AbilityHelper = require('../AbilityHelper.js');
 const { AbilityLimitInstance } = require('./ability/AbilityLimit.js');
 const { getAbilityHelper } = require('../AbilityHelper.js');
@@ -119,7 +119,7 @@ class Game extends EventEmitter {
     }
 
     get isUndoEnabled() {
-        return this.snapshotManager.undoEnabled;
+        return this.snapshotManager.undoMode === UndoMode.Full;
     }
 
     get actionNumber() {
@@ -208,7 +208,7 @@ class Game extends EventEmitter {
         validateGameOptions(options);
 
         /** @private */
-        this.snapshotManager = new SnapshotManager(this, details.enableUndo);
+        this.snapshotManager = new SnapshotManager(this, details.undoMode);
 
         this.ongoingEffectEngine = new OngoingEffectEngine(this);
 

--- a/server/game/core/GameInterfaces.ts
+++ b/server/game/core/GameInterfaces.ts
@@ -7,6 +7,7 @@ import type { EventWindow } from './event/EventWindow';
 import type { AbilityResolver } from './gameSteps/AbilityResolver';
 import type { ActionWindow } from './gameSteps/ActionWindow';
 import type { UiPrompt } from './gameSteps/prompts/UiPrompt';
+import type { UndoMode } from './snapshot/SnapshotManager';
 import * as Contract from './utils/Contract';
 
 export interface GameConfiguration {
@@ -21,7 +22,7 @@ export interface GameConfiguration {
     pushUpdate: () => void;
     buildSafeTimeout: (callback: () => void, delayMs: number, errorMessage: string) => NodeJS.Timeout;
     userTimeoutDisconnect: (userId: string) => void;
-    enableUndo?: boolean;
+    undoMode?: UndoMode;
 }
 
 export interface ICurrentlyResolving {

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -20,6 +20,7 @@ import { GameMode } from '../GameMode';
 import type { GameServer } from './GameServer';
 import { AlertType } from '../game/core/Constants';
 import { v4 as uuidv4 } from 'uuid';
+import { UndoMode } from '../game/core/snapshot/SnapshotManager';
 
 interface LobbySpectator {
     id: string;
@@ -741,7 +742,7 @@ export class Lobby {
             owner: 'Order66',
             gameMode: GameMode.Premier,
             players,
-            enableUndo: process.env.ENVIRONMENT === 'development',
+            undoMode: process.env.ENVIRONMENT === 'development' ? UndoMode.Full : UndoMode.CurrentSnapshotOnly,
             cardDataGetter: this.cardDataGetter,
             useActionTimer,
             pushUpdate: () => this.sendGameState(this.game),

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -7,14 +7,16 @@ const TestSetupError = require('./TestSetupError.js');
 const playableCardTitles = require('../json/_playableCardTitles.json');
 const Util = require('./Util.js');
 const { GameMode } = require('../../server/GameMode.js');
+const { UndoMode } = require('../../server/game/core/snapshot/SnapshotManager.js');
 
 class GameFlowWrapper {
     /**
      * @param {any} router
      * @param {PlayerInfo} player1Info
      * @param {PlayerInfo} player2Info
+     * @param {UndoMode} undoMode
      */
-    constructor(cardDataGetter, router, player1Info, player2Info, enableUndo = false) {
+    constructor(cardDataGetter, router, player1Info, player2Info, undoMode = UndoMode.Disabled) {
         /** @type {import('../../server/game/core/GameInterfaces.js').GameConfiguration} */
         var details = {
             name: `${player1Info.username}'s game`,
@@ -30,7 +32,7 @@ class GameFlowWrapper {
             pushUpdate: () => true,
             buildSafeTimeout: () => undefined,
             userTimeoutDisconnect: () => undefined,
-            enableUndo,
+            undoMode,
         };
 
         this.game = new Game(details, { router });

--- a/test/helpers/IntegrationHelper.js
+++ b/test/helpers/IntegrationHelper.js
@@ -14,6 +14,7 @@ const DeckBuilder = require('./DeckBuilder.js');
 const { cards } = require('../../server/game/cards/Index.js');
 const CardHelpers = require('../../server/game/core/card/CardHelpers.js');
 const { SnapshotType } = require('../../server/game/core/Constants.js');
+const { UndoMode } = require('../../server/game/core/snapshot/SnapshotManager.js');
 
 // set to true to run all tests with undo enabled
 const ENABLE_UNDO_ALL_TESTS = false;
@@ -65,7 +66,7 @@ global.integration = function (definitions, enableUndo = false) {
                 gameRouter,
                 { id: '111', username: 'player1', settings: { optionSettings: { autoSingleTarget: false } } },
                 { id: '222', username: 'player2', settings: { optionSettings: { autoSingleTarget: false } } },
-                enableUndo
+                enableUndo ? UndoMode.Full : UndoMode.Disabled
             );
 
             /** @type {SwuTestContext} */


### PR DESCRIPTION
Next step in soft rollout of undo. We're adding saving the current snapshot in prod. This shouldn't have dramatic impact since we're just saving one snapshot, but will be a good next step.