### PR TITLE
[Bugfix] Prevent Seasoned Fleet Admiral's ability from double-triggering

### DIFF
--- a/server/game/cards/04_JTL/units/SeasonedFleetAdmiral.ts
+++ b/server/game/cards/04_JTL/units/SeasonedFleetAdmiral.ts
@@ -14,6 +14,7 @@ export default class SeasonedFleetAdmiral extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
             title: 'Give an Experience token to a unit',
+            collectiveTrigger: true,
             when: {
                 onCardsDrawn: (event, context) => event.player === context.player.opponent && context.game.currentPhase === PhaseName.Action,
             },

--- a/test/server/cards/04_JTL/units/SeasonedFleetAdmiral.spec.ts
+++ b/test/server/cards/04_JTL/units/SeasonedFleetAdmiral.spec.ts
@@ -9,8 +9,9 @@ describe('Seasoned Fleet Admiral', function () {
                         groundArena: ['seasoned-fleet-admiral', 'battlefield-marine'],
                     },
                     player2: {
-                        hand: ['strategic-analysis', 'mission-briefing'],
-                        groundArena: ['wampa']
+                        hand: ['strategic-analysis', 'this-is-the-way'],
+                        groundArena: ['wampa'],
+                        deck: ['sabine-wren#explosives-artist', 'supercommando-squad']
                     }
                 });
             });
@@ -42,8 +43,10 @@ describe('Seasoned Fleet Admiral', function () {
                 const { context } = contextRef;
 
                 context.player1.passAction();
-                context.player2.clickCard(context.missionBriefing);
-                context.player2.clickPrompt('You');
+                context.player2.clickCard(context.thisIsTheWay);
+                context.player2.clickCardInDisplayCardPrompt(context.sabineWren);
+                context.player2.clickCardInDisplayCardPrompt(context.supercommandoSquad);
+                context.player2.clickDone();
 
                 expect(context.player1).toHavePrompt('Give an Experience token to a unit');
                 expect(context.player1).toBeAbleToSelectExactly([context.seasonedFleetAdmiral, context.battlefieldMarine, context.wampa]);

--- a/test/server/cards/04_JTL/units/SeasonedFleetAdmiral.spec.ts
+++ b/test/server/cards/04_JTL/units/SeasonedFleetAdmiral.spec.ts
@@ -9,7 +9,7 @@ describe('Seasoned Fleet Admiral', function () {
                         groundArena: ['seasoned-fleet-admiral', 'battlefield-marine'],
                     },
                     player2: {
-                        hand: ['strategic-analysis'],
+                        hand: ['strategic-analysis', 'mission-briefing'],
                         groundArena: ['wampa']
                     }
                 });
@@ -36,6 +36,25 @@ describe('Seasoned Fleet Admiral', function () {
 
                 expect(context.player1).toBeActivePlayer();
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['experience']);
+            });
+
+            it('should only give 1 experience token if opponent draws multiple cards at once during action phase', function () {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+                context.player2.clickCard(context.missionBriefing);
+                context.player2.clickPrompt('You');
+
+                expect(context.player1).toHavePrompt('Give an Experience token to a unit');
+                expect(context.player1).toBeAbleToSelectExactly([context.seasonedFleetAdmiral, context.battlefieldMarine, context.wampa]);
+                expect(context.player1).toHavePassAbilityButton();
+
+                context.player1.clickCard(context.seasonedFleetAdmiral);
+
+                expect(context.player1).toBeActivePlayer();
+                expect(context.seasonedFleetAdmiral).toHaveExactUpgradeNames(['experience']);
+                expect(context.battlefieldMarine.upgrades.length).toBe(0);
+                expect(context.wampa.upgrades.length).toBe(0);
             });
 
             it('should not give experience token if opponent draw cards during regroup phase', function () {


### PR DESCRIPTION
Fixes #1127