### PR TITLE
Enable undo test mode in prod

### DIFF
--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1823,7 +1823,8 @@ class Game extends EventEmitter {
                 }),
                 started: this.started,
                 gameMode: this.gameMode,
-                winners: this.winnerNames
+                winners: this.winnerNames,
+                undoEnabled: this.isUndoEnabled,
             };
 
             // clean out any properies that are null or undefined to reduce the message size

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1888,6 +1888,8 @@ class Game extends EventEmitter {
             return false;
         }
 
+        const player = this.getPlayerById(settings.playerId);
+
         const preUndoState = this.captureGameState('any');
 
         try {
@@ -1898,6 +1900,8 @@ class Game extends EventEmitter {
             }
 
             this.postRollbackOperations(rollbackResult.entryPoint, preUndoState);
+
+            this.addAlert(AlertType.Notification, '{0} has rolled back to a previous action', player);
 
             return true;
         } catch (error) {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1879,16 +1879,18 @@ class Game extends EventEmitter {
      * @param {import('./snapshot/SnapshotInterfaces.js').IGetSnapshotSettings} settings - Settings for the snapshot restoration
      * @returns True if a snapshot was restored, false otherwise
      */
-    rollbackToSnapshot(_playerId, settings) {
-        return this.rollbackToSnapshotInternal(settings);
+    rollbackToSnapshot(playerId, settings) {
+        const result = this.rollbackToSnapshotInternal(settings);
+
+        if (result) {
+            this.addAlert(AlertType.Notification, '{0} has rolled back to a previous action', this.getPlayerById(playerId));
+        }
     }
 
     rollbackToSnapshotInternal(settings) {
         if (!this.isUndoEnabled) {
             return false;
         }
-
-        const player = this.getPlayerById(settings.playerId);
 
         const preUndoState = this.captureGameState('any');
 
@@ -1900,8 +1902,6 @@ class Game extends EventEmitter {
             }
 
             this.postRollbackOperations(rollbackResult.entryPoint, preUndoState);
-
-            this.addAlert(AlertType.Notification, '{0} has rolled back to a previous action', player);
 
             return true;
         } catch (error) {

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -1918,6 +1918,10 @@ class Game extends EventEmitter {
     }
 
     reportSevereRollbackFailure(error, description) {
+        if (process.env.NODE_ENV === 'test') {
+            throw error;
+        }
+
         logger.error('Rollback failed', {
             lobbyId: this.lobbyId,
             gameId: this.id,

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -245,6 +245,7 @@ class Game extends EventEmitter {
         this.statsUpdated = false;
         this.playStarted = false;
         this.createdAt = new Date();
+        this.preUndoStateForError = null;
 
         this.buildSafeTimeoutHandler = details.buildSafeTimeout;
         this.userTimeoutDisconnect = details.userTimeoutDisconnect;
@@ -313,7 +314,7 @@ class Game extends EventEmitter {
 
 
     /**
-     * Reports errors from the game engine back to the router
+     * Reports errors from the game engine back to the router, optionally halting the game if the error is severe.
      * @param {Error} e
      */
     reportError(e, severeGameMessage = false) {
@@ -1892,49 +1893,49 @@ class Game extends EventEmitter {
             return false;
         }
 
-        const preUndoState = this.captureGameState('any');
+        this.preUndoStateForError = { gameState: this.captureGameState('any'), settings };
 
+        let rollbackResult;
         try {
-            const rollbackResult = this._snapshotManager.rollbackTo(settings);
+            rollbackResult = this._snapshotManager.rollbackTo(settings);
 
             if (!rollbackResult.success) {
                 return false;
             }
 
-            this.postRollbackOperations(rollbackResult.entryPoint, preUndoState);
-
-            return true;
+            this.postRollbackOperations(rollbackResult.entryPoint);
         } catch (error) {
             if (process.env.NODE_ENV !== 'test') {
-                logger.error('Rollback failed', {
-                    lobbyId: this._router.id,
-                    gameId: this.id,
-                    settings,
-                    preUndoState,
-                    error: error.message,
-                    stack: error.stack,
-                });
-
-                this.discordDispatcher.formatAndSendUndoFailureReportAsync({
-                    gameId: this.id,
-                    lobbyId: this._router.id,
-                    settings,
-                    preUndoState,
-                });
+                this.reportSevereRollbackFailure(error, 'Severe error during rollback operation');
             }
 
             throw error;
+        } finally {
+            this.preUndoStateForError = null;
         }
+
+        return true;
+    }
+
+    reportSevereRollbackFailure(error, description) {
+        logger.error('Rollback failed', {
+            lobbyId: this.lobbyId,
+            gameId: this.id,
+            settings: this.preUndoStateForError.settings,
+            preUndoState: this.preUndoStateForError.gameState,
+            error: { message: error.message, stack: error.stack }
+        });
+        this.discordDispatcher.formatAndSendServerErrorAsync(description, error, this.lobbyId);
+        this.reportError(error, true);
     }
 
     /**
      * @param {import('./snapshot/SnapshotInterfaces.js').IRollbackSetupEntryPoint | import('./snapshot/SnapshotInterfaces.js').IRollbackRoundEntryPoint} entryPoint
-     * @param {import ('../Interfaces.js').ISerializedGameState} preUndoState
      */
-    postRollbackOperations(entryPoint, preUndoState) {
+    postRollbackOperations(entryPoint) {
         const postUndoState = this.captureGameState('any');
         const gameStates = {
-            preUndoState,
+            preUndoState: this.preUndoStateForError,
             postUndoState,
         };
         if (process.env.NODE_ENV !== 'test') {

--- a/server/game/core/snapshot/GameStateManager.ts
+++ b/server/game/core/snapshot/GameStateManager.ts
@@ -152,10 +152,6 @@ export class GameStateManager implements IGameObjectRegistrar {
                 for (const removed of removals) {
                     removed.go.cleanupOnRemove(removed.oldState);
                 }
-
-                if (beforeRollbackSnapshot) {
-                    throw new Error('test');
-                }
             } catch (error) {
                 if (!beforeRollbackSnapshot) {
                     this.game.reportSevereRollbackFailure(error, 'Error during rollback to snapshot and no beforeRollbackSnapshot provided. Game has reached an unrecoverable state.');
@@ -177,11 +173,11 @@ export class GameStateManager implements IGameObjectRegistrar {
             }
 
             // Remove GOs that hadn't yet been created by this point.
-            // Because the for loop to determine removals is done from end to beginning, we don't have to worry about deleted indexes causing a problem when the array shifts.
-            for (const removed of removals) {
-                // TODO THIS PR: stop using repeated splice
+            // Use filter for efficient removal instead of multiple splice operations
+            const removalIndexSet = new Set(removals.map((r) => r.index));
+            this.allGameObjects = this.allGameObjects.filter((_, index) => !removalIndexSet.has(index));
 
-                this.allGameObjects.splice(removed.index, 1);
+            for (const removed of removals) {
                 this.gameObjectMapping.delete(removed.go.uuid);
             }
 

--- a/server/game/core/snapshot/container/SnapshotArray.ts
+++ b/server/game/core/snapshot/container/SnapshotArray.ts
@@ -84,8 +84,8 @@ export class SnapshotArray extends SnapshotContainerBase {
             return null;
         }
 
-        super.rollbackToSnapshotInternal(snapshot);
-        return snapshot.id;
+        const success = super.rollbackToSnapshotInternal(snapshot);
+        return success ? snapshot.id : null;
     }
 
     public override clearNewerSnapshots(snapshotId: number): void {

--- a/server/game/core/snapshot/container/SnapshotContainerBase.ts
+++ b/server/game/core/snapshot/container/SnapshotContainerBase.ts
@@ -57,16 +57,21 @@ export abstract class SnapshotContainerBase {
     public rollbackById(snapshotId: number): number | null {
         const snapshot = this.getAllSnapshots().find((s) => s.id === snapshotId);
         if (snapshot) {
-            this.rollbackToSnapshotInternal(snapshot);
-            return snapshot.id;
+            const success = this.rollbackToSnapshotInternal(snapshot);
+            return success ? snapshot.id : null;
         }
         return null;
     }
 
-    protected rollbackToSnapshotInternal(snapshot: IGameSnapshot): void {
-        this.gameStateManager.rollbackToSnapshot(snapshot);
+    protected rollbackToSnapshotInternal(snapshot: IGameSnapshot): boolean {
+        const success = this.gameStateManager.rollbackToSnapshot(snapshot, this.getCurrentSnapshotFn());
+        if (!success) {
+            return false;
+        }
+
         this.updateCurrentSnapshotFn(snapshot);
         this.game.randomGenerator.restore(snapshot.rngState);
+        return true;
     }
 
     /**

--- a/server/game/core/snapshot/container/SnapshotHistoryMap.ts
+++ b/server/game/core/snapshot/container/SnapshotHistoryMap.ts
@@ -110,8 +110,8 @@ export class SnapshotHistoryMap<T> extends SnapshotContainerBase {
             return null;
         }
 
-        super.rollbackToSnapshotInternal(snapshot);
-        return snapshot.id;
+        const success = super.rollbackToSnapshotInternal(snapshot);
+        return success ? snapshot.id : null;
     }
 
     public override clearNewerSnapshots(snapshotId: number): void {

--- a/server/game/core/snapshot/container/SnapshotMap.ts
+++ b/server/game/core/snapshot/container/SnapshotMap.ts
@@ -53,8 +53,8 @@ export class SnapshotMap<T> extends SnapshotContainerBase {
             return null;
         }
 
-        super.rollbackToSnapshotInternal(snapshot);
-        return snapshot.id;
+        const success = super.rollbackToSnapshotInternal(snapshot);
+        return success ? snapshot.id : null;
     }
 
     public override clearNewerSnapshots(snapshotId: number): void {

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -671,19 +671,20 @@ export class GameServer {
 
         app.post('/api/create-lobby', authMiddleware(), async (req, res, next) => {
             try {
-                const { deck, format, isPrivate, lobbyName } = req.body;
+                const { deck, format, isPrivate, lobbyName, enableUndo } = req.body;
                 const user = req.user;
                 // Check if the user is already in a lobby
                 if (!this.canUserJoinNewLobby(user.getId())) {
                     // TODO shouldn't return 403
                     logger.error(`GameServer (create-lobby): Error in create-lobby User ${user.getId()} attempted to create a different lobby while already being in a lobby`);
+                    logger.info(`enableUndo value: '${enableUndo}'`);
                     return res.status(403).json({
                         success: false,
                         message: 'User is already in a lobby'
                     });
                 }
                 await this.processDeckValidation(deck, format, res, () => {
-                    this.createLobby(lobbyName, user, deck, format, isPrivate);
+                    this.createLobby(lobbyName, user, deck, format, isPrivate, enableUndo);
                     res.status(200).json({ success: true });
                 });
             } catch (err) {
@@ -958,7 +959,7 @@ export class GameServer {
      * @param {boolean} isPrivate - Whether or not this lobby is private.
      * @returns {string} The ID of the user who owns and created the newly created lobby.
      */
-    private createLobby(lobbyName: string, user: User, deck: Deck, format: SwuGameFormat, isPrivate: boolean) {
+    private createLobby(lobbyName: string, user: User, deck: Deck, format: SwuGameFormat, isPrivate: boolean, enableUndo = false) {
         if (!user) {
             throw new Error('User must be provided to create a lobby');
         }
@@ -974,7 +975,8 @@ export class GameServer {
             this.cardDataGetter,
             this.deckValidator,
             this,
-            this.testGameBuilder
+            this.testGameBuilder,
+            enableUndo
         );
         this.lobbies.set(lobby.id, lobby);
         lobby.createLobbyUser(user, deck);
@@ -990,7 +992,8 @@ export class GameServer {
             this.cardDataGetter,
             this.deckValidator,
             this,
-            this.testGameBuilder
+            this.testGameBuilder,
+            true
         );
         this.lobbies.set(lobby.id, lobby);
         const order66 = this.userFactory.createAnonymousUser('exe66', 'Order66');

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -121,7 +121,7 @@ export class Lobby {
         this.deckValidator = deckValidator;
         this.gameFormat = lobbyGameFormat;
         this.server = gameServer;
-        this.undoMode = process.env.ENVIRONMENT === 'development' || enableUndo ? UndoMode.Full : UndoMode.CurrentSnapshotOnly;
+        this.undoMode = enableUndo ? UndoMode.Full : UndoMode.CurrentSnapshotOnly;
     }
 
     public get id(): string {

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -80,6 +80,7 @@ export class Lobby {
     private readonly testGameBuilder?: any;
     private readonly server: GameServer;
     private readonly lobbyCreateTime: Date = new Date();
+    private readonly undoMode: UndoMode = UndoMode.Disabled;
 
     private game?: Game;
     public users: LobbyUser[] = [];
@@ -103,6 +104,7 @@ export class Lobby {
         deckValidator: DeckValidator,
         gameServer: GameServer,
         testGameBuilder?: any,
+        enableUndo = false
     ) {
         Contract.assertTrue(
             [MatchType.Custom, MatchType.Private, MatchType.Quick].includes(lobbyGameType),
@@ -119,6 +121,7 @@ export class Lobby {
         this.deckValidator = deckValidator;
         this.gameFormat = lobbyGameFormat;
         this.server = gameServer;
+        this.undoMode = process.env.ENVIRONMENT === 'development' || enableUndo ? UndoMode.Full : UndoMode.CurrentSnapshotOnly;
     }
 
     public get id(): string {
@@ -748,7 +751,7 @@ export class Lobby {
             owner: 'Order66',
             gameMode: GameMode.Premier,
             players,
-            undoMode: process.env.ENVIRONMENT === 'development' ? UndoMode.Full : UndoMode.CurrentSnapshotOnly,
+            undoMode: this.undoMode,
             cardDataGetter: this.cardDataGetter,
             useActionTimer,
             pushUpdate: () => this.sendGameState(this.game),


### PR DESCRIPTION
Added a hidden query parameter `?undoTest=true` which will enable undo in private games only. FE PR: https://github.com/SWU-Karabast/forceteki-client/pull/452

Added some piping to support this, as well as a few minor UX and polish things that are required for this test. Includes:
- There was an N^2 operation during rollback, made it more efficient
- Game chat message for undo success or failure
- Better error handling of undo failures in general
- Will attempt to roll back to the prior state if a rollback fails