### PR TITLE
Remove dangling "and to" from 1st Spare the Target chat message

### DIFF
--- a/server/game/gameSystems/SimultaneousSystem.ts
+++ b/server/game/gameSystems/SimultaneousSystem.ts
@@ -15,7 +15,7 @@ export class SimultaneousSystem<TContext extends AbilityContext = AbilityContext
 
     public override getEffectMessage(context: TContext): [string, any[]] {
         const { gameSystems } = this.generatePropertiesFromContext(context);
-        const legalSystems = gameSystems.filter((system) => system.hasLegalTarget(context) && system.name !== 'collect bounty'); /* collecting a bounty always gets its own message */
+        const legalSystems = gameSystems.filter((system) => system.hasLegalTarget(context) && system.getEffectMessage(context)[0] !== '');
         const message = ChatHelpers.formatWithLength(legalSystems.length, 'to ');
         const legalSystemsMessages = legalSystems.map((system) => {
             const [format, args] = system.getEffectMessage(context);


### PR DESCRIPTION
The problem this addresses is that if someone uses Spare The Target, there is an "and to" at the end of the chat message (regardless of if the target has a Bounty or not; if it does have a Bounty, the bounty-collecting is still a separate message). This is because the code wants to put bounties in the same chat message as other actions, but bounties always have to be their own message. I assumed when making this that the latter is the desired behavior, so this simply removes the "and to" (regardless of if the target has a Bounty or not) with no other changes.

I know this may not be a very elegant fix and I'm obviously open to feedback.

| Original  | This PR |
| ------------- | ------------- |
| <img width="296" height="107" alt="Player 2 plays Spare The Target to return Mace Windu to Player 1's hand and to" src="https://github.com/user-attachments/assets/093e457b-c7f5-4536-87a7-85696e62ccf7" />  | <img width="308" height="107" alt="Order66 plays Spare The Target to return Blizzard Assault AT-AT to ThisIsTheWay's hand" src="https://github.com/user-attachments/assets/24995e54-d80a-4846-b91e-78db3cee8842" />   |
| <img width="316" height="227" alt="Order66 plays Spare The Target to return Clone Deserter to ThisIsTheWay's hand and to (next message starts) Order66 collects the 'Draw a Card' Bounty on Clone Deserter to draw a card" src="https://github.com/user-attachments/assets/e2b96be7-b027-4974-b393-71a07af062c6" />  | <img width="317" height="216" alt="Order66 plays Spare The Target to return Clone Deserter to ThisIsTheWay's hand (next message starts) Order66 collects the 'Draw a Card' Bounty on Clone Deserter to draw a card" src="https://github.com/user-attachments/assets/78da9ff5-4222-4b08-8641-556688494e3f" /> |