### PR TITLE
[Bugfix] Update AttacksThisPhaseWatcher to see current traits for attacker

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from './core/ability/AbilityContext';
 import type { TriggeredAbilityContext } from './core/ability/TriggeredAbilityContext';
 import type { GameSystem } from './core/gameSystem/GameSystem';
 import type { Card } from './core/card/Card';
-import type { Aspect, DamagePreventionType, Duration, RelativePlayerFilter, StandardTriggeredAbilityType } from './core/Constants';
+import type { Aspect, DamagePreventionType, Duration, RelativePlayerFilter, StandardTriggeredAbilityType, Trait } from './core/Constants';
 import { type RelativePlayer, type CardType, type EventName, type PhaseName, type ZoneFilter, type KeywordName, type AbilityType, type CardTypeFilter } from './core/Constants';
 import type { GameEvent } from './core/event/GameEvent';
 import type { IActionTargetResolver, IActionTargetsResolver, ITriggeredAbilityTargetResolver, ITriggeredAbilityTargetsResolver } from './TargetInterfaces';
@@ -555,3 +555,8 @@ export type NumericKeywordName =
   | KeywordName.Raid
   | KeywordName.Restore
   | KeywordName.Exploit;
+
+export interface ICardAttributes {
+    // TODO: Add more attributes as needed
+    traits: Set<Trait>;
+}

--- a/server/game/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.ts
+++ b/server/game/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.ts
@@ -28,7 +28,8 @@ export default class BoKatanKryzePrincessInExile extends LeaderUnitCard {
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
                     condition: (context) => this.attacksThisPhaseWatcher.someUnitAttackedControlledByPlayer({
                         controller: context.player,
-                        filter: (attack) => context.source !== attack.attacker && attack.attacker.hasSomeTrait(Trait.Mandalorian)
+                        filter: (attack) => context.source !== attack.attacker &&
+                          attack.attackerAttributes.traits.has(Trait.Mandalorian)
                     }),
                     onTrue: AbilityHelper.immediateEffects.damage({ amount: 1 }),
                 })
@@ -48,7 +49,8 @@ export default class BoKatanKryzePrincessInExile extends LeaderUnitCard {
                 title: 'Deal 1 damage to a unit',
                 thenCondition: (context) => this.attacksThisPhaseWatcher.someUnitAttackedControlledByPlayer({
                     controller: context.player,
-                    filter: (attack) => context.source !== attack.attacker && attack.attacker.hasSomeTrait(Trait.Mandalorian)
+                    filter: (attack) => context.source !== attack.attacker &&
+                      attack.attackerAttributes.traits.has(Trait.Mandalorian)
                 }),
                 immediateEffect: AbilityHelper.immediateEffects.selectCard({
                     optional: true,

--- a/server/game/cards/05_LOF/leaders/KitFistoFocusedJediMaster.ts
+++ b/server/game/cards/05_LOF/leaders/KitFistoFocusedJediMaster.ts
@@ -28,7 +28,8 @@ export default class KitFistoFocusedJediMaster extends LeaderUnitCard {
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
                     condition: (context) => this.attacksThisPhaseWatcher.someUnitAttackedControlledByPlayer({
                         controller: context.player,
-                        filter: (attack) => context.source !== attack.attacker && attack.attacker.hasSomeTrait(Trait.Jedi)
+                        filter: (attack) => context.source !== attack.attacker &&
+                          attack.attackerAttributes.traits.has(Trait.Jedi)
                     }),
                     onTrue: AbilityHelper.immediateEffects.damage({ amount: 2 }),
                 })

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -4,7 +4,8 @@ import type {
     ISetId,
     Zone,
     ITriggeredAbilityProps,
-    ISerializedCardState
+    ISerializedCardState,
+    ICardAttributes
 } from '../../Interfaces';
 import { ActionAbility } from '../ability/ActionAbility';
 import type { PlayerOrCardAbility } from '../ability/PlayerOrCardAbility';
@@ -182,6 +183,13 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
         }
 
         return this._printedType;
+    }
+
+    public get attributes(): ICardAttributes {
+        return {
+            // TODO: Add more attributes as needed
+            traits: this.traits
+        };
     }
 
     // ******************************************** PROPERTY GETTERS ********************************************
@@ -761,7 +769,6 @@ export class Card<T extends ICardState = ICardState> extends OngoingEffectSource
     public hasEveryTrait(traits: Set<Trait> | Trait[]): boolean {
         return this.hasEvery(traits, this.traits);
     }
-
 
     // ******************************************* ASPECT HELPERS *******************************************
     public hasSomeAspect(aspects: Set<Aspect> | Aspect | Aspect[]): boolean {

--- a/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/AttacksThisPhaseWatcher.ts
@@ -7,10 +7,12 @@ import type { IUnitCard } from '../core/card/propertyMixins/UnitProperties';
 import type { IAttackableCard } from '../core/card/CardInterfaces';
 import type Game from '../core/Game';
 import type { GameObjectRef, UnwrapRef } from '../core/GameObjectBase';
+import type { ICardAttributes } from '../Interfaces';
 
 export interface AttackEntry {
     attacker: GameObjectRef<IUnitCard>;
     attackerInPlayId: number;
+    attackerAttributes: ICardAttributes;
     attackingPlayer: GameObjectRef<Player>;
     targets: GameObjectRef<IAttackableCard>[];
     targetInPlayId?: number;
@@ -29,6 +31,7 @@ export class AttacksThisPhaseWatcher extends StateWatcher<AttackEntry> {
         return stateValue.map((x) => ({
             attacker: this.game.getFromRef(x.attacker),
             attackerInPlayId: x.attackerInPlayId,
+            attackerAttributes: x.attackerAttributes,
             attackingPlayer: this.game.getFromRef(x.attackingPlayer),
             targets: x.targets.map((y) => this.game.getFromRef(y)),
             targetInPlayId: x.targetInPlayId,
@@ -88,6 +91,7 @@ export class AttacksThisPhaseWatcher extends StateWatcher<AttackEntry> {
                 currentState.concat({
                     attacker: event.attack.attacker.getRef(),
                     attackerInPlayId: event.attack.attacker.inPlayId,
+                    attackerAttributes: event.attack.attacker.attributes,
                     attackingPlayer: event.attack.attacker.controller.getRef(),
                     targets: event.attack.getAllTargets().map((x) => x.getRef()),
                     targetInPlayId: event.attack.targetInPlayId,

--- a/test/server/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.spec.ts
+++ b/test/server/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.spec.ts
@@ -5,11 +5,19 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        groundArena: ['mandalorian-warrior', 'battlefield-marine'],
                         leader: 'bokatan-kryze#princess-in-exile',
-                        resources: 4 // making leader undeployable makes testing the activated ability's condition smoother
+                        resources: 4, // making leader undeployable makes testing the activated ability's condition smoother
+                        groundArena: [
+                            'mandalorian-warrior',
+                            'battlefield-marine',
+                            {
+                                card: 'crafty-smuggler',
+                                upgrades: ['foundling']
+                            }
+                        ],
                     },
                     player2: {
+                        hand: ['confiscate'],
                         groundArena: ['protector-of-the-throne'],
                         spaceArena: ['alliance-xwing'],
                     }
@@ -61,12 +69,33 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 // attack was done with mandalorian, ability should have an effect
                 context.player2.passAction();
                 context.player1.clickCard(context.bokatanKryze);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.protectorOfTheThrone, context.allianceXwing]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.protectorOfTheThrone, context.allianceXwing, context.craftySmuggler]);
                 expect(context.player1).not.toHavePassAbilityButton();
                 context.player1.clickCard(context.allianceXwing);
                 expect(context.protectorOfTheThrone.damage).toBe(0);
                 expect(context.allianceXwing.damage).toBe(1);
                 expect(context.bokatanKryze.exhausted).toBeTrue();
+            });
+
+            it('should count units that had the Mandalorian trait when they attacked even if they no longer have it', function () {
+                const { context } = contextRef;
+
+                // P1 attacks with crafty smuggler
+                context.player1.clickCard(context.craftySmuggler);
+                context.player1.clickCard(context.p2Base);
+
+                // P2 plays Confiscate to remove Foundling from Crafty Smuggler
+                context.player2.clickCard(context.confiscate);
+                context.player2.clickCard(context.foundling);
+
+                // P1 uses bo katan's ability
+                context.player1.clickCard(context.bokatanKryze);
+                expect(context.player1).toHavePrompt('If you attacked with a Mandalorian unit this phase, deal 1 damage to a unit');
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.protectorOfTheThrone, context.allianceXwing, context.craftySmuggler]);
+                context.player1.clickCard(context.protectorOfTheThrone);
+                expect(context.protectorOfTheThrone.damage).toBe(1);
+                expect(context.bokatanKryze.exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
             });
         });
 
@@ -75,10 +104,18 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        groundArena: ['mandalorian-warrior', 'battlefield-marine'],
                         leader: { card: 'bokatan-kryze#princess-in-exile', deployed: true },
+                        groundArena: [
+                            'mandalorian-warrior',
+                            'battlefield-marine',
+                            {
+                                card: 'crafty-smuggler',
+                                upgrades: ['foundling']
+                            }
+                        ],
                     },
                     player2: {
+                        hand: ['confiscate'],
                         groundArena: ['protector-of-the-throne', 'jedha-agitator'],
                         spaceArena: ['alliance-xwing'],
                     }
@@ -91,7 +128,7 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 // first attack : only 1 damage
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.protectorOfTheThrone);
                 expect(context.p2Base.damage).toBe(4);
@@ -103,7 +140,7 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.bokatanKryze);
                 expect(context.player2).toBeActivePlayer();
@@ -116,7 +153,7 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 context.readyCard(context.bokatanKryze);
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.bokatanKryze);
                 expect(context.player2).toBeActivePlayer();
@@ -131,11 +168,11 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 // 2 triggers as we attack with another mandalorian (1 damage to 2 different unit)
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 // prompt does not change between 2 effects of bo katan ability
                 context.player1.clickCardNonChecking(context.protectorOfTheThrone);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.allianceXwing);
                 expect(context.allianceXwing.damage).toBe(1);
@@ -148,11 +185,11 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 // prompt does not change between 2 effects of bo katan ability
                 context.player1.clickCardNonChecking(context.battlefieldMarine);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.battlefieldMarine);
                 expect(context.battlefieldMarine.damage).toBe(2);
@@ -162,11 +199,11 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 // prompt does not change between 2 effects of bo katan ability
                 context.player1.clickCard(context.jedhaAgitator);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.bokatanKryze);
                 expect(context.jedhaAgitator.zoneName).toBe('discard');
@@ -177,11 +214,11 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.bokatanKryze);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 // prompt does not change between 2 effects of bo katan ability
                 context.player1.clickPrompt('Choose nothing');
-                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing]);
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.craftySmuggler]);
                 expect(context.player1).toHaveChooseNothingButton();
                 context.player1.clickCard(context.bokatanKryze);
                 expect(context.player2).toBeActivePlayer();
@@ -207,7 +244,8 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                     context.bokatanKryze,
                     context.protectorOfTheThrone,
                     context.allianceXwing,
-                    context.jedhaAgitator
+                    context.jedhaAgitator,
+                    context.craftySmuggler
                 ]);
                 context.player1.clickCard(context.jedhaAgitator);
                 expect(context.jedhaAgitator).toBeInZone('discard');
@@ -219,7 +257,8 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                     context.battlefieldMarine,
                     context.bokatanKryze,
                     context.protectorOfTheThrone,
-                    context.allianceXwing
+                    context.allianceXwing,
+                    context.craftySmuggler
                 ]);
                 context.player1.clickPrompt('Choose nothing');
 
@@ -229,6 +268,33 @@ describe('Bo-Katan Kryze, Princess in Exile', function() {
                 expect(context.bokatanKryze.damage).toBe(0);
                 expect(context.protectorOfTheThrone.damage).toBe(0);
                 expect(context.allianceXwing.damage).toBe(0);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should count units that had the Mandalorian trait when they attacked even if they no longer have it', function () {
+                const { context } = contextRef;
+
+                // P1 attacks with crafty smuggler
+                context.player1.clickCard(context.craftySmuggler);
+                context.player1.clickCard(context.p2Base);
+
+                // P2 plays Confiscate to remove Foundling from Crafty Smuggler
+                context.player2.clickCard(context.confiscate);
+                context.player2.clickCard(context.foundling);
+
+                // P1 attacks with Bo-Katan to activate her ability
+                context.player1.clickCard(context.bokatanKryze);
+                context.player1.clickCard(context.p2Base);
+
+                // First damage prompt
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
+                context.player1.clickCardNonChecking(context.protectorOfTheThrone);
+                expect(context.protectorOfTheThrone.damage).toBe(1);
+
+                // Second damage prompt
+                expect(context.player1).toBeAbleToSelectExactly([context.mandalorianWarrior, context.battlefieldMarine, context.bokatanKryze, context.protectorOfTheThrone, context.allianceXwing, context.jedhaAgitator, context.craftySmuggler]);
+                context.player1.clickCard(context.allianceXwing);
+                expect(context.allianceXwing.damage).toBe(1);
                 expect(context.player2).toBeActivePlayer();
             });
         });

--- a/test/server/cards/05_LOF/leaders/KitFistoFocusedJediMaster.spec.ts
+++ b/test/server/cards/05_LOF/leaders/KitFistoFocusedJediMaster.spec.ts
@@ -6,14 +6,27 @@ describe('Kit Fisto, Focused Jedi Master', function() {
                     phase: 'action',
                     player1: {
                         hand: ['change-of-heart'],
-                        groundArena: ['yoda#old-master', 'battlefield-marine', 'jedi-guardian'],
+                        groundArena: [
+                            'yoda#old-master',
+                            'battlefield-marine',
+                            'jedi-guardian',
+                            {
+                                card: 'secretive-sage', // Force, but not Jedi
+                                upgrades: [
+                                    'shield',
+                                    'jedi-trials',      // Gives Jedi trait while unit has 4+ upgrades
+                                    'experience',
+                                    'experience'
+                                ]
+                            }
+                        ],
                         spaceArena: ['anakins-interceptor#where-the-fun-begins'],
                         leader: 'kit-fisto#focused-jedi-master'
                     },
                     player2: {
                         groundArena: ['count-dooku#fallen-jedi'],
                         spaceArena: ['alliance-xwing', 'padawan-starfighter'],
-                        hand: ['traitorous']
+                        hand: ['traitorous', 'confiscate']
                     }
                 });
             });
@@ -31,7 +44,7 @@ describe('Kit Fisto, Focused Jedi Master', function() {
                 context.player1.clickPrompt('If you attacked with a Jedi unit this phase, deal 2 damage to a unit');
 
                 // Only units are selectable, deals 2 damage to the selected unit
-                expect(context.player1).toBeAbleToSelectExactly([context.yoda, context.battlefieldMarine, context.jediGuardian, context.countDooku, context.allianceXwing, context.padawanStarfighter, context.anakinsInterceptor]);
+                expect(context.player1).toBeAbleToSelectExactly([context.yoda, context.battlefieldMarine, context.jediGuardian, context.secretiveSage, context.countDooku, context.allianceXwing, context.padawanStarfighter, context.anakinsInterceptor]);
                 expect(context.player1).not.toHavePassAbilityButton();
                 context.player1.clickCard(context.countDooku);
 
@@ -58,7 +71,7 @@ describe('Kit Fisto, Focused Jedi Master', function() {
                 context.player1.clickCard(context.kitFisto);
                 context.player1.clickPrompt('If you attacked with a Jedi unit this phase, deal 2 damage to a unit');
 
-                expect(context.player1).toBeAbleToSelectExactly([context.yoda, context.battlefieldMarine, context.jediGuardian, context.countDooku, context.allianceXwing, context.padawanStarfighter, context.anakinsInterceptor]);
+                expect(context.player1).toBeAbleToSelectExactly([context.yoda, context.battlefieldMarine, context.jediGuardian, context.secretiveSage, context.countDooku, context.allianceXwing, context.padawanStarfighter, context.anakinsInterceptor]);
                 expect(context.player1).not.toHavePassAbilityButton();
                 context.player1.clickCard(context.allianceXwing);
 
@@ -118,6 +131,38 @@ describe('Kit Fisto, Focused Jedi Master', function() {
                 context.player1.clickPrompt('Use it anyway');
 
                 expect(context.kitFisto.exhausted).toBeTrue();
+                expect(context.player1.exhaustedResourceCount).toBe(1);
+            });
+
+            it('works if a unit with the Jedi trait loses the Jedi trait after attacking', function () {
+                const { context } = contextRef;
+
+                // P1 attacks with Secretive Sage (has Jedi trait because of Jedi Trials)
+                context.player1.clickCard(context.secretiveSage);
+                context.player1.clickCard(context.p2Base);
+
+                // P2 plays Confiscate to remove Jedi Trials
+                context.player2.clickCard(context.confiscate);
+                context.player2.clickCard(context.jediTrials);
+
+                // Use Kit Fisto's ability
+                context.player1.clickCard(context.kitFisto);
+                context.player1.clickPrompt('If you attacked with a Jedi unit this phase, deal 2 damage to a unit');
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.yoda,
+                    context.battlefieldMarine,
+                    context.jediGuardian,
+                    context.secretiveSage,
+                    context.countDooku,
+                    context.allianceXwing,
+                    context.padawanStarfighter,
+                    context.anakinsInterceptor
+                ]);
+                expect(context.player1).not.toHavePassAbilityButton();
+                context.player1.clickCard(context.allianceXwing);
+
+                expect(context.kitFisto.exhausted).toBeTrue();
+                expect(context.allianceXwing.damage).toBe(2);
                 expect(context.player1.exhaustedResourceCount).toBe(1);
             });
         });


### PR DESCRIPTION
Fixes #1555

This fixes issues with both Bo-Katan and Kit Fisto leader abilities. Previously, they only check the card's at the time of evaluating the leader abilities, but now the attacker's traits at the time of the attack are captured in the watcher's entry.