### PR TITLE
Fix capture-related exception causing server issues

### DIFF
--- a/server/game/core/attack/Attack.ts
+++ b/server/game/core/attack/Attack.ts
@@ -29,6 +29,11 @@ export class Attack {
         isAmbush: boolean = false,
         attackerCombatDamageOverride?: (attack: Attack, context: AbilityContext) => number
     ) {
+        Contract.assertTrue(attacker.isInPlay(), `Attempting to construct an Attack but designated attacker ${attacker.internalName} is not in play`);
+
+        const notInPlayTargets = targets.filter((target) => !target.isBase() && !target.isInPlay());
+        Contract.assertTrue(notInPlayTargets.length === 0, `Attempting to construct an Attack but the following targets are not in play: ${notInPlayTargets.map((target) => target.internalName).join(', ')}`);
+
         this.game = game;
         this.attacker = attacker;
         this.attackingPlayer = attacker.controller;

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -118,7 +118,7 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
 
     /** This method is checking whether cards are a valid target for an attack. */
     public override canAffectInternal(targetCard: Card, context: TContext, additionalProperties: Partial<IAttackProperties<TContext>> = {}): boolean {
-        if (!targetCard.isUnit() && !targetCard.isBase()) {
+        if (!targetCard.isBase() && (!targetCard.isUnit() || !targetCard.isInPlay())) {
             return false;
         }
 

--- a/test/server/actions/UnitAttack.spec.ts
+++ b/test/server/actions/UnitAttack.spec.ts
@@ -180,6 +180,31 @@ describe('Basic attack', function() {
             expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
             expect(context.poeDameron.damage).toBe(0);
         });
+
+        it('When evaluating attack targets for a card that grants an attacker effect, should not consider captured cards (and should not throw an exception)', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['breaking-in'],
+                    groundArena: ['battlefield-marine', { card: 'atst', capturedUnits: ['wild-rancor'] }],
+                },
+                player2: {
+                    hand: ['change-of-heart'],
+                    groundArena: ['wampa'],
+                    hasInitiative: true
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.changeOfHeart);
+            context.player2.clickCard(context.atst);
+
+            context.player1.clickCard(context.breakingIn);
+            context.player1.clickCard(context.battlefieldMarine);
+            context.player1.clickCard(context.p2Base);
+
+            expect(context.p2Base.damage).toBe(5);
+        });
     });
 });
-


### PR DESCRIPTION
Found that one cause of some of the game crashes is that when an enemy unit has become captured by another enemy unit, the attack logic handles it incorrectly and tries to create a hypothetical attack targeting the captured unit. This causes a targeting exception, which gets hit repeatedly very fast and exceeds the server error limit.