### PR TITLE
Fix ownership on friendly shields created by opponents

### DIFF
--- a/server/game/gameSystems/GiveShieldSystem.ts
+++ b/server/game/gameSystems/GiveShieldSystem.ts
@@ -2,6 +2,7 @@ import type { AbilityContext } from '../core/ability/AbilityContext';
 import { TokenUpgradeName } from '../core/Constants';
 import type { IGiveTokenUpgradeProperties } from './GiveTokenUpgradeSystem';
 import { GiveTokenUpgradeSystem } from './GiveTokenUpgradeSystem';
+import type { Player } from '../core/Player';
 
 export type IGiveShieldProperties = Omit<IGiveTokenUpgradeProperties, 'tokenType'> & {
     highPriorityRemoval?: boolean;
@@ -14,8 +15,8 @@ export class GiveShieldSystem<TContext extends AbilityContext = AbilityContext> 
         return TokenUpgradeName.Shield;
     }
 
-    protected override generateToken(context: TContext) {
+    protected override generateToken(context: TContext, owner: Player) {
         const { highPriorityRemoval } = this.generatePropertiesFromContext(context) as IGiveShieldProperties;
-        return context.game.generateToken(context.player, this.getTokenType(), { highPriorityRemoval });
+        return context.game.generateToken(owner, this.getTokenType(), { highPriorityRemoval });
     }
 }

--- a/test/server/cards/01_SOR/tokens/Shield.spec.ts
+++ b/test/server/cards/01_SOR/tokens/Shield.spec.ts
@@ -105,7 +105,7 @@ describe('Shield', function() {
                 });
             });
 
-            it('its owner and controller should be the player who created it', function () {
+            it('its owner and controller should be the player whose unit it is attached to', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.momentOfPeace);
@@ -113,8 +113,8 @@ describe('Shield', function() {
                 expect(context.tielnFighter.upgrades.length).toBe(1);
                 const shield = context.tielnFighter.upgrades[0];
                 expect(shield.internalName).toBe('shield');
-                expect(shield.owner).toBe(context.player1.player);
-                expect(shield.controller).toBe(context.player1.player);
+                expect(shield.owner).toBe(context.player2.player);
+                expect(shield.controller).toBe(context.player2.player);
             });
         });
     });

--- a/test/server/cards/02_SHD/leaders/FinnThisIsARescue.spec.ts
+++ b/test/server/cards/02_SHD/leaders/FinnThisIsARescue.spec.ts
@@ -179,5 +179,42 @@ describe('Finn, This is a Rescue', function () {
             expect(context.player2).toBeActivePlayer();
             expect(context.battlefieldMarine).toHaveExactUpgradeNames(['shield']);
         });
+
+        it('Finn\'s undeployed ability can defeat a shield token on a friendly unit created by an opponent', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'finn#this-is-a-rescue',
+                    resources: 4,
+                    groundArena: ['wampa']
+                },
+                player2: {
+                    groundArena: ['val#its-been-a-ride-babe']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.wampa);
+            context.player1.clickCard(context.valItsBeenARideBabe);
+
+            expect(context.player2).toHavePrompt('Give a Shield token to an enemy unit');
+            expect(context.player2).toBeAbleToSelectExactly([context.wampa]);
+            context.player2.clickCard(context.wampa);
+
+            // Wampa now has a shield from Val's ability
+            expect(context.wampa).toHaveExactUpgradeNames(['shield']);
+
+            context.player2.passAction();
+
+            const shield = context.player1.findCardByName('shield');
+            context.player1.clickCard(context.finn);
+            expect(context.player1).toBeAbleToSelectExactly([shield]);
+            context.player1.clickCard(shield);
+
+            // Shield is defeated and Wampa gains a new shield from Finn
+            expect(shield).toBeInZone('outsideTheGame');
+            expect(context.wampa).toHaveExactUpgradeNames(['shield']);
+        });
     });
 });

--- a/test/server/cards/02_SHD/units/LomPykeDealerInTruths.spec.ts
+++ b/test/server/cards/02_SHD/units/LomPykeDealerInTruths.spec.ts
@@ -82,9 +82,7 @@ describe('Lom Pyke, Dealer in Truths', function() {
                 expect(context.player1).not.toHavePassAbilityButton();
                 context.player1.clickCard(context.lomPyke);
 
-                // TODO: replacement effect ordering logic is not fully in place. since both shields are owned by player1,
-                // that player is then prompted to order the shield defeat resolution. This will be fixed eventually.
-                context.player1.clickPrompt('Defeat shield to prevent attached unit from taking damage');
+                context.player1.clickPrompt('You');
 
                 expect(context.cartelSpacer).toHaveExactUpgradeNames(['shield']);
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['shield']);

--- a/test/server/cards/07_LAW/bases/AllianceOutpost.spec.ts
+++ b/test/server/cards/07_LAW/bases/AllianceOutpost.spec.ts
@@ -215,5 +215,49 @@ describe('Alliance Outpost', function() {
                 expect(context.player1.credits).toBe(2);
             });
         });
+
+        describe('Epic Action - Val when-defeated shield interaction', function() {
+            beforeEach(async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        base: 'alliance-outpost',
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['val#its-been-a-ride-babe']
+                    }
+                });
+            });
+
+            it('can defeat a shield on a friendly unit created by an opponent', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.wampa);
+                context.player1.clickCard(context.valItsBeenARideBabe);
+
+                expect(context.player2).toHavePrompt('Give a Shield token to an enemy unit');
+                expect(context.player1).toHavePrompt('Waiting for opponent to select a unit for Val\'s ability');
+                expect(context.player2).toBeAbleToSelectExactly([context.wampa]);
+                context.player2.clickCard(context.wampa);
+
+                expect(context.wampa).toHaveExactUpgradeNames(['shield']);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.allianceOutpost);
+                expect(context.player1).toHavePrompt('Select one');
+                context.player1.clickPrompt('Create Credit');
+
+                expect(context.player1).toHavePrompt('Choose a friendly token to defeat');
+                const shield = context.player1.findCardByName('shield');
+                expect(context.player1).toBeAbleToSelectExactly([shield]);
+                context.player1.clickCard(shield);
+
+                // Shield is gone, and a Credit token was created
+                expect(shield).toBeInZone('outsideTheGame');
+                expect(context.player1.credits).toBe(1);
+            });
+        });
     });
 });


### PR DESCRIPTION
Previously, Shields created by a player and put on another player's units were maintaining ownership to the creator due to a bug in the GiveShieldSystem