### PR TITLE
Allow Kylo's leader ability to be cancelled

### DIFF
--- a/server/game/cards/05_LOF/leaders/KyloRenWereNotDoneYet.ts
+++ b/server/game/cards/05_LOF/leaders/KyloRenWereNotDoneYet.ts
@@ -2,7 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
-import { CardType, EventName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { CardType, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
 import type { IThenAbilityPropsWithSystems } from '../../../Interfaces';
 
 export default class KyloRenWereNotDoneYet extends LeaderUnitCard {
@@ -17,18 +17,17 @@ export default class KyloRenWereNotDoneYet extends LeaderUnitCard {
         registrar.addActionAbility({
             title: 'Discard a card from your hand. If you discard an Upgrade this way, draw a card',
             cost: AbilityHelper.costs.exhaustSelf(),
-            immediateEffect: AbilityHelper.immediateEffects.sequential([
-                AbilityHelper.immediateEffects.discardCardsFromOwnHand((context) => ({
-                    target: context.player,
-                    amount: 1
-                })),
-                AbilityHelper.immediateEffects.conditional((context) => ({
-                    condition: context.events.some(
-                        (event) => event.name === EventName.OnCardDiscarded && event.card.isUpgrade()
-                    ),
-                    onTrue: AbilityHelper.immediateEffects.draw(),
-                }))
-            ])
+            targetResolver: {
+                zoneFilter: ZoneName.Hand,
+                controller: RelativePlayer.Self,
+                canChooseNoCards: false,
+                immediateEffect: AbilityHelper.immediateEffects.discardSpecificCard(),
+            },
+            ifYouDo: {
+                title: 'If you discarded an Upgrade this way, draw a card',
+                ifYouDoCondition: (context) => context.events[0].card.isUpgrade(),
+                immediateEffect: AbilityHelper.immediateEffects.draw()
+            }
         });
     }
 

--- a/test/helpers/CustomMatchers.js
+++ b/test/helpers/CustomMatchers.js
@@ -533,6 +533,28 @@ var customMatchers = {
             }
         };
     },
+    toHaveNoEffectAbilityPrompt: function () {
+        return {
+            compare: function (player, abilityText) {
+                var result = {};
+
+                if (abilityText == null) {
+                    throw new TestSetupError('toHaveNoEffectAbilityPrompt requires an abilityText parameter');
+                }
+
+                const noEffectPromptText = `The ability "${abilityText}" will have no effect. Are you sure you want to use it?`;
+                result.pass = player.hasPrompt(noEffectPromptText);
+
+                if (result.pass) {
+                    result.message = `Expected ${player.name} not to have no effect prompt '${noEffectPromptText}' but it did.`;
+                } else {
+                    result.message = `Expected ${player.name} to have no effect prompt '${noEffectPromptText}' but it has prompt:\n${generatePromptHelpMessage(player.testContext)}`;
+                }
+
+                return result;
+            }
+        };
+    },
     toHavePassSingleTargetPrompt: function () {
         return {
             compare: function (player, abilityText, target) {

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -134,6 +134,7 @@ declare namespace jasmine {
         toBeActivePlayer<T extends PlayerInteractionWrapper>(this: Matchers<T>): boolean;
         toHaveInitiative<T extends PlayerInteractionWrapper>(this: Matchers<T>): boolean;
         toHavePassAbilityPrompt<T extends PlayerInteractionWrapper>(this: Matchers<T>, abilityText: any): boolean;
+        toHaveNoEffectAbilityPrompt<T extends PlayerInteractionWrapper>(this: Matchers<T>, abilityText: any): boolean;
         toHavePassSingleTargetPrompt<T extends PlayerInteractionWrapper>(this: Matchers<T>, abilityText: any, target: any): boolean;
         toBeInBottomOfDeck(player: PlayerInteractionWrapper, numCards: number): boolean;
         toAllBeInBottomOfDeck(player: PlayerInteractionWrapper, numCards: number): boolean;

--- a/test/server/actions/ActionAbility.spec.ts
+++ b/test/server/actions/ActionAbility.spec.ts
@@ -15,7 +15,7 @@ describe('An action ability', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.grandInquisitor);
-            expect(context.player1).toHavePrompt('The ability "Deal 2 damage to a friendly unit with 3 or less power and ready it" will have no effect. Are you sure you want to use it?');
+            expect(context.player1).toHaveNoEffectAbilityPrompt('Deal 2 damage to a friendly unit with 3 or less power and ready it');
             expect(context.player1).toHaveExactPromptButtons(['Use it anyway', 'Cancel']);
 
             context.player1.clickPrompt('Cancel');
@@ -24,7 +24,7 @@ describe('An action ability', function() {
             expect(context.getChatLogs(1)).not.toContain('player1 attempted to use Grand Inquisitor, but there are insufficient legal targets');
 
             context.player1.clickCard(context.grandInquisitor);
-            expect(context.player1).toHavePrompt('The ability "Deal 2 damage to a friendly unit with 3 or less power and ready it" will have no effect. Are you sure you want to use it?');
+            expect(context.player1).toHaveNoEffectAbilityPrompt('Deal 2 damage to a friendly unit with 3 or less power and ready it');
             expect(context.player1).toHaveExactPromptButtons(['Use it anyway', 'Cancel']);
 
             context.player1.clickPrompt('Use it anyway');

--- a/test/server/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.spec.ts
+++ b/test/server/cards/01_SOR/leaders/CassianAndorDedicatedToTheRebellion.spec.ts
@@ -150,7 +150,7 @@ describe('Cassian Andor, Dedicated to the Rebellion', function() {
                 context.player1.clickCard(context.cassianAndor);
                 context.player1.clickPrompt(prompt);
 
-                expect(context.player1).toHavePrompt(`The ability "${prompt}" will have no effect. Are you sure you want to use it?`);
+                expect(context.player1).toHaveNoEffectAbilityPrompt(prompt);
                 context.player1.clickPrompt('Use it anyway');
 
                 expect(context.cassianAndor.exhausted).toBeTrue();

--- a/test/server/cards/05_LOF/leaders/KyloRenWereNotDoneYet.spec.ts
+++ b/test/server/cards/05_LOF/leaders/KyloRenWereNotDoneYet.spec.ts
@@ -60,6 +60,25 @@ describe('Kylo Ren, We\'re Not Done Yet', function () {
                 expect(context.fifthBrother).toBeInZone('deck');
                 expect(context.kyloRen.exhausted).toBeTrue();
             });
+
+            it('can be cancelled before a card is discarded', function () {
+                const { context } = contextRef;
+
+                // Use Kylo Ren's ability
+                context.player1.clickCard(context.kyloRen);
+                context.player1.clickPrompt('Discard a card from your hand. If you discard an Upgrade this way, draw a card');
+
+                // Verify the player can cancel
+                expect(context.player1).not.toHaveEnabledPromptButton('Choose nothing');
+                expect(context.player1).toHaveEnabledPromptButton('Cancel');
+                context.player1.clickPrompt('Cancel');
+
+                // Ability was not used, it is still Player 1's action
+                expect(context.kyloRen.exhausted).toBeFalse();
+                expect(context.player1.hand.length).toBe(5);
+                expect(context.player1.discard.length).toBe(0);
+                expect(context.player1).toBeActivePlayer();
+            });
         });
 
         describe('Kylo Ren\'s leader side edge cases', function() {
@@ -78,8 +97,11 @@ describe('Kylo Ren, We\'re Not Done Yet', function () {
                 // Use Kylo Ren's ability
                 context.player1.clickCard(context.kyloRen);
                 context.player1.clickPrompt('Discard a card from your hand. If you discard an Upgrade this way, draw a card');
+                expect(context.player1).toHaveNoEffectAbilityPrompt('Discard a card from your hand. If you discard an Upgrade this way, draw a card');
+                context.player1.clickPrompt('Use it anyway');
 
-                // No cards should be discarded or drawn
+                // No cards should be discarded or drawn, it is now Player 2's action
+                expect(context.player2).toBeActivePlayer();
                 expect(context.kyloRen.exhausted).toBeTrue();
                 expect(context.fifthBrother).toBeInZone('deck');
                 expect(context.player1.discard.length).toBe(0);

--- a/test/server/cards/05_LOF/leaders/MorganElsbethFollowingTheCall.spec.ts
+++ b/test/server/cards/05_LOF/leaders/MorganElsbethFollowingTheCall.spec.ts
@@ -60,7 +60,7 @@ describe('Morgan Elsbeth, Following the Call', function() {
                 context.player1.clickPrompt(prompt);
 
                 // It cannot fully resolve, so the user is prompted to confirm using it anyway
-                expect(context.player1).toHavePrompt(`The ability "${prompt}" will have no effect. Are you sure you want to use it?`);
+                expect(context.player1).toHaveNoEffectAbilityPrompt(prompt);
                 context.player1.clickPrompt('Use it anyway');
 
                 // Resolution ends because there are no valid units to play
@@ -114,7 +114,7 @@ describe('Morgan Elsbeth, Following the Call', function() {
                 context.player1.clickPrompt(prompt);
 
                 // It cannot fully resolve because there are no units with Smuggle in hand (only an event)
-                expect(context.player1).toHavePrompt(`The ability "${prompt}" will have no effect. Are you sure you want to use it?`);
+                expect(context.player1).toHaveNoEffectAbilityPrompt(prompt);
                 context.player1.clickPrompt('Use it anyway');
 
                 expect(context.morganElsbeth.exhausted).toBeTrue();

--- a/test/server/cards/05_LOF/units/BabuFrikHeyyy.spec.ts
+++ b/test/server/cards/05_LOF/units/BabuFrikHeyyy.spec.ts
@@ -138,7 +138,7 @@ describe('Babu Frik, Heyyy!', function () {
                 context.player1.clickPrompt(prompt);
 
                 // Player is warned that the ability has no effect
-                expect(context.player1).toHavePrompt(`The ability "${prompt}" will have no effect. Are you sure you want to use it?`);
+                expect(context.player1).toHaveNoEffectAbilityPrompt(prompt);
                 context.player1.clickPrompt('Use it anyway');
                 context.player1.clickPrompt('Trigger');
 


### PR DESCRIPTION
Fixes #1664

This also adds a new test matcher for the prompt that informs a player if an ability will have no effect.
