### PR TITLE
Fix Mace Windu leader issue causing game crashes

### DIFF
--- a/server/game/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.ts
+++ b/server/game/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.ts
@@ -21,10 +21,10 @@ export default class MaceWinduVaapadFormMaster extends LeaderUnitCard {
                 cardCondition: (card) => card.isUnit() && card.damage > 0,
                 immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1 })
             },
-            then: (thenContext) => ({
+            ifYouDo: (ifYouDoContext) => ({
                 title: 'Deal 1 damage to it',
-                thenCondition: (context) => context.target && context.target.isUnit() && context.target.isInPlay() && context.target.damage >= 5,
-                immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1, target: thenContext.target }),
+                ifYouDoCondition: (context) => context.target.isUnit() && context.target.isInPlay() && context.target.damage >= 5,
+                immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1, target: ifYouDoContext.target }),
             })
         });
     }

--- a/server/game/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.ts
+++ b/server/game/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.ts
@@ -23,7 +23,7 @@ export default class MaceWinduVaapadFormMaster extends LeaderUnitCard {
             },
             then: (thenContext) => ({
                 title: 'Deal 1 damage to it',
-                thenCondition: (context) => context.target.isUnit() && context.target.isInPlay() && context.target.damage >= 5,
+                thenCondition: (context) => context.target && context.target.isUnit() && context.target.isInPlay() && context.target.damage >= 5,
                 immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 1, target: thenContext.target }),
             })
         });

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -542,3 +542,22 @@ export enum RollbackSetupEntryPoint {
     StartOfSetupPhase = 'startOfSetupPhase',
     WithinSetupPhase = 'withinSetupPhase',
 }
+
+export enum GameErrorSeverity {
+    Normal = 'normal',
+
+    /**
+     * Indicates that we should inform the player that something has gone wrong and send a discord update, but do not throw and interrupt
+     * game flow.
+     *
+     * Used for cases when something unexpected happens but we can potentially recover without losing game state.
+     */
+    SevereGameMessageOnly = 'severeGameMessageOnly',
+
+    /**
+     * Indicates that we should inform the player that something has gone wrong and send a discord update, then throw to interrupt game flow.
+     *
+     * Used for cases when something unexpected happens and we cannot recover.
+     */
+    SevereHaltGame = 'severeHaltGame',
+}

--- a/server/game/core/Game.js
+++ b/server/game/core/Game.js
@@ -21,7 +21,7 @@ const { AbilityContext } = require('./ability/AbilityContext.js');
 const Contract = require('./utils/Contract.js');
 const { cards } = require('../cards/Index.js');
 
-const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName, TokenUnitName, PhaseName, TokenCardName, AlertType, SnapshotType, RollbackRoundEntryPoint, RollbackSetupEntryPoint } = require('./Constants.js');
+const { EventName, ZoneName, Trait, WildcardZoneName, TokenUpgradeName, TokenUnitName, PhaseName, TokenCardName, AlertType, SnapshotType, RollbackRoundEntryPoint, RollbackSetupEntryPoint, GameErrorSeverity } = require('./Constants.js');
 const { StateWatcherRegistrar } = require('./stateWatcher/StateWatcherRegistrar.js');
 const { DistributeAmongTargetsPrompt } = require('./gameSteps/prompts/DistributeAmongTargetsPrompt.js');
 const HandlerMenuMultipleSelectionPrompt = require('./gameSteps/prompts/HandlerMenuMultipleSelectionPrompt.js');
@@ -317,9 +317,10 @@ class Game extends EventEmitter {
     /**
      * Reports errors from the game engine back to the router, optionally halting the game if the error is severe.
      * @param {Error} e
+     * @param {GameErrorSeverity} severity
      */
-    reportError(e, severeGameMessage = false) {
-        this._router.handleError(this, e, severeGameMessage);
+    reportError(e, severity = GameErrorSeverity.Normal) {
+        this._router.handleError(this, e, severity);
     }
 
     /**
@@ -2009,7 +2010,7 @@ class Game extends EventEmitter {
             error: { message: error.message, stack: error.stack }
         });
         this.discordDispatcher.formatAndSendServerErrorAsync(description, error, this.lobbyId);
-        this.reportError(error, true);
+        this.reportError(error, GameErrorSeverity.SevereHaltGame);
     }
 
     /**

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -74,7 +74,7 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
               (properties.immediateEffect == null || properties.immediateEffect.hasLegalTarget(contextCopy, {}, this.properties.mustChangeGameState));
         } catch (err) {
             // if an error happens while evaluating a card's condition, report it silently and return false so we have a chance to recover
-            context.game.reportError(err, false);
+            context.game.reportError(err);
             return false;
         }
     }

--- a/server/game/core/gameSteps/AbilityResolver.ts
+++ b/server/game/core/gameSteps/AbilityResolver.ts
@@ -1,6 +1,6 @@
 import { BaseStepWithPipeline } from './BaseStepWithPipeline.js';
 import { SimpleStep } from './SimpleStep.js';
-import { ZoneName, Stage, EventName, RelativePlayer } from '../Constants.js';
+import { ZoneName, Stage, EventName, RelativePlayer, GameErrorSeverity } from '../Constants.js';
 import { GameEvent } from '../event/GameEvent.js';
 import type Game from '../Game.js';
 import type { AbilityContext } from '../ability/AbilityContext.js';
@@ -341,7 +341,7 @@ export class AbilityResolver extends BaseStepWithPipeline {
         try {
             return this.pipeline.continue(this.game);
         } catch (err) {
-            this.game.reportError(err, true);
+            this.game.reportError(err, GameErrorSeverity.SevereGameMessageOnly);
 
             // if we hit an error resolving an ability, try to close out the ability gracefully and move on
             // to see if we can preserve a playable game state

--- a/server/game/core/gameSystem/GameSystem.ts
+++ b/server/game/core/gameSystem/GameSystem.ts
@@ -215,7 +215,7 @@ export abstract class GameSystem<TContext extends AbilityContext = AbilityContex
             return this.canAffectInternal(target, context, additionalProperties, mustChangeGameState);
         } catch (err) {
             // if there's an error in the canAffect method, we want to report it but not throw an exception so as to try and preserve the game state
-            context.game?.reportError(err, false);
+            context.game?.reportError(err);
             return false;
         }
     }

--- a/server/game/core/snapshot/GameStateManager.ts
+++ b/server/game/core/snapshot/GameStateManager.ts
@@ -6,7 +6,7 @@ import * as Helpers from '../utils/Helpers.js';
 import { to } from '../utils/TypeHelpers';
 import v8 from 'node:v8';
 import { logger } from '../../../logger';
-import { AlertType } from '../Constants';
+import { AlertType, GameErrorSeverity } from '../Constants';
 
 export interface IGameObjectRegistrar {
     register(gameObject: GameObjectBase | GameObjectBase[]): void;
@@ -51,7 +51,7 @@ export class GameStateManager implements IGameObjectRegistrar {
         try {
             Contract.assertNotNullLike(ref, errorMessage);
         } catch (error) {
-            this.game.reportError(error, true);
+            this.game.reportError(error, GameErrorSeverity.SevereHaltGame);
 
             throw error;
         }

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -18,7 +18,7 @@ import { ScoreType } from '../utils/deck/DeckInterfaces';
 import type { GameConfiguration } from '../game/core/GameInterfaces';
 import { GameMode } from '../GameMode';
 import type { GameServer, ISwuStatsToken } from './GameServer';
-import { AlertType } from '../game/core/Constants';
+import { AlertType, GameErrorSeverity } from '../game/core/Constants';
 import { UndoMode } from '../game/core/snapshot/SnapshotManager';
 import { formatBugReport } from '../utils/bugreport/BugReportFormatter';
 
@@ -926,7 +926,7 @@ export class Lobby {
         return timeout;
     }
 
-    public handleError(game: Game, error: Error, severeGameMessage = false) {
+    public handleError(game: Game, error: Error, severity = GameErrorSeverity.Normal) {
         logger.error('Game: handleError', { error: { message: error.message, stack: error.stack }, lobbyId: this.id });
 
         let maxErrorCountExceeded = false;
@@ -934,11 +934,11 @@ export class Lobby {
         this.gameMessageErrorCount++;
         if (this.gameMessageErrorCount > Lobby.MaxGameMessageErrors) {
             logger.error('Game: too many errors for request, halting', { lobbyId: this.id });
-            severeGameMessage = true;
+            severity = GameErrorSeverity.SevereHaltGame;
             maxErrorCountExceeded = true;
         }
 
-        if (game && severeGameMessage) {
+        if (game && (severity === GameErrorSeverity.SevereGameMessageOnly || severity === GameErrorSeverity.SevereHaltGame)) {
             const discordMessage = maxErrorCountExceeded
                 ? `Maximum error count ${Lobby.MaxGameMessageErrors} exceeded, game halted to prevent server crash`
                 : 'Severe game error reported, game is in an unrecoverable state';
@@ -947,14 +947,16 @@ export class Lobby {
                 .catch((e) => logger.error('Server error could not be sent to Discord: Unhandled error', { error: { message: e.message, stack: e.stack }, lobbyId: this.id }));
 
             game.addMessage(
-                `A server error has occurred, apologies.  Your game may now be in an inconsistent state, or you may be able to continue. The error has been reported to the dev team. If this happens again, please take a screenshot and reach out in the Karabast discord (game id ${this.id})`,
+                `A server error has occurred, apologies. Your game may now be in an inconsistent state, or you may be able to continue. The error has been reported to the dev team. If this happens again, please take a screenshot and reach out in the Karabast discord (game id ${this.id})`,
             );
 
             // send game state so that the message can be seen
             this.sendGameState(this.game);
 
-            // this is ugly since we're probably within an exception handler currently, but if we get here it's already crisis
-            throw error;
+            if (severity === GameErrorSeverity.SevereHaltGame) {
+                // this is ugly since we're probably within an exception handler currently, but if we get here it's already crisis
+                throw error;
+            }
         }
     }
 

--- a/test/server/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.spec.ts
+++ b/test/server/cards/03_TWI/leaders/MaceWinduVaapadFormMaster.spec.ts
@@ -67,6 +67,23 @@ describe('Mace Windu, Vaapad Form Master', function () {
             });
         });
 
+        it('Mace Windu\'s leader undeployed ability should not cause an error if there are no enemy units', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'mace-windu#vaapad-form-master',
+                    resources: 3
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.maceWindu);
+            context.player1.clickPrompt('Use it anyway');
+            expect(context.player2).toBeActivePlayer();
+            expect(context.player1.exhaustedResourceCount).toBe(1);
+        });
+
         describe('Mace Windu\'s leader deployed ability', function () {
             it('should deal 2 damage to each damaged enemy unit', async function () {
                 await contextRef.setupTestAsync({


### PR DESCRIPTION
The Mace Windu leader's `thenCondition` was missing a null check that could cause severe game crashes. Fixed this issue and changed the severe error handling to allow the game to potentially recover in simple cases like this one.