### PR TITLE
add a test that I thought should have failed but works

### DIFF
--- a/test/server/cards/01_SOR/leaders/EmperorPalpatineGalacticRuler.spec.ts
+++ b/test/server/cards/01_SOR/leaders/EmperorPalpatineGalacticRuler.spec.ts
@@ -135,33 +135,43 @@ describe('Emperor Palpatine, Galactic Ruler', function() {
                 phase: 'action',
                 player1: {
                     leader: 'emperor-palpatine#galactic-ruler',
-                    groundArena: ['lothcat', 'battlefield-marine'],
+                    hand: ['lothcat'],
                     resources: 5
                 },
                 player2: {
-                    leader: { card: 'darth-maul#sith-revealed', deployed: true },
-                    groundArena: ['wampa']
+                    leader: 'darth-maul#sith-revealed',
+                    resources: 6
                 }
             });
 
             const { context } = contextRef;
 
+            // Play Loth-Cat to have a unit to defeat
+            context.player1.clickCard(context.lothcat);
+            expect(context.lothcat).toBeInZone('groundArena');
+            expect(context.player1.exhaustedResourceCount).toBe(4);
+
+            // Player 2 deploys Darth Maul
+            expect(context.player2).toBeActivePlayer();
+            context.player2.clickCard(context.darthMaul);
+            context.player2.clickPrompt('Deploy Darth Maul');
+            expect(context.darthMaul).toBeInZone('groundArena');
+
             // Activate Palpatine's undeployed ability
-            expect(context.darthMaul.exhausted).toBeFalse();
             context.player1.clickCard(context.emperorPalpatine);
 
             // Select Loth-Cat to defeat as cost
-            expect(context.player1).toBeAbleToSelectExactly([context.lothcat, context.battlefieldMarine]);
+            expect(context.player1).toBeAbleToSelectExactly([context.lothcat]);
             expect(context.player1).not.toHavePassAbilityButton();
             context.player1.clickCard(context.lothcat);
 
             // Verify costs paid
             expect(context.lothcat).toBeInZone('discard');
             expect(context.emperorPalpatine.exhausted).toBeTrue();
-            expect(context.player1.exhaustedResourceCount).toBe(1);
+            expect(context.player1.exhaustedResourceCount).toBe(5);
 
             // Select target for Palpatine's damage effect
-            expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.wampa, context.darthMaul]);
+            expect(context.player1).toBeAbleToSelectExactly([context.darthMaul]);
             expect(context.player1).not.toHavePassAbilityButton();
             context.player1.clickCard(context.darthMaul);
 
@@ -170,7 +180,7 @@ describe('Emperor Palpatine, Galactic Ruler', function() {
             expect(context.player1.handSize).toBe(1);
 
             // Loth-Cat's whenDefeated ability should trigger, allowing exhausting a ground unit (Maul)
-            expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.wampa, context.darthMaul]);
+            expect(context.player1).toBeAbleToSelectExactly([context.darthMaul]);
             expect(context.player1).toHavePassAbilityButton();
             context.player1.clickCard(context.darthMaul);
 


### PR DESCRIPTION
I had what I think is a bug (description [here](https://discord.com/channels/1220057752961814568/1360259166618259727/1429173080361668661))

I tried to reproduce it with this test but the test passes. So I am probably missing something but I do not see what.

During the game, I haven't been able to exhaust Maul with Loth-Cat.

<img width="753" height="431" alt="Screenshot 2025-10-19 at 15 47 47" src="https://github.com/user-attachments/assets/ebc04457-ca0d-47cb-b240-81b3c1d0e23e" />
