### PR TITLE
[Bugfix] Only consider collective triggers on a per-player basis

### DIFF
--- a/server/game/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.ts
+++ b/server/game/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.ts
@@ -15,7 +15,7 @@ export default class ChairmanPapanoidaUndauntedDiplomat extends NonLeaderUnitCar
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         const aspects = [Aspect.Aggression, Aspect.Aggression];
         registrar.addTriggeredAbility({
-            title: `Disclose ${EnumHelpers.aspectString(aspects)}. If you do, create a Spy token`,
+            title: `Disclose ${EnumHelpers.aspectString(aspects)} to create a Spy token`,
             collectiveTrigger: true,
             when: {
                 onCardsDrawn: (_event, context) => context.game.currentPhase === PhaseName.Action,

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -170,7 +170,7 @@ export abstract class TriggerWindowBase extends BaseStep {
         }
 
         // Check to if we're dealing with a multi-selection of the 'same' ability
-        const repeatedAbilities = this.getRepeatedAbilityTriggers(abilitiesToResolve, this.resolved.map((resolved) => resolved.ability));
+        const repeatedAbilities = this.getRepeatedAbilityTriggers(abilitiesToResolve);
 
         for (const repeatedAbility of repeatedAbilities) {
             // if an ability is triggered multiple times and uses a collective trigger, filter down to one instance of it
@@ -222,15 +222,32 @@ export abstract class TriggerWindowBase extends BaseStep {
         return `${context.ability.getTitle(context)}: ${context.event.card.title}`;
     }
 
-    private getRepeatedAbilityTriggers(abilitiesToResolve: TriggeredAbilityContext[], resolvedAbilities: TriggeredAbility[]) {
+    private getRepeatedAbilityTriggers(abilitiesToResolve: TriggeredAbilityContext[]) {
         const repeatedAbilities = new Set<TriggeredAbility>();
-        const allAbilities = new Set<TriggeredAbility>(resolvedAbilities);
+        const allAbilitiesByPlayer = new Map<Player, Set<TriggeredAbility>>();
 
-        for (const ability of abilitiesToResolve.map((context) => context.ability)) {
-            if (allAbilities.has(ability)) {
+        function addAbilityForPlayer(player: Player, ability: TriggeredAbility) {
+            if (!allAbilitiesByPlayer.has(player)) {
+                allAbilitiesByPlayer.set(player, new Set([ability]));
+            } else {
+                allAbilitiesByPlayer.get(player).add(ability);
+            }
+        }
+
+        for (const entry of this.resolved) {
+            const player = entry.event['player'] as Player;
+            addAbilityForPlayer(player, entry.ability);
+        }
+
+        for (const abilityContext of abilitiesToResolve) {
+            const ability = abilityContext.ability;
+            const player = abilityContext.event['player'] as Player;
+
+            // Only count abilities as "repeated" if they were triggered by the same player
+            if (allAbilitiesByPlayer.has(player) && allAbilitiesByPlayer.get(player).has(ability)) {
                 repeatedAbilities.add(ability);
             } else {
-                allAbilities.add(ability);
+                addAbilityForPlayer(player, ability);
             }
         }
 

--- a/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
+++ b/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
@@ -1,13 +1,13 @@
 describe('Chairman Papanoida, Undaunted Diplomat', function () {
     integration(function (contextRef) {
-        const disclosePrompt = 'Disclose Aggression, Aggression. If you do, create a Spy token';
+        const disclosePrompt = 'Disclose Aggression, Aggression to create a Spy token';
         describe('Chairman Papanoida, Undaunted Diplomat\'s ability', function () {
             beforeEach(function () {
                 return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         hand: ['no-bargain', 'aggression'],
-                        groundArena: ['chairman-papanoida#undaunted-diplomat', 'battlefield-marine'],
+                        groundArena: ['chairman-papanoida#undaunted-diplomat', 'battlefield-marine', 'chio-fain#fourarmed-slicer'],
                     },
                     player2: {
                         hand: ['strategic-analysis', 'this-is-the-way', 'pillage', 'change-of-heart'],
@@ -85,6 +85,58 @@ describe('Chairman Papanoida, Undaunted Diplomat', function () {
                 expect(spy[0].exhausted).toBeTrue();
 
                 expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should trigger for each players if both players draw cards during action phase simultaneously', function () {
+                const { context } = contextRef;
+
+                // Attack with Chio Fain to make each player draw a card
+                context.player1.clickCard(context.chioFain);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toHavePassAbilityPrompt('Both players draw a card');
+                context.player1.clickPrompt('Trigger');
+
+                // One trigger per player, choose which one to resolve first
+                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    disclosePrompt,
+                    disclosePrompt
+                ]);
+
+                // Resolve one of the triggers first
+                context.player1.clickPrompt(disclosePrompt);
+                expect(context.player1).toHavePrompt(disclosePrompt);
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.aggression
+                ]);
+                context.player1.clickCard(context.aggression);
+                context.player2.clickPrompt('Done');
+
+                // Verify a Spy token was created for player 1
+                let spy = context.player1.findCardsByName('spy');
+                expect(spy.length).toBe(1);
+
+                // Resolve the other trigger
+                expect(context.player1).toHavePrompt(disclosePrompt);
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.aggression
+                ]);
+                context.player1.clickCard(context.aggression);
+                context.player2.clickPrompt('Done');
+
+                // Verify another Spy token was created for player 1
+                spy = context.player1.findCardsByName('spy');
+                expect(spy.length).toBe(2);
+
+                for (const spyToken of spy) {
+                    expect(spyToken).toBeInZone('groundArena');
+                    expect(spyToken.exhausted).toBeTrue();
+                }
+
+                expect(context.player2).toBeActivePlayer();
             });
 
             it('should not trigger during regroup phase', function () {


### PR DESCRIPTION
Fixes #2131

This fixes an issue where Chairman Papanoida was only triggering once when each player drew a card. This was due to the way we consider an ability "repeated", regardless of the triggering player. Now, we only consider an ability repeated if it was triggered by the same player, and only then will it utilize the `collectiveTrigger` logic