### PR TITLE
Handle serialization errors better

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -297,42 +297,58 @@ export interface ISetId {
     number: number;
 }
 
+export type ISerializationError = Record<string, string>;
+
 export interface IResourceState {
     readyCount: number;
     exhaustedCount: number;
 }
 
+type ISafeSerializedType<T> = T | ISerializationError;
+type ISafeSerializedArrayType<T> = (T | ISerializationError)[] | ISerializationError;
+
+export interface ISerializedUpgradeState {
+    card: string;
+    ownerAndController: ISafeSerializedType<string>;
+}
+
+export interface ISerializedCapturedCardState {
+    card: string;
+    owner: ISafeSerializedType<string>;
+}
+
 /* Serialized state retrieving interfaces */
 export interface ISerializedCardState {
     card: string;
-    damage?: number;
-    upgrades?: ({ card: string; ownerAndController: string } | string)[];
-    deployed?: boolean;
-    exhausted?: boolean;
-    capturedUnits?: ({ card: string; owner: string } | string)[];
-    flipped?: boolean;
-    owner?: string;
+    damage?: ISafeSerializedType<number>;
+    upgrades?: ISafeSerializedArrayType<ISerializedUpgradeState | string>;
+    deployed?: ISafeSerializedType<boolean>;
+    exhausted?: ISafeSerializedType<boolean>;
+    capturedUnits?: ISafeSerializedArrayType<ISerializedCapturedCardState | string>;
+    flipped?: ISafeSerializedType<boolean>;
+    owner?: ISafeSerializedType<string>;
 }
 
 export interface IPlayerSerializedState {
     hand?: number | string[];
-    groundArena?: (string | ISerializedCardState)[];
-    spaceArena?: (string | ISerializedCardState)[];
-    discard?: string[];
-    resources?: number | IResourceState | (string | ISerializedCardState)[];
-    base?: string | ISerializedCardState;
-    leader?: string | ISerializedCardState;
-    deck?: number | string[];
-    hasInitiative?: boolean;
-    hasForceToken?: boolean;
+    groundArena?: ISafeSerializedArrayType<string | ISerializedCardState>;
+    spaceArena?: ISafeSerializedArrayType<string | ISerializedCardState>;
+    discard?: ISafeSerializedArrayType<string>;
+    resources?: ISafeSerializedArrayType<number | IResourceState | (string | ISerializedCardState)>;
+    base?: ISafeSerializedType<string | ISerializedCardState>;
+    leader?: ISafeSerializedType<string | ISerializedCardState>;
+    deck?: ISafeSerializedType<number> | ISafeSerializedArrayType<string>;
+    hasInitiative?: ISafeSerializedType<boolean>;
+    hasForceToken?: ISafeSerializedType<boolean>;
 }
 
 export interface ISerializedGameState {
     phase?: string;
-    reportingPlayer?: IPlayerSerializedState;
-    opponent?: IPlayerSerializedState;
-    player1?: IPlayerSerializedState;
-    player2?: IPlayerSerializedState;
+    reportingPlayer?: ISafeSerializedType<IPlayerSerializedState>;
+    opponent?: ISafeSerializedType<IPlayerSerializedState>;
+    player1?: ISafeSerializedType<IPlayerSerializedState>;
+    player2?: ISafeSerializedType<IPlayerSerializedState>;
+    error?: string;
 }
 
 export type MessageText = string | (string | number)[];

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -1396,15 +1396,15 @@ export class Player extends GameObject<IPlayerState> implements IGameStatisticsT
             const groundArenaCards = this.game.groundArena.getCards({ controller: this });
             if (groundArenaCards.length > 0) {
                 state.groundArena = groundArenaCards
-                    .filter((card) => !card.isLeaderUnit() && card.captureCardState() !== null)
-                    .map((card) => card.captureCardState());
+                    .filter((card) => !card.isLeaderUnit())
+                    .map((card) => Helpers.safeSerialize(this.game, () => card.captureCardState(), card.internalName));
             }
             // Space arena units
             const spaceArenaCards = this.game.spaceArena.getCards({ controller: this });
             if (spaceArenaCards.length > 0) {
                 state.spaceArena = spaceArenaCards
-                    .filter((card) => !card.isLeaderUnit() && card.captureCardState() !== null)
-                    .map((card) => card.captureCardState());
+                    .filter((card) => !card.isLeaderUnit())
+                    .map((card) => Helpers.safeSerialize(this.game, () => card.captureCardState(), card.internalName));
             }
             // Discard pile
             if (this.discardZone.count > 0) {
@@ -1416,20 +1416,23 @@ export class Player extends GameObject<IPlayerState> implements IGameStatisticsT
 
             // Resources
             if (this.resourceZone.count > 0) {
-                state.resources = this.resourceZone.cards.map((card) => {
-                    // If it's ready, just return the card name
-                    return !card.exhausted ? card.internalName : {
-                        card: card.internalName,
-                        exhausted: card.exhausted
-                    };
-                });
+                // If it's ready, just return the card name
+                state.resources = this.resourceZone.cards.map((card) =>
+                    (Helpers.safeSerialize(this.game, () =>
+                        (!card.exhausted
+                            ? card.internalName
+                            : {
+                                card: card.internalName,
+                                exhausted: card.exhausted
+                            }), card.internalName
+                    )));
             }
 
             // Leader
-            state.leader = this.leader.captureCardState();
+            state.leader = Helpers.safeSerialize(this.game, () => this.leader.captureCardState(), null);
 
             // Base
-            state.base = this.base.captureCardState();
+            state.base = Helpers.safeSerialize(this.game, () => this.base.captureCardState(), null);
 
             // Initiative
             state.hasInitiative = this.hasInitiative();

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -5,6 +5,8 @@ import type { IRandomness } from '../Randomness';
 import { CardType, ZoneName } from '../Constants';
 import * as Contract from './Contract';
 import * as EnumHelpers from './EnumHelpers';
+import type Game from '../Game';
+import type { ISerializationError } from '../../Interfaces';
 
 /* Randomize array in-place using Durstenfeld shuffle algorithm */
 export function shuffleArray<T>(array: T[], randomGenerator: IRandomness): void {
@@ -346,5 +348,17 @@ function deleteEmptyPropertiesRecursiveInPlaceInternal(obj, visited) {
     for (const key of keysToDelete) {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete obj[key];
+    }
+}
+
+export function safeSerialize<T>(game: Game, serialize: () => T, entityName?: string): T | ISerializationError {
+    try {
+        return serialize();
+    } catch (e) {
+        if (game.serializationFailure) {
+            return { [entityName ?? 'error']: `${(e as Error).message}\n${(e as Error).stack}` };
+        }
+
+        game.reportSerializationFailure(e);
     }
 }


### PR DESCRIPTION
During undo testing we found that if an undo failure brings the game into an unserializable state, there's not really much reporting that we get and the player just sees the screen freeze.

Added some logic to safely serialize and generate a report including as much as game state as possible on failure. Right now the players will just receive a blank screen indicating a disconnect, which is not ideal but at least communicates more clearly that something broke.