### PR TITLE
Clarify prompt when player is resolving multiple triggers

### DIFF
--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -265,7 +265,7 @@ export abstract class TriggerWindowBase extends BaseStep {
         handlers = abilitiesToResolve.map((context) => () => this.resolveAbility(context));
 
         this.game.promptWithHandlerMenu(this.currentlyResolvingPlayer, {
-            activePromptTitle: 'Choose an ability to resolve:',
+            activePromptTitle: 'You have multiple triggers to resolve. Choose which to resolve first:',
             source: 'Choose Triggered Ability Resolution Order',
             choices,
             handlers,

--- a/test/scenarios/ability/CloneScenarios.spec.ts
+++ b/test/scenarios/ability/CloneScenarios.spec.ts
@@ -35,7 +35,7 @@ describe('Specific Clone scenarios', function() {
                 expect(context.p1Base.damage).toBe(0);
 
                 // Nested triggers: Resolve each of the two When You Use the Force abilities
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'When you use the Force',
                     'When you use the Force'

--- a/test/scenarios/timingWindows/DefeatTiming.spec.ts
+++ b/test/scenarios/timingWindows/DefeatTiming.spec.ts
@@ -59,7 +59,7 @@ describe('Defeat timing', function() {
                 context.player1.passAction();
 
                 context.player2.clickCard(context.vanguardInfantry);
-                expect(context.player2).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player2).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHavePrompt('Waiting for opponent');
                 expect(context.vanguardInfantry).toBeInZone('discard');
 
@@ -139,7 +139,7 @@ describe('Defeat timing', function() {
                 // triggered abilities happen
                 expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
                 context.player1.clickPrompt('You');
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Draw a card',
                     'Draw a card',
@@ -160,7 +160,7 @@ describe('Defeat timing', function() {
                 context.player1.clickPrompt('Pass');
 
                 // automatically moves to other player's triggers
-                expect(context.player2).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player2).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player2).toHaveExactPromptButtons(['Put Superlaser Technician into play as a resource and ready it', 'Choose any number of players to draw 1 card']);
                 context.player2.clickPrompt('Choose any number of players to draw 1 card');
                 context.player2.clickPrompt('You');

--- a/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
@@ -96,7 +96,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 ]));
 
                 // Choose resolution order
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine',
                     'Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant',
@@ -317,7 +317,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 ]));
 
                 // Choose resolution order
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine',
                     'Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant',
@@ -432,7 +432,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 ]));
 
                 // Choose resolution order
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Exhaust the damaged enemy unit: Volunteer Soldier',
                     'Exhaust the damaged enemy unit: Fleet Lieutenant',
@@ -447,7 +447,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 expect(context.volunteerSoldier.exhausted).toBeTrue();
 
                 // Choose resolution order again
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Exhaust the damaged enemy unit: Fleet Lieutenant',
                     'Exhaust the damaged enemy unit: Battlefield Marine'
@@ -532,7 +532,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 ]));
 
                 // Choose resolution order
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Exhaust the damaged enemy unit: Fleet Lieutenant',
                     'Exhaust the damaged enemy unit: Battlefield Marine',
@@ -547,7 +547,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 expect(context.volunteerSoldier.exhausted).toBeTrue();
 
                 // Choose resolution order again
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Exhaust the damaged enemy unit: Fleet Lieutenant',
                     'Exhaust the damaged enemy unit: Battlefield Marine',

--- a/test/server/cards/03_TWI/units/BrainInvaders.spec.ts
+++ b/test/server/cards/03_TWI/units/BrainInvaders.spec.ts
@@ -384,7 +384,7 @@ describe('Brain Invaders', () => {
 
                 // Player 1 plays an underworld card, Cad Bane's ability triggers
                 context.player1.clickCard(context.craftySmuggler);
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:'); // Choose resolution order
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:'); // Choose resolution order
                 context.player1.clickPrompt('Exhaust this leader to deal 1 damage to a unit controlled by the opponent');
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader to deal 1 damage to a unit controlled by the opponent');
                 context.player1.clickPrompt('Pass');

--- a/test/server/cards/04_JTL/units/ChimaeraReinforcingTheCenter.spec.ts
+++ b/test/server/cards/04_JTL/units/ChimaeraReinforcingTheCenter.spec.ts
@@ -342,7 +342,7 @@ describe('Chimaera, Reinforcing the Center', function() {
                 expect(context.chimaeraInHand).toBeInZone('discard');
 
                 // Choose which ability to resolve first
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Use a When Defeated ability on another unit',  // When Played
                     'Create 2 TIE Fighters'                         // When Defeated

--- a/test/server/cards/05_LOF/leaders/DarthRevanScourgeOfTheOldRepublic.spec.ts
+++ b/test/server/cards/05_LOF/leaders/DarthRevanScourgeOfTheOldRepublic.spec.ts
@@ -628,7 +628,7 @@ describe('Darth Revan, Scourge of the Old Republic', function () {
                 context.player1.clickDone();
 
                 // Choose resolution order
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 // TODO: these names are unintuitive, since it names the attack target and not Maul. Need to find a way to improve this
                 expect(context.player1).toHaveExactPromptButtons([
                     'Give an Experience token to the attacking unit: Warzone Lieutenant',

--- a/test/server/cards/05_LOF/units/OldDakaOldestAndWisest.spec.ts
+++ b/test/server/cards/05_LOF/units/OldDakaOldestAndWisest.spec.ts
@@ -114,7 +114,7 @@ describe('Old Daka, Oldest and Wisest', function() {
             expect(context.talzinsAssassin).toBeInZone('groundArena');
             expect(context.player1.readyResourceCount).toBe(p1ResourceCount);
 
-            expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+            expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
             expect(context.player1).toHaveExactPromptButtons([
                 'Use the Force to give a unit -3/-3 for this phase',
                 'Give an Experience token to another friendly unit',

--- a/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
+++ b/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
@@ -102,7 +102,7 @@ describe('Chairman Papanoida, Undaunted Diplomat', function () {
                 context.player1.clickPrompt('Trigger');
 
                 // One trigger per player, choose which one to resolve first
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     disclosePrompt,
                     disclosePrompt

--- a/test/server/cards/07_LAW/leaders/EnfysNestUntilWeCanGoNoHigher.spec.ts
+++ b/test/server/cards/07_LAW/leaders/EnfysNestUntilWeCanGoNoHigher.spec.ts
@@ -46,7 +46,7 @@ describe('Enfys Nest, Until We Can Go No Higher', function() {
                 // Attack with Han Solo to trigger his On Attack abilities
                 context.player1.clickCard(context.hanSolo);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Give an Experience token to this unit',
                     'Discard a card from your hand'

--- a/test/server/cards/07_LAW/units/DengarTakeYourShot.spec.ts
+++ b/test/server/cards/07_LAW/units/DengarTakeYourShot.spec.ts
@@ -259,7 +259,7 @@ describe('Dengar, Take Your Shot', function () {
                 expect(context.battlefieldMarine).toBeInZone('discard');
 
                 // Ability triggers twice since they're both the highest cost
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Create a Credit token: Battlefield Marine',
                     'Create a Credit token: Chandrilan Sponsor'

--- a/test/server/cards/08_ASH/tokens/Advantage.spec.ts
+++ b/test/server/cards/08_ASH/tokens/Advantage.spec.ts
@@ -118,7 +118,7 @@ describe('Advantage', function() {
                 context.player1.clickCard(context.battlefieldMarine);
 
                 // Resolve simultaneous triggers
-                expect(context.player2).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player2).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player2).toHaveExactPromptButtons(['Defeat Advantage token', 'Defeat Advantage token']);
                 context.player2.clickPrompt('Defeat Advantage token');
 

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -673,7 +673,7 @@ describe('Uniqueness rule', function() {
                 expect(context.getChatLogs(1)).toContain('player1 defeats 2 copies of Obi-Wan Kenobi due to the uniqueness rule');
 
                 // Once both are defeated, the player can resolve the When Defeated abilities
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
                     'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.'
@@ -743,7 +743,7 @@ describe('Uniqueness rule', function() {
                 expect(obi3).toBeInZone('discard');
 
                 // Once both are defeated, the player can resolve the When Defeated abilities
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
                     'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.'

--- a/test/server/core/gameSteps/regroupWindow/RegroupPhase.spec.ts
+++ b/test/server/core/gameSteps/regroupWindow/RegroupPhase.spec.ts
@@ -426,7 +426,7 @@ describe('Regroup phase', function() {
                 expect(context.dilapidatedSkiSpeeder).toBeInZone('groundArena');
 
                 // Choose which ability to resolve first
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons(['Shielded', 'Ambush', 'Deal 3 damage to this unit']);
                 context.player1.clickPrompt('Ambush');
 
@@ -438,7 +438,7 @@ describe('Regroup phase', function() {
                 expect(context.dilapidatedSkiSpeeder.damage).toBe(3);
 
                 // Deal damage from When Played
-                expect(context.player1).toHavePrompt('Choose an ability to resolve:');
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons(['Shielded', 'Deal 3 damage to this unit']);
                 context.player1.clickPrompt('Deal 3 damage to this unit');
                 expect(context.dilapidatedSkiSpeeder.damage).toBe(6);


### PR DESCRIPTION
Players are sometimes confused about the multiple triggers prompt this small change helps clarify what the player is choosing.
