### PR TITLE
Fix issue with Mulligan + Undo where player can end up with a different hand

### DIFF
--- a/server/game/core/gameSteps/prompts/MulliganPrompt.ts
+++ b/server/game/core/gameSteps/prompts/MulliganPrompt.ts
@@ -100,14 +100,19 @@ export class MulliganPrompt extends AllPlayerPrompt {
                         TriggerHandlingMode.ResolvesTriggers
                     );
             } else {
-                // Perform a fake shuffle to ensure that the same amount of random numbers are generated
-                // in case the game was rolled back to before the mulligan decision and the players make
-                // different choices. For example, if both players decide to mulligan and after the rollback
-                // player1 decides to keep instead, we want player2 to draw the same cards as before.
-                Helpers.shuffle([
-                    ...player.deckZone.getCards(),
-                    ...player.hand,
-                ], this.game.randomGenerator);
+                // Queue a fake shuffle to ensure the same number of random numbers are generated
+                // in this player's slot of the queue, regardless of whether they chose to mulligan.
+                // This matters when the game is rolled back to before the mulligan decision and the
+                // players make different choices: we want each player's outcome to be independent
+                // of their opponent's choice. The step must be queued (not run synchronously) so it
+                // executes in the same pipeline order as the real ShuffleDeckSystem above would.
+                this.game.queueSimpleStep(
+                    () => Helpers.shuffle([
+                        ...player.deckZone.getCards(),
+                        ...player.hand,
+                    ], this.game.randomGenerator),
+                    `mulligan keep fake-shuffle for ${player.name}`
+                );
             }
         }
         return super.complete();

--- a/test/scenarios/undo/SnapshotTypes.spec.ts
+++ b/test/scenarios/undo/SnapshotTypes.spec.ts
@@ -67,12 +67,12 @@ describe('Snapshot types', function() {
                 context.player2.clickPrompt('Keep');
 
                 expect(context.player1.hand.map((card) => card.internalName)).toEqual([
+                    'armed-to-the-teeth',
+                    'collections-starhopper',
                     'battlefield-marine',
-                    'covert-strength',
-                    'battlefield-marine',
-                    'moment-of-peace',
-                    'moment-of-peace',
                     'chewbacca#pykesbane',
+                    'moment-of-peace',
+                    'battlefield-marine',
                 ]);
                 expect(context.player2.hand.map((card) => card.internalName)).toEqual([
                     'atst',
@@ -92,8 +92,8 @@ describe('Snapshot types', function() {
                 context.player2.clickDone();
 
                 expect(context.player1.resources.map((card) => card.internalName)).toEqual([
-                    'battlefield-marine',
-                    'covert-strength',
+                    'armed-to-the-teeth',
+                    'collections-starhopper',
                 ]);
                 expect(context.player2.resources.map((card) => card.internalName)).toEqual([
                     'atst',
@@ -137,12 +137,12 @@ describe('Snapshot types', function() {
 
             const assertSetupPhaseBeforeResourceState = (context) => {
                 expect(context.player1.hand.map((card) => card.internalName)).toEqual([
+                    'armed-to-the-teeth',
+                    'collections-starhopper',
                     'battlefield-marine',
-                    'covert-strength',
-                    'battlefield-marine',
-                    'moment-of-peace',
-                    'moment-of-peace',
                     'chewbacca#pykesbane',
+                    'moment-of-peace',
+                    'battlefield-marine',
                 ]);
                 expect(context.player2.hand.map((card) => card.internalName)).toEqual([
                     'atst',
@@ -240,8 +240,8 @@ describe('Snapshot types', function() {
                     context.player2.clickDone();
 
                     expect(context.player1.resources.map((card) => card.internalName)).toEqual([
-                        'battlefield-marine',
-                        'covert-strength',
+                        'armed-to-the-teeth',
+                        'collections-starhopper',
                     ]);
                     expect(context.player2.resources.map((card) => card.internalName)).toEqual([
                         'atst',
@@ -269,8 +269,8 @@ describe('Snapshot types', function() {
                     context.player2.clickDone();
 
                     expect(context.player1.resources.map((card) => card.internalName)).toEqual([
-                        'battlefield-marine',
-                        'covert-strength',
+                        'armed-to-the-teeth',
+                        'collections-starhopper',
                     ]);
                     expect(context.player2.resources.map((card) => card.internalName)).toEqual([
                         'atst',
@@ -351,8 +351,8 @@ describe('Snapshot types', function() {
                     context.player2.clickDone();
 
                     expect(context.player1.resources.map((card) => card.internalName)).toEqual([
-                        'battlefield-marine',
-                        'covert-strength',
+                        'armed-to-the-teeth',
+                        'collections-starhopper',
                     ]);
                     expect(context.player2.resources.map((card) => card.internalName)).toEqual([
                         'atst',
@@ -379,8 +379,8 @@ describe('Snapshot types', function() {
                     context.player2.clickDone();
 
                     expect(context.player1.resources.map((card) => card.internalName)).toEqual([
-                        'battlefield-marine',
-                        'covert-strength',
+                        'armed-to-the-teeth',
+                        'collections-starhopper',
                     ]);
                     expect(context.player2.resources.map((card) => card.internalName)).toEqual([
                         'atst',

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -1830,6 +1830,25 @@ describe('Undo', function() {
                 expect(context.player2.hand).toEqualArray(player2StartingHandAfterMulligan);
                 expect(context.player1.deck).toEqualArray(player1DeckBeforeMulligan);
                 expect(context.player2.deck).toEqualArray(player2DeckAfterMulligan);
+
+                // Rollback to the mulligan decision
+                contextRef.snapshot.rollbackToSnapshot({
+                    type: 'action',
+                    playerId: context.player2.id,
+                    actionOffset: -1,
+                });
+                expect(context.player1.hand).toEqualArray(player1StartingHandBeforeMulligan);
+                expect(context.player2.hand).toEqualArray(player2StartingHandBeforeMulligan);
+                expect(context.player1.deck).toEqualArray(player1DeckBeforeMulligan);
+                expect(context.player2.deck).toEqualArray(player2DeckBeforeMulligan);
+
+                // Choose whether to take a mulligan
+                context.player1.clickPrompt('Mulligan');
+                context.player2.clickPrompt('Keep');
+                expect(context.player1.hand).toEqualArray(player1StartingHandAfterMulligan);
+                expect(context.player2.hand).toEqualArray(player2StartingHandBeforeMulligan);
+                expect(context.player1.deck).toEqualArray(player1DeckAfterMulligan);
+                expect(context.player2.deck).toEqualArray(player2DeckBeforeMulligan);
             });
         });
 


### PR DESCRIPTION
The fake shuffle in MulliganPrompt.complete() ran synchronously while the real ShuffleDeckSystem ran via a queued event window. This made P1's mulligan shuffle observe a different RNG state when paired with a keeping opponent versus a mulliganing opponent, breaking determinism on rollback + different mulligan choices.
 
Wrapping the fake shuffle in queueSimpleStep places it at the same pipeline position the real shuffle would occupy.
