### PR TITLE
LookAtSystem chat logging

### DIFF
--- a/server/game/gameSystems/LookAtSystem.ts
+++ b/server/game/gameSystems/LookAtSystem.ts
@@ -4,6 +4,8 @@ import type { Player } from '../core/Player';
 import type { IViewCardProperties } from './ViewCardSystem';
 import { ViewCardInteractMode, ViewCardSystem } from './ViewCardSystem';
 import * as Helpers from '../core/utils/Helpers';
+import * as ChatHelpers from '../core/chat/ChatHelpers';
+import type { FormatMessage } from '../core/chat/GameChat';
 
 export type ILookAtProperties = IViewCardProperties;
 
@@ -19,21 +21,27 @@ export class LookAtSystem<TContext extends AbilityContext = AbilityContext> exte
 
     public override getEffectMessage(context: TContext, additionalProperties?: Partial<ILookAtProperties>): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        let effectArgs: any[] = ['a card'];
 
-        let effectArg = 'a card';
+        let format = 'look at {0}';
+        const cardsFormat: FormatMessage = { format: ChatHelpers.formatWithLength(Helpers.asArray(properties.target).length, ''), args: this.getTargetMessage(properties.target, context) };
 
         if (Helpers.equalArrays(Helpers.asArray(properties.target), context.player.opponent.hand)) {
-            effectArg = 'the opponent’s hand';
+            const handSize = Helpers.asArray(properties.target).length;
+            format = 'look at the opponent\'s hand and sees ' + ChatHelpers.formatWithLength(handSize, '');
+            effectArgs = this.getTargetMessage(properties.target, context);
         } else if (Helpers.asArray(properties.target)
             .every((card) => card.zone.owner === context.player.opponent && card.zoneName === ZoneName.Resource)
         ) {
             const targetCount = Helpers.asArray(properties.target).length;
-            effectArg = targetCount === 1
-                ? 'an enemy resource'
-                : `${targetCount} enemy resources`;
+            format = targetCount === 1
+                ? 'look at an enemy resource and sees'
+                : `look at ${targetCount} enemy resources and sees`;
+            format += ' ' + ChatHelpers.formatWithLength(targetCount, '');
+            effectArgs = this.getTargetMessage(properties.target, context);
         }
 
-        return ['look at {0}', [effectArg]];
+        return [format, effectArgs];
     }
 
     protected override getPromptedPlayer(properties: ILookAtProperties, context: TContext): Player {

--- a/test/server/cards/01_SOR/events/SparkOfRebellion.spec.ts
+++ b/test/server/cards/01_SOR/events/SparkOfRebellion.spec.ts
@@ -19,10 +19,10 @@ describe('Spark Of Rebellion', function () {
                 // First check that the lookAt sends ALL the opponents cards in hand to chat
                 expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.battlefieldMarine, context.waylay, context.protector, context.infernoFour]);
                 expect(context.player1).not.toHaveEnabledPromptButton('Take nothing');
-                expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.protector.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.battlefieldMarine.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.waylay.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.protector.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.infernoFour.title);
 
                 context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);
                 expect(context.battlefieldMarine).toBeInZone('discard');
@@ -37,7 +37,7 @@ describe('Spark Of Rebellion', function () {
 
                 expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.infernoFour]);
                 expect(context.player1).not.toHaveEnabledPromptButton('Done');
-                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.infernoFour.title);
 
                 context.player1.clickCardInDisplayCardPrompt(context.infernoFour);
                 expect(context.infernoFour).toBeInZone('discard');

--- a/test/server/cards/01_SOR/units/BodhiRook.spec.ts
+++ b/test/server/cards/01_SOR/units/BodhiRook.spec.ts
@@ -27,12 +27,12 @@ describe('Bodhi Rook', function () {
                 });
                 expect(context.player1).not.toHaveEnabledPromptButton('Done');
 
-                // Check that cards are not revealed in chat
-                expect(context.getChatLogs(1)[0]).not.toContain(context.sabineWren.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.protector.title);
+                // Check that cards are revealed in chat
+                expect(context.getChatLogs(1)[0]).toContain(context.sabineWren.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.battlefieldMarine.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.infernoFour.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.waylay.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.protector.title);
 
                 context.player1.clickCardInDisplayCardPrompt(context.waylay);
                 expect(context.waylay).toBeInZone('discard');

--- a/test/server/cards/01_SOR/units/ViperProbeDroid.spec.ts
+++ b/test/server/cards/01_SOR/units/ViperProbeDroid.spec.ts
@@ -20,7 +20,7 @@ describe('Viper Probe Droid', function() {
                 context.player1.clickCard(context.viperProbeDroid);
                 expect(context.viperProbeDroid.zoneName).toBe('groundArena');
                 expect(context.player1).toHaveExactViewableDisplayPromptCards([context.wampa, context.battlefieldMarine, context.pykeSentinel]);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.wampa.title);  // confirm that there is no chat message for the cards
+                expect(context.getChatLogs(1)[0]).toContain(context.wampa.title);  // confirm that there is a chat message for the cards
                 context.player1.clickDone();
                 expect(context.player2).toBeActivePlayer();
             });

--- a/test/server/cards/02_SHD/units/BazineNetalSpyForTheFirstOrder.spec.ts
+++ b/test/server/cards/02_SHD/units/BazineNetalSpyForTheFirstOrder.spec.ts
@@ -23,9 +23,9 @@ describe('Bazin Netal, Spy For The First Order', function() {
                 // Player looks at the opponent's hand and discards a card from it, opponent draws a card
                 context.player1.clickCard(context.bazineNetal);
 
-                // Cards are not revealed in chat
-                expect(context.getChatLogs(1)[0]).not.toContain(context.atst.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
+                // Cards are revealed in chat
+                expect(context.getChatLogs(1)[0]).toContain(context.atst.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.waylay.title);
 
                 // Player sees the opponent's hand and is able to optionally discard a card from it
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');
@@ -48,9 +48,9 @@ describe('Bazin Netal, Spy For The First Order', function() {
                 // Player looks at the opponent's hand and decides not to discard a card from it
                 context.player1.clickCard(context.bazineNetal);
 
-                // Cards are not revealed in chat
-                expect(context.getChatLogs(1)[0]).not.toContain(context.atst.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.wampa.title);
+                // Cards are revealed in chat
+                expect(context.getChatLogs(1)[0]).toContain(context.atst.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.wampa.title);
 
                 // Player sees the opponent's hand and is able to optionally discard a card from it
                 expect(context.player1).toHaveEnabledPromptButton('Take nothing');

--- a/test/server/cards/02_SHD/units/QiraPlayingHerPart.spec.ts
+++ b/test/server/cards/02_SHD/units/QiraPlayingHerPart.spec.ts
@@ -23,11 +23,11 @@ describe('Qi\'ra, Playing Her Part', function () {
             // play qira and increase cost of Battlefield Marine
             context.player1.clickCard(context.qira);
 
-            // Cards are not revealed in chat
-            expect(context.getChatLogs(1)[0]).not.toContain(marine2.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.resupply.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.vanquish.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.changeOfHeart.title);
+            // Cards are revealed in chat
+            expect(context.getChatLogs(1)[0]).toContain(marine2.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.resupply.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.vanquish.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.changeOfHeart.title);
 
             // Player sees the opponent's hand
             expect(context.player1).toHaveEnabledPromptButton('Done');
@@ -44,7 +44,7 @@ describe('Qi\'ra, Playing Her Part', function () {
             context.player1.chooseListOption('Battlefield Marine');
             expect(context.getChatLogs(4)).toEqual([
                 'player1 plays Qi\'ra',
-                'player1 uses Qi\'ra to look at the opponent’s hand',
+                'player1 uses Qi\'ra to look at the opponent\'s hand and sees Battlefield Marine, Resupply, Vanquish, and Change of Heart',
                 'player1 names Battlefield Marine using Qi\'ra',
                 'player1 uses Qi\'ra to apply a lasting effect to player2 while in play',
             ]);

--- a/test/server/cards/03_TWI/events/UnmaskingTheConspiracy.spec.ts
+++ b/test/server/cards/03_TWI/events/UnmaskingTheConspiracy.spec.ts
@@ -27,8 +27,8 @@ describe('Unmasking the Conspiracy', function() {
             expect(context.battlefieldMarine).toBeInZone('discard');
 
             // Check that the lookAt sends ALL the opponents cards in hand to chat
-            expect(context.getChatLogs(1)[0]).not.toContain(context.atst.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.atst.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.waylay.title);
 
             // Discards a card from the opponent's hand
             expect(context.player1).toHaveExactSelectableDisplayPromptCards([context.atst, context.waylay]);

--- a/test/server/cards/04_JTL/events/JamCommunications.spec.ts
+++ b/test/server/cards/04_JTL/events/JamCommunications.spec.ts
@@ -23,11 +23,11 @@ describe('Jam Communications', function () {
             });
             expect(context.player1).not.toHaveEnabledPromptButton('Done');
 
-            // Check that cards are not revealed in chat
-            expect(context.getChatLogs(1)[0]).not.toContain(context.sabineWren.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
-            expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
+            // Check that cards are revealed in chat
+            expect(context.getChatLogs(1)[0]).toContain(context.sabineWren.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.battlefieldMarine.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.infernoFour.title);
+            expect(context.getChatLogs(1)[0]).toContain(context.waylay.title);
 
             context.player1.clickCardInDisplayCardPrompt(context.waylay);
             expect(context.waylay).toBeInZone('discard');

--- a/test/server/cards/05_LOF/events/TipTheScale.spec.ts
+++ b/test/server/cards/05_LOF/events/TipTheScale.spec.ts
@@ -27,12 +27,12 @@ describe('Tip The Scale', function () {
                 });
                 expect(context.player1).not.toHaveEnabledPromptButton('Done');
 
-                // Check that cards are not revealed in chat
-                expect(context.getChatLogs(1)[0]).not.toContain(context.sabineWren.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.waylay.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.protector.title);
+                // Check that cards are revealed in chat
+                expect(context.getChatLogs(1)[0]).toContain(context.sabineWren.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.battlefieldMarine.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.infernoFour.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.waylay.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.protector.title);
 
                 context.player1.clickCardInDisplayCardPrompt(context.waylay);
                 expect(context.waylay).toBeInZone('discard');

--- a/test/server/cards/06_SEC/events/ChargedWithEspionage.spec.ts
+++ b/test/server/cards/06_SEC/events/ChargedWithEspionage.spec.ts
@@ -31,11 +31,11 @@ describe('Charged With Espionage', function () {
                 });
                 expect(context.player1).not.toHaveEnabledPromptButton('Done');
 
-                // Card names should not be revealed in chat
-                expect(context.getChatLogs(1)[0]).not.toContain(context.battlefieldMarine.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.infernoFour.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.vigilance.title);
-                expect(context.getChatLogs(1)[0]).not.toContain(context.protector.title);
+                // Card names should be revealed in chat
+                expect(context.getChatLogs(1)[0]).toContain(context.battlefieldMarine.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.infernoFour.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.vigilance.title);
+                expect(context.getChatLogs(1)[0]).toContain(context.protector.title);
 
                 // Discard one of the units
                 context.player1.clickCardInDisplayCardPrompt(context.battlefieldMarine);

--- a/test/server/cards/06_SEC/units/EliaKaneFalseConvert.spec.ts
+++ b/test/server/cards/06_SEC/units/EliaKaneFalseConvert.spec.ts
@@ -59,7 +59,7 @@ describe('Elia Kane, False Convert', function() {
 
                 expect(context.getChatLogs(3)).toEqual([
                     'player1 plays Elia Kane',
-                    'player1 uses Elia Kane to randomly select 3 cards, and to look at 3 enemy resources',
+                    'player1 uses Elia Kane to randomly select 3 cards, and to look at 3 enemy resources and sees Lom Pyke, Cad Bane, and Restock',
                     'player1 uses Elia Kane to defeat a ready Restock and to move the top card of player2\'s deck to their resources and to ready it',
                 ]);
             });


### PR DESCRIPTION
Add card names to chat logs if information is now available to both players (Target is Opponent's hand/resources) https://github.com/SWU-Karabast/forceteki/issues/1695

All relevant tests changed to now look for the card names in the chat log.