### PR TITLE
Resource prompting for non-iniatie player

### DIFF
--- a/server/game/core/gameSteps/prompts/VariableResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/VariableResourcePrompt.ts
@@ -3,7 +3,6 @@ import type { Player } from '../../Player';
 import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
 import * as Contract from '../../utils/Contract';
 import { ResourcePrompt } from './ResourcePrompt';
-import { PhaseName } from '../../Constants';
 import { PromptType, SelectCardMode } from '../PromptInterfaces';
 
 export class VariableResourcePrompt extends ResourcePrompt {
@@ -41,7 +40,7 @@ export class VariableResourcePrompt extends ResourcePrompt {
         const initiativePlayer = this.game.initiativePlayer;
         const initiativeDone = initiativePlayer ? this.completionCondition(initiativePlayer) : true;
 
-        if ( initiativePlayer && initiativePlayer !== player && !initiativeDone) {
+        if (initiativePlayer && initiativePlayer !== player && !initiativeDone) {
             return `${basePrompt}. The initiative player is choosing whether to resource; you may choose now or wait until they've finished.`;
         }
 


### PR DESCRIPTION
# Patch Notes 
* Updates variableResource class to update the prompt based one whether the player with iniative has finished resourcing or not. Only occurs after the initial resourcing in the beginning of the game.
<img width="3813" height="2099" alt="resource-prompt" src="https://github.com/user-attachments/assets/0e1618ee-19eb-4eba-b174-090d81de4c3f" />

