### PR TITLE
[Bugfix] Third Sister leader ability should not target a unit if costs can't be paid to play it

### DIFF
--- a/server/game/cards/05_LOF/leaders/ThirdSisterSeethingWithAmbition.ts
+++ b/server/game/cards/05_LOF/leaders/ThirdSisterSeethingWithAmbition.ts
@@ -11,6 +11,7 @@ import {
     WildcardCardType,
     ZoneName
 } from '../../../core/Constants';
+import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class ThirdSisterSeethingWithAmbition extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -29,14 +30,17 @@ export default class ThirdSisterSeethingWithAmbition extends LeaderUnitCard {
                 cardTypeFilter: CardType.BasicUnit,
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous([
-                    AbilityHelper.immediateEffects.playCardFromHand({
-                        playAsType: WildcardCardType.Unit,
-                    }),
-                    AbilityHelper.immediateEffects.forThisPhaseCardEffect({
-                        effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Hidden)
-                    }),
-                ])
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous({
+                    resolutionMode: ResolutionMode.AllGameSystemsMustBeLegal,
+                    gameSystems: [
+                        AbilityHelper.immediateEffects.playCardFromHand({
+                            playAsType: WildcardCardType.Unit,
+                        }),
+                        AbilityHelper.immediateEffects.forThisPhaseCardEffect({
+                            effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Hidden)
+                        }),
+                    ]
+                })
             }
         });
     }
@@ -50,7 +54,7 @@ export default class ThirdSisterSeethingWithAmbition extends LeaderUnitCard {
                     onCardPlayed: (event, context) => this.isUnitPlayedEvent(event, context),
                 },
                 duration: Duration.UntilEndOfPhase,
-                effectDescription: 'give Hidden to the next unit they will play this phase',
+                effectDescription: 'give Hidden to the next unit they play this phase',
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     target: context.events.find((event) => this.isUnitPlayedEvent(event, context)).card,
                     effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Hidden),

--- a/test/server/cards/05_LOF/leaders/ThirdSisterSeethingWithAmbition.spec.ts
+++ b/test/server/cards/05_LOF/leaders/ThirdSisterSeethingWithAmbition.spec.ts
@@ -47,6 +47,28 @@ describe('Third Sister, Seething With Ambition', function () {
                 context.player2.clickCard(context.idenVersio);
                 expect(context.idenVersio).toHaveExactUpgradeNames([]);
             });
+
+            it('should not be able to select a unit if the player cannot pay the costs to play it', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'third-sister#seething-with-ambition',
+                        hand: ['krayt-dragon', 'infused-brawler'],
+                        resources: 5,
+                    },
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.thirdSister);
+                context.player1.clickPrompt('Play a unit from your hand. It gains Hidden for this phase');
+                expect(context.player1).not.toBeAbleToSelect(context.kraytDragon);
+                expect(context.player1).toBeAbleToSelectExactly([context.infusedBrawler]);
+                expect(context.player1).toHaveChooseNothingButton();
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.thirdSister.exhausted).toBeTrue();
+            });
         });
 
         describe('Third Sister\'s deployed on attack ability', function () {
@@ -68,7 +90,7 @@ describe('Third Sister, Seething With Ambition', function () {
 
                 context.player1.clickCard(context.thirdSister);
                 context.player1.clickCard(context.p2Base);
-                expect(context.getChatLogs(1)).toEqual(['player1 uses Third Sister to give Hidden to the next unit they will play this phase']);
+                expect(context.getChatLogs(1)).toEqual(['player1 uses Third Sister to give Hidden to the next unit they play this phase']);
 
                 context.player2.clickCard(context.wampa);
                 expect(context.wampa.hasSomeKeyword('hidden')).toBeFalse();


### PR DESCRIPTION
Fixes #2156 