### PR TITLE
Ignore PostResolutionTriggers on Bossk

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -236,7 +236,7 @@ export type ITriggeredAbilityBaseProps<TSource extends Card = Card> = IAbilityPr
     then?: ((context?: TriggeredAbilityContext<TSource>) => IThenAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>) | IThenAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>;
     ifYouDo?: ((context?: TriggeredAbilityContext<TSource>) => IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>) | IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>;
     ifYouDoNot?: ((context?: TriggeredAbilityContext<TSource>) => IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>) | IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>;
-    ignorePostResolutionEventTriggers?: boolean;
+    ignoreAlreadyResolvedEvents?: boolean;
 };
 
 /** Interface definition for setEventAbility */

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -236,6 +236,7 @@ export type ITriggeredAbilityBaseProps<TSource extends Card = Card> = IAbilityPr
     then?: ((context?: TriggeredAbilityContext<TSource>) => IThenAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>) | IThenAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>;
     ifYouDo?: ((context?: TriggeredAbilityContext<TSource>) => IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>) | IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>;
     ifYouDoNot?: ((context?: TriggeredAbilityContext<TSource>) => IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>) | IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>>;
+    ignorePostResolutionEventTriggers?: boolean;
 };
 
 /** Interface definition for setEventAbility */

--- a/server/game/cards/01_SOR/units/BosskDeadlyStalker.ts
+++ b/server/game/cards/01_SOR/units/BosskDeadlyStalker.ts
@@ -21,7 +21,8 @@ export default class BosskDeadlyStalker extends NonLeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 }),
-            }
+            },
+            ignorePostResolutionEventTriggers: true
         });
     }
 }

--- a/server/game/cards/01_SOR/units/BosskDeadlyStalker.ts
+++ b/server/game/cards/01_SOR/units/BosskDeadlyStalker.ts
@@ -22,7 +22,7 @@ export default class BosskDeadlyStalker extends NonLeaderUnitCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.damage({ amount: 2 }),
             },
-            ignorePostResolutionEventTriggers: true
+            ignoreAlreadyResolvedEvents: true
         });
     }
 }

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -50,7 +50,7 @@ export default class TriggeredAbility extends CardAbility<ITriggeredAbillityStat
     public readonly anyPlayer: boolean;
     public readonly collectiveTrigger: boolean;
     public readonly standardTriggerTypes: StandardTriggeredAbilityType[] = [];
-    public readonly ignorePostResolutionEventTriggers: boolean;
+    public readonly ignoreAlreadyResolvedEvents: boolean;
 
     protected eventRegistrations?: IEventRegistration<(event: GameEvent, window: TriggeredAbilityWindow) => void>[];
     protected eventsTriggeredFor: GameEvent[] = [];
@@ -95,7 +95,7 @@ export default class TriggeredAbility extends CardAbility<ITriggeredAbillityStat
         }
 
         this.collectiveTrigger = !!properties.collectiveTrigger;
-        this.ignorePostResolutionEventTriggers = !!properties.ignorePostResolutionEventTriggers;
+        this.ignoreAlreadyResolvedEvents = !!properties.ignoreAlreadyResolvedEvents;
 
         this.mustChangeGameState = !!this.properties.ifYouDo || !!this.properties.ifYouDoNot
             ? GameStateChangeRequired.MustFullyResolve
@@ -113,7 +113,7 @@ export default class TriggeredAbility extends CardAbility<ITriggeredAbillityStat
 
         // If this ability should ignore post-resolution triggers and the event has already resolved,
         // skip this trigger. This handles cases like Sneak Attack and No Glory with Bossk.  Bossk ability shouldn't be eligible to trigger the second time
-        if (this.ignorePostResolutionEventTriggers && event.isResolved) {
+        if (this.ignoreAlreadyResolvedEvents && event.isResolved) {
             return;
         }
 

--- a/test/server/cards/01_SOR/units/BosskDeadlyStalker.spec.ts
+++ b/test/server/cards/01_SOR/units/BosskDeadlyStalker.spec.ts
@@ -41,7 +41,7 @@ describe('Bossk, Deadly Stalker', function () {
                 expect(context.greenSquadronAwing.isUpgraded()).toBeFalse();
             });
 
-            it('should not trigger off of the event card that played him', async function () {
+            it('should not trigger off of the event card that played him (Now There Are Two)', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -54,6 +54,44 @@ describe('Bossk, Deadly Stalker', function () {
 
                 context.player1.clickCard(context.nowThereAreTwoOfThem);
                 context.player1.clickCard(context.bossk);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should not trigger off of the event card that played him (Sneak Attack)', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['sneak-attack', 'bossk#deadly-stalker'],
+                        groundArena: ['boba-fett#disintegrator'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.sneakAttack);
+                context.player1.clickCard(context.bossk);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should not trigger off of playing No Glory Only Results on opponent\'s Bossk', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['no-glory-only-results'],
+                        groundArena: [],
+                    },
+                    player2: {
+                        hand: ['now-there-are-two-of-them'],
+                        groundArena: ['boba-fett#disintegrator', 'bossk#deadly-stalker'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.noGloryOnlyResults);
+                context.player1.clickCard(context.bosskDeadlyStalker);
 
                 expect(context.player2).toBeActivePlayer();
             });


### PR DESCRIPTION
Added a new property for Trigger Abilities `ignorePostResolutionEventTriggers` to not evaluate the ability trigger when it is invoked during `EventWindow.postResolutionTriggers`; and set this new property to true for Bossk.

Tries to address issues #1090 and the issues with Bossk reported under #1443