### PR TITLE
[Bugfix] Determine "friendly unit" correctly for upgrades played from an opponent's resource zone

### DIFF
--- a/server/game/gameSystems/AttachUpgradeSystem.ts
+++ b/server/game/gameSystems/AttachUpgradeSystem.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
 import { GameEvent } from '../core/event/GameEvent.js';
 import type { CardTypeFilter } from '../core/Constants';
-import { RelativePlayer, ZoneName } from '../core/Constants';
+import { RelativePlayer } from '../core/Constants';
 import { AbilityRestriction, EventName, WildcardCardType } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
@@ -121,11 +121,8 @@ export class AttachUpgradeSystem<TContext extends AbilityContext = AbilityContex
     }
 
     private getFinalController(properties: IAttachUpgradeProperties, context: TContext) {
-        // If playing from out of play, the controller is always the player
-        if (
-            properties.upgrade.zoneName === ZoneName.Discard ||
-            properties.upgrade.zoneName === ZoneName.Deck
-        ) {
+        // If playing from out of play (tokens excluded), the controller is always the player
+        if (!properties.upgrade.isInPlay() && !properties.upgrade.isTokenUpgrade()) {
             return context.player;
         }
 

--- a/test/server/cards/07_LAW/events/TearThisShipApart.spec.ts
+++ b/test/server/cards/07_LAW/events/TearThisShipApart.spec.ts
@@ -195,6 +195,42 @@ describe('Tear This Ship Apart', function() {
                 // expect(context.yoda).toBeInZone('discard', context.player2);
                 expect(context.player2).toBeActivePlayer();
             });
+
+            it('should play upgrades that have friendly unit restrictions on friendly units', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'jabba-the-hutt#crime-boss',
+                        base: 'echo-base',
+                        hand: ['tear-this-ship-apart'],
+                        groundArena: ['consular-security-force']
+                    },
+                    player2: {
+                        deck: ['awing', 'confiscate'],
+                        groundArena: ['battlefield-marine'],
+                        resources: ['craving-power']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Tear This Ship Apart and select Craving Power
+                context.player1.clickCard(context.tearThisShipApart);
+                context.player1.clickCardInDisplayCardPrompt(context.cravingPower);
+
+                // Craving Power can only be played on friendly units
+                expect(context.player1).toHavePrompt('Attach Craving Power to a unit');
+                expect(context.player1).toBeAbleToSelectExactly([context.consularSecurityForce]);
+                context.player1.clickCard(context.consularSecurityForce);
+                expect(context.consularSecurityForce).toHaveExactUpgradeNames(['craving-power']);
+
+                // Resolve its When Played ability to deal damage to Battlefield Marine
+                context.player1.clickCard(context.battlefieldMarine);
+
+                expect(context.battlefieldMarine).toBeInZone('discard', context.player2);
+                expect(context.awing).toBeInZone('resource', context.player2);
+                expect(context.confiscate).toBeInZone('deck', context.player2);
+            });
         });
     });
 });


### PR DESCRIPTION
When Tear This Ship Apart was used to play an upgrade with a "friendly unit" restriction from the opponent's resource zone, it would only allow it to target enemy units because the controller was not being determined correctly.