### PR TITLE
Feature: Undo V8 Serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "devDependencies": {
         "@types/eslint__js": "^8.42.3",
         "@types/jasmine": "^5.1.4",
-        "@types/node": "^20.14.10",
+        "@types/node": "^20.19.11",
         "@types/underscore": "^1.11.15",
         "concurrently": "^9.1.0",
         "console-log-colors": "^0.5.0",
@@ -2194,11 +2194,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -6599,15 +6600,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/node-ts/node_modules/@types/node": {
-      "version": "20.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
-      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/nodemon": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
@@ -8428,9 +8420,10 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@types/eslint__js": "^8.42.3",
     "@types/jasmine": "^5.1.4",
-    "@types/node": "^20.14.10",
+    "@types/node": "^20.19.11",
     "@types/underscore": "^1.11.15",
     "concurrently": "^9.1.0",
     "console-log-colors": "^0.5.0",

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -93,9 +93,14 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
     /** Sets the state.  */
     public setState(state: T) {
         const oldState = this.state;
-        this.state = structuredClone(state);
-        copyState(this, state);
+        this.state = state;
+        copyState(this, this.state);
         this.afterSetState(oldState);
+    }
+
+    /** Be ***very*** careful with this function. This returns a direct reference and should only be used for serialization, never keep this reference stored anywhere. */
+    public getStateUnsafe() {
+        return this.state;
     }
 
     public getState() {

--- a/server/game/core/GameObjectBase.ts
+++ b/server/game/core/GameObjectBase.ts
@@ -98,7 +98,9 @@ export abstract class GameObjectBase<T extends IGameObjectBaseState = IGameObjec
         this.afterSetState(oldState);
     }
 
-    /** Be ***very*** careful with this function. This returns a direct reference and should only be used for serialization, never keep this reference stored anywhere. */
+    /**
+     * @deprecated Be ***very*** careful with this function. This returns a direct reference and should only be used for serialization, never keep this reference stored anywhere.
+     */
     public getStateUnsafe() {
         return this.state;
     }

--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -139,8 +139,8 @@ export function undoMap<T extends GameObjectBase, TValue extends GameObjectBase>
             },
             init(this: GameObjectBase, value) {
                 Contract.assertTrue(value.size === 0, 'UndoMap cannot be init with entries');
-                // If this is not-null, create a equivalent map in the state. Otherwise, leave it as-is.
                 this.state[name] = value;
+                // If this is not-null, create a equivalent map in the state. Otherwise, leave it as-is.
                 return value ? new UndoMap(this, name) : value;
             },
         };
@@ -219,8 +219,8 @@ export function undoObject<T extends GameObjectBase, TValue extends GameObjectBa
     };
 }
 
-/** Uses proxies to cause any in-place mutation functions to also affect the underlying state. */
-export function UndoSafeRecord<T extends GameObjectBase, TValue extends GameObjectBase>(go: T, record: Record<string, TValue>, name: string) {
+/** Experimental: Uses proxies to cause any in-place mutation functions to also affect the underlying state. */
+function UndoSafeRecord<T extends GameObjectBase, TValue extends GameObjectBase>(go: T, record: Record<string, TValue>, name: string) {
     // @ts-expect-error these functions can bypass the accessibility safeties.
     Contract.assertTrue(Object.prototype.hasOwnProperty.call(go.state, name), 'Property ' + name + ' not found on the state of the GameObject');
 

--- a/server/game/core/ongoingEffect/effectImpl/DetachedOngoingEffectValueWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/DetachedOngoingEffectValueWrapper.ts
@@ -1,34 +1,23 @@
 import type { AbilityContext } from '../../ability/AbilityContext';
 import type Game from '../../Game';
 import type { GameObjectBase, GameObjectRef, IGameObjectBaseState } from '../../GameObjectBase';
+import { registerState, undoRecord } from '../../GameObjectUtils';
 import { OngoingEffectValueWrapper } from './OngoingEffectValueWrapper';
 
 export interface IDetachedOngoingEffectValueWrapperState extends IGameObjectBaseState {
-    targetStates: Map<string, GameObjectRef>;
+    targetStates: Record<string, GameObjectRef>;
 }
 
+@registerState()
 export default class DetachedOngoingEffectValueWrapper<TValue> extends OngoingEffectValueWrapper<TValue, IDetachedOngoingEffectValueWrapperState> {
     public readonly applyFunc: any;
     public readonly unapplyFunc: any;
 
-    public get targetStates(): ReadonlyMap<string, GameObjectBase> {
-        const entries: [string, GameObjectBase][] = [];
+    @undoRecord()
+    private accessor _targetStates: Record<string, GameObjectBase> = {};
 
-        for (const [key, ref] of this.state.targetStates) {
-            entries.push([key, this.game.getFromRef(ref)]);
-        }
-
-        return new Map(entries);
-    }
-
-    public set targetStates(value: Map<string, GameObjectBase>) {
-        const entries: [string, GameObjectRef][] = [];
-
-        for (const [key, gameObject] of value) {
-            entries.push([key, gameObject.getRef()]);
-        }
-
-        this.state.targetStates = new Map(entries);
+    public get targetStates(): Readonly<Record<string, GameObjectBase>> {
+        return this._targetStates;
     }
 
     public constructor(
@@ -41,37 +30,26 @@ export default class DetachedOngoingEffectValueWrapper<TValue> extends OngoingEf
         this.unapplyFunc = unapplyFunc;
     }
 
-    protected override setupDefaultState() {
-        super.setupDefaultState();
-        this.state.targetStates = new Map<string, GameObjectRef>();
-    }
-
     public override apply(target: any) {
-        const targetStates = this.targetStates;
-
-        const currentValue = targetStates.get(target.uuid);
+        const currentValue = this._targetStates[target.uuid];
         const newValue = this.applyFunc(target, this.context, currentValue);
-
-        this.targetStates = new Map(targetStates).set(target.uuid, newValue);
+        this._targetStates[target.uuid] = newValue;
     }
 
     public override unapply(target: any) {
-        const targetStates = this.targetStates;
-
-        const currentValue = targetStates.get(target.uuid);
+        const currentValue = this._targetStates[target.uuid];
         const newValue = this.unapplyFunc(target, this.context, currentValue);
         if (newValue === undefined) {
-            const updatedStates = new Map(targetStates);
-            updatedStates.delete(target.uuid);
-            this.targetStates = updatedStates;
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete this._targetStates[target.uuid];
         } else {
-            this.targetStates = new Map(targetStates).set(target.uuid, newValue);
+            this._targetStates[target.uuid] = newValue;
         }
     }
 
     public override setContext(context: AbilityContext) {
         super.setContext(context);
-        for (const [_uuid, targetState] of this.targetStates) {
+        for (const [_uuid, targetState] of Object.entries(this.targetStates)) {
             if (targetState && (targetState as any).context) {
                 (targetState as any).context = context;
             }

--- a/server/game/core/ongoingEffect/effectImpl/OngoingEffectImpl.ts
+++ b/server/game/core/ongoingEffect/effectImpl/OngoingEffectImpl.ts
@@ -2,10 +2,11 @@ import type { AbilityContext } from '../../ability/AbilityContext';
 import type { FormatMessage } from '../../chat/GameChat';
 import type { Duration, EffectName } from '../../Constants';
 import type Game from '../../Game';
-import type { IGameObjectBaseState } from '../../GameObjectBase';
 import { GameObjectBase } from '../../GameObjectBase';
+import { registerState } from '../../GameObjectUtils';
 
-export abstract class OngoingEffectImpl<TValue, TState extends IGameObjectBaseState = IGameObjectBaseState> extends GameObjectBase<TState> {
+@registerState()
+export abstract class OngoingEffectImpl<TValue> extends GameObjectBase {
     public duration?: Duration = null;
     public isConditional = false;
     protected context?: AbilityContext = null;

--- a/server/game/core/ongoingEffect/effectImpl/OngoingEffectValueWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/OngoingEffectValueWrapper.ts
@@ -5,11 +5,6 @@ import type { IGameObjectBaseState } from '../../GameObjectBase';
 import { GameObjectBase } from '../../GameObjectBase';
 import { registerState } from '../../GameObjectUtils';
 
-// STATE TODO: I don't think value needs to be state, I think GainedAbility needs the state.
-// export interface IOngoingEffectValueWrapperState<T> extends IGameObjectBaseState {
-//     value: T;
-// }
-
 @registerState()
 export class OngoingEffectValueWrapper<TValue, TState extends IGameObjectBaseState = IGameObjectBaseState> extends GameObjectBase<TState> {
     private readonly value: TValue;

--- a/server/game/core/ongoingEffect/effectImpl/OngoingEffectValueWrapper.ts
+++ b/server/game/core/ongoingEffect/effectImpl/OngoingEffectValueWrapper.ts
@@ -3,12 +3,14 @@ import type { FormatMessage } from '../../chat/GameChat';
 import type Game from '../../Game';
 import type { IGameObjectBaseState } from '../../GameObjectBase';
 import { GameObjectBase } from '../../GameObjectBase';
+import { registerState } from '../../GameObjectUtils';
 
 // STATE TODO: I don't think value needs to be state, I think GainedAbility needs the state.
 // export interface IOngoingEffectValueWrapperState<T> extends IGameObjectBaseState {
 //     value: T;
 // }
 
+@registerState()
 export class OngoingEffectValueWrapper<TValue, TState extends IGameObjectBaseState = IGameObjectBaseState> extends GameObjectBase<TState> {
     private readonly value: TValue;
     public context?: AbilityContext;

--- a/server/game/core/snapshot/GameStateManager.ts
+++ b/server/game/core/snapshot/GameStateManager.ts
@@ -97,7 +97,7 @@ export class GameStateManager implements IGameObjectRegistrar {
         Contract.assertNotNullLike(snapshot, 'Empty snapshot provided for rollback');
         this._isRollingBack = true;
         try {
-            this.game.state = structuredClone(snapshot.gameState);
+            this.game.state = v8.deserialize(snapshot.gameState);
 
             const removals: { index: number; go: GameObjectBase; oldState: IGameObjectBaseState }[] = [];
             const updates: { go: GameObjectBase; oldState: IGameObjectBaseState }[] = [];

--- a/server/game/core/snapshot/GameStateManager.ts
+++ b/server/game/core/snapshot/GameStateManager.ts
@@ -4,6 +4,8 @@ import type { IGameSnapshot } from './SnapshotInterfaces';
 import * as Contract from '../utils/Contract.js';
 import * as Helpers from '../utils/Helpers.js';
 import { DiscordDispatcher } from '../DiscordDispatcher';
+import { to } from '../utils/TypeHelpers';
+import v8 from 'node:v8';
 
 export interface IGameObjectRegistrar {
     register(gameObject: GameObjectBase | GameObjectBase[]): void;
@@ -84,11 +86,11 @@ export class GameStateManager implements IGameObjectRegistrar {
         }
     }
 
-    public buildGameStateForSnapshot(): IGameObjectBaseState[] {
+    public buildGameStateForSnapshot(): Buffer {
         this.removeUnusedGameObjects();
 
         // Return the state of all game objects that are still in the game.
-        return this.allGameObjects.map((go) => go.getState());
+        return v8.serialize(to.record(this.allGameObjects, (item) => item.uuid, (item) => item.getStateUnsafe()));
     }
 
     public rollbackToSnapshot(snapshot: IGameSnapshot) {
@@ -100,13 +102,13 @@ export class GameStateManager implements IGameObjectRegistrar {
             const removals: { index: number; go: GameObjectBase; oldState: IGameObjectBaseState }[] = [];
             const updates: { go: GameObjectBase; oldState: IGameObjectBaseState }[] = [];
 
-            const snapshotStatesByUuid = new Map<string, IGameObjectBaseState>(snapshot.states.map((x) => [x.uuid, x]));
+            const snapshotStatesByUuid = v8.deserialize(snapshot.states) as Record<string, IGameObjectBaseState>;
 
             // Indexes in last to first for the purpose of removal.
             for (let i = this.allGameObjects.length - 1; i >= 0; i--) {
                 const go = this.allGameObjects[i];
 
-                const updatedState = snapshotStatesByUuid.get(go.uuid);
+                const updatedState = snapshotStatesByUuid[go.uuid];
                 if (!updatedState) {
                     removals.push({ index: i, go, oldState: go.getState() });
                     continue;

--- a/server/game/core/snapshot/SnapshotFactory.ts
+++ b/server/game/core/snapshot/SnapshotFactory.ts
@@ -7,6 +7,7 @@ import type { IClearNewerSnapshotsBinding, IClearNewerSnapshotsHandler, Snapshot
 import { SnapshotMap } from './container/SnapshotMap';
 import { SnapshotHistoryMap } from './container/SnapshotHistoryMap';
 import type { PhaseName } from '../Constants';
+import v8 from 'node:v8';
 
 export type IGetCurrentSnapshotHandler = () => IGameSnapshot;
 export type IUpdateCurrentSnapshotHandler = (snapshot: IGameSnapshot) => void;
@@ -129,7 +130,7 @@ export class SnapshotFactory {
             roundNumber: this.game.roundNumber,
             timepoint,
             phase: this.game.currentPhase,
-            gameState: structuredClone(this.game.state),
+            gameState: v8.serialize(this.game.state),
             states: this.gameStateManager.buildGameStateForSnapshot(),
             rngState: this.game.randomGenerator.rngState
         };

--- a/server/game/core/snapshot/SnapshotInterfaces.ts
+++ b/server/game/core/snapshot/SnapshotInterfaces.ts
@@ -107,7 +107,7 @@ export interface IGameSnapshot {
     phase: PhaseName;
     timepoint: SnapshotTimepoint;
 
-    gameState: IGameState;
+    gameState: Buffer;
     states: Buffer;
     rngState: IRandomness['rngState'];
 }

--- a/server/game/core/snapshot/SnapshotInterfaces.ts
+++ b/server/game/core/snapshot/SnapshotInterfaces.ts
@@ -1,6 +1,6 @@
 import type { Card } from '../card/Card';
 import type { PhaseName, RollbackRoundEntryPoint, RollbackSetupEntryPoint, SnapshotType } from '../Constants';
-import type { GameObjectRef, IGameObjectBaseState } from '../GameObjectBase';
+import type { GameObjectRef } from '../GameObjectBase';
 import type { Player } from '../Player';
 import type { IRandomness } from '../Randomness';
 
@@ -108,7 +108,7 @@ export interface IGameSnapshot {
     timepoint: SnapshotTimepoint;
 
     gameState: IGameState;
-    states: IGameObjectBaseState[];
+    states: Buffer;
     rngState: IRandomness['rngState'];
 }
 

--- a/server/game/core/stateWatcher/StateWatcherRegistrar.ts
+++ b/server/game/core/stateWatcher/StateWatcherRegistrar.ts
@@ -13,7 +13,7 @@ import type { StateWatcher } from './StateWatcher';
 @registerState()
 export class StateWatcherRegistrar extends GameObjectBase {
     @undoMap()
-    private accessor watchers: ReadonlyMap<string, StateWatcher> = new Map();
+    private accessor watchers: Map<string, StateWatcher> = new Map();
 
     public constructor(game: Game) {
         super(game);
@@ -32,8 +32,7 @@ export class StateWatcherRegistrar extends GameObjectBase {
         let watcher = this.watchers.get(name) as TWatcher;
         if (!watcher) {
             watcher = watcherFactory();
-            const watchers = new Map(this.watchers).set(name, watcher);
-            this.watchers = watchers;
+            this.watchers.set(name, watcher);
         }
         return watcher;
     }

--- a/server/game/core/utils/TypeHelpers.ts
+++ b/server/game/core/utils/TypeHelpers.ts
@@ -122,5 +122,17 @@ export const to = {
         }
 
         return date;
+    },
+    record<T, TValue = T>(arr: T[], keyFunc: (item: T) => string | number, valueFunc?: (item: T) => TValue): Record<string | number, TValue> {
+        const result: Record<string | number, TValue> = {};
+
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < arr.length; i++) {
+            const item = arr[i];
+            const key = keyFunc(item);
+            result[key] = valueFunc ? valueFunc(item) : item as unknown as TValue;
+        }
+
+        return result;
     }
 };


### PR DESCRIPTION
Moved from using structuredClone to using v8.serialization. Also eliminated some additional bulk copy usages.

This includes V2 of @undoMap, which no longer requires the type to be Readonly. Still a bit experimental but it should cut down on creating new objects every time want to update a map.