### PR TITLE
sendGameState Optimization: fix an O(n) operation in deleteEmptyPropertiesRecursiveInPlace

### DIFF
--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -326,15 +326,15 @@ export function setUnion<T>(setA: Set<T>, setB: Set<T>): Set<T> {
  * This is an _in-place_ operation, meaning it modifies the original object.
  */
 export function deleteEmptyPropertiesRecursiveInPlace(obj) {
-    deleteEmptyPropertiesRecursiveInPlaceInternal(obj, []);
+    deleteEmptyPropertiesRecursiveInPlaceInternal(obj, new Set());
 }
 
 function deleteEmptyPropertiesRecursiveInPlaceInternal(obj, visited) {
-    if (obj == null || visited.includes(obj)) {
+    if (obj == null || visited.has(obj)) {
         return;
     }
 
-    visited.push(obj);
+    visited.add(obj);
 
     const keysToDelete = [];
     for (const key in obj) {


### PR DESCRIPTION
Converted the array to a set to remove the O(n) includes call at the beginning of each recursive call