### PR TITLE
Update draw system effect message to include all targets

### DIFF
--- a/server/game/gameSystems/DrawSystem.ts
+++ b/server/game/gameSystems/DrawSystem.ts
@@ -7,6 +7,8 @@ import { DamageSystem } from './DamageSystem';
 import * as ChatHelpers from '../core/chat/ChatHelpers';
 import type { GameEvent } from '../core/event/GameEvent';
 import * as Contract from '../core/utils/Contract';
+import * as Helpers from '../core/utils/Helpers';
+import type { FormatMessage } from '../core/chat/GameChat';
 
 export interface IDrawProperties extends IPlayerTargetSystemProperties {
     amount?: number;
@@ -34,7 +36,20 @@ export class DrawSystem<TContext extends AbilityContext = AbilityContext> extend
 
     public override getEffectMessage(context: TContext): [string, any[]] {
         const properties = this.generatePropertiesFromContext(context);
-        return ['draw {0}', [ChatHelpers.pluralize(properties.amount, 'a card', 'cards')]];
+        const effects: FormatMessage[] = Helpers.asArray(properties.target).map((target) => {
+            const cardAmount = ChatHelpers.pluralize(properties.amount, 'a card', 'cards');
+            if (target === context.player) {
+                return {
+                    format: 'draw {0}',
+                    args: [cardAmount],
+                };
+            }
+            return {
+                format: 'make {0} draw {1}',
+                args: [target, cardAmount],
+            };
+        });
+        return [ChatHelpers.formatWithLength(effects.length, 'to '), effects];
     }
 
     public override canAffectInternal(player: Player, context: TContext, additionalProperties: Partial<IDrawProperties> = {}): boolean {

--- a/test/server/cards/01_SOR/units/YodaOldMaster.spec.ts
+++ b/test/server/cards/01_SOR/units/YodaOldMaster.spec.ts
@@ -30,6 +30,7 @@ describe('Yoda, Old Master', function() {
                 expect(context.player1.hand.length).toBe(2);
                 expect(context.player2.hand.length).toBe(0);
                 expect(context.player2).toBeActivePlayer();
+                expect(context.getChatLogs(3)).toContain('player1 uses Yoda to draw a card');
             });
 
             it('should draw a card for each selected player', function () {
@@ -45,6 +46,7 @@ describe('Yoda, Old Master', function() {
                 expect(context.player1.hand.length).toBe(1);
                 expect(context.player2.hand.length).toBe(1);
                 expect(context.player2).toBeActivePlayer();
+                expect(context.getChatLogs(3)).toContain('player1 uses Yoda to make player2 draw a card');
             });
 
             it('should draw a card for each selected player', function () {
@@ -61,6 +63,7 @@ describe('Yoda, Old Master', function() {
                 expect(context.player1.hand.length).toBe(2);
                 expect(context.player2.hand.length).toBe(1);
                 expect(context.player2).toBeActivePlayer();
+                expect(context.getChatLogs(3)).toContain('player1 uses Yoda to draw a card and to make player2 draw a card');
             });
 
             it('should draw a card for each selected player', function () {

--- a/test/server/cards/07_LAW/units/ChioFainFourArmedSlicer.spec.ts
+++ b/test/server/cards/07_LAW/units/ChioFainFourArmedSlicer.spec.ts
@@ -34,6 +34,7 @@ describe('Chio Fain, Four-Armed Slicer', function() {
                 expect(context.player2.handSize).toBe(player2HandSizeBefore + 1);
                 expect(context.overwhelmingBarrage).toBeInZone('hand', context.player2);
                 expect(context.player2).toBeActivePlayer();
+                expect(context.getChatLogs(3)).toContain('player1 uses Chio Fain to draw a card and to make player2 draw a card');
             });
 
             it('should allow the player to pass the ability', function () {


### PR DESCRIPTION
`DrawSystem`'s effect message wasn't including all the targets when multiple players draw at the same time (e.g. because of Chio Fain effect).