### PR TITLE
Improve Savage Opress log

### DIFF
--- a/server/game/cards/05_LOF/units/SavageOpressImbuedWithHate.ts
+++ b/server/game/cards/05_LOF/units/SavageOpressImbuedWithHate.ts
@@ -19,7 +19,7 @@ export default class SavageOpressImbuedWithHate extends NonLeaderUnitCard {
             },
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.useTheForce(),
-            effect: 'not take damage by using the Force',
+            effect: 'not damage their base by instead using the Force',
             ifYouDoNot: {
                 title: 'Deal 9 damage to your base',
                 immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({

--- a/test/server/cards/05_LOF/units/SavageOpressImbuedWithHate.spec.ts
+++ b/test/server/cards/05_LOF/units/SavageOpressImbuedWithHate.spec.ts
@@ -1,6 +1,6 @@
 describe('Savage Opress, Imbued with Hate', () => {
     integration(function (contextRef) {
-        const useTheForce = 'player1 uses Savage Opress to not take damage by using the Force';
+        const useTheForce = 'player1 uses Savage Opress to not damage their base by instead using the Force';
         const doNotUseTheForce = 'player1 uses Savage Opress to deal 9 damage to their own base';
 
         describe('Savage Opress\' when played ability', () => {


### PR DESCRIPTION
Currently, logs are :

- player1 uses Savage Opress to use the Force
- player1 uses Savage Opress to deal 9 damage to their own base

I update the first log to 'player1 uses Savage Opress to not take damage by using the Force'

Improve and resolve #1454 