### PR TITLE
Include attack lasting effects in chat logs

### DIFF
--- a/server/game/actions/InitiateAttackAction.ts
+++ b/server/game/actions/InitiateAttackAction.ts
@@ -24,7 +24,9 @@ interface IInitiateAttackProperties extends IAttackProperties {
  * See {@link GameSystemLibrary.initiateAttack} for using it in abilities.
  */
 export class InitiateAttackAction extends PlayerAction {
-    public constructor(game: Game, card: Card, private attackProperties?: IInitiateAttackProperties) {
+    public readonly initiateAttackSource?: Card;
+
+    public constructor(game: Game, card: Card, private attackProperties?: IInitiateAttackProperties, initiateAttackSource?: Card) {
         const exhaustCost = attackProperties?.allowExhaustedAttacker
             ? new GameSystemCost(new ExhaustSystem({ isCost: true }), true)
             : exhaustSelf();
@@ -40,6 +42,8 @@ export class InitiateAttackAction extends PlayerAction {
             attackTargetingHighlightAttacker: card,
             activePromptTitle: 'Choose a target for attack'
         });
+
+        this.initiateAttackSource = initiateAttackSource;
     }
 
     public override meetsRequirements(context = this.createContext(), ignoredRequirements: string[] = []): string {

--- a/server/game/gameSystems/CardWhileSourceInPlayLastingEffectSystem.ts
+++ b/server/game/gameSystems/CardWhileSourceInPlayLastingEffectSystem.ts
@@ -27,8 +27,8 @@ export class CardWhileSourceInPlayLastingEffectSystem<TContext extends AbilityCo
         super(propertyWithDurationType);
     }
 
-    protected override filterApplicableEffects(card: Card, effects: any[]) {
-        return super.filterApplicableEffects(card, effects)
+    protected override filterApplicableEffects(card: Card, effects: any[], context?: TContext) {
+        return super.filterApplicableEffects(card, effects, context)
             .filter((effect) => this.whileSourceInPlayCondition(effect));
     }
 

--- a/server/game/gameSystems/InitiateAttackSystem.ts
+++ b/server/game/gameSystems/InitiateAttackSystem.ts
@@ -46,7 +46,7 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
 
         super.addPropertiesToEvent(event, attacker, context, additionalProperties);
 
-        event.attackAbility = this.generateAttackAbilityNoTarget(attacker, properties);
+        event.attackAbility = this.generateAttackAbilityNoTarget(attacker, properties, context.source);
         event.optional = properties.optional ?? context.ability.optional;
     }
 
@@ -60,7 +60,7 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
             return false;
         }
 
-        const attackAbility = this.generateAttackAbilityNoTarget(card, properties);
+        const attackAbility = this.generateAttackAbilityNoTarget(card, properties, context.source);
         const newContext = attackAbility.createContext(context.player);
 
         return !attackAbility.meetsRequirements(newContext, properties.ignoredRequirements) &&
@@ -71,8 +71,8 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
      * Generate an attack ability for the specified card.
      * Uses the passed properties but strips out the `target` property to avoid overriding it in the attack.
      */
-    private generateAttackAbilityNoTarget(card: IUnitCard, properties: IAttackProperties) {
+    private generateAttackAbilityNoTarget(card: IUnitCard, properties: IAttackProperties, initiateAttackSource: Card) {
         const { target, ...propertiesNoTarget } = properties;
-        return card.game.gameObjectManager.createWithoutRefsUnsafe(() => new InitiateAttackAction(card.game, card, propertiesNoTarget));
+        return card.game.gameObjectManager.createWithoutRefsUnsafe(() => new InitiateAttackAction(card.game, card, propertiesNoTarget, initiateAttackSource));
     }
 }

--- a/server/game/gameSystems/helpers/LastingEffectSystemHelpers.ts
+++ b/server/game/gameSystems/helpers/LastingEffectSystemHelpers.ts
@@ -17,7 +17,7 @@ export function getEffectMessage<TContext extends AbilityContext, TProperties ex
     properties: TProperties,
     additionalProperties: Partial<TProperties> = {},
     getEffectFactoriesAndProperties: (target: TargetOf<TProperties>, context: TContext, additionalProperties?: Partial<TProperties>) => { effectFactories: IOngoingCardOrPlayerEffectGenerator<Flatten<TargetOf<TProperties>>>[]; effectProperties: IOngoingCardOrPlayerEffectProps<Flatten<TargetOf<TProperties>>> | IOngoingCardOrPlayerEffectProps<Flatten<TargetOf<TProperties>>>[] },
-    filterApplicableEffects: (target: Flatten<TargetOf<TProperties>>, effects: IOngoingCardOrPlayerEffect<Flatten<TargetOf<TProperties>>>[]) => IOngoingCardOrPlayerEffect<Flatten<TargetOf<TProperties>>>[] = (_target, effects) => effects,
+    filterApplicableEffects: (target: Flatten<TargetOf<TProperties>>, effects: IOngoingCardOrPlayerEffect<Flatten<TargetOf<TProperties>>>[], context: TContext) => IOngoingCardOrPlayerEffect<Flatten<TargetOf<TProperties>>>[] = (_target, effects) => effects,
 ): [string, any[]] {
     const targetDescription = properties.ongoingEffectTargetDescription ?? gameSystem.getTargetMessage(properties.target, context);
 
@@ -32,7 +32,7 @@ export function getEffectMessage<TContext extends AbilityContext, TProperties ex
         for (const factory of effectFactories) {
             for (const [i, props] of Helpers.asArray(effectProperties).entries()) {
                 const effect = factory(context.game, context.source, props);
-                if (effect.impl.effectDescription && filterApplicableEffects(properties.target[i] as any, [effect]).length > 0) {
+                if (effect.impl.effectDescription && filterApplicableEffects(properties.target[i] as any, [effect], context).length > 0) {
                     if (effect.impl.type === EffectName.AbilityRestrictions) {
                         abilityRestrictions.push(effect.impl.effectDescription);
                     } else if (effect.impl.type === EffectName.CloneUnit) {

--- a/test/server/cards/01_SOR/events/PrecisionFire.spec.ts
+++ b/test/server/cards/01_SOR/events/PrecisionFire.spec.ts
@@ -29,6 +29,10 @@ describe('Precision Fire', function () {
 
             expect(context.player2).toBeActivePlayer();
             expect(context.battlefieldMarine.getPower()).toBe(3);
+            expect(context.getChatLogs(2)).toEqual([
+                'player1 plays Precision Fire to initiate an attack with Battlefield Marine',
+                'player1 attacks player2\'s base with Battlefield Marine and uses Precision Fire to give Saboteur and to give +2/+0 to Battlefield Marine for this attack',
+            ]);
 
             // reset
             context.readyCard(context.battlefieldMarine);
@@ -46,9 +50,48 @@ describe('Precision Fire', function () {
             expect(context.player1).toBeAbleToSelectExactly([context.corellianFreighter, context.p2Base]);
             context.player1.clickCard(context.p2Base);
             expect(context.p2Base.damage).toBe(2);
+            expect(context.getChatLogs(2)).toEqual([
+                'player1 plays Precision Fire to initiate an attack with Alliance X-Wing',
+                'player1 attacks player2\'s base with Alliance X-Wing and uses Precision Fire to give Saboteur to Alliance X-Wing for this attack',
+            ]);
 
             expect(context.player2).toBeActivePlayer();
             expect(context.allianceXwing.getPower()).toBe(2);
+        });
+
+        it('Precision Fire\'s ability should initiate an attack with no sabouteur if played on a blanked unit', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['precision-fire'],
+                    groundArena: ['battlefield-marine'],
+                    spaceArena: [{ card: 'alliance-xwing', upgrades: ['imprisoned'] }]
+                },
+                player2: {
+                    groundArena: ['echo-base-defender'],
+                    spaceArena: ['corellian-freighter']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.precisionFire);
+            expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.allianceXwing]);
+
+            // do not choose a trooper unit
+            context.player1.clickCard(context.allianceXwing);
+
+            // no saboteur: we cannot ignore sentinel
+            expect(context.player1).toBeAbleToSelectExactly([context.corellianFreighter]);
+            context.player1.clickCard(context.corellianFreighter);
+            expect(context.corellianFreighter.damage).toBe(2);
+            expect(context.getChatLogs(3)).toEqual([
+                'player1 plays Precision Fire to initiate an attack with Alliance X-Wing',
+                'player1 attacks Corellian Freighter with Alliance X-Wing',
+                'player1\'s Alliance X-Wing is defeated by player2 due to having no remaining HP',
+            ]);
+
+            expect(context.player2).toBeActivePlayer();
         });
     });
 });

--- a/test/server/cards/02_SHD/events/SwoopDown.spec.ts
+++ b/test/server/cards/02_SHD/events/SwoopDown.spec.ts
@@ -46,6 +46,10 @@ describe('Swoop Down', function () {
             expect(context.player2).toBeActivePlayer();
             expect(context.allianceXwing.damage).toBe(1); // 3-2
             expect(context.consularSecurityForce.damage).toBe(4); // 2+2
+            expect(context.getChatLogs(2)).toEqual([
+                'player1 plays Swoop Down to initiate an attack with Alliance X-Wing',
+                'player1 attacks Consular Security Force with Alliance X-Wing and uses Swoop Down to give Saboteur and to give +2/+0 to Alliance X-Wing for this attack and to give -2/-0 to Consular Security Force for this attack',
+            ]);
         });
     });
 });

--- a/test/server/cards/03_TWI/events/CornerThePrey.spec.ts
+++ b/test/server/cards/03_TWI/events/CornerThePrey.spec.ts
@@ -20,6 +20,10 @@ describe('Corner The Prey', function () {
                 context.player1.clickCard(context.cornerThePrey);
                 context.player1.clickCard(context.consularSecurityForce);
                 context.player1.clickCard(context.chewbacca);
+                expect(context.getChatLogs(2)).toEqual([
+                    'player1 plays Corner the Prey to initiate an attack with Consular Security Force',
+                    'player1 attacks Chewbacca with Consular Security Force and uses Corner the Prey to give +2/+0 to Consular Security Force for this attack',
+                ]);
 
                 // The Consular Security Force should have +2 power for this attack
                 expect(context.consularSecurityForce.getPower()).toBe(6);


### PR DESCRIPTION
This does a few things in addition to improving the chat log:
- it adds a new field to `InitiateAttackAction` to get the card that initiated the attack (to be used in the chat logs).
- Now `AttackStepsSystem`  creates a single `CardLastingEffectSystem` for all attacker/defender effects and skips them if there are no valid effects.
- Now `CardLastingEffectSystem` filters applicable effects by also checking their condition.