### PR TITLE
Brianries/emf metric stats

### DIFF
--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -10,7 +10,7 @@ import { getHeapStatistics } from 'v8';
 import { freemem, cpus } from 'os';
 import { monitorEventLoopDelay, performance, type EventLoopUtilization, type IntervalHistogram } from 'perf_hooks';
 
-import { logger } from '../logger';
+import { logger, jsonOnlyLogger } from '../logger';
 
 import { Lobby, MatchType } from './Lobby';
 import Socket from '../socket';
@@ -32,6 +32,7 @@ import { DeckService } from '../utils/deck/DeckService';
 import { BugReportHandler } from '../utils/bugreport/BugReportHandler';
 import { usernameContainsProfanity } from '../utils/profanityFilter/ProfanityFilter';
 import { SwuStatsHandler } from '../utils/SWUStats/SwuStatsHandler';
+import { GameServerMetrics } from '../utils/GameServerMetrics';
 
 
 /**
@@ -254,7 +255,8 @@ export class GameServer {
         // set up queue heartbeat once a second
         setInterval(() => this.queue.sendHeartbeat(), 500);
 
-        if (process.env.ENVIRONMENT !== 'development') {
+        //if (process.env.ENVIRONMENT !== 'development') {
+        if (true) {
             // initialize cpu usage and event loop stats
             this.lastCpuUsage = process.cpuUsage();
             this.lastCpuUsageTime = process.hrtime.bigint();
@@ -270,7 +272,7 @@ export class GameServer {
                 this.logHeapStats();
                 this.logCpuUsage();
                 this.logEventLoopStats();
-            }, 30000);
+            }, 5000);
         }
     }
 
@@ -1395,12 +1397,17 @@ export class GameServer {
             const currentUtilization = performance.eventLoopUtilization();
             const deltaUtilization = performance.eventLoopUtilization(currentUtilization, this.lastLoopUtilization);
 
-            const eventLoopPercent = (deltaUtilization.utilization * 100).toFixed(1);
-            const loopDelayMinMs = (this.loopDelayHistogram.min / 1e6).toFixed(1);
-            const loopDelayP50Ms = (this.loopDelayHistogram.percentile(50) / 1e6).toFixed(1);
-            const loopDelayP90Ms = (this.loopDelayHistogram.percentile(90) / 1e6).toFixed(1);
-            const loopDelayMaxMs = (this.loopDelayHistogram.max / 1e6).toFixed(1);
-            logger.info(`[EventLoopStats] Event Loop Utilization: ${eventLoopPercent}% | Event Loop Duration (ms): min: ${loopDelayMinMs}, P50: ${loopDelayP50Ms}, P90: ${loopDelayP90Ms}, max: ${loopDelayMaxMs}`);
+            const eventLoopPercent = deltaUtilization.utilization * 100;
+            const loopDelayP50Ms = this.loopDelayHistogram.percentile(50) / 1e6;
+            const loopDelayP90Ms = this.loopDelayHistogram.percentile(90) / 1e6;
+            const loopDelayP99Ms = this.loopDelayHistogram.percentile(99) / 1e6;
+            const loopDelayMaxMs = this.loopDelayHistogram.max / 1e6;
+
+            // Log a standard human readable log
+            logger.info(`[EventLoopStats] Event Loop Utilization: ${eventLoopPercent.toFixed(1)}% | Event Loop Duration (ms): P50: ${loopDelayP50Ms.toFixed(1)}, P90: ${loopDelayP90Ms.toFixed(1)}, P99: ${loopDelayP99Ms.toFixed(1)}, max: ${loopDelayMaxMs.toFixed(1)}`);
+
+            // Log this again in EMF format for CloudWatch metrics capture
+            jsonOnlyLogger.info(GameServerMetrics.eventLoopPerformance(eventLoopPercent, loopDelayP50Ms, loopDelayP90Ms, loopDelayP99Ms, loopDelayMaxMs));
 
             this.lastLoopUtilization = currentUtilization;
             this.loopDelayHistogram.reset();

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -255,8 +255,7 @@ export class GameServer {
         // set up queue heartbeat once a second
         setInterval(() => this.queue.sendHeartbeat(), 500);
 
-        //if (process.env.ENVIRONMENT !== 'development') {
-        if (true) {
+        if (process.env.ENVIRONMENT !== 'development') {
             // initialize cpu usage and event loop stats
             this.lastCpuUsage = process.cpuUsage();
             this.lastCpuUsageTime = process.hrtime.bigint();
@@ -272,7 +271,7 @@ export class GameServer {
                 this.logHeapStats();
                 this.logCpuUsage();
                 this.logEventLoopStats();
-            }, 5000);
+            }, 30000);
         }
     }
 

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -42,3 +42,16 @@ export const logger = winston.createLogger({
         isRunningInAWS ? winston.format.json() : logFormatter
     ),
 });
+
+const jsonOnlyFormatter = winston.format.printf((info) => {
+    // Only output if message is an object, otherwise do nothing
+    if (typeof info.message === 'object') {
+        return JSON.stringify(info.message);
+    }
+    return '';
+});
+
+export const jsonOnlyLogger = winston.createLogger({
+    transports: [new winston.transports.Console()],
+    format: jsonOnlyFormatter
+});

--- a/server/utils/GameServerMetrics.ts
+++ b/server/utils/GameServerMetrics.ts
@@ -1,0 +1,102 @@
+/**
+ * Pre-canned EMF builder for GameServer metrics
+ * http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+ *
+ * Simplified interface for logging GameServer performance metrics to CloudWatch.
+ * - Fixed namespace: "GameServer"
+ * - No dimensions (empty dimension set)
+ * - Predefined metric names and units
+ * - Simple JSON input: { metricName: value }
+ */
+
+// Essential GameServer metrics - focused on memory and heap compaction
+export const GAMESERVER_METRICS = {
+    EventLoopUtilization: 'Percent',     // Event loop utilization percentage
+    EventLoopDelayP50: 'Milliseconds',   // 50th percentile delay
+    EventLoopDelayP90: 'Milliseconds',   // 90th percentile delay
+    EventLoopDelayP99: 'Milliseconds',   // 99th percentile delay
+    EventLoopDelayMax: 'Milliseconds',   // Maximum delay
+} as const;
+
+export type GameServerMetricName = keyof typeof GAMESERVER_METRICS;
+export type GameServerMetricValues = Partial<Record<GameServerMetricName, number | number[]>>;
+
+// EMF document structure (standalone, no external dependencies)
+interface EmfMetricDefinition {
+    Name: string;
+    Unit: string;
+}
+
+interface EmfMetricDirective {
+    Namespace: string;
+    Dimensions: string[][];
+    Metrics: EmfMetricDefinition[];
+}
+
+interface EmfMetadata {
+    Timestamp: number;
+    CloudWatchMetrics: EmfMetricDirective[];
+}
+
+interface EmfDocument {
+    _aws: EmfMetadata;
+    [key: string]: unknown;
+}
+
+export namespace GameServerMetrics {
+
+    /**
+     * Create an EMF document for GameServer metrics
+     * @param metrics - Object with metric names as keys and values as numbers or arrays
+     * @param timestamp - Optional timestamp in milliseconds since Unix epoch (defaults to Date.now())
+     * @returns EMF document ready for jsonOnlyLogger
+     */
+    export function create(metrics: GameServerMetricValues, timestamp?: number): EmfDocument {
+        const metricNames = Object.keys(metrics) as GameServerMetricName[];
+
+        // Validate all metrics are known
+        for (const metricName of metricNames) {
+            if (!(metricName in GAMESERVER_METRICS)) {
+                throw new Error(`Unknown metric: ${metricName}. Available metrics: ${Object.keys(GAMESERVER_METRICS).join(', ')}`);
+            }
+        }
+
+        // Build the EMF document
+        const document: EmfDocument = {
+            _aws: {
+                Timestamp: timestamp || Date.now(),
+                CloudWatchMetrics: [{
+                    Namespace: 'GameServer',
+                    Dimensions: [[]], // Empty dimension set - no dimensions
+                    Metrics: metricNames.map((name) => ({
+                        Name: name,
+                        Unit: GAMESERVER_METRICS[name]
+                    }))
+                }],
+            },
+            ...metrics // Spread the metric values into the root
+        };
+
+        return document;
+    }
+
+    /**
+     * Helper function for creating an EMF document for event loop performance metrics
+     * @param utilization - Event loop utilization percentage (0-100)
+     * @param delayP50 - 50th percentile event loop delay in milliseconds
+     * @param delayP90 - 90th percentile event loop delay in milliseconds
+     * @param delayP99 - 99th percentile event loop delay in milliseconds
+     * @param delayMax - Maximum event loop delay in milliseconds
+     * @returns EMF document ready for jsonOnlyLogger
+     */
+    export function eventLoopPerformance(utilization: number, delayP50: number, delayP90: number, delayP99: number, delayMax: number): EmfDocument {
+        return create({
+            // We just want 1 decimal place - so do the rounding here
+            EventLoopUtilization: Math.round(utilization * 10) / 10,
+            EventLoopDelayP50: Math.round(delayP50 * 10) / 10,
+            EventLoopDelayP90: Math.round(delayP90 * 10) / 10,
+            EventLoopDelayP99: Math.round(delayP99 * 10) / 10,
+            EventLoopDelayMax: Math.round(delayMax * 10) / 10
+        });
+    }
+}


### PR DESCRIPTION
Added support to log Cloudwatch Metrics.  This uses an explicit JSON format defined here:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html

These logs should be parsed from the stdout of our logger. To afford this, I created a "jsonOnlyLogger" from winston that also logs to STDOUT but without any additional logging -- just a pure JSON payload

Example output of one of the lines for event loop duration -- I also dropped MIN and added P99

```
{
  "_aws": {
    "Timestamp": 1755829171297,
    "CloudWatchMetrics": [
      {
        "Namespace": "GameServer",
        "Dimensions": [[]],
        "Metrics": [
          {
            "Name": "EventLoopUtilization",
            "Unit": "Percent"
          },
          {
            "Name": "EventLoopDelayP50",
            "Unit": "Milliseconds"
          },
          {
            "Name": "EventLoopDelayP90",
            "Unit": "Milliseconds"
          },
          {
            "Name": "EventLoopDelayP99",
            "Unit": "Milliseconds"
          },
          {
            "Name": "EventLoopDelayMax",
            "Unit": "Milliseconds"
          }
        ]
      }
    ]
  },
  "EventLoopUtilization": 0.3,
  "EventLoopDelayP50": 15.4,
  "EventLoopDelayP90": 15.9,
  "EventLoopDelayP99": 16.1,
  "EventLoopDelayMax": 16.3
}
```