### PR TITLE
Undo: UndoArray species fix

### DIFF
--- a/server/game/core/GameObjectUtils.ts
+++ b/server/game/core/GameObjectUtils.ts
@@ -474,6 +474,10 @@ class UndoArray<TValue extends GameObjectBase> extends Array<TValue> {
     public prop: string;
     private accessing = false;
 
+    public static override get [Symbol.species]() {
+        return Array; // Return the native Array constructor
+    }
+
     public override push(...items: TValue[]): number {
         this.accessing = true;
         try {
@@ -527,17 +531,6 @@ class UndoArray<TValue extends GameObjectBase> extends Array<TValue> {
         } finally {
             this.accessing = false;
         }
-    }
-
-    // Shadow Array.prototype methods so that they return a normal array instead of a UndoArray.
-    public override filter(...args): TValue[] {
-        return [...super.filter.apply(this, args)];
-    }
-
-    public override map<U>(callbackfn: (value: TValue, index: number, array: TValue[]) => U, thisArg?: any): U[] {
-        // @ts-expect-error We need the argument definitions so we can infer the generic return value, but need to pass all of the arguments down to the apply.
-        // eslint-disable-next-line prefer-rest-params
-        return [...super.map.apply(this, arguments)] as U[];
     }
 
     public override sort(): this {


### PR DESCRIPTION
Makes map/filter implicitly return a pure array instead of a UndoArray.

[Example](https://www.typescriptlang.org/play/?#code/MYGwhgzhAECqB2ATA9gQQE7rATwDwBUA1MEAVwFMA+acgDwBdykYMs8iSLqBvAKGgHQADqQBGIAJbBoAc2QAuaACVywZOkS4w8bABpo27JQDc-QSPFTh6ZEMUR66CfBmnB1iQDcwjA8GDkUM4y0AC80ABmJBDkboIOPlYy5PTQANoAytgAtqLIIAB0EEKqEoEAugAUAJTQfO7u6Cmk6PDQrDjG0AD03crNrdD0ABbk0PCJnmMd2NBq8A7opMD06mYCAL686z19FpLS84vLq+iVcooqahpaOvqGlPpCNnbQi8H6BV9MjmUQihwyOQ0uVavVBL0GhBSCUzl8Cj8nIFqnEBJD3CMJBACnIwrJkKjdg1MdjnrY8WShIT0YISQUwP5AhBgnjHBRqX0tjt9lZkFNMBJEGMRBBhpV4RJGNl-tBARQQdVFPBSLlyOg6jsMcMsfTGUEXKylrFNbT0LNwQ0iQABegQAC0dBKKwdmHU0AA8vynIgWQlfAyAkFRBJJPRsCbLZU6XIivQfMC6ZTygYYABxMDZcju0QAK1U9BUEQIxCBlAVBRFYolUux2TAQkqlVotVC1FoOJShZq1RREYaTXoLTa0NhFdIovFX0l5Glvctm0izhIIHNfa1OoDTJZ4SiIBihPcW0P23cPOkfLV3rGpAW2oi9EnBWn0oBJfloKVKtEao186G2uxTd9RCcI2WNP9HFXP9IRte1HXzF0bHVT1L0FX0439PVmWDUNwz-dwowAnFkFjeM0kTF5k0gaB00zbM8xWQti04KhyxvUUJHvR9n1retG2bMI2w7AtyAibs53wgQByHN4YTVAp2LvB9qxnCAJMtDZFwmEAV1-ST-w3LDt0iaJwPnI9BC5U8xAOaALwFIVhFsGo9MtOkgOZA1QKNA9TSg-SYNtB1aCdehELdFCHPQ+M-EDbCQ0lPD9MInUYz9BMiKTFMaIzLNc3zJi5VY0EK2c9T8OkwYR3koQyt8hcIiXHT-Mk9yjK8ky9zMjSdis8wbN5L1BTGDiuLBPs2ri4ywPqoYzVc-DArgkKEMvCKhp9A10tirccMStdBBS7E0owjKdSy6jaLyhiRKLIqyxK0aH3Kv9KuHOT0CKJSalmzTGu03SLXwyatw63d9z7CzNhPfrLHPDaxiafkYhqV8WJBBb10A9qQLm9kJvmoHoL6WDgtC8LkI26LMKmvawwOgQjuI0jGHIzLKOyq76IK0TmNLcskbVFGXvnN7ZNHQX0GF36tOXFrgaIjzjPB7qGih6A+oEM87IRt51GexQSUx2lhhsAB3cZyAtgBRV0zgAcgyfXoCxcZkFSEdavQRhEBdtoEBQGYCnt8rNeEAb4dQxzigOchKgSb3P1VdB9CFEAUnIABhZAb3oAB+JPv3QRVZTfYFkyJwROOgSowHQGQVR+bF05cEZoGoAAmcb9P-c3LZtu3KntgO0EwHAiiEWO7PgXTPf1mAYSGZAhjN5e64bzN4FtYORehiDFZxw18YgwmGetIL4OdNbKaj6mxiVumkskpmTrIijbCotNcu5xjefu8sY5SDjgnegqdyDp0YNnXOu9+wDHeqOQBAR45xm9mAiBWcc5bxgX9JqgMz4g2AniFWv1eowy1hHHWUcxiNR0pUbwQI0ZAn0CAgu4wvxqn0EwRArDlTJxLkbSuAgRh93gFbaAtskJDwAGIhhAC7GA8B3biy9j7P2cAkCjzYDvQkWwuS9COKkOu6pwiiItiPGYuB3guEoJUbg4xcqKHts4SUEgSAGDHtge2Gt9D23tj4vx0BfG9gMe44x-d1GBw8ZY341ih4BKCaYIxxE8R2ImJmRxABZWYAA5XKXiNiJMwBWF4eJHbIEzNAAACi8e2pgjj5HIAUEAyAZBD2AE0eMvsACMjjoAAGpQkFAMUsFY6gChpPIPcTAUzPpyGCcgBYhjMAdzxEkusDZaCCWgM2OpCyIANKaS0tpHTVEd16QMoxHchl7LZKMz6EyZkd0ecReZizQkAGZVnLIKOspsWydm8HqenQ5rT7btPIJ06AnyvEXMwO865iyRmnHGblGZ7yURAA)