### PR TITLE
Distinguish betwen Token and Non-Token Leader Units

### DIFF
--- a/server/game/cards/01_SOR/units/JedhaAgitator.ts
+++ b/server/game/cards/01_SOR/units/JedhaAgitator.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, ZoneName } from '../../../core/Constants';
+import { WildcardCardType, ZoneName } from '../../../core/Constants';
 
 export default class JedhaAgitator extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -18,7 +18,7 @@ export default class JedhaAgitator extends NonLeaderUnitCard {
                 activePromptTitle: 'Deal 2 damage to a ground unit or base',
                 cardCondition: (card) => (card.isUnit() && card.zoneName === ZoneName.GroundArena) || card.isBase(),
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => context.player.hasSomeArenaCard({ type: CardType.LeaderUnit }),
+                    condition: (context) => context.player.hasSomeArenaCard({ type: WildcardCardType.LeaderUnit }),
                     onTrue: AbilityHelper.immediateEffects.damage({ amount: 2 }),
                 })
             }

--- a/server/game/cards/01_SOR/units/OuterRimHeadhunter.ts
+++ b/server/game/cards/01_SOR/units/OuterRimHeadhunter.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, WildcardCardType } from '../../../core/Constants';
+import { WildcardCardType } from '../../../core/Constants';
 
 export default class OuterRimHeadhunter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -18,7 +18,7 @@ export default class OuterRimHeadhunter extends NonLeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => context.player.hasSomeArenaCard({ type: CardType.LeaderUnit }),
+                    condition: (context) => context.player.hasSomeArenaCard({ type: WildcardCardType.LeaderUnit }),
                     onTrue: AbilityHelper.immediateEffects.exhaust(),
                 })
             }

--- a/server/game/cards/01_SOR/units/RuggedSurvivors.ts
+++ b/server/game/cards/01_SOR/units/RuggedSurvivors.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType } from '../../../core/Constants';
+import { WildcardCardType } from '../../../core/Constants';
 
 export default class RuggedSurvivors extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -16,7 +16,7 @@ export default class RuggedSurvivors extends NonLeaderUnitCard {
             title: 'Draw a card if you control a leader unit',
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => context.player.hasSomeArenaCard({ type: CardType.LeaderUnit }),
+                condition: (context) => context.player.hasSomeArenaCard({ type: WildcardCardType.LeaderUnit }),
                 onTrue: AbilityHelper.immediateEffects.draw((context) => ({ target: context.player })),
             })
         });

--- a/server/game/cards/01_SOR/units/SteadfastBattalion.ts
+++ b/server/game/cards/01_SOR/units/SteadfastBattalion.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class SteadfastBattalion extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -19,7 +19,7 @@ export default class SteadfastBattalion extends NonLeaderUnitCard {
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => context.player.hasSomeArenaCard({ type: CardType.LeaderUnit }),
+                    condition: (context) => context.player.hasSomeArenaCard({ type: WildcardCardType.LeaderUnit }),
                     onTrue: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                         effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })
                     }),

--- a/server/game/cards/03_TWI/bases/PauCity.ts
+++ b/server/game/cards/03_TWI/bases/PauCity.ts
@@ -1,6 +1,6 @@
 import { BaseCard } from '../../../core/card/BaseCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
-import { CardType, RelativePlayer } from '../../../core/Constants';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import type { IBaseAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 
 export default class PauCity extends BaseCard {
@@ -15,7 +15,7 @@ export default class PauCity extends BaseCard {
         registrar.addConstantAbility({
             title: 'Each leader unit you control gets +0/+1',
             targetController: RelativePlayer.Self,
-            targetCardTypeFilter: CardType.LeaderUnit,
+            targetCardTypeFilter: WildcardCardType.LeaderUnit,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 0, hp: 1 })
         });
     }

--- a/server/game/cards/03_TWI/bases/PetranakiArena.ts
+++ b/server/game/cards/03_TWI/bases/PetranakiArena.ts
@@ -1,6 +1,6 @@
 import { BaseCard } from '../../../core/card/BaseCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
-import { CardType, RelativePlayer } from '../../../core/Constants';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import type { IBaseAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 
 export default class PetranakiArena extends BaseCard {
@@ -15,7 +15,7 @@ export default class PetranakiArena extends BaseCard {
         registrar.addConstantAbility({
             title: 'Each leader unit you control gets +1/+0',
             targetController: RelativePlayer.Self,
-            targetCardTypeFilter: CardType.LeaderUnit,
+            targetCardTypeFilter: WildcardCardType.LeaderUnit,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 })
         });
     }

--- a/server/game/cards/05_LOF/units/DarthMalakCovetousApprentice.ts
+++ b/server/game/cards/05_LOF/units/DarthMalakCovetousApprentice.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, Trait } from '../../../core/Constants';
+import { Trait, WildcardCardType } from '../../../core/Constants';
 
 export default class DarthMalakCovetousApprentice extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -18,7 +18,7 @@ export default class DarthMalakCovetousApprentice extends NonLeaderUnitCard {
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.hasSomeArenaCard({
                     trait: Trait.Sith,
-                    type: CardType.LeaderUnit
+                    type: WildcardCardType.LeaderUnit
                 }),
                 onTrue: AbilityHelper.immediateEffects.ready()
             })

--- a/server/game/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.ts
+++ b/server/game/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, KeywordName } from '../../../core/Constants';
+import { KeywordName, WildcardCardType } from '../../../core/Constants';
 
 export default class ChancellorPalpatineIAmTheSenate extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -15,7 +15,7 @@ export default class ChancellorPalpatineIAmTheSenate extends NonLeaderUnitCard {
         registrar.addWhenPlayedAbility({
             title: 'Create 2 Spy tokens and give those tokens Sentinel for this phase',
             immediateEffect: abilityHelper.immediateEffects.conditional({
-                condition: (context) => context.player.hasSomeArenaCard({ type: CardType.LeaderUnit }),
+                condition: (context) => context.player.hasSomeArenaCard({ type: WildcardCardType.LeaderUnit }),
                 onTrue: abilityHelper.immediateEffects.createSpy({ amount: 2 }),
             }),
             ifYouDo: (ifYouDoContext) => ({

--- a/server/game/cards/06_SEC/units/NabooRoyalStarshipFitForAQueen.ts
+++ b/server/game/cards/06_SEC/units/NabooRoyalStarshipFitForAQueen.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, KeywordName, RelativePlayer } from '../../../core/Constants';
+import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class NabooRoyalStarshipFitForAQueen extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -15,7 +15,7 @@ export default class NabooRoyalStarshipFitForAQueen extends NonLeaderUnitCard {
         registrar.addConstantAbility({
             title: 'Each friendly leader unit gains Raid 2 and Overwhelm',
             targetController: RelativePlayer.Self,
-            targetCardTypeFilter: CardType.LeaderUnit,
+            targetCardTypeFilter: WildcardCardType.LeaderUnit,
             ongoingEffect: [
                 abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 }),
                 abilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm),

--- a/server/game/cards/07_LAW/units/AdmiralMottiChainOfCommand.ts
+++ b/server/game/cards/07_LAW/units/AdmiralMottiChainOfCommand.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { CardType, RelativePlayer } from '../../../core/Constants';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class AdmiralMottiChainOfCommand extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -15,7 +15,7 @@ export default class AdmiralMottiChainOfCommand extends NonLeaderUnitCard {
         registrar.addConstantAbility({
             title: 'Friendly leader units get +2/+2',
             targetController: RelativePlayer.Self,
-            targetCardTypeFilter: CardType.LeaderUnit,
+            targetCardTypeFilter: WildcardCardType.LeaderUnit,
             ongoingEffect: [
                 abilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })
             ]

--- a/server/game/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.ts
+++ b/server/game/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.ts
@@ -23,12 +23,7 @@ export default class DarthSidiousUndeerACloakOfDarkness extends NonLeaderUnitCar
         registrar.addTriggeredAbility({
             title: 'Create a Battle Droid token',
             when: {
-                onCardDefeated: (event) => {
-                    const info = event.lastKnownInformation;
-                    // Check the printed type of the unit to exclude tokens
-                    return EnumHelpers.isUnit(info.type) &&
-                      !EnumHelpers.isToken(info.card.printedType);
-                },
+                onCardDefeated: (event) => EnumHelpers.isNonTokenUnit(event.lastKnownInformation.type),
             },
             immediateEffect: AbilityHelper.immediateEffects.createBattleDroid()
         });

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -203,7 +203,8 @@ export enum CardType {
     BasicUpgrade = 'basicUpgrade',
     Event = 'event',
     Leader = 'leader',
-    LeaderUnit = 'leaderUnit',
+    NonTokenLeaderUnit = 'nonTokenLeaderUnit',
+    TokenLeaderUnit = 'tokenLeaderUnit',
     LeaderUpgrade = 'leaderUpgrade',
     TokenUnit = 'tokenUnit',
     TokenUpgrade = 'tokenUpgrade',
@@ -213,8 +214,10 @@ export enum CardType {
 
 export enum WildcardCardType {
     Any = 'any',
+    LeaderUnit = 'leaderUnit',
     NonLeaderUnit = 'nonLeaderUnit',
     NonLeaderUpgrade = 'nonLeaderUpgrade',
+    NonTokenUnit = 'nonTokenUnit',
     NonUnit = 'nonUnit',
     /** Any card type that can be played from hand */
     Playable = 'playable',

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -57,7 +57,7 @@ export class LeaderUnitCardInternal extends LeaderUnitCardParent implements IDep
         if (this.canBeUpgrade && this.isAttached()) {
             return CardType.LeaderUpgrade;
         }
-        return this.state.deployed ? CardType.LeaderUnit : CardType.Leader;
+        return this.state.deployed ? CardType.NonTokenLeaderUnit : CardType.Leader;
     }
 
     public constructor(owner: Player, cardData: ICardDataJson) {

--- a/server/game/core/card/TokenCards.ts
+++ b/server/game/core/card/TokenCards.ts
@@ -5,6 +5,7 @@ import { NonLeaderUnitCard } from './NonLeaderUnitCard';
 import { UpgradeCard } from './UpgradeCard';
 import type { IUpgradeCard } from './CardInterfaces';
 import { InPlayCard } from './baseClasses/InPlayCard';
+import { CardType } from '../Constants';
 
 const TokenUnitParent = AsToken(NonLeaderUnitCard);
 const TokenUpgradeParent = AsToken(UpgradeCard);
@@ -18,6 +19,13 @@ export class TokenUnitCard extends TokenUnitParent implements ITokenUnitCard {
 
     public override isTokenUnit(): this is ITokenUnitCard {
         return true;
+    }
+
+    protected override getType(): CardType {
+        if (this.isLeaderAttachedToThis()) {
+            return CardType.TokenLeaderUnit;
+        }
+        return super.getType();
     }
 }
 

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -358,7 +358,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor<TSta
 
         protected override getType(): CardType {
             if (this.isLeaderAttachedToThis()) {
-                return CardType.LeaderUnit;
+                return CardType.NonTokenLeaderUnit;
             }
             return super.getType();
         }

--- a/server/game/core/cardSelector/BaseCardSelector.ts
+++ b/server/game/core/cardSelector/BaseCardSelector.ts
@@ -59,6 +59,12 @@ export abstract class BaseCardSelector<TContext extends AbilityContext> {
                 case WildcardCardType.NonLeaderUpgrade:
                     filters.push(plural ? 'non-leader upgrades' : 'non-leader upgrade');
                     break;
+                case WildcardCardType.NonTokenUnit:
+                    filters.push(plural ? 'non-token units' : 'non-token unit');
+                    break;
+                case WildcardCardType.LeaderUnit:
+                    filters.push(plural ? 'leader units' : 'leader unit');
+                    break;
                 case WildcardCardType.NonUnit:
                     filters.push(plural ? 'non-units' : 'non-unit');
                     break;
@@ -77,8 +83,11 @@ export abstract class BaseCardSelector<TContext extends AbilityContext> {
                 case CardType.Leader:
                     filters.push(plural ? 'leaders' : 'leader');
                     break;
-                case CardType.LeaderUnit:
-                    filters.push(plural ? 'leader units' : 'leader unit');
+                case CardType.NonTokenLeaderUnit:
+                    filters.push(plural ? 'non-token leader units' : 'non-token leader unit');
+                    break;
+                case CardType.TokenLeaderUnit:
+                    filters.push(plural ? 'token leader units' : 'token leader unit');
                     break;
                 default:
                     return fallback;

--- a/server/game/core/utils/EnumHelpers.ts
+++ b/server/game/core/utils/EnumHelpers.ts
@@ -113,12 +113,14 @@ export const zoneMoveRequiresControllerReset = (prevZone: ZoneName, nextZone: Mo
     return (isArena(prevZone) || prevZone === ZoneName.Resource) && !(isArena(nextZoneName) || nextZoneName === ZoneName.Resource);
 };
 
-export const isUnit = (cardType: CardTypeFilter): cardType is WildcardCardType.Unit | WildcardCardType.NonLeaderUnit | CardType.BasicUnit | CardType.LeaderUnit | CardType.TokenUnit => {
+export const isUnit = (cardType: CardTypeFilter): cardType is WildcardCardType.Unit | WildcardCardType.NonLeaderUnit | WildcardCardType.LeaderUnit | CardType.BasicUnit | CardType.NonTokenLeaderUnit | CardType.TokenLeaderUnit | CardType.TokenUnit => {
     switch (cardType) {
         case WildcardCardType.Unit:
         case WildcardCardType.NonLeaderUnit:
+        case WildcardCardType.LeaderUnit:
         case CardType.BasicUnit:
-        case CardType.LeaderUnit:
+        case CardType.NonTokenLeaderUnit:
+        case CardType.TokenLeaderUnit:
         case CardType.TokenUnit:
             return true;
         default:
@@ -126,11 +128,22 @@ export const isUnit = (cardType: CardTypeFilter): cardType is WildcardCardType.U
     }
 };
 
-export const isNonTokenUnit = (cardType: CardTypeFilter): cardType is CardType.BasicUnit | CardType.LeaderUnit => {
+export const isLeaderUnit = (cardType: CardTypeFilter): cardType is WildcardCardType.LeaderUnit | CardType.NonTokenLeaderUnit | CardType.TokenLeaderUnit => {
     switch (cardType) {
-        case CardType.BasicUnit:
+        case WildcardCardType.LeaderUnit:
+        case CardType.NonTokenLeaderUnit:
+        case CardType.TokenLeaderUnit:
             return true;
-        case CardType.LeaderUnit:
+        default:
+            return false;
+    }
+};
+
+export const isNonTokenUnit = (cardType: CardTypeFilter): cardType is WildcardCardType.NonTokenUnit | CardType.BasicUnit | CardType.NonTokenLeaderUnit => {
+    switch (cardType) {
+        case WildcardCardType.NonTokenUnit:
+        case CardType.BasicUnit:
+        case CardType.NonTokenLeaderUnit:
             return true;
         default:
             return false;
@@ -220,10 +233,14 @@ export const cardTypeMatches = (cardType: CardType, cardTypeFilter: CardTypeFilt
         switch (allowedCardType) {
             case WildcardCardType.Any:
                 return true;
+            case WildcardCardType.LeaderUnit:
+                return isLeaderUnit(cardType);
             case WildcardCardType.NonLeaderUnit:
                 return isNonLeaderUnit(cardType);
             case WildcardCardType.NonLeaderUpgrade:
                 return isNonLeaderUpgrade(cardType);
+            case WildcardCardType.NonTokenUnit:
+                return isNonTokenUnit(cardType);
             case WildcardCardType.NonUnit:
                 return !isUnit(cardType);
             case WildcardCardType.UnitUpgrade:
@@ -245,17 +262,21 @@ export const cardTypeMatches = (cardType: CardType, cardTypeFilter: CardTypeFilt
 export const getCardTypesForFilter = (cardTypeFilter: CardTypeFilter): CardType[] => {
     switch (cardTypeFilter) {
         case WildcardCardType.Any:
-            return [CardType.Base, CardType.Event, CardType.Leader, CardType.BasicUnit, CardType.BasicUpgrade, CardType.TokenUnit, CardType.TokenUpgrade, CardType.TokenCard, CardType.LeaderUnit];
+            return [CardType.Base, CardType.Event, CardType.Leader, CardType.BasicUnit, CardType.BasicUpgrade, CardType.TokenUnit, CardType.TokenUpgrade, CardType.TokenCard, CardType.TokenLeaderUnit, CardType.NonTokenLeaderUnit, CardType.LeaderUpgrade, CardType.NonLeaderUnitUpgrade];
+        case WildcardCardType.LeaderUnit:
+            return [CardType.NonTokenLeaderUnit, CardType.TokenLeaderUnit];
         case WildcardCardType.NonLeaderUnit:
             return [CardType.BasicUnit, CardType.TokenUnit];
         case WildcardCardType.NonLeaderUpgrade:
             return [CardType.BasicUpgrade, CardType.TokenUpgrade, CardType.NonLeaderUnitUpgrade];
+        case WildcardCardType.NonTokenUnit:
+            return [CardType.BasicUnit, CardType.NonTokenLeaderUnit];
         case WildcardCardType.NonUnit:
             return [CardType.BasicUpgrade, CardType.TokenUpgrade, CardType.NonLeaderUnitUpgrade, CardType.Event];
         case WildcardCardType.UnitUpgrade:
             return [CardType.LeaderUpgrade, CardType.NonLeaderUnitUpgrade];
         case WildcardCardType.Unit:
-            return [CardType.BasicUnit, CardType.LeaderUnit, CardType.TokenUnit];
+            return [CardType.BasicUnit, CardType.NonTokenLeaderUnit, CardType.TokenLeaderUnit, CardType.TokenUnit];
         case WildcardCardType.Upgrade:
             return [CardType.BasicUpgrade, CardType.LeaderUpgrade, CardType.TokenUpgrade, CardType.NonLeaderUnitUpgrade];
         case WildcardCardType.Token:

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -87,7 +87,8 @@ export function defaultLegalZonesForCardType(cardType: CardType) {
         case CardType.TokenUnit:
         case CardType.TokenUpgrade:
             return [ZoneName.SpaceArena, ZoneName.GroundArena, ZoneName.OutsideTheGame];
-        case CardType.LeaderUnit:
+        case CardType.NonTokenLeaderUnit:
+        case CardType.TokenLeaderUnit:
             return [ZoneName.SpaceArena, ZoneName.GroundArena];
         case CardType.Base:
         case CardType.Leader:


### PR DESCRIPTION
- Added `TokenLeaderUnit` and `NonTokenLeaderUnit` to `CardType`
- Added `LeaderUnit` and `NonTokenUnit` to `WildCardType`
- Modified card implementations to use these new enums.