### PR TITLE
hasOngoingEffect optimization

### DIFF
--- a/server/game/core/GameObject.ts
+++ b/server/game/core/GameObject.ts
@@ -72,10 +72,11 @@ export abstract class GameObject<T extends IGameObjectState = IGameObjectState> 
     }
 
     public hasOngoingEffect(type: EffectName): boolean {
-        // This will want to be swapped out when the decorator is in place
-        // We can simply traverse the raw array of ongoing effects
-        for (const ref of this.state.ongoingEffects) {
-            if (this.game.getFromRef(ref).type === type) {
+        const effects = this.state.ongoingEffects;
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < effects.length; i++) {
+            // This call will want to be swapped out when the decorator is in place
+            if (this.game.getFromRef(effects[i]).type === type) {
                 return true;
             }
         }


### PR DESCRIPTION
Updated the hasOngoingEffect method to ignore the old LOT5R code for suppressed effects, it uses a simple for loop that exits early by derefing the game objects one by one

Also explicitly removed the suppressed effect logic as its no longer needed

<img width="745" height="284" alt="image" src="https://github.com/user-attachments/assets/0b93c22f-4f69-44dc-a9e2-9608a6f31914" />
