### PR TITLE
Double Cross Fix for Unique Rule

### DIFF
--- a/server/game/cards/07_LAW/events/DoubleCross.ts
+++ b/server/game/cards/07_LAW/events/DoubleCross.ts
@@ -46,15 +46,14 @@ export default class DoubleCross extends EventCard {
                 const hasTargets = friendlyUnit && enemyUnit;
                 const costDifference = hasTargets ? Math.abs(friendlyUnit.cost - enemyUnit.cost) : 0;
 
-                // Determine which unit is lower-cost
+                // Determine which unit is lower-cost and who took control of it.
                 const lowerCostUnit = hasTargets
                     ? (friendlyUnit.cost < enemyUnit.cost ? friendlyUnit : enemyUnit)
                     : null;
-                // If the unit is still in play, use its current controller directly.
-                // If the unit was defeated (e.g. by unique rule), controller has reverted to owner, so we use owner.opponent since the exchange did give control to the other player.
-                const creditRecipient = lowerCostUnit
-                    ? (lowerCostUnit.isInPlay() ? lowerCostUnit.controller : lowerCostUnit.owner.opponent)
-                    : null;
+                const lowerCostEvent = thenContext.events.find((event) => event.card === lowerCostUnit);
+                const creditRecipient = lowerCostEvent?.isResolved
+                    ? lowerCostEvent.lastKnownInformation.controller.opponent
+                    : lowerCostUnit?.controller;
 
                 return {
                     title: 'The player who takes control of the lower-cost unit creates Credit tokens equal to the difference between those units\' costs.',

--- a/server/game/cards/07_LAW/events/DoubleCross.ts
+++ b/server/game/cards/07_LAW/events/DoubleCross.ts
@@ -50,10 +50,9 @@ export default class DoubleCross extends EventCard {
                 const lowerCostUnit = hasTargets
                     ? (friendlyUnit.cost < enemyUnit.cost ? friendlyUnit : enemyUnit)
                     : null;
-                const lowerCostEvent = thenContext.events.find((event) => event.card === lowerCostUnit);
-                const creditRecipient = lowerCostEvent?.isResolved
-                    ? lowerCostEvent.lastKnownInformation.controller.opponent
-                    : lowerCostUnit?.controller;
+                const creditRecipient = lowerCostUnit?.isInPlay()
+                    ? lowerCostUnit.controller
+                    : thenContext.events.find((event) => event.card === lowerCostUnit)?.newController;
 
                 return {
                     title: 'The player who takes control of the lower-cost unit creates Credit tokens equal to the difference between those units\' costs.',

--- a/server/game/cards/07_LAW/events/DoubleCross.ts
+++ b/server/game/cards/07_LAW/events/DoubleCross.ts
@@ -45,10 +45,15 @@ export default class DoubleCross extends EventCard {
                 const enemyUnit = thenContext.targets.enemyUnit;
                 const hasTargets = friendlyUnit && enemyUnit;
                 const costDifference = hasTargets ? Math.abs(friendlyUnit.cost - enemyUnit.cost) : 0;
-                const creditRecipient = hasTargets
-                    ? friendlyUnit.cost < enemyUnit.cost
-                        ? friendlyUnit.controller
-                        : enemyUnit.controller
+
+                // Determine which unit is lower-cost
+                const lowerCostUnit = hasTargets
+                    ? (friendlyUnit.cost < enemyUnit.cost ? friendlyUnit : enemyUnit)
+                    : null;
+                // If the unit is still in play, use its current controller directly.
+                // If the unit was defeated (e.g. by unique rule), controller has reverted to owner, so we use owner.opponent since the exchange did give control to the other player.
+                const creditRecipient = lowerCostUnit
+                    ? (lowerCostUnit.isInPlay() ? lowerCostUnit.controller : lowerCostUnit.owner.opponent)
                     : null;
 
                 return {

--- a/server/game/gameSystems/TakeControlOfUnitSystem.ts
+++ b/server/game/gameSystems/TakeControlOfUnitSystem.ts
@@ -73,6 +73,8 @@ export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityCo
     protected override updateEvent(event, player: Player, context: TContext, additionalProperties: Partial<ITakeControlOfUnitProperties>): void {
         super.updateEvent(event, player, context, additionalProperties);
 
+        this.addLastKnownInformationToEvent(event, event.card);
+
         // By rule, leader units are always defeated instead of changing control (CR 3.4.6)
         event.setReplacementEventsGenerator((event) => {
             if (event.card.isLeader() && event.newController !== event.card.controller) {

--- a/server/game/gameSystems/TakeControlOfUnitSystem.ts
+++ b/server/game/gameSystems/TakeControlOfUnitSystem.ts
@@ -73,8 +73,6 @@ export class TakeControlOfUnitSystem<TContext extends AbilityContext = AbilityCo
     protected override updateEvent(event, player: Player, context: TContext, additionalProperties: Partial<ITakeControlOfUnitProperties>): void {
         super.updateEvent(event, player, context, additionalProperties);
 
-        this.addLastKnownInformationToEvent(event, event.card);
-
         // By rule, leader units are always defeated instead of changing control (CR 3.4.6)
         event.setReplacementEventsGenerator((event) => {
             if (event.card.isLeader() && event.newController !== event.card.controller) {

--- a/test/server/cards/07_LAW/events/DoubleCross.spec.ts
+++ b/test/server/cards/07_LAW/events/DoubleCross.spec.ts
@@ -193,6 +193,42 @@ describe('Double-Cross', function() {
                 expect(context.player1.credits).toBe(6);
                 expect(context.player2.credits).toBe(0);
             });
+
+            it('gives credits to the correct player when the exchanged unit is defeated by unique rule', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['doublecross'],
+                        groundArena: ['jyn-erso#take-the-next-chance'], // cost 2
+                        leader: { card: 'boba-fett#daimyo', deployed: true },
+                    },
+                    player2: {
+                        groundArena: ['rugged-survivors', 'jyn-erso#take-the-next-chance'], // cost 5, cost 2
+                        leader: { card: 'sabine-wren#galvanized-revolutionary', deployed: true },
+                    }
+                });
+
+                const { context } = contextRef;
+
+                const p1JynErso = context.player1.findCardByName('jyn-erso#take-the-next-chance');
+
+                context.player1.clickCard(context.doublecross);
+
+                // Give Jyn Erso (cost 2) to opponent, take Rugged Survivors (cost 5)
+                context.player1.clickCard(p1JynErso);
+                context.player1.clickCard(context.ruggedSurvivors);
+
+                // Unique rule triggers: opponent now has two Jyn Ersos, must defeat one
+                expect(context.player2).toHavePrompt('Choose which copy of Jyn Erso, Take the Next Chance to defeat');
+                context.player2.clickCard(p1JynErso);
+                expect(p1JynErso).toBeInZone('discard');
+
+                // Rugged Survivors (cost 5) is now controlled by player1, Jyn Erso (cost 2) was given to player2
+                // Player2 received the lower-cost unit, so player2 should get 2 credits
+                expect(context.ruggedSurvivors.controller).toBe(context.player1Object);
+                expect(context.player1.credits).toBe(0);
+                expect(context.player2.credits).toBe(3);
+            });
         });
     });
 });

--- a/test/server/cards/07_LAW/events/DoubleCross.spec.ts
+++ b/test/server/cards/07_LAW/events/DoubleCross.spec.ts
@@ -194,7 +194,7 @@ describe('Double-Cross', function() {
                 expect(context.player2.credits).toBe(0);
             });
 
-            it('gives credits to the correct player when the exchanged unit is defeated by unique rule', async function() {
+            it('gives credits to the correct player when the lower cost exchanged unit is defeated by unique rule', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -228,6 +228,42 @@ describe('Double-Cross', function() {
                 expect(context.ruggedSurvivors.controller).toBe(context.player1Object);
                 expect(context.player1.credits).toBe(0);
                 expect(context.player2.credits).toBe(3);
+            });
+
+            it('gives credits to the correct player when the higher cost exchanged unit is defeated by unique rule', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['doublecross'],
+                        groundArena: ['poe-dameron#quick-to-improvise'], // cost 5
+                        leader: { card: 'boba-fett#daimyo', deployed: true },
+                    },
+                    player2: {
+                        groundArena: ['poe-dameron#quick-to-improvise', 'jyn-erso#take-the-next-chance'], // cost 5, cost 2
+                        leader: { card: 'sabine-wren#galvanized-revolutionary', deployed: true },
+                    }
+                });
+
+                const { context } = contextRef;
+
+                const p1Poe = context.player1.findCardByName('poe-dameron#quick-to-improvise');
+
+                context.player1.clickCard(context.doublecross);
+
+                // Give Poe Dameron (cost 5) to opponent, take Jyn Erso (cost 2)
+                context.player1.clickCard(p1Poe);
+                context.player1.clickCard(context.jynErso);
+
+                // Unique rule triggers: opponent now has two Poes, must defeat one
+                expect(context.player2).toHavePrompt('Choose which copy of Poe Dameron, Quick to Improvise to defeat');
+                context.player2.clickCard(p1Poe);
+                expect(p1Poe).toBeInZone('discard');
+
+                // Jyn Erso (cost 2) is now controlled by player1, Poe Dameron (cost 5) was given to player2
+                // Player1 received the lower-cost unit, so player1 should get 2 credits
+                expect(context.jynErso.controller).toBe(context.player1Object);
+                expect(context.player1.credits).toBe(3);
+                expect(context.player2.credits).toBe(0);
             });
         });
     });


### PR DESCRIPTION
Fix issue referenced in https://discord.com/channels/1220057752961814568/1360259166618259727/1493432403899842663

Credits being rewarded to the wrong player if one of the cards exchanged is defeated due to unique rule