### PR TITLE
Feature: Zone Undo Decorator Conversion

### DIFF
--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -48,8 +48,9 @@ type UnwrapRefProperty<T> = T extends GameObjectRef<infer U> ?
     (T extends (infer R)[] ? (R extends GameObjectRef<infer U> ? U[] : R[]) :
         T);
 
+// NOTE: We are *temporarily* marking registerState as useFullCopy = true, but in the future this should be removed and moved into the deriving classes as need.
 /** GameObjectBase simply defines this as an object with state, and with a unique identifier. */
-@registerState()
+@registerState(true)
 export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjectBaseState> implements IGameObjectBase<T> {
     public readonly game: Game;
 

--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -14,7 +14,7 @@ const stateClassesStr: Record<string, string> = {};
 
 /**
  * Decorator to capture the names of any accessors flagged as @undoState, @undoObject, or @undoArray for copyState, and then clear the array for the next derived class to use.
- * @param useFullCopy If true, simply uses the bulk copy method rather than using any meta data. This is flagged *per prototype*, and only affects  This is going to be slower, but helps if we have state not easily capturable by the undo decorators.
+ * @param useFullCopy If true, simply uses the bulk copy method rather than using any meta data. This is going to be slower, but helps if we have state not easily capturable by the undo decorators.
  */
 export function registerState<T extends GameObjectBase>(useFullCopy = false) {
     return function (targetClass: any, context: ClassDecoratorContext) {
@@ -218,7 +218,7 @@ export function UndoSafeArray<T extends GameObjectBase, TValue extends GameObjec
                 return function(...args) {
                     Contract.assertTrue(args.length <= 2, 'State Array Splice does not support adding elements to the array.');
                     const result = Reflect.apply(target[prop], target, args);
-                    // @ts-expect-error call the same method on the internal state.
+                    // @ts-expect-error Override accessibility and call the same method on the internal state.
                     Reflect.apply(go.state[name][prop], go.state[name], args);
 
                     return result;
@@ -226,7 +226,7 @@ export function UndoSafeArray<T extends GameObjectBase, TValue extends GameObjec
             } else if (prop === 'push' || prop === 'unshift') {
                 return function(...args) {
                     const result = Reflect.apply(target[prop], target, args);
-                    // @ts-expect-error call the same method on the internal state.
+                    // @ts-expect-error Override accessibility and call the same method on the internal state.
                     Reflect.apply(go.state[name][prop], go.state[name], args.map((x) => x.getRef()));
 
                     return result;

--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -207,6 +207,7 @@ export function undoObject<T extends GameObjectBase, TValue extends GameObjectBa
     };
 }
 
+/** Uses proxies to cause any in-place mutation functions to also affect the underlying state. */
 export function UndoSafeArray<T extends GameObjectBase, TValue extends GameObjectBase>(go: T, arr: readonly TValue[], name: string) {
     // @ts-expect-error these functions can bypass the accessibility safeties.
     Contract.assertTrue(Object.prototype.hasOwnProperty.call(go.state, name), 'Property ' + name + ' not found on the state of the GameObject');

--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -77,13 +77,11 @@ export function undoState<T extends GameObjectBase, TValue extends string | numb
     };
 }
 
-// Forces the incoming value to be either a boolean literal, or a constant boolean.
+// Forces the incoming value to be either a boolean literal, or a constant boolean. This is meant to be used with const generic arguments.
 type ConstantBoolean<T extends boolean> = boolean extends T ? never : T;
 
 /**
- *
  * @param readonly If false, returns the array wrapped in a Proxy object, which allows the safe use of push, pop, unshift, and splice. If true, returns the array as-is and requires it be marked as readonly.
- * @returns
  */
 export function undoArray<T extends GameObjectBase, TValue extends GameObjectBase, const TReadonly extends boolean>(readonly: ConstantBoolean<TReadonly> = (true as ConstantBoolean<TReadonly>)) {
     return function (

--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -82,7 +82,7 @@ type ConstantBoolean<T extends boolean> = boolean extends T ? never : T;
 
 /**
  *
- * @param readonly If false, returns the array wrapped in a Proxy, which allows the safe use of push, pop, unshift, and splice. If true, returns the array as-is and requires it be marked as readonly.
+ * @param readonly If false, returns the array wrapped in a Proxy object, which allows the safe use of push, pop, unshift, and splice. If true, returns the array as-is and requires it be marked as readonly.
  * @returns
  */
 export function undoArray<T extends GameObjectBase, TValue extends GameObjectBase, const TReadonly extends boolean>(readonly: ConstantBoolean<TReadonly> = (true as ConstantBoolean<TReadonly>)) {

--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -28,8 +28,6 @@ export function registerState<T extends GameObjectBase>(useFullCopy = false) {
             context.metadata[fullCopyMetadata] = true;
         }
         if (metaState) {
-            // HACK: For now we always are full copying state.
-            metaState[fullCopyMetadata] = true;
             // Move metadata from the stateMedata symbol to the name of the class, so that we can look it up later in copyStruct.
             context.metadata[targetClass.name] = metaState;
             // Delete field to clear for the next derived class, if any.

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -331,7 +331,7 @@ export class Player extends GameObject<IPlayerState> {
      * @param {ZoneName} zoneName
      * @returns {Card[]}
      */
-    public getCardsInZone(zoneName: ZoneName): Card[] {
+    public getCardsInZone(zoneName: ZoneName): readonly Card[] {
         switch (zoneName) {
             case ZoneName.Hand:
                 return this.handZone.cards;
@@ -1054,7 +1054,7 @@ export class Player extends GameObject<IPlayerState> {
         return this.resourceZone.cards;
     }
 
-    public get drawDeck() {
+    public get drawDeck(): readonly IPlayableCard[] {
         return this.deckZone?.deck;
     }
 
@@ -1104,7 +1104,7 @@ export class Player extends GameObject<IPlayerState> {
      * @param {number} count
      * @returns {number}
      */
-    public exhaustResourcesInList(resources: ICardWithExhaustProperty[], count: number): number {
+    public exhaustResourcesInList(resources: readonly ICardWithExhaustProperty[], count: number): number {
         if (count < resources.length) {
             resources.slice(0, count).forEach((resource) => resource.exhaust());
             return count;

--- a/server/game/core/cardSelector/BaseCardSelector.ts
+++ b/server/game/core/cardSelector/BaseCardSelector.ts
@@ -174,7 +174,7 @@ export abstract class BaseCardSelector<TContext extends AbilityContext> {
     }
 
     public getCardsForPlayerZones(zone: ZoneFilter, player: Player, game: Game) {
-        let cards: Card[] = [];
+        let cards: readonly Card[] = [];
         switch (zone) {
             case WildcardZoneName.Any:
                 // TODO: is this ever a case we should have? this would allow targeting deck, discard, etc.

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -15,7 +15,14 @@ export function shuffleArray<T>(array: T[], randomGenerator: IRandomness): void 
     }
 }
 
-export function randomItem<T>(array: T[], randomGenerator: IRandomness): undefined | T {
+/* Randomize array copy using Durstenfeld shuffle algorithm */
+export function shuffle<T>(array: readonly T[], randomGenerator: IRandomness): T[] {
+    const arrayCopy = [...array];
+    shuffleArray<T>(arrayCopy, randomGenerator);
+    return arrayCopy;
+}
+
+export function randomItem<T>(array: readonly T[], randomGenerator: IRandomness): undefined | T {
     const j = Math.floor(randomGenerator.next() * array.length);
     return array[j];
 }
@@ -33,17 +40,6 @@ export function countUniqueAspects(cards: Card | Card[]): number {
         card.aspects.forEach((aspect) => aspects.add(aspect));
     });
     return aspects.size;
-}
-
-// TODO: remove this
-/** @deprecated Use `shuffleArray` instead */
-export function shuffle<T>(array: T[], randomGenerator: IRandomness): T[] {
-    const shuffleArray = [...array];
-    for (let i = shuffleArray.length - 1; i > 0; i--) {
-        const j = Math.floor(randomGenerator.next() * (i + 1));
-        [shuffleArray[i], shuffleArray[j]] = [shuffleArray[j], shuffleArray[i]];
-    }
-    return shuffleArray;
 }
 
 export function defaultLegalZonesForCardTypeFilter(cardTypeFilter: CardTypeFilter) {

--- a/server/game/core/utils/TypeHelpers.ts
+++ b/server/game/core/utils/TypeHelpers.ts
@@ -122,5 +122,18 @@ export const to = {
         }
 
         return date;
+    },
+
+    record<T, TValue = T>(arr: T[], keyFunc: (item: T) => string | number, valueFunc?: (item: T) => TValue): Record<string | number, TValue> {
+        const result: Record<string | number, TValue> = {};
+
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < arr.length; i++) {
+            const item = arr[i];
+            const key = keyFunc(item);
+            result[key] = valueFunc ? valueFunc(item) : item as unknown as TValue;
+        }
+
+        return result;
     }
 };

--- a/server/game/core/zone/AllArenasZone.ts
+++ b/server/game/core/zone/AllArenasZone.ts
@@ -2,6 +2,7 @@ import type { IInPlayCard } from '../card/baseClasses/InPlayCard';
 import type { ZoneName } from '../Constants';
 import { WildcardZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { ConcreteArenaZone } from './ConcreteArenaZone';
 import type { IArenaZoneCardFilterProperties } from './ConcreteOrMetaArenaZone';
 import { ConcreteOrMetaArenaZone } from './ConcreteOrMetaArenaZone';
@@ -21,6 +22,7 @@ export type IAllArenasForPlayerSpecificTypeCardFilterProperties = Omit<IAllArena
  * This is a meta-zone that allows doing operations across both the ground arena and space arena as one.
  * Can't add or remove cards but all accessor operations are supported.
  */
+@registerState()
 export class AllArenasZone extends ConcreteOrMetaArenaZone {
     public declare readonly hiddenForPlayers: null;
     public override readonly name: WildcardZoneName.AnyArena;

--- a/server/game/core/zone/BaseZone.ts
+++ b/server/game/core/zone/BaseZone.ts
@@ -3,27 +3,29 @@ import type { ILeaderCard } from '../card/propertyMixins/LeaderProperties';
 import type { ITokenCard } from '../card/propertyMixins/Token';
 import { ZoneName } from '../Constants';
 import type Game from '../Game';
-import type { GameObjectRef, IGameObjectBaseState } from '../GameObjectBase';
+import { registerState, undoObject } from '../GameObjectUtils';
 import type { Player } from '../Player';
 import * as Contract from '../utils/Contract';
 import type { IZoneCardFilterProperties } from './ZoneAbstract';
 import { ZoneAbstract } from './ZoneAbstract';
-
-export interface IBaseZoneState extends IGameObjectBaseState {
-    leader: GameObjectRef<ILeaderCard> | null;
-    forceToken: GameObjectRef<ITokenCard> | null;    // Use abstraction or concrete type?
-}
 
 type IBaseZoneCard = ILeaderCard | IBaseCard | ITokenCard;
 
 /**
  * Base zone which holds the player's base and leader
  */
-export class BaseZone extends ZoneAbstract<IBaseZoneCard, IBaseZoneState> {
+@registerState()
+export class BaseZone extends ZoneAbstract<IBaseZoneCard> {
     public readonly base: IBaseCard;
     public override readonly hiddenForPlayers: null;
     public declare readonly owner: Player;
     public override readonly name: ZoneName.Base;
+
+    @undoObject()
+    private accessor _leader: ILeaderCard | null = null;
+
+    @undoObject()
+    private accessor _forceToken: ITokenCard | null = null;
 
     public override get cards(): (IBaseZoneCard)[] {
         return [this.base, this.forceToken, this.leader]
@@ -31,27 +33,19 @@ export class BaseZone extends ZoneAbstract<IBaseZoneCard, IBaseZoneState> {
     }
 
     public override get count() {
-        return this.state.leader ? 2 : 1;
+        return this._leader ? 2 : 1;
     }
 
     public get leader(): ILeaderCard | null {
-        return this.game.gameObjectManager.get(this.state.leader);
-    }
-
-    private set leader(value: ILeaderCard | null) {
-        this.state.leader = value?.getRef();
+        return this._leader;
     }
 
     public get forceToken(): ITokenCard | null {
-        return this.game.gameObjectManager.get(this.state.forceToken);
-    }
-
-    private set forceToken(value: ITokenCard | null) {
-        this.state.forceToken = value?.getRef();
+        return this._forceToken;
     }
 
     public hasForceToken(): boolean {
-        return this.forceToken !== null;
+        return this.forceToken != null;
     }
 
     public constructor(game: Game, owner: Player, base: IBaseCard, leader: ILeaderCard) {
@@ -61,15 +55,10 @@ export class BaseZone extends ZoneAbstract<IBaseZoneCard, IBaseZoneState> {
         this.name = ZoneName.Base;
 
         this.base = base;
-        this.leader = leader;
+        this._leader = leader;
 
         base.initializeZone(this);
         leader.initializeZone(this);
-    }
-
-    protected override setupDefaultState() {
-        super.setupDefaultState();
-        this.state.leader = null;
     }
 
     public override getCards(filter?: IZoneCardFilterProperties): (IBaseZoneCard)[] {
@@ -78,27 +67,27 @@ export class BaseZone extends ZoneAbstract<IBaseZoneCard, IBaseZoneState> {
 
     public setLeader(leader: ILeaderCard) {
         Contract.assertEqual(leader.controller, this.owner, `Attempting to add card ${leader.internalName} to ${this} as leader but its controller is ${leader.controller}`);
-        Contract.assertIsNullLike(this.state.leader, `Attempting to add leader ${leader.internalName} to ${this} but a leader is already there`);
+        Contract.assertIsNullLike(this._leader, `Attempting to add leader ${leader.internalName} to ${this} but a leader is already there`);
 
-        this.leader = leader;
+        this._leader = leader;
     }
 
     public removeLeader() {
-        Contract.assertNotNullLike(this.state.leader, `Attempting to remove leader from ${this} but it is in zone ${this.owner.leader.zone}`);
+        Contract.assertNotNullLike(this._leader, `Attempting to remove leader from ${this} but it is in zone ${this.owner.leader.zone}`);
 
-        this.leader = null;
+        this._leader = null;
     }
 
     public setForceToken(forceToken: ITokenCard) {
         Contract.assertEqual(forceToken.controller, this.owner, `Attempting to add a force token to ${this} but its controller is ${forceToken.controller}`);
         Contract.assertIsNullLike(this.forceToken, `Attempting to add a force token to ${this} but a force token is already there`);
 
-        this.forceToken = forceToken;
+        this._forceToken = forceToken;
     }
 
     public removeForceToken() {
         Contract.assertNotNullLike(this.forceToken, `Attempting to remove force token from ${this} but none exists`);
 
-        this.forceToken = null;
+        this._forceToken = null;
     }
 }

--- a/server/game/core/zone/CaptureZone.ts
+++ b/server/game/core/zone/CaptureZone.ts
@@ -2,11 +2,13 @@ import type { Card } from '../card/Card';
 import type { IUnitCard } from '../card/propertyMixins/UnitProperties';
 import { ZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { Player } from '../Player';
 import * as Contract from '../utils/Contract';
 import { SimpleZone } from './SimpleZone';
 
 // STATE TODO: Because these spawn during the Game's life span, do we need to make the captor a Ref? Hm, in-place no, but for file saves yes.
+@registerState()
 export class CaptureZone extends SimpleZone<IUnitCard> {
     public readonly captor: IUnitCard;
     public override readonly hiddenForPlayers: null;

--- a/server/game/core/zone/ConcreteArenaZone.ts
+++ b/server/game/core/zone/ConcreteArenaZone.ts
@@ -1,6 +1,7 @@
 import type { IInPlayCard } from '../card/baseClasses/InPlayCard';
 import type { ZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { IArenaZoneCardFilterProperties } from './ConcreteOrMetaArenaZone';
 import { ConcreteOrMetaArenaZone } from './ConcreteOrMetaArenaZone';
 import type { IAddRemoveZone } from './ZoneAbstract';
@@ -9,6 +10,7 @@ import type { IAddRemoveZone } from './ZoneAbstract';
 /**
  * Base class for the "concrete" arena zones - ground and space - which are not the meta-zone AllArenasZone
  */
+@registerState()
 export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone implements IAddRemoveZone {
     public declare readonly hiddenForPlayers: null;
     public abstract override readonly name: ZoneName;
@@ -22,7 +24,7 @@ export abstract class ConcreteArenaZone extends ConcreteOrMetaArenaZone implemen
     public override getCards(filter?: IArenaZoneCardFilterProperties): IInPlayCard[] {
         const filterFn = this.buildFilterFn(filter);
 
-        let cards: IInPlayCard[] = this.cards;
+        let cards = this.cards;
         if (filter?.controller) {
             cards = cards.filter((card) => card.controller === filter.controller);
         }

--- a/server/game/core/zone/ConcreteOrMetaArenaZone.ts
+++ b/server/game/core/zone/ConcreteOrMetaArenaZone.ts
@@ -3,8 +3,8 @@ import type { IUnitCard } from '../card/propertyMixins/UnitProperties';
 import type { UpgradeCard } from '../card/UpgradeCard';
 import { WildcardCardType } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { Player } from '../Player';
-import type { IZoneState } from './SimpleZone';
 import { SimpleZone } from './SimpleZone';
 import type { IZoneCardFilterProperties } from './ZoneAbstract';
 
@@ -15,7 +15,8 @@ export interface IArenaZoneCardFilterProperties extends IZoneCardFilterPropertie
 /**
  * Base class for arena zones, including the meta-zone for all arenas
  */
-export abstract class ConcreteOrMetaArenaZone<TState extends IZoneState<IInPlayCard> = IZoneState<IInPlayCard>> extends SimpleZone<IInPlayCard, TState> {
+@registerState()
+export abstract class ConcreteOrMetaArenaZone extends SimpleZone<IInPlayCard> {
     public override readonly hiddenForPlayers: null;
     public declare readonly owner: Game;
 
@@ -30,6 +31,6 @@ export abstract class ConcreteOrMetaArenaZone<TState extends IZoneState<IInPlayC
     }
 
     public getUpgradeCards(filter?: Omit<IArenaZoneCardFilterProperties, 'type'>): UpgradeCard[] {
-        return this.getCards({ ...filter, type: WildcardCardType.Upgrade }) as UpgradeCard[];
+        return this.getCards({ ...filter, type: WildcardCardType.Upgrade }) as unknown as UpgradeCard[];
     }
 }

--- a/server/game/core/zone/DiscardZone.ts
+++ b/server/game/core/zone/DiscardZone.ts
@@ -1,9 +1,11 @@
 import type { IPlayableCard } from '../card/baseClasses/PlayableOrDeployableCard';
 import { ZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { Player } from '../Player';
 import { PlayerZone } from './PlayerZone';
 
+@registerState()
 export class DiscardZone extends PlayerZone<IPlayableCard> {
     public override readonly hiddenForPlayers: null;
     public override readonly name: ZoneName.Discard;

--- a/server/game/core/zone/GroundArenaZone.ts
+++ b/server/game/core/zone/GroundArenaZone.ts
@@ -1,7 +1,9 @@
 import { ZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import { ConcreteArenaZone } from './ConcreteArenaZone';
 
+@registerState()
 export class GroundArenaZone extends ConcreteArenaZone {
     public override readonly name: ZoneName.GroundArena;
 

--- a/server/game/core/zone/HandZone.ts
+++ b/server/game/core/zone/HandZone.ts
@@ -1,9 +1,11 @@
 import type { IPlayableCard } from '../card/baseClasses/PlayableOrDeployableCard';
 import { ZoneName, RelativePlayer } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { Player } from '../Player';
 import { PlayerZone } from './PlayerZone';
 
+@registerState()
 export class HandZone extends PlayerZone<IPlayableCard> {
     public override readonly hiddenForPlayers: RelativePlayer.Opponent;
     public override readonly name: ZoneName.Hand;

--- a/server/game/core/zone/OutsideTheGameZone.ts
+++ b/server/game/core/zone/OutsideTheGameZone.ts
@@ -1,12 +1,14 @@
 import type { Card } from '../card/Card';
 import { ZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import type { Player } from '../Player';
 import { PlayerZone } from './PlayerZone';
 
 /**
  * Catch-all zone for cards that are outside the game. Used for staging cards such as tokens.
  */
+@registerState()
 export class OutsideTheGameZone extends PlayerZone<Card> {
     public override readonly hiddenForPlayers: null;
     public override readonly name: ZoneName.OutsideTheGame;

--- a/server/game/core/zone/PlayerZone.ts
+++ b/server/game/core/zone/PlayerZone.ts
@@ -1,15 +1,16 @@
 import type { Card } from '../card/Card';
 import type { ZoneName } from '../Constants';
 import type { Player } from '../Player';
-import type { IZoneState } from './SimpleZone';
 import { SimpleZone } from './SimpleZone';
 import type { IAddRemoveZone } from './ZoneAbstract';
 import * as Contract from '../utils/Contract';
+import { registerState } from '../GameObjectUtils';
 
 /**
  * Base class for zones that are player specific.
  */
-export abstract class PlayerZone<TCard extends Card, TState extends IZoneState<TCard> = IZoneState<TCard>> extends SimpleZone<TCard, TState> implements IAddRemoveZone {
+@registerState()
+export abstract class PlayerZone<TCard extends Card> extends SimpleZone<TCard> implements IAddRemoveZone {
     public abstract override readonly name: ZoneName;
     public declare readonly owner: Player;
 

--- a/server/game/core/zone/ResourceZone.ts
+++ b/server/game/core/zone/ResourceZone.ts
@@ -14,7 +14,7 @@ export class ResourceZone extends PlayerZone<IPlayableCard> {
         return this.exhaustedResources.length;
     }
 
-    public get exhaustedResources() {
+    public get exhaustedResources(): readonly IPlayableCard[] {
         return this.cards.filter((card) => card.exhausted);
     }
 
@@ -22,7 +22,7 @@ export class ResourceZone extends PlayerZone<IPlayableCard> {
         return this.readyResources.length;
     }
 
-    public get readyResources() {
+    public get readyResources(): readonly IPlayableCard[] {
         return this.cards.filter((card) => !card.exhausted);
     }
 
@@ -36,12 +36,11 @@ export class ResourceZone extends PlayerZone<IPlayableCard> {
     public rearrangeResourceExhaustState(context: AbilityContext, prioritizeSmuggle: boolean = false): void {
         const exhaustCount = this.exhaustedResourceCount;
         // Cards is an accessor and a copy of the array.
-        let cards = this.cards;
-        this.cards.forEach((card) => card.exhausted = false);
-        Helpers.shuffleArray(this.state.cards, context.game.randomGenerator);
+        const cards = this._cards.concat();
+        cards.forEach((card) => card.exhausted = false);
+        Helpers.shuffleArray(cards, context.game.randomGenerator);
 
-        // Reacquire cards array in new, shuffled order.
-        cards = this.cards;
+        this._cards = cards;
 
         let exhausted = 0;
 

--- a/server/game/core/zone/SimpleZone.ts
+++ b/server/game/core/zone/SimpleZone.ts
@@ -1,12 +1,8 @@
 import type { Card } from '../card/Card';
 import * as Contract from '../utils/Contract';
 import type { Aspect, CardTypeFilter, KeywordName, MoveZoneDestination, Trait } from '../Constants';
-import type { GameObjectRef, IGameObjectBaseState } from '../GameObjectBase';
 import { ZoneAbstract } from './ZoneAbstract';
-
-export interface ISimpleZoneState<TCard extends Card> extends IGameObjectBaseState {
-    cards: GameObjectRef<TCard>[];
-}
+import { registerState, undoArray } from '../GameObjectUtils';
 
 /**
  * Collection of filters for searching cards in a zone.
@@ -31,26 +27,21 @@ export interface IAddRemoveZone {
     removeCard(card: Card): void;
 }
 
-export interface IZoneState<TCard extends Card> extends IGameObjectBaseState {
-    cards: GameObjectRef<TCard>[];
-}
-
 /**
  * Base class for all Zones that contain a list of Cards. Defines some common properties and methods.
  */
-export abstract class SimpleZone<TCard extends Card = Card, TState extends IZoneState<TCard> = IZoneState<TCard>> extends ZoneAbstract<TCard, TState> {
+@registerState()
+export abstract class SimpleZone<TCard extends Card = Card> extends ZoneAbstract<TCard> {
     /** Number of cards in the zone */
     public override get count(): number {
-        return this.state.cards.length;
+        return this._cards.length;
     }
+
+    @undoArray(true)
+    protected accessor _cards: readonly TCard[] = [];
 
     public override get cards(): TCard[] {
-        return this.state.cards.map((x) => this.game.gameObjectManager.get(x));
-    }
-
-    protected override setupDefaultState() {
-        super.setupDefaultState();
-        this.state.cards = [];
+        return this._cards as TCard[];
     }
 
     /** Get the cards from this zone with an optional filter */
@@ -61,15 +52,15 @@ export abstract class SimpleZone<TCard extends Card = Card, TState extends IZone
     public addCard(card: TCard) {
         Contract.assertFalse(this.cards.includes(card), `Attempting to add card ${card.internalName} to ${this} twice`);
 
-        this.state.cards.push(card.getRef());
+
+        this._cards = [...this._cards, card];
     }
 
     public removeCard(card: Card) {
-        const cardIdx = this.cards.indexOf(card as TCard);
+        const cards = this.cards.filter((x) => x !== card);
+        Contract.assertFalse(cards.length === this._cards.length, `Attempting to remove card ${card.internalName} from ${this} but it is not there. Its current zone is ${card.zone}.`);
 
-        Contract.assertFalse(cardIdx === -1, `Attempting to remove card ${card.internalName} from ${this} but it is not there. Its current zone is ${card.zone}.`);
-
-        this.state.cards.splice(cardIdx, 1);
+        this._cards = cards;
     }
 
     public override toString() {

--- a/server/game/core/zone/SpaceArenaZone.ts
+++ b/server/game/core/zone/SpaceArenaZone.ts
@@ -1,7 +1,9 @@
 import { ZoneName } from '../Constants';
 import type Game from '../Game';
+import { registerState } from '../GameObjectUtils';
 import { ConcreteArenaZone } from './ConcreteArenaZone';
 
+@registerState()
 export class SpaceArenaZone extends ConcreteArenaZone {
     public override readonly name: ZoneName.SpaceArena;
 

--- a/server/game/core/zone/ZoneAbstract.ts
+++ b/server/game/core/zone/ZoneAbstract.ts
@@ -6,6 +6,7 @@ import type Game from '../Game';
 import * as EnumHelpers from '../utils/EnumHelpers';
 import type { IGameObjectBaseState } from '../GameObjectBase';
 import { GameObjectBase } from '../GameObjectBase';
+import { registerState } from '../GameObjectUtils';
 
 /**
  * Collection of filters for searching cards in a zone.
@@ -33,6 +34,7 @@ export interface IAddRemoveZone {
 /**
  * Base class for all Zone types. Defines some common properties and methods.
  */
+@registerState(true)
 export abstract class ZoneAbstract<TCard extends Card = Card, TState extends IGameObjectBaseState = IGameObjectBaseState> extends GameObjectBase<TState> {
     public readonly owner: Player | Game;
 
@@ -43,7 +45,7 @@ export abstract class ZoneAbstract<TCard extends Card = Card, TState extends IGa
     /** Number of cards in the zone */
     public abstract get count(): number;
 
-    public get cards(): TCard[] {
+    public get cards(): readonly TCard[] {
         return this.getCards();
     }
 

--- a/server/game/gameSystems/SearchDeckSystem.ts
+++ b/server/game/gameSystems/SearchDeckSystem.ts
@@ -135,7 +135,7 @@ export class SearchDeckSystem<TContext extends AbilityContext = AbilityContext, 
         return typeof shuffle === 'function' ? shuffle(context) : shuffle;
     }
 
-    private getDeck(player: Player): Card[] {
+    private getDeck(player: Player): readonly Card[] {
         return player.drawDeck;
     }
 

--- a/test/server/cards/01_SOR/units/InfernoFourUnforgetting.spec.ts
+++ b/test/server/cards/01_SOR/units/InfernoFourUnforgetting.spec.ts
@@ -16,7 +16,7 @@ describe('Inferno Four - Unforgetting', function() {
 
             it('while playing/defeating lets you look at the top 2 cards of the deck and decide whether to put either them on the bottom or top of deck in any order.', function () {
                 const { context } = contextRef;
-                let preSwapDeck = context.player1.deck;
+                let preSwapDeck = context.player1.deck.concat();
 
                 // Case 1 on play move the first top card to top and second card to bottom.
                 context.player1.clickCard(context.infernoFour);
@@ -37,13 +37,13 @@ describe('Inferno Four - Unforgetting', function() {
 
                 // preswap deck: ['foundling', 'pyke-sentinel', 'atst', 'cartel-spacer', 'wampa']
                 // expected after deck: ['atst', 'cartel-spacer', 'wampa', 'pyke-sentinel', 'foundling']
-                expect(context.player1.deck[0]).toEqual(preSwapDeck[1]);
-                expect(context.player1.deck[1]).toEqual(preSwapDeck[2]);
-                expect(context.player1.deck[4]).toEqual(preSwapDeck[0]);
+                expect(context.player1.deck[0]).toBe(preSwapDeck[1]);
+                expect(context.player1.deck[1]).toBe(preSwapDeck[2]);
+                expect(context.player1.deck[4]).toBe(preSwapDeck[0]);
                 expect(context.player2).toBeActivePlayer();
 
                 // record new state.
-                preSwapDeck = context.player1.deck;
+                preSwapDeck = context.player1.deck.concat();
 
                 // Case 2 on defeat move both cards to the top of the deck
                 context.player2.clickCard(context.tieAdvanced);
@@ -58,8 +58,8 @@ describe('Inferno Four - Unforgetting', function() {
                 // preswap deck deck: ['pyke-sentinel', 'atst', 'cartel-spacer', 'wampa', 'foundling']
                 // expected after deck: ['atst', 'pyke-sentinel', 'cartel-spacer', 'wampa', 'foundling']
                 expect(context.player1.deck.length).toBe(5);
-                expect(context.player1.deck[0]).toEqual(preSwapDeck[1]);
-                expect(context.player1.deck[1]).toEqual(preSwapDeck[0]);
+                expect(context.player1.deck[0]).toBe(preSwapDeck[1]);
+                expect(context.player1.deck[1]).toBe(preSwapDeck[0]);
                 expect(context.player1).toBeActivePlayer();
             });
         });

--- a/test/server/cards/01_SOR/units/R2D2IgnoringProtocol.spec.ts
+++ b/test/server/cards/01_SOR/units/R2D2IgnoringProtocol.spec.ts
@@ -16,7 +16,7 @@ describe('R2D2 - Ignoring Protocol', function() {
 
             it('while playing/attacking lets you look at the top card of the deck and decide whether to put it on the bottom or top of deck.', function () {
                 const { context } = contextRef;
-                let preSwapDeck = context.player1.deck;
+                let preSwapDeck = context.player1.deck.concat();
 
                 // Case 1 on play move top card to bottom
                 context.player1.clickCard(context.r2d2);
@@ -26,14 +26,14 @@ describe('R2D2 - Ignoring Protocol', function() {
 
                 // check board state
                 expect(context.player1.deck.length).toBe(5);
-                expect(context.player1.deck[0]).toEqual(preSwapDeck[1]);
-                expect(context.player1.deck[4]).toEqual(preSwapDeck[0]);
+                expect(context.player1.deck[0]).toBe(preSwapDeck[1]);
+                expect(context.player1.deck[4]).toBe(preSwapDeck[0]);
                 expect(context.player2).toBeActivePlayer();
 
                 // record new state.
                 context.player2.passAction();
                 context.readyCard(context.r2d2);
-                preSwapDeck = context.player1.deck;
+                preSwapDeck = context.player1.deck.concat();
 
                 // Case 2 on attack move to top
                 context.player1.clickCard(context.r2d2);


### PR DESCRIPTION
Converted all of the Zone classes to use decorators. Added some additional functionality to @undoArray to optionally allow for the use of in-place modification methods. Using it adds another object but might help make conversions easier.

Included a little more code for @registerState to prepare to move away from structuredClone.