### PR TITLE
add support for custom starting board json

### DIFF
--- a/server/game/core/Game.ts
+++ b/server/game/core/Game.ts
@@ -21,6 +21,8 @@ import { AbilityResolver } from './gameSteps/AbilityResolver';
 import { AbilityContext } from './ability/AbilityContext';
 import { Contract } from './utils/Contract';
 import { cards } from '../cards/Index';
+import { CustomSetupApplier } from './customSetup/CustomSetupApplier';
+import type { ICustomSetupState } from './customSetup/CustomSetupTypes';
 
 import {
     AlertType,
@@ -299,6 +301,7 @@ export class Game extends EventEmitter {
     public readonly buildSafeTimeoutHandler: (callback: () => void, delayMs: number, errorMessage: string) => NodeJS.Timeout;
     public readonly userTimeoutDisconnect: (userId: string) => void;
     public readonly preselectedFirstPlayerId: string | undefined;
+    private readonly _customSetupState: ICustomSetupState | undefined;
     public manualMode: boolean;
     public gameMode: GameMode;
     public currentlyResolving: ICurrentlyResolving;
@@ -361,6 +364,7 @@ export class Game extends EventEmitter {
         this.buildSafeTimeoutHandler = details.buildSafeTimeout;
         this.userTimeoutDisconnect = details.userTimeoutDisconnect;
         this.preselectedFirstPlayerId = details.preselectedFirstPlayerId;
+        this._customSetupState = details.customSetupState;
 
         // Debug flags, intended only for manual testing, and should always be false. Use the debug methods to temporarily flag these on.
         this._debug = { pipeline: false };
@@ -1082,7 +1086,27 @@ export class Game extends EventEmitter {
         );
 
         this.resolveGameState(true);
-        this.initializePipelineForSetup();
+
+        if (this._customSetupState) {
+            // Skip the SetupPhase entirely; the supplied state describes the
+            // exact starting board, so initiative/mulligan/resource-2 prompts
+            // would just be busywork. If no initiative was specified in the
+            // setup, fall back to the random/preselected pick used by
+            // SetupPhase.chooseFirstPlayer so the game still has one.
+            CustomSetupApplier.apply(this, this._customSetupState);
+
+            if (!this.initiativePlayer) {
+                this.initiativePlayer = this.preselectedFirstPlayerId
+                    ? this.getPlayerById(this.preselectedFirstPlayerId)
+                    : Helpers.randomItem(this.getPlayers(), this.randomGenerator);
+            }
+
+            this.pipeline.initialise([
+                new SimpleStep(this, () => this.beginRound(), 'beginRound')
+            ]);
+        } else {
+            this.initializePipelineForSetup();
+        }
 
         this.playStarted = true;
         this.startedAt = new Date();

--- a/server/game/core/Game.ts
+++ b/server/game/core/Game.ts
@@ -21,7 +21,7 @@ import { AbilityResolver } from './gameSteps/AbilityResolver';
 import { AbilityContext } from './ability/AbilityContext';
 import { Contract } from './utils/Contract';
 import { cards } from '../cards/Index';
-import { CustomSetupApplier } from './customSetup/CustomSetupApplier';
+import { applyCustomSetup } from './customSetup/CustomSetupApplier';
 import type { ICustomSetupState } from './customSetup/CustomSetupTypes';
 
 import {
@@ -1093,7 +1093,7 @@ export class Game extends EventEmitter {
             // would just be busywork. If no initiative was specified in the
             // setup, fall back to the random/preselected pick used by
             // SetupPhase.chooseFirstPlayer so the game still has one.
-            CustomSetupApplier.apply(this, this._customSetupState);
+            applyCustomSetup(this, this._customSetupState);
 
             if (!this.initiativePlayer) {
                 this.initiativePlayer = this.preselectedFirstPlayerId

--- a/server/game/core/GameInterfaces.ts
+++ b/server/game/core/GameInterfaces.ts
@@ -4,6 +4,7 @@ import type { IUser } from '../../Settings';
 import type { CardDataGetter } from '../../utils/cardData/CardDataGetter';
 import type { Attack } from './attack/Attack';
 import type { AttackRulesVersion } from './attack/AttackFlow';
+import type { ICustomSetupState } from './customSetup/CustomSetupTypes';
 import type { EventWindow } from './event/EventWindow';
 import type { AbilityResolver } from './gameSteps/AbilityResolver';
 import type { ActionWindow } from './gameSteps/ActionWindow';
@@ -28,6 +29,14 @@ export interface GameConfiguration {
 
     /** Player ID who gets to choose who starts with initiative, or undefined for random selection */
     preselectedFirstPlayerId?: string;
+
+    /**
+     * Optional starting board state. When set, the SetupPhase (initiative
+     * choice + mulligan + resource-2 prompt) is skipped and the supplied state
+     * is applied directly before round 1 begins. `players[0]` is treated as
+     * `setup.player1` and `players[1]` as `setup.player2`.
+     */
+    customSetupState?: ICustomSetupState;
 }
 
 export interface ICurrentlyResolving {

--- a/server/game/core/customSetup/CustomSetupApplier.ts
+++ b/server/game/core/customSetup/CustomSetupApplier.ts
@@ -1,0 +1,415 @@
+import type { Game } from '../Game';
+import type { Player } from '../Player';
+import type { Card } from '../card/Card';
+import type { InPlayCard } from '../card/baseClasses/InPlayCard';
+import type { LeaderUnitCard } from '../card/LeaderUnitCard';
+import { DeployType, DeckZoneDestination, ZoneName } from '../Constants';
+import { Contract } from '../utils/Contract';
+import type { SimpleZone } from '../zone/SimpleZone';
+import {
+    type CardEntry,
+    type IBaseSpec,
+    type ICustomSetupPlayerState,
+    type ICustomSetupState,
+    type ICustomSetupValidationError,
+    type ILeaderSpec,
+    type ResourceEntry,
+    CustomSetupValidationFailure,
+    isTokenUpgradeName,
+} from './CustomSetupTypes';
+
+/**
+ * Applies a custom setup state to a freshly-initialised game. Must be called
+ * after `Player.initialiseAsync` has hydrated each player's deck zone but
+ * before the game pipeline begins running phases. The caller is responsible
+ * for skipping the SetupPhase pipeline.
+ *
+ * Mirrors the post-startGame portion of GameStateBuilder.setupGameStateAsync
+ * (forceteki/test/helpers/GameStateBuilder.js) but talks to Game/Player/Card
+ * directly instead of going through the test PlayerInteractionWrapper, and
+ * makes no assumption that decks were synthesized — every named card must
+ * already exist in the player's loaded deck.
+ */
+export class CustomSetupApplier {
+    public static apply(game: Game, setup: ICustomSetupState): void {
+        const errors: ICustomSetupValidationError[] = [];
+
+        const players = game.getPlayers();
+        Contract.assertTrue(players.length === 2, 'Custom setup requires exactly two players');
+
+        const owner = players[0];
+        const opponent = players[1];
+
+        const ownerCtx = new PlayerSetupContext(game, owner, 'player1', errors);
+        const opponentCtx = new PlayerSetupContext(game, opponent, 'player2', errors);
+
+        if (setup.player1?.hasInitiative) {
+            game.initiativePlayer = owner;
+        } else if (setup.player2?.hasInitiative) {
+            game.initiativePlayer = opponent;
+        }
+
+        // Both players' action windows are pre-prompted so the action phase
+        // begins immediately without an extra "First action" UI step.
+        owner.promptedActionWindows.action = true;
+        opponent.promptedActionWindows.action = true;
+
+        // Clear all non-base zones for both players first so cross-player
+        // upgrade attachments and shared zone moves don't trip over each other.
+        ownerCtx.moveAllNonBaseZonesToOutside();
+        opponentCtx.moveAllNonBaseZonesToOutside();
+
+        ownerCtx.applyState(setup.player1 ?? {});
+        opponentCtx.applyState(setup.player2 ?? {});
+
+        if (errors.length > 0) {
+            throw new CustomSetupValidationFailure(errors);
+        }
+
+        game.resolveGameState(true);
+    }
+}
+
+/**
+ * Per-player helper that mutates one Player's state. All errors are pushed to
+ * the shared `errors` array; we don't throw mid-apply so that the user sees
+ * every problem at once when they validate JSON in the lobby.
+ */
+class PlayerSetupContext {
+    public constructor(
+        private readonly game: Game,
+        private readonly player: Player,
+        private readonly path: string,
+        private readonly errors: ICustomSetupValidationError[],
+    ) {}
+
+    public applyState(state: ICustomSetupPlayerState): void {
+        this.applyLeader(state.leader);
+        this.applyBase(state.base);
+
+        // Order matters: resources/discard/hand consume cards from outsideTheGame
+        // (the staging zone we just dumped everything into), and arenas pull
+        // upgrades from outsideTheGame too. Deck must be set last so any
+        // remaining requested cards aren't accidentally claimed by an earlier
+        // step.
+        this.applyResources(state.resources);
+        this.applyArena(state.groundArena, ZoneName.GroundArena);
+        this.applyArena(state.spaceArena, ZoneName.SpaceArena);
+        this.applyHand(state.hand);
+        this.applyDiscard(state.discard);
+        this.applyDeck(state.deck);
+
+        this.applyForceToken(state.hasForceToken);
+        this.applyCredits(state.credits);
+    }
+
+    public moveAllNonBaseZonesToOutside(): void {
+        const arenaCards = this.player.getArenaCards();
+        const resourceCards = this.player.resourceZone.clearCards();
+        const discardCards = this.player.discardZone.clearCards();
+        const handCards = this.player.handZone.clearCards();
+        const deckCards = this.player.deckZone.clearDeck();
+
+        // Arena zones are shared across both players, so we can't bulk-clear
+        // them — we have to remove this player's cards individually. The cast
+        // is safe because getArenaCards only returns cards in arena zones,
+        // which all extend SimpleZone.
+        for (const card of arenaCards) {
+            (card.zone as unknown as SimpleZone).removeCard(card);
+        }
+
+        const outside = this.player.outsideTheGameZone;
+        const allCards: Card[] = [...arenaCards, ...resourceCards, ...discardCards, ...handCards, ...deckCards];
+        for (const card of allCards) {
+            // Direct zone assignment, bypassing moveTo, so we don't fire
+            // leave-zone effects during the wipe.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (card as any).zone = outside;
+        }
+        outside.addCards(allCards);
+    }
+
+    private applyLeader(leader: string | ILeaderSpec | undefined): void {
+        if (leader === undefined) {
+            return;
+        }
+        const spec: ILeaderSpec = typeof leader === 'string' ? { card: leader } : leader;
+        const leaderCard = this.player.leader as LeaderUnitCard;
+
+        if (spec.card !== undefined && spec.card !== leaderCard.internalName) {
+            this.errors.push({
+                path: `${this.path}.leader.card`,
+                message: `Leader '${spec.card}' does not match the player's deck leader '${leaderCard.internalName}'`,
+            });
+            return;
+        }
+
+        if ('flipped' in spec && spec.flipped) {
+            // Some leaders are double-sided; the test wrapper guards behind a typeof check.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const flip = (leaderCard as any).flipLeader;
+            if (typeof flip === 'function') {
+                flip.call(leaderCard);
+            } else {
+                this.errors.push({ path: `${this.path}.leader.flipped`, message: 'This leader cannot be flipped' });
+            }
+        }
+
+        if (spec.deployed) {
+            try {
+                leaderCard.deploy({ type: DeployType.LeaderUnit });
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const deployAbility = leaderCard.getActionAbilities().find((ability: any) => ability.getTitle().includes('Deploy'));
+                if (deployAbility?.limit) {
+                    deployAbility.limit.increment(this.player);
+                }
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (leaderCard as any).damage = spec.damage ?? 0;
+                if (spec.exhausted) {
+                    leaderCard.exhaust();
+                } else {
+                    leaderCard.ready();
+                }
+                if (spec.upgrades) {
+                    this.attachUpgrades(`${this.path}.leader`, leaderCard, spec.upgrades);
+                }
+            } catch (err) {
+                this.errors.push({ path: `${this.path}.leader`, message: `Failed to deploy leader: ${(err as Error).message}` });
+            }
+        } else {
+            if (leaderCard.deployed) {
+                leaderCard.undeploy();
+            }
+            if (spec.exhausted) {
+                leaderCard.exhaust();
+            } else {
+                leaderCard.ready();
+            }
+        }
+    }
+
+    private applyBase(base: string | IBaseSpec | undefined): void {
+        if (base === undefined) {
+            return;
+        }
+        const spec: IBaseSpec = typeof base === 'string' ? { card: base } : base;
+        if (spec.card !== undefined && spec.card !== this.player.base.internalName) {
+            this.errors.push({
+                path: `${this.path}.base.card`,
+                message: `Base '${spec.card}' does not match the player's deck base '${this.player.base.internalName}'`,
+            });
+            return;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this.player.base as any).damage = spec.damage ?? 0;
+    }
+
+    private applyResources(resources: number | ResourceEntry[] | undefined): void {
+        if (resources === undefined) {
+            return;
+        }
+        if (typeof resources === 'number') {
+            for (let i = 0; i < resources; i++) {
+                const card = this.takeFromOutside(() => true);
+                if (!card) {
+                    this.errors.push({ path: `${this.path}.resources`, message: `Not enough cards in deck to fill ${resources} resources` });
+                    return;
+                }
+                card.moveTo(ZoneName.Resource);
+            }
+            return;
+        }
+        // Reverse so first-listed ends up on top (matches test framework).
+        [...resources].reverse().forEach((entry, idx) => {
+            const realIdx = resources.length - 1 - idx;
+            const name = typeof entry === 'string' ? entry : entry.card;
+            const card = this.takeFromOutside((c) => c.internalName === name);
+            if (!card) {
+                this.errors.push({ path: `${this.path}.resources[${realIdx}]`, message: `Card '${name}' is not available to place as a resource` });
+                return;
+            }
+            card.moveTo(ZoneName.Resource);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (card as any).exhausted = typeof entry === 'string' ? false : !!entry.exhausted;
+        });
+    }
+
+    private applyArena(arena: CardEntry[] | undefined, arenaZone: ZoneName.GroundArena | ZoneName.SpaceArena): void {
+        if (arena === undefined) {
+            return;
+        }
+        arena.forEach((entry, i) => {
+            const spec = typeof entry === 'string' ? { card: entry } : entry;
+            const card = this.takeFromOutside((c) => c.internalName === spec.card);
+            if (!card) {
+                this.errors.push({ path: `${this.path}.${arenaZone}[${i}]`, message: `Card '${spec.card}' is not available to place in ${arenaZone}` });
+                return;
+            }
+            if (!card.isUnit()) {
+                this.errors.push({ path: `${this.path}.${arenaZone}[${i}]`, message: `Card '${spec.card}' is not a unit` });
+                return;
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if ((card as any).defaultArena !== arenaZone) {
+                this.errors.push({ path: `${this.path}.${arenaZone}[${i}]`, message: `Card '${spec.card}' belongs in a different arena` });
+                return;
+            }
+            card.moveTo(arenaZone);
+            if (spec.exhausted) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (card as any).exhaust();
+            } else {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (card as any).ready();
+            }
+            if (spec.damage !== undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (card as any).damage = spec.damage;
+            }
+            if (spec.upgrades) {
+                this.attachUpgrades(`${this.path}.${arenaZone}[${i}]`, card as unknown as InPlayCard, spec.upgrades);
+            }
+        });
+    }
+
+    private applyHand(hand: string[] | undefined): void {
+        if (hand === undefined) {
+            return;
+        }
+        hand.forEach((name, i) => {
+            const card = this.takeFromOutside((c) => c.internalName === name);
+            if (!card) {
+                this.errors.push({ path: `${this.path}.hand[${i}]`, message: `Card '${name}' is not available to place in hand` });
+                return;
+            }
+            card.moveTo(ZoneName.Hand);
+        });
+    }
+
+    private applyDiscard(discard: string[] | undefined): void {
+        if (discard === undefined) {
+            return;
+        }
+        // Reverse so first-listed ends up on top of the discard pile.
+        [...discard].reverse().forEach((name, idx) => {
+            const realIdx = discard.length - 1 - idx;
+            const card = this.takeFromOutside((c) => c.internalName === name);
+            if (!card) {
+                this.errors.push({ path: `${this.path}.discard[${realIdx}]`, message: `Card '${name}' is not available to place in discard` });
+                return;
+            }
+            card.moveTo(ZoneName.Discard);
+        });
+    }
+
+    private applyDeck(deck: string[] | undefined): void {
+        if (deck === undefined) {
+            // Default: every card still in outsideTheGame goes back into the deck (preserving original order).
+            const remaining = [...this.player.outsideTheGameZone.cards].filter((c) => this.isPlayableDeckCard(c));
+            for (const card of remaining) {
+                card.moveTo(DeckZoneDestination.DeckBottom);
+            }
+            return;
+        }
+        // Specified deck: place named cards in order on top, leave the rest outside (effectively removed).
+        [...deck].reverse().forEach((name, idx) => {
+            const realIdx = deck.length - 1 - idx;
+            const card = this.takeFromOutside((c) => c.internalName === name);
+            if (!card) {
+                this.errors.push({ path: `${this.path}.deck[${realIdx}]`, message: `Card '${name}' is not available to place in deck` });
+                return;
+            }
+            card.moveTo(DeckZoneDestination.DeckTop);
+        });
+    }
+
+    private applyForceToken(hasForce: boolean | undefined): void {
+        if (hasForce === undefined) {
+            return;
+        }
+        if (hasForce && !this.player.hasTheForce) {
+            const forceTokens = this.player.outsideTheGameZone.getCards({
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                condition: (card: any) => typeof card.isForceToken === 'function' && card.isForceToken(),
+            });
+            if (forceTokens.length === 0) {
+                this.errors.push({ path: `${this.path}.hasForceToken`, message: 'No Force token available for this player' });
+                return;
+            }
+            forceTokens[0].moveTo(ZoneName.Base);
+        } else if (!hasForce && this.player.hasTheForce) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const forceToken = (this.player.baseZone as any)?.forceToken;
+            if (forceToken) {
+                forceToken.moveTo(ZoneName.OutsideTheGame);
+            }
+        }
+    }
+
+    private applyCredits(credits: number | undefined): void {
+        if (credits === undefined) {
+            return;
+        }
+        const current = this.player.creditTokenCount;
+        if (credits === current) {
+            return;
+        }
+        if (credits < current) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const tokens = (this.player.baseZone as any)?.credits?.slice(0, current - credits) ?? [];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            for (const token of tokens) {
+                token.moveTo(ZoneName.OutsideTheGame);
+            }
+            return;
+        }
+        const toAdd = credits - current;
+        for (let i = 0; i < toAdd; i++) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const token = this.game.generateToken(this.player, 'credit' as any);
+            token.moveTo(ZoneName.Base);
+        }
+    }
+
+    private attachUpgrades(parentPath: string, target: InPlayCard, upgrades: CardEntry[]): void {
+        upgrades.forEach((u, i) => {
+            const upgradePath = `${parentPath}.upgrades[${i}]`;
+            const name = typeof u === 'string' ? u : u.card;
+
+            let upgradeCard: InPlayCard | undefined;
+            if (isTokenUpgradeName(name)) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                upgradeCard = this.game.generateToken(this.player, name as any) as InPlayCard;
+            } else {
+                upgradeCard = this.takeFromOutside((c) => c.internalName === name) as InPlayCard | undefined;
+            }
+            if (!upgradeCard) {
+                this.errors.push({ path: upgradePath, message: `Upgrade '${name}' is not available` });
+                return;
+            }
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (upgradeCard as any).attachTo(target);
+            } catch (err) {
+                this.errors.push({ path: upgradePath, message: `Failed to attach '${name}': ${(err as Error).message}` });
+            }
+        });
+    }
+
+    /**
+     * Pulls one card matching `predicate` from the outside-the-game staging
+     * zone and returns it (still in outsideTheGame at this point — the caller
+     * moves it to the desired destination via `card.moveTo`).
+     */
+    private takeFromOutside(predicate: (card: Card) => boolean): Card | undefined {
+        const candidates = this.player.outsideTheGameZone.cards;
+        return candidates.find((c) => this.isPlayableDeckCard(c) && predicate(c));
+    }
+
+    private isPlayableDeckCard(card: Card): boolean {
+        // Filter out tokens (force, credit) that share outsideTheGame with deck cards during setup.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const isToken = typeof (card as any).isToken === 'function' && (card as any).isToken();
+        return !isToken;
+    }
+}

--- a/server/game/core/customSetup/CustomSetupApplier.ts
+++ b/server/game/core/customSetup/CustomSetupApplier.ts
@@ -30,44 +30,42 @@ import {
  * makes no assumption that decks were synthesized — every named card must
  * already exist in the player's loaded deck.
  */
-export class CustomSetupApplier {
-    public static apply(game: Game, setup: ICustomSetupState): void {
-        const errors: ICustomSetupValidationError[] = [];
+export function applyCustomSetup(game: Game, setup: ICustomSetupState): void {
+    const errors: ICustomSetupValidationError[] = [];
 
-        const players = game.getPlayers();
-        Contract.assertTrue(players.length === 2, 'Custom setup requires exactly two players');
+    const players = game.getPlayers();
+    Contract.assertTrue(players.length === 2, 'Custom setup requires exactly two players');
 
-        const owner = players[0];
-        const opponent = players[1];
+    const owner = players[0];
+    const opponent = players[1];
 
-        const ownerCtx = new PlayerSetupContext(game, owner, 'player1', errors);
-        const opponentCtx = new PlayerSetupContext(game, opponent, 'player2', errors);
+    const ownerCtx = new PlayerSetupContext(game, owner, 'player1', errors);
+    const opponentCtx = new PlayerSetupContext(game, opponent, 'player2', errors);
 
-        if (setup.player1?.hasInitiative) {
-            game.initiativePlayer = owner;
-        } else if (setup.player2?.hasInitiative) {
-            game.initiativePlayer = opponent;
-        }
-
-        // Both players' action windows are pre-prompted so the action phase
-        // begins immediately without an extra "First action" UI step.
-        owner.promptedActionWindows.action = true;
-        opponent.promptedActionWindows.action = true;
-
-        // Clear all non-base zones for both players first so cross-player
-        // upgrade attachments and shared zone moves don't trip over each other.
-        ownerCtx.moveAllNonBaseZonesToOutside();
-        opponentCtx.moveAllNonBaseZonesToOutside();
-
-        ownerCtx.applyState(setup.player1 ?? {});
-        opponentCtx.applyState(setup.player2 ?? {});
-
-        if (errors.length > 0) {
-            throw new CustomSetupValidationFailure(errors);
-        }
-
-        game.resolveGameState(true);
+    if (setup.player1?.hasInitiative) {
+        game.initiativePlayer = owner;
+    } else if (setup.player2?.hasInitiative) {
+        game.initiativePlayer = opponent;
     }
+
+    // Both players' action windows are pre-prompted so the action phase
+    // begins immediately without an extra "First action" UI step.
+    owner.promptedActionWindows.action = true;
+    opponent.promptedActionWindows.action = true;
+
+    // Clear all non-base zones for both players first so cross-player
+    // upgrade attachments and shared zone moves don't trip over each other.
+    ownerCtx.moveAllNonBaseZonesToOutside();
+    opponentCtx.moveAllNonBaseZonesToOutside();
+
+    ownerCtx.applyState(setup.player1 ?? {});
+    opponentCtx.applyState(setup.player2 ?? {});
+
+    if (errors.length > 0) {
+        throw new CustomSetupValidationFailure(errors);
+    }
+
+    game.resolveGameState(true);
 }
 
 /**
@@ -98,6 +96,14 @@ class PlayerSetupContext {
         this.applyHand(state.hand);
         this.applyDiscard(state.discard);
         this.applyDeck(state.deck);
+
+        // The standard SetupPhase shuffles each deck before drawing starting
+        // hands; we skip that phase here, so we have to shuffle ourselves to
+        // avoid deterministic draws. If the user specified a deck list
+        // explicitly, treat that as an intentional order and leave it alone.
+        if (state.deck === undefined) {
+            this.player.shuffleDeck();
+        }
 
         this.applyForceToken(state.hasForceToken);
         this.applyCredits(state.credits);
@@ -357,7 +363,7 @@ class PlayerSetupContext {
         if (credits < current) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const tokens = (this.player.baseZone as any)?.credits?.slice(0, current - credits) ?? [];
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
             for (const token of tokens) {
                 token.moveTo(ZoneName.OutsideTheGame);
             }

--- a/server/game/core/customSetup/CustomSetupTypes.ts
+++ b/server/game/core/customSetup/CustomSetupTypes.ts
@@ -1,0 +1,116 @@
+/**
+ * Types describing a custom starting board state that a private-lobby owner
+ * can define to override the default game-start (mulligan + resource-2) flow.
+ *
+ * The shape mirrors the test fixtures in `forceteki/test/gameSetups/*.json`,
+ * but with these production-only constraints:
+ *   - All named cards must already exist in the corresponding player's
+ *     uploaded deck (we do not synthesize decks).
+ *   - Leader/base identity always comes from each player's loaded deck — the
+ *     JSON's leader/base fields only describe state (deployed, damage, etc).
+ *     A `card` field is allowed for self-documentation but must match.
+ *   - Only the 'action' phase is supported as a starting point.
+ *
+ * `player1` is the lobby owner; `player2` is the opponent.
+ */
+
+export type CardEntry = string | ICardSpec;
+
+export interface ICardSpec {
+    card: string;
+    damage?: number;
+    exhausted?: boolean;
+    upgrades?: CardEntry[];
+}
+
+export interface ILeaderSpec {
+    /** Optional self-documentation; if present, must match the player's deck leader. */
+    card?: string;
+    deployed?: boolean;
+    damage?: number;
+    exhausted?: boolean;
+    upgrades?: CardEntry[];
+    flipped?: boolean;
+}
+
+export interface IBaseSpec {
+    /** Optional self-documentation; if present, must match the player's deck base. */
+    card?: string;
+    damage?: number;
+}
+
+export interface IResourceSpec {
+    card: string;
+    exhausted?: boolean;
+}
+
+export type ResourceEntry = string | IResourceSpec;
+
+export interface ICustomSetupPlayerState {
+    hand?: string[];
+    groundArena?: CardEntry[];
+    spaceArena?: CardEntry[];
+    discard?: string[];
+    /**
+     * Cards (by internalName) to leave on top of the deck. Cards not listed are
+     * removed from play. If omitted, the entire remaining deck is left intact.
+     */
+    deck?: string[];
+    /** Either a count of generic resources or an explicit list of cards from the deck. */
+    resources?: number | ResourceEntry[];
+    base?: string | IBaseSpec;
+    leader?: string | ILeaderSpec;
+    hasInitiative?: boolean;
+    hasForceToken?: boolean;
+    credits?: number;
+}
+
+export interface ICustomSetupState {
+    /** Only 'action' is supported for now. */
+    phase?: 'action';
+    player1: ICustomSetupPlayerState;
+    player2: ICustomSetupPlayerState;
+}
+
+export interface ICustomSetupValidationError {
+    /** Dot/bracket path into the JSON document, e.g. "player1.hand[2]". */
+    path: string;
+    message: string;
+}
+
+export class CustomSetupValidationFailure extends Error {
+    public constructor(public readonly errors: ICustomSetupValidationError[]) {
+        super(`Custom setup validation failed with ${errors.length} error(s)`);
+        this.name = 'CustomSetupValidationFailure';
+    }
+}
+
+const TOKEN_UPGRADE_NAMES = new Set(['shield', 'experience', 'advantage']);
+
+export function isTokenUpgradeName(name: string): boolean {
+    return TOKEN_UPGRADE_NAMES.has(name);
+}
+
+const ALLOWED_PLAYER_KEYS = new Set([
+    'hand',
+    'groundArena',
+    'spaceArena',
+    'discard',
+    'deck',
+    'resources',
+    'base',
+    'leader',
+    'hasInitiative',
+    'hasForceToken',
+    'credits',
+]);
+
+const ALLOWED_TOP_LEVEL_KEYS = new Set(['phase', 'player1', 'player2']);
+
+export function getAllowedPlayerKeys(): ReadonlySet<string> {
+    return ALLOWED_PLAYER_KEYS;
+}
+
+export function getAllowedTopLevelKeys(): ReadonlySet<string> {
+    return ALLOWED_TOP_LEVEL_KEYS;
+}

--- a/server/game/core/customSetup/CustomSetupTypes.ts
+++ b/server/game/core/customSetup/CustomSetupTypes.ts
@@ -24,6 +24,7 @@ export interface ICardSpec {
 }
 
 export interface ILeaderSpec {
+
     /** Optional self-documentation; if present, must match the player's deck leader. */
     card?: string;
     deployed?: boolean;
@@ -34,6 +35,7 @@ export interface ILeaderSpec {
 }
 
 export interface IBaseSpec {
+
     /** Optional self-documentation; if present, must match the player's deck base. */
     card?: string;
     damage?: number;
@@ -51,11 +53,13 @@ export interface ICustomSetupPlayerState {
     groundArena?: CardEntry[];
     spaceArena?: CardEntry[];
     discard?: string[];
+
     /**
      * Cards (by internalName) to leave on top of the deck. Cards not listed are
      * removed from play. If omitted, the entire remaining deck is left intact.
      */
     deck?: string[];
+
     /** Either a count of generic resources or an explicit list of cards from the deck. */
     resources?: number | ResourceEntry[];
     base?: string | IBaseSpec;
@@ -66,6 +70,7 @@ export interface ICustomSetupPlayerState {
 }
 
 export interface ICustomSetupState {
+
     /** Only 'action' is supported for now. */
     phase?: 'action';
     player1: ICustomSetupPlayerState;
@@ -73,6 +78,7 @@ export interface ICustomSetupState {
 }
 
 export interface ICustomSetupValidationError {
+
     /** Dot/bracket path into the JSON document, e.g. "player1.hand[2]". */
     path: string;
     message: string;

--- a/server/game/core/customSetup/CustomSetupValidator.ts
+++ b/server/game/core/customSetup/CustomSetupValidator.ts
@@ -4,7 +4,6 @@ import {
     type CardEntry,
     type IBaseSpec,
     type ICustomSetupPlayerState,
-    type ICustomSetupState,
     type ICustomSetupValidationError,
     type ILeaderSpec,
     type ResourceEntry,
@@ -21,313 +20,311 @@ import {
  * stops walking a sub-tree only when it can't make progress; otherwise it
  * collects every problem so the user sees them all at once.
  */
-export class CustomSetupValidator {
-    public static validate(
-        setup: unknown,
-        ownerDeck: Deck | undefined,
-        opponentDeck: Deck | undefined,
-        cardDataGetter: CardDataGetter,
-    ): ICustomSetupValidationError[] {
-        const errors: ICustomSetupValidationError[] = [];
+export function validateCustomSetup(
+    setup: unknown,
+    ownerDeck: Deck | undefined,
+    opponentDeck: Deck | undefined,
+    cardDataGetter: CardDataGetter,
+): ICustomSetupValidationError[] {
+    const errors: ICustomSetupValidationError[] = [];
 
-        if (!isPlainObject(setup)) {
-            errors.push({ path: '', message: 'Setup must be a JSON object' });
-            return errors;
-        }
-
-        for (const key of Object.keys(setup)) {
-            if (!getAllowedTopLevelKeys().has(key)) {
-                errors.push({ path: key, message: `Unknown top-level key '${key}'` });
-            }
-        }
-
-        if (Object.prototype.hasOwnProperty.call(setup, 'phase')) {
-            const phase = setup.phase;
-            if (phase !== 'action' && phase !== undefined) {
-                errors.push({ path: 'phase', message: `Only 'action' phase is supported (got '${String(phase)}')` });
-            }
-        }
-
-        if (!('player1' in setup)) {
-            errors.push({ path: 'player1', message: 'Missing player1 block' });
-        }
-        if (!('player2' in setup)) {
-            errors.push({ path: 'player2', message: 'Missing player2 block' });
-        }
-
-        if (setup.player1 !== undefined) {
-            this.validatePlayer('player1', setup.player1, ownerDeck, cardDataGetter, errors);
-        }
-        if (setup.player2 !== undefined) {
-            this.validatePlayer('player2', setup.player2, opponentDeck, cardDataGetter, errors);
-        }
-
-        const player1HasInit = isPlainObject(setup.player1) && setup.player1.hasInitiative === true;
-        const player2HasInit = isPlainObject(setup.player2) && setup.player2.hasInitiative === true;
-        if (player1HasInit && player2HasInit) {
-            errors.push({ path: 'hasInitiative', message: 'Only one player can start with initiative' });
-        }
-
+    if (!isPlainObject(setup)) {
+        errors.push({ path: '', message: 'Setup must be a JSON object' });
         return errors;
     }
 
-    private static validatePlayer(
-        path: string,
-        playerRaw: unknown,
-        deck: Deck | undefined,
-        cardDataGetter: CardDataGetter,
-        errors: ICustomSetupValidationError[],
-    ): void {
-        if (!isPlainObject(playerRaw)) {
-            errors.push({ path, message: 'Player block must be an object' });
-            return;
-        }
-        const player = playerRaw as ICustomSetupPlayerState;
-
-        for (const key of Object.keys(player)) {
-            if (!getAllowedPlayerKeys().has(key)) {
-                errors.push({ path: `${path}.${key}`, message: `Unknown player property '${key}'` });
-            }
-        }
-
-        if (!deck) {
-            errors.push({ path, message: 'No deck loaded for this player yet — both players must load a deck before applying a custom setup' });
-            return;
-        }
-
-        const availableCards = collectDeckInternalNames(deck, cardDataGetter);
-
-        this.validateLeader(`${path}.leader`, player.leader, deck, cardDataGetter, errors);
-        this.validateBase(`${path}.base`, player.base, deck, cardDataGetter, errors);
-
-        for (const zoneKey of ['hand', 'discard', 'deck'] as const) {
-            const list = player[zoneKey];
-            if (list === undefined) {
-                continue;
-            }
-            if (!Array.isArray(list)) {
-                errors.push({ path: `${path}.${zoneKey}`, message: 'Must be an array of card names' });
-                continue;
-            }
-            list.forEach((entry, i) => {
-                if (typeof entry !== 'string') {
-                    errors.push({ path: `${path}.${zoneKey}[${i}]`, message: 'Must be a card internalName string' });
-                    return;
-                }
-                if (!availableCards.has(entry)) {
-                    errors.push({ path: `${path}.${zoneKey}[${i}]`, message: `Card '${entry}' is not in this player's deck` });
-                }
-            });
-        }
-
-        for (const arenaKey of ['groundArena', 'spaceArena'] as const) {
-            const list = player[arenaKey];
-            if (list === undefined) {
-                continue;
-            }
-            if (!Array.isArray(list)) {
-                errors.push({ path: `${path}.${arenaKey}`, message: 'Must be an array' });
-                continue;
-            }
-            list.forEach((entry, i) => {
-                this.validateCardEntry(`${path}.${arenaKey}[${i}]`, entry, availableCards, errors, true);
-            });
-        }
-
-        if (player.resources !== undefined) {
-            this.validateResources(`${path}.resources`, player.resources, availableCards, errors);
-        }
-
-        if (player.credits !== undefined && (typeof player.credits !== 'number' || !Number.isInteger(player.credits) || player.credits < 0)) {
-            errors.push({ path: `${path}.credits`, message: 'Must be a non-negative integer' });
-        }
-
-        if (player.hasInitiative !== undefined && typeof player.hasInitiative !== 'boolean') {
-            errors.push({ path: `${path}.hasInitiative`, message: 'Must be a boolean' });
-        }
-        if (player.hasForceToken !== undefined && typeof player.hasForceToken !== 'boolean') {
-            errors.push({ path: `${path}.hasForceToken`, message: 'Must be a boolean' });
+    for (const key of Object.keys(setup)) {
+        if (!getAllowedTopLevelKeys().has(key)) {
+            errors.push({ path: key, message: `Unknown top-level key '${key}'` });
         }
     }
 
-    private static validateLeader(
-        path: string,
-        leader: string | ILeaderSpec | undefined,
-        deck: Deck,
-        cardDataGetter: CardDataGetter,
-        errors: ICustomSetupValidationError[],
-    ): void {
-        if (leader === undefined) {
-            return;
+    if (Object.prototype.hasOwnProperty.call(setup, 'phase')) {
+        const phase = setup.phase;
+        if (phase !== 'action' && phase !== undefined) {
+            errors.push({ path: 'phase', message: `Only 'action' phase is supported (got '${String(phase)}')` });
         }
-        const deckLeaderName = resolveInternalName(deck.leader.id, cardDataGetter);
-        if (typeof leader === 'string') {
-            if (leader !== deckLeaderName) {
-                errors.push({
-                    path,
-                    message: `Leader '${leader}' does not match the player's deck leader '${deckLeaderName}'`,
+    }
+
+    if (!('player1' in setup)) {
+        errors.push({ path: 'player1', message: 'Missing player1 block' });
+    }
+    if (!('player2' in setup)) {
+        errors.push({ path: 'player2', message: 'Missing player2 block' });
+    }
+
+    if (setup.player1 !== undefined) {
+        validatePlayer('player1', setup.player1, ownerDeck, cardDataGetter, errors);
+    }
+    if (setup.player2 !== undefined) {
+        validatePlayer('player2', setup.player2, opponentDeck, cardDataGetter, errors);
+    }
+
+    const player1HasInit = isPlainObject(setup.player1) && setup.player1.hasInitiative === true;
+    const player2HasInit = isPlainObject(setup.player2) && setup.player2.hasInitiative === true;
+    if (player1HasInit && player2HasInit) {
+        errors.push({ path: 'hasInitiative', message: 'Only one player can start with initiative' });
+    }
+
+    return errors;
+}
+
+function validatePlayer(
+    path: string,
+    playerRaw: unknown,
+    deck: Deck | undefined,
+    cardDataGetter: CardDataGetter,
+    errors: ICustomSetupValidationError[],
+): void {
+    if (!isPlainObject(playerRaw)) {
+        errors.push({ path, message: 'Player block must be an object' });
+        return;
+    }
+    const player = playerRaw as ICustomSetupPlayerState;
+
+    for (const key of Object.keys(player)) {
+        if (!getAllowedPlayerKeys().has(key)) {
+            errors.push({ path: `${path}.${key}`, message: `Unknown player property '${key}'` });
+        }
+    }
+
+    if (!deck) {
+        errors.push({ path, message: 'No deck loaded for this player yet — both players must load a deck before applying a custom setup' });
+        return;
+    }
+
+    const availableCards = collectDeckInternalNames(deck, cardDataGetter);
+
+    validateLeader(`${path}.leader`, player.leader, deck, cardDataGetter, errors);
+    validateBase(`${path}.base`, player.base, deck, cardDataGetter, errors);
+
+    for (const zoneKey of ['hand', 'discard', 'deck'] as const) {
+        const list = player[zoneKey];
+        if (list === undefined) {
+            continue;
+        }
+        if (!Array.isArray(list)) {
+            errors.push({ path: `${path}.${zoneKey}`, message: 'Must be an array of card names' });
+            continue;
+        }
+        list.forEach((entry, i) => {
+            if (typeof entry !== 'string') {
+                errors.push({ path: `${path}.${zoneKey}[${i}]`, message: 'Must be a card internalName string' });
+                return;
+            }
+            if (!availableCards.has(entry)) {
+                errors.push({ path: `${path}.${zoneKey}[${i}]`, message: `Card '${entry}' is not in this player's deck` });
+            }
+        });
+    }
+
+    for (const arenaKey of ['groundArena', 'spaceArena'] as const) {
+        const list = player[arenaKey];
+        if (list === undefined) {
+            continue;
+        }
+        if (!Array.isArray(list)) {
+            errors.push({ path: `${path}.${arenaKey}`, message: 'Must be an array' });
+            continue;
+        }
+        list.forEach((entry, i) => {
+            validateCardEntry(`${path}.${arenaKey}[${i}]`, entry, availableCards, errors, true);
+        });
+    }
+
+    if (player.resources !== undefined) {
+        validateResources(`${path}.resources`, player.resources, availableCards, errors);
+    }
+
+    if (player.credits !== undefined && (typeof player.credits !== 'number' || !Number.isInteger(player.credits) || player.credits < 0)) {
+        errors.push({ path: `${path}.credits`, message: 'Must be a non-negative integer' });
+    }
+
+    if (player.hasInitiative !== undefined && typeof player.hasInitiative !== 'boolean') {
+        errors.push({ path: `${path}.hasInitiative`, message: 'Must be a boolean' });
+    }
+    if (player.hasForceToken !== undefined && typeof player.hasForceToken !== 'boolean') {
+        errors.push({ path: `${path}.hasForceToken`, message: 'Must be a boolean' });
+    }
+}
+
+function validateLeader(
+    path: string,
+    leader: string | ILeaderSpec | undefined,
+    deck: Deck,
+    cardDataGetter: CardDataGetter,
+    errors: ICustomSetupValidationError[],
+): void {
+    if (leader === undefined) {
+        return;
+    }
+    const deckLeaderName = resolveInternalName(deck.leader.id, cardDataGetter);
+    if (typeof leader === 'string') {
+        if (leader !== deckLeaderName) {
+            errors.push({
+                path,
+                message: `Leader '${leader}' does not match the player's deck leader '${deckLeaderName}'`,
+            });
+        }
+        return;
+    }
+    if (!isPlainObject(leader)) {
+        errors.push({ path, message: 'Leader must be a string or an object' });
+        return;
+    }
+    if (leader.card !== undefined && leader.card !== deckLeaderName) {
+        errors.push({
+            path: `${path}.card`,
+            message: `Leader '${leader.card}' does not match the player's deck leader '${deckLeaderName}'`,
+        });
+        return;
+    }
+    if (typeof leader !== 'string') {
+        if (leader.deployed === false) {
+            if (typeof leader.damage === 'number' && leader.damage > 0) {
+                errors.push({ path: `${path}.damage`, message: 'Leader cannot have damage when not deployed' });
+            }
+            if (Array.isArray(leader.upgrades) && leader.upgrades.length > 0) {
+                errors.push({ path: `${path}.upgrades`, message: 'Leader cannot have upgrades when not deployed' });
+            }
+        }
+        if (leader.upgrades !== undefined) {
+            if (!Array.isArray(leader.upgrades)) {
+                errors.push({ path: `${path}.upgrades`, message: 'Must be an array' });
+            } else {
+                const availableCards = collectDeckInternalNames(deck, cardDataGetter);
+                leader.upgrades.forEach((u, i) => {
+                    validateCardEntry(`${path}.upgrades[${i}]`, u, availableCards, errors, false);
                 });
             }
-            return;
         }
-        if (!isPlainObject(leader)) {
-            errors.push({ path, message: 'Leader must be a string or an object' });
-            return;
-        }
-        if (leader.card !== undefined && leader.card !== deckLeaderName) {
+    }
+}
+
+function validateBase(
+    path: string,
+    base: string | IBaseSpec | undefined,
+    deck: Deck,
+    cardDataGetter: CardDataGetter,
+    errors: ICustomSetupValidationError[],
+): void {
+    if (base === undefined) {
+        return;
+    }
+    const deckBaseName = resolveInternalName(deck.base.id, cardDataGetter);
+    if (typeof base === 'string') {
+        if (base !== deckBaseName) {
             errors.push({
-                path: `${path}.card`,
-                message: `Leader '${leader.card}' does not match the player's deck leader '${deckLeaderName}'`,
+                path,
+                message: `Base '${base}' does not match the player's deck base '${deckBaseName}'`,
             });
-            return;
         }
-        if (typeof leader !== 'string') {
-            if (leader.deployed === false) {
-                if (typeof leader.damage === 'number' && leader.damage > 0) {
-                    errors.push({ path: `${path}.damage`, message: 'Leader cannot have damage when not deployed' });
-                }
-                if (Array.isArray(leader.upgrades) && leader.upgrades.length > 0) {
-                    errors.push({ path: `${path}.upgrades`, message: 'Leader cannot have upgrades when not deployed' });
-                }
-            }
-            if (leader.upgrades !== undefined) {
-                if (!Array.isArray(leader.upgrades)) {
-                    errors.push({ path: `${path}.upgrades`, message: 'Must be an array' });
+        return;
+    }
+    if (!isPlainObject(base)) {
+        errors.push({ path, message: 'Base must be a string or an object' });
+        return;
+    }
+    if (base.card !== undefined && base.card !== deckBaseName) {
+        errors.push({
+            path: `${path}.card`,
+            message: `Base '${base.card}' does not match the player's deck base '${deckBaseName}'`,
+        });
+    }
+    if (base.damage !== undefined && (typeof base.damage !== 'number' || base.damage < 0)) {
+        errors.push({ path: `${path}.damage`, message: 'Must be a non-negative number' });
+    }
+}
+
+function validateCardEntry(
+    path: string,
+    entry: CardEntry,
+    availableCards: Set<string>,
+    errors: ICustomSetupValidationError[],
+    allowUpgrades: boolean,
+): void {
+    if (typeof entry === 'string') {
+        if (!availableCards.has(entry)) {
+            errors.push({ path, message: `Card '${entry}' is not in this player's deck` });
+        }
+        return;
+    }
+    if (!isPlainObject(entry) || typeof entry.card !== 'string') {
+        errors.push({ path, message: 'Must be a card name string or an object with a card field' });
+        return;
+    }
+    if (!availableCards.has(entry.card)) {
+        errors.push({ path: `${path}.card`, message: `Card '${entry.card}' is not in this player's deck` });
+    }
+    if (entry.damage !== undefined && (typeof entry.damage !== 'number' || entry.damage < 0)) {
+        errors.push({ path: `${path}.damage`, message: 'Must be a non-negative number' });
+    }
+    if (entry.exhausted !== undefined && typeof entry.exhausted !== 'boolean') {
+        errors.push({ path: `${path}.exhausted`, message: 'Must be a boolean' });
+    }
+    if (entry.upgrades !== undefined) {
+        if (!allowUpgrades) {
+            errors.push({ path: `${path}.upgrades`, message: 'Upgrades are not allowed here' });
+        } else if (!Array.isArray(entry.upgrades)) {
+            errors.push({ path: `${path}.upgrades`, message: 'Must be an array' });
+        } else {
+            entry.upgrades.forEach((u, i) => {
+                if (typeof u === 'string') {
+                    if (isTokenUpgradeName(u)) {
+                        return;
+                    }
+                    if (!availableCards.has(u)) {
+                        errors.push({ path: `${path}.upgrades[${i}]`, message: `Upgrade '${u}' is not in this player's deck` });
+                    }
+                } else if (isPlainObject(u) && typeof u.card === 'string') {
+                    if (isTokenUpgradeName(u.card)) {
+                        return;
+                    }
+                    if (!availableCards.has(u.card)) {
+                        errors.push({ path: `${path}.upgrades[${i}].card`, message: `Upgrade '${u.card}' is not in this player's deck` });
+                    }
                 } else {
-                    const availableCards = collectDeckInternalNames(deck, cardDataGetter);
-                    leader.upgrades.forEach((u, i) => {
-                        this.validateCardEntry(`${path}.upgrades[${i}]`, u, availableCards, errors, false);
-                    });
+                    errors.push({ path: `${path}.upgrades[${i}]`, message: 'Must be a card name string or an object with a card field' });
                 }
-            }
-        }
-    }
-
-    private static validateBase(
-        path: string,
-        base: string | IBaseSpec | undefined,
-        deck: Deck,
-        cardDataGetter: CardDataGetter,
-        errors: ICustomSetupValidationError[],
-    ): void {
-        if (base === undefined) {
-            return;
-        }
-        const deckBaseName = resolveInternalName(deck.base.id, cardDataGetter);
-        if (typeof base === 'string') {
-            if (base !== deckBaseName) {
-                errors.push({
-                    path,
-                    message: `Base '${base}' does not match the player's deck base '${deckBaseName}'`,
-                });
-            }
-            return;
-        }
-        if (!isPlainObject(base)) {
-            errors.push({ path, message: 'Base must be a string or an object' });
-            return;
-        }
-        if (base.card !== undefined && base.card !== deckBaseName) {
-            errors.push({
-                path: `${path}.card`,
-                message: `Base '${base.card}' does not match the player's deck base '${deckBaseName}'`,
             });
         }
-        if (base.damage !== undefined && (typeof base.damage !== 'number' || base.damage < 0)) {
-            errors.push({ path: `${path}.damage`, message: 'Must be a non-negative number' });
-        }
     }
+}
 
-    private static validateCardEntry(
-        path: string,
-        entry: CardEntry,
-        availableCards: Set<string>,
-        errors: ICustomSetupValidationError[],
-        allowUpgrades: boolean,
-    ): void {
+function validateResources(
+    path: string,
+    resources: number | ResourceEntry[],
+    availableCards: Set<string>,
+    errors: ICustomSetupValidationError[],
+): void {
+    if (typeof resources === 'number') {
+        if (!Number.isInteger(resources) || resources < 0) {
+            errors.push({ path, message: 'Must be a non-negative integer' });
+        }
+        return;
+    }
+    if (!Array.isArray(resources)) {
+        errors.push({ path, message: 'Must be a number or an array of card names' });
+        return;
+    }
+    resources.forEach((entry, i) => {
         if (typeof entry === 'string') {
             if (!availableCards.has(entry)) {
-                errors.push({ path, message: `Card '${entry}' is not in this player's deck` });
+                errors.push({ path: `${path}[${i}]`, message: `Card '${entry}' is not in this player's deck` });
             }
             return;
         }
         if (!isPlainObject(entry) || typeof entry.card !== 'string') {
-            errors.push({ path, message: 'Must be a card name string or an object with a card field' });
+            errors.push({ path: `${path}[${i}]`, message: 'Must be a card name string or an object with a card field' });
             return;
         }
         if (!availableCards.has(entry.card)) {
-            errors.push({ path: `${path}.card`, message: `Card '${entry.card}' is not in this player's deck` });
-        }
-        if (entry.damage !== undefined && (typeof entry.damage !== 'number' || entry.damage < 0)) {
-            errors.push({ path: `${path}.damage`, message: 'Must be a non-negative number' });
+            errors.push({ path: `${path}[${i}].card`, message: `Card '${entry.card}' is not in this player's deck` });
         }
         if (entry.exhausted !== undefined && typeof entry.exhausted !== 'boolean') {
-            errors.push({ path: `${path}.exhausted`, message: 'Must be a boolean' });
+            errors.push({ path: `${path}[${i}].exhausted`, message: 'Must be a boolean' });
         }
-        if (entry.upgrades !== undefined) {
-            if (!allowUpgrades) {
-                errors.push({ path: `${path}.upgrades`, message: 'Upgrades are not allowed here' });
-            } else if (!Array.isArray(entry.upgrades)) {
-                errors.push({ path: `${path}.upgrades`, message: 'Must be an array' });
-            } else {
-                entry.upgrades.forEach((u, i) => {
-                    if (typeof u === 'string') {
-                        if (isTokenUpgradeName(u)) {
-                            return;
-                        }
-                        if (!availableCards.has(u)) {
-                            errors.push({ path: `${path}.upgrades[${i}]`, message: `Upgrade '${u}' is not in this player's deck` });
-                        }
-                    } else if (isPlainObject(u) && typeof u.card === 'string') {
-                        if (isTokenUpgradeName(u.card)) {
-                            return;
-                        }
-                        if (!availableCards.has(u.card)) {
-                            errors.push({ path: `${path}.upgrades[${i}].card`, message: `Upgrade '${u.card}' is not in this player's deck` });
-                        }
-                    } else {
-                        errors.push({ path: `${path}.upgrades[${i}]`, message: 'Must be a card name string or an object with a card field' });
-                    }
-                });
-            }
-        }
-    }
-
-    private static validateResources(
-        path: string,
-        resources: number | ResourceEntry[],
-        availableCards: Set<string>,
-        errors: ICustomSetupValidationError[],
-    ): void {
-        if (typeof resources === 'number') {
-            if (!Number.isInteger(resources) || resources < 0) {
-                errors.push({ path, message: 'Must be a non-negative integer' });
-            }
-            return;
-        }
-        if (!Array.isArray(resources)) {
-            errors.push({ path, message: 'Must be a number or an array of card names' });
-            return;
-        }
-        resources.forEach((entry, i) => {
-            if (typeof entry === 'string') {
-                if (!availableCards.has(entry)) {
-                    errors.push({ path: `${path}[${i}]`, message: `Card '${entry}' is not in this player's deck` });
-                }
-                return;
-            }
-            if (!isPlainObject(entry) || typeof entry.card !== 'string') {
-                errors.push({ path: `${path}[${i}]`, message: 'Must be a card name string or an object with a card field' });
-                return;
-            }
-            if (!availableCards.has(entry.card)) {
-                errors.push({ path: `${path}[${i}].card`, message: `Card '${entry.card}' is not in this player's deck` });
-            }
-            if (entry.exhausted !== undefined && typeof entry.exhausted !== 'boolean') {
-                errors.push({ path: `${path}[${i}].exhausted`, message: 'Must be a boolean' });
-            }
-        });
-    }
+    });
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/server/game/core/customSetup/CustomSetupValidator.ts
+++ b/server/game/core/customSetup/CustomSetupValidator.ts
@@ -1,0 +1,369 @@
+import type { CardDataGetter } from '../../../utils/cardData/CardDataGetter';
+import type { Deck } from '../../../utils/deck/Deck';
+import {
+    type CardEntry,
+    type IBaseSpec,
+    type ICustomSetupPlayerState,
+    type ICustomSetupState,
+    type ICustomSetupValidationError,
+    type ILeaderSpec,
+    type ResourceEntry,
+    getAllowedPlayerKeys,
+    getAllowedTopLevelKeys,
+    isTokenUpgradeName,
+} from './CustomSetupTypes';
+
+/**
+ * Validates that a parsed custom setup JSON is structurally well-formed and
+ * that every named card is present in the corresponding player's deck.
+ *
+ * Returns an array of all errors found (empty array means valid). Validation
+ * stops walking a sub-tree only when it can't make progress; otherwise it
+ * collects every problem so the user sees them all at once.
+ */
+export class CustomSetupValidator {
+    public static validate(
+        setup: unknown,
+        ownerDeck: Deck | undefined,
+        opponentDeck: Deck | undefined,
+        cardDataGetter: CardDataGetter,
+    ): ICustomSetupValidationError[] {
+        const errors: ICustomSetupValidationError[] = [];
+
+        if (!isPlainObject(setup)) {
+            errors.push({ path: '', message: 'Setup must be a JSON object' });
+            return errors;
+        }
+
+        for (const key of Object.keys(setup)) {
+            if (!getAllowedTopLevelKeys().has(key)) {
+                errors.push({ path: key, message: `Unknown top-level key '${key}'` });
+            }
+        }
+
+        if (Object.prototype.hasOwnProperty.call(setup, 'phase')) {
+            const phase = setup.phase;
+            if (phase !== 'action' && phase !== undefined) {
+                errors.push({ path: 'phase', message: `Only 'action' phase is supported (got '${String(phase)}')` });
+            }
+        }
+
+        if (!('player1' in setup)) {
+            errors.push({ path: 'player1', message: 'Missing player1 block' });
+        }
+        if (!('player2' in setup)) {
+            errors.push({ path: 'player2', message: 'Missing player2 block' });
+        }
+
+        if (setup.player1 !== undefined) {
+            this.validatePlayer('player1', setup.player1, ownerDeck, cardDataGetter, errors);
+        }
+        if (setup.player2 !== undefined) {
+            this.validatePlayer('player2', setup.player2, opponentDeck, cardDataGetter, errors);
+        }
+
+        const player1HasInit = isPlainObject(setup.player1) && setup.player1.hasInitiative === true;
+        const player2HasInit = isPlainObject(setup.player2) && setup.player2.hasInitiative === true;
+        if (player1HasInit && player2HasInit) {
+            errors.push({ path: 'hasInitiative', message: 'Only one player can start with initiative' });
+        }
+
+        return errors;
+    }
+
+    private static validatePlayer(
+        path: string,
+        playerRaw: unknown,
+        deck: Deck | undefined,
+        cardDataGetter: CardDataGetter,
+        errors: ICustomSetupValidationError[],
+    ): void {
+        if (!isPlainObject(playerRaw)) {
+            errors.push({ path, message: 'Player block must be an object' });
+            return;
+        }
+        const player = playerRaw as ICustomSetupPlayerState;
+
+        for (const key of Object.keys(player)) {
+            if (!getAllowedPlayerKeys().has(key)) {
+                errors.push({ path: `${path}.${key}`, message: `Unknown player property '${key}'` });
+            }
+        }
+
+        if (!deck) {
+            errors.push({ path, message: 'No deck loaded for this player yet — both players must load a deck before applying a custom setup' });
+            return;
+        }
+
+        const availableCards = collectDeckInternalNames(deck, cardDataGetter);
+
+        this.validateLeader(`${path}.leader`, player.leader, deck, cardDataGetter, errors);
+        this.validateBase(`${path}.base`, player.base, deck, cardDataGetter, errors);
+
+        for (const zoneKey of ['hand', 'discard', 'deck'] as const) {
+            const list = player[zoneKey];
+            if (list === undefined) {
+                continue;
+            }
+            if (!Array.isArray(list)) {
+                errors.push({ path: `${path}.${zoneKey}`, message: 'Must be an array of card names' });
+                continue;
+            }
+            list.forEach((entry, i) => {
+                if (typeof entry !== 'string') {
+                    errors.push({ path: `${path}.${zoneKey}[${i}]`, message: 'Must be a card internalName string' });
+                    return;
+                }
+                if (!availableCards.has(entry)) {
+                    errors.push({ path: `${path}.${zoneKey}[${i}]`, message: `Card '${entry}' is not in this player's deck` });
+                }
+            });
+        }
+
+        for (const arenaKey of ['groundArena', 'spaceArena'] as const) {
+            const list = player[arenaKey];
+            if (list === undefined) {
+                continue;
+            }
+            if (!Array.isArray(list)) {
+                errors.push({ path: `${path}.${arenaKey}`, message: 'Must be an array' });
+                continue;
+            }
+            list.forEach((entry, i) => {
+                this.validateCardEntry(`${path}.${arenaKey}[${i}]`, entry, availableCards, errors, true);
+            });
+        }
+
+        if (player.resources !== undefined) {
+            this.validateResources(`${path}.resources`, player.resources, availableCards, errors);
+        }
+
+        if (player.credits !== undefined && (typeof player.credits !== 'number' || !Number.isInteger(player.credits) || player.credits < 0)) {
+            errors.push({ path: `${path}.credits`, message: 'Must be a non-negative integer' });
+        }
+
+        if (player.hasInitiative !== undefined && typeof player.hasInitiative !== 'boolean') {
+            errors.push({ path: `${path}.hasInitiative`, message: 'Must be a boolean' });
+        }
+        if (player.hasForceToken !== undefined && typeof player.hasForceToken !== 'boolean') {
+            errors.push({ path: `${path}.hasForceToken`, message: 'Must be a boolean' });
+        }
+    }
+
+    private static validateLeader(
+        path: string,
+        leader: string | ILeaderSpec | undefined,
+        deck: Deck,
+        cardDataGetter: CardDataGetter,
+        errors: ICustomSetupValidationError[],
+    ): void {
+        if (leader === undefined) {
+            return;
+        }
+        const deckLeaderName = resolveInternalName(deck.leader.id, cardDataGetter);
+        if (typeof leader === 'string') {
+            if (leader !== deckLeaderName) {
+                errors.push({
+                    path,
+                    message: `Leader '${leader}' does not match the player's deck leader '${deckLeaderName}'`,
+                });
+            }
+            return;
+        }
+        if (!isPlainObject(leader)) {
+            errors.push({ path, message: 'Leader must be a string or an object' });
+            return;
+        }
+        if (leader.card !== undefined && leader.card !== deckLeaderName) {
+            errors.push({
+                path: `${path}.card`,
+                message: `Leader '${leader.card}' does not match the player's deck leader '${deckLeaderName}'`,
+            });
+            return;
+        }
+        if (typeof leader !== 'string') {
+            if (leader.deployed === false) {
+                if (typeof leader.damage === 'number' && leader.damage > 0) {
+                    errors.push({ path: `${path}.damage`, message: 'Leader cannot have damage when not deployed' });
+                }
+                if (Array.isArray(leader.upgrades) && leader.upgrades.length > 0) {
+                    errors.push({ path: `${path}.upgrades`, message: 'Leader cannot have upgrades when not deployed' });
+                }
+            }
+            if (leader.upgrades !== undefined) {
+                if (!Array.isArray(leader.upgrades)) {
+                    errors.push({ path: `${path}.upgrades`, message: 'Must be an array' });
+                } else {
+                    const availableCards = collectDeckInternalNames(deck, cardDataGetter);
+                    leader.upgrades.forEach((u, i) => {
+                        this.validateCardEntry(`${path}.upgrades[${i}]`, u, availableCards, errors, false);
+                    });
+                }
+            }
+        }
+    }
+
+    private static validateBase(
+        path: string,
+        base: string | IBaseSpec | undefined,
+        deck: Deck,
+        cardDataGetter: CardDataGetter,
+        errors: ICustomSetupValidationError[],
+    ): void {
+        if (base === undefined) {
+            return;
+        }
+        const deckBaseName = resolveInternalName(deck.base.id, cardDataGetter);
+        if (typeof base === 'string') {
+            if (base !== deckBaseName) {
+                errors.push({
+                    path,
+                    message: `Base '${base}' does not match the player's deck base '${deckBaseName}'`,
+                });
+            }
+            return;
+        }
+        if (!isPlainObject(base)) {
+            errors.push({ path, message: 'Base must be a string or an object' });
+            return;
+        }
+        if (base.card !== undefined && base.card !== deckBaseName) {
+            errors.push({
+                path: `${path}.card`,
+                message: `Base '${base.card}' does not match the player's deck base '${deckBaseName}'`,
+            });
+        }
+        if (base.damage !== undefined && (typeof base.damage !== 'number' || base.damage < 0)) {
+            errors.push({ path: `${path}.damage`, message: 'Must be a non-negative number' });
+        }
+    }
+
+    private static validateCardEntry(
+        path: string,
+        entry: CardEntry,
+        availableCards: Set<string>,
+        errors: ICustomSetupValidationError[],
+        allowUpgrades: boolean,
+    ): void {
+        if (typeof entry === 'string') {
+            if (!availableCards.has(entry)) {
+                errors.push({ path, message: `Card '${entry}' is not in this player's deck` });
+            }
+            return;
+        }
+        if (!isPlainObject(entry) || typeof entry.card !== 'string') {
+            errors.push({ path, message: 'Must be a card name string or an object with a card field' });
+            return;
+        }
+        if (!availableCards.has(entry.card)) {
+            errors.push({ path: `${path}.card`, message: `Card '${entry.card}' is not in this player's deck` });
+        }
+        if (entry.damage !== undefined && (typeof entry.damage !== 'number' || entry.damage < 0)) {
+            errors.push({ path: `${path}.damage`, message: 'Must be a non-negative number' });
+        }
+        if (entry.exhausted !== undefined && typeof entry.exhausted !== 'boolean') {
+            errors.push({ path: `${path}.exhausted`, message: 'Must be a boolean' });
+        }
+        if (entry.upgrades !== undefined) {
+            if (!allowUpgrades) {
+                errors.push({ path: `${path}.upgrades`, message: 'Upgrades are not allowed here' });
+            } else if (!Array.isArray(entry.upgrades)) {
+                errors.push({ path: `${path}.upgrades`, message: 'Must be an array' });
+            } else {
+                entry.upgrades.forEach((u, i) => {
+                    if (typeof u === 'string') {
+                        if (isTokenUpgradeName(u)) {
+                            return;
+                        }
+                        if (!availableCards.has(u)) {
+                            errors.push({ path: `${path}.upgrades[${i}]`, message: `Upgrade '${u}' is not in this player's deck` });
+                        }
+                    } else if (isPlainObject(u) && typeof u.card === 'string') {
+                        if (isTokenUpgradeName(u.card)) {
+                            return;
+                        }
+                        if (!availableCards.has(u.card)) {
+                            errors.push({ path: `${path}.upgrades[${i}].card`, message: `Upgrade '${u.card}' is not in this player's deck` });
+                        }
+                    } else {
+                        errors.push({ path: `${path}.upgrades[${i}]`, message: 'Must be a card name string or an object with a card field' });
+                    }
+                });
+            }
+        }
+    }
+
+    private static validateResources(
+        path: string,
+        resources: number | ResourceEntry[],
+        availableCards: Set<string>,
+        errors: ICustomSetupValidationError[],
+    ): void {
+        if (typeof resources === 'number') {
+            if (!Number.isInteger(resources) || resources < 0) {
+                errors.push({ path, message: 'Must be a non-negative integer' });
+            }
+            return;
+        }
+        if (!Array.isArray(resources)) {
+            errors.push({ path, message: 'Must be a number or an array of card names' });
+            return;
+        }
+        resources.forEach((entry, i) => {
+            if (typeof entry === 'string') {
+                if (!availableCards.has(entry)) {
+                    errors.push({ path: `${path}[${i}]`, message: `Card '${entry}' is not in this player's deck` });
+                }
+                return;
+            }
+            if (!isPlainObject(entry) || typeof entry.card !== 'string') {
+                errors.push({ path: `${path}[${i}]`, message: 'Must be a card name string or an object with a card field' });
+                return;
+            }
+            if (!availableCards.has(entry.card)) {
+                errors.push({ path: `${path}[${i}].card`, message: `Card '${entry.card}' is not in this player's deck` });
+            }
+            if (entry.exhausted !== undefined && typeof entry.exhausted !== 'boolean') {
+                errors.push({ path: `${path}[${i}].exhausted`, message: 'Must be a boolean' });
+            }
+        });
+    }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Looks up a card's actual `internalName` slug (e.g. "porg") from its set
+ * code. We can't trust `IInternalCardEntry.internalName` because
+ * `Deck.buildDecklistEntry` populates it with the cardMap entry's `id` field
+ * (e.g. "porg-id"), which is the wrong field. Resolving via setCodeMap +
+ * cardMap gives us the real internalName players type into the JSON.
+ */
+function resolveInternalName(setCode: string, cardDataGetter: CardDataGetter): string | undefined {
+    const internalId = cardDataGetter.setCodeMap.get(setCode);
+    if (internalId == null) {
+        return undefined;
+    }
+    return cardDataGetter.cardMap.get(internalId)?.internalName;
+}
+
+function collectDeckInternalNames(deck: Deck, cardDataGetter: CardDataGetter): Set<string> {
+    const set = new Set<string>();
+    const leaderName = resolveInternalName(deck.leader.id, cardDataGetter);
+    if (leaderName) {
+        set.add(leaderName);
+    }
+    const baseName = resolveInternalName(deck.base.id, cardDataGetter);
+    if (baseName) {
+        set.add(baseName);
+    }
+    for (const entry of deck.getDecklist().deck) {
+        const name = resolveInternalName(entry.id, cardDataGetter);
+        if (name) {
+            set.add(name);
+        }
+    }
+    return set;
+}

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -2,7 +2,7 @@ import { Game } from '../game/core/Game';
 import { v4 as uuid, v4 as uuidv4 } from 'uuid';
 import type Socket from '../socket';
 import { Contract } from '../game/core/utils/Contract';
-import { CustomSetupValidator } from '../game/core/customSetup/CustomSetupValidator';
+import { validateCustomSetup } from '../game/core/customSetup/CustomSetupValidator';
 import type { ICustomSetupState, ICustomSetupValidationError } from '../game/core/customSetup/CustomSetupTypes';
 import { EnumHelpers } from '../game/core/utils/EnumHelpers';
 import fs from 'fs';
@@ -1001,7 +1001,7 @@ export class Lobby {
         }
         const ownerUser = this.users.find((u) => u.id === this.lobbyOwnerId);
         const opponentUser = this.users.find((u) => u.id !== this.lobbyOwnerId);
-        const errors = CustomSetupValidator.validate(this.customSetupState, ownerUser?.deck, opponentUser?.deck, this.cardDataGetter);
+        const errors = validateCustomSetup(this.customSetupState, ownerUser?.deck, opponentUser?.deck, this.cardDataGetter);
         if (errors.length > 0) {
             this.customSetupState = null;
             this.customSetupErrors = errors;
@@ -1413,7 +1413,7 @@ export class Lobby {
         }
         const ownerUser = this.users.find((u) => u.id === this.lobbyOwnerId);
         const opponentUser = this.users.find((u) => u.id !== this.lobbyOwnerId);
-        const errors = CustomSetupValidator.validate(
+        const errors = validateCustomSetup(
             this.customSetupState,
             ownerUser?.deck,
             opponentUser?.deck,
@@ -1462,7 +1462,7 @@ export class Lobby {
 
         const ownerUser = this.users.find((u) => u.id === this.lobbyOwnerId);
         const opponentUser = this.users.find((u) => u.id !== this.lobbyOwnerId);
-        const errors = CustomSetupValidator.validate(parsed, ownerUser?.deck, opponentUser?.deck, this.cardDataGetter);
+        const errors = validateCustomSetup(parsed, ownerUser?.deck, opponentUser?.deck, this.cardDataGetter);
 
         this.customSetupRawJson = rawJson;
         this.customSetupErrors = errors;

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -2,6 +2,8 @@ import { Game } from '../game/core/Game';
 import { v4 as uuid, v4 as uuidv4 } from 'uuid';
 import type Socket from '../socket';
 import { Contract } from '../game/core/utils/Contract';
+import { CustomSetupValidator } from '../game/core/customSetup/CustomSetupValidator';
+import type { ICustomSetupState, ICustomSetupValidationError } from '../game/core/customSetup/CustomSetupTypes';
 import { EnumHelpers } from '../game/core/utils/EnumHelpers';
 import fs from 'fs';
 import path from 'path';
@@ -153,6 +155,9 @@ export class Lobby {
     // configurable lobby properties
     private undoMode: UndoMode = UndoMode.Disabled;
     private allowSpectators = false;
+    private customSetupRawJson: string | null = null;
+    private customSetupState: ICustomSetupState | null = null;
+    private customSetupErrors: ICustomSetupValidationError[] = [];
 
     private game?: Game;
     public users: LobbyUserWrapper[] = [];
@@ -352,6 +357,11 @@ export class Lobby {
             settings: {
                 requestUndo: this.undoMode === UndoMode.Request,
                 allowSpectators: this.allowSpectators,
+                customSetup: this.isPrivate ? {
+                    json: this.customSetupRawJson,
+                    errors: this.customSetupErrors,
+                    valid: this.customSetupState !== null,
+                } : null,
             },
         };
     }
@@ -974,7 +984,29 @@ export class Lobby {
         }
         logger.info(`Lobby: user ${activeUser.username} changing deck`, { lobbyId: this.id, userName: activeUser.username, userId: activeUser.id });
 
+        this.invalidateCustomSetupIfStale();
+
         this.updateUserLastActivity(activeUser.id);
+    }
+
+    /**
+     * Re-validates the saved custom setup against the current decks. If it no
+     * longer applies cleanly (most commonly: a player swapped decks so their
+     * leader/base or referenced cards changed), drop the saved state and let
+     * the leader know.
+     */
+    private invalidateCustomSetupIfStale(): void {
+        if (!this.customSetupState) {
+            return;
+        }
+        const ownerUser = this.users.find((u) => u.id === this.lobbyOwnerId);
+        const opponentUser = this.users.find((u) => u.id !== this.lobbyOwnerId);
+        const errors = CustomSetupValidator.validate(this.customSetupState, ownerUser?.deck, opponentUser?.deck, this.cardDataGetter);
+        if (errors.length > 0) {
+            this.customSetupState = null;
+            this.customSetupErrors = errors;
+            this.gameChat.addAlert(AlertType.Warning, 'Custom starting board was cleared because a deck change made it invalid.');
+        }
     }
 
     private updateDeck(socket: Socket, ...args) {
@@ -1366,7 +1398,80 @@ export class Lobby {
             buildSafeTimeout: (callback: () => void, delayMs: number, errorMessage: string) =>
                 this.buildSafeTimeout(callback, delayMs, errorMessage),
             userTimeoutDisconnect: (userId: string) => this.userTimeoutDisconnect(userId),
+            customSetupState: this.buildCustomSetupForGameStart() ?? undefined,
         };
+    }
+
+    /**
+     * Returns the saved custom setup state if it is still valid against the
+     * current decks. The state is dropped (and a chat alert posted) if either
+     * player's deck has changed since the leader saved the JSON.
+     */
+    private buildCustomSetupForGameStart(): ICustomSetupState | null {
+        if (!this.customSetupState) {
+            return null;
+        }
+        const ownerUser = this.users.find((u) => u.id === this.lobbyOwnerId);
+        const opponentUser = this.users.find((u) => u.id !== this.lobbyOwnerId);
+        const errors = CustomSetupValidator.validate(
+            this.customSetupState,
+            ownerUser?.deck,
+            opponentUser?.deck,
+            this.cardDataGetter,
+        );
+        if (errors.length > 0) {
+            // Re-validation failed; clear and let the game start normally.
+            this.customSetupState = null;
+            this.customSetupRawJson = null;
+            this.customSetupErrors = errors;
+            this.gameChat.addAlert(AlertType.Warning, 'Custom starting board was discarded because the decks have changed since it was set.');
+            return null;
+        }
+        return this.customSetupState;
+    }
+
+    /**
+     * Owner-only socket command. Accepts a raw JSON string, validates against
+     * the current decks, and stores it for use at game start. Pass null/empty
+     * to clear.
+     */
+    private setCustomSetupState(socket: Socket, rawJson: string | null): void {
+        Contract.assertTrue(this.isPrivate, 'Custom starting board is only available in private lobbies');
+        const user = this.getUser(socket.user.getId());
+        Contract.assertTrue(user.id === this.lobbyOwnerId, `User ${user.id} attempted to set custom setup but is not the lobby owner`);
+        Contract.assertFalse(!!this.game, 'Cannot change custom setup after the game has started');
+
+        if (rawJson == null || rawJson.trim() === '') {
+            this.customSetupRawJson = null;
+            this.customSetupState = null;
+            this.customSetupErrors = [];
+            this.sendLobbyState();
+            return;
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(rawJson);
+        } catch (err) {
+            this.customSetupRawJson = rawJson;
+            this.customSetupState = null;
+            this.customSetupErrors = [{ path: '', message: `Invalid JSON: ${(err as Error).message}` }];
+            this.sendLobbyState();
+            return;
+        }
+
+        const ownerUser = this.users.find((u) => u.id === this.lobbyOwnerId);
+        const opponentUser = this.users.find((u) => u.id !== this.lobbyOwnerId);
+        const errors = CustomSetupValidator.validate(parsed, ownerUser?.deck, opponentUser?.deck, this.cardDataGetter);
+
+        this.customSetupRawJson = rawJson;
+        this.customSetupErrors = errors;
+        this.customSetupState = errors.length === 0 ? (parsed as ICustomSetupState) : null;
+
+        if (errors.length === 0) {
+            this.gameChat.addAlert(AlertType.Warning, `${user.username} set a custom starting board for this game.`);
+        }
+        this.sendLobbyState();
     }
 
     private userTimeoutDisconnect(userId: string) {

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -18,7 +18,7 @@ class GameFlowWrapper {
      * @param {UndoMode} undoMode
      * @param {boolean} enableConfirmationToUndo
      */
-    constructor(cardDataGetter, router, player1Info, player2Info, undoMode = UndoMode.Free) {
+    constructor(cardDataGetter, router, player1Info, player2Info, undoMode = UndoMode.Free, customSetupState = null) {
         /** @type {import('../../server/game/core/GameInterfaces.js').GameConfiguration} */
         var details = {
             name: `${player1Info.username}'s game`,
@@ -36,6 +36,10 @@ class GameFlowWrapper {
             userTimeoutDisconnect: () => undefined,
             undoMode
         };
+
+        if (customSetupState) {
+            details.customSetupState = customSetupState;
+        }
 
         this.game = new Game(details, { router });
         this.game.started = true;

--- a/test/scenarios/customSetup/CustomSetupApplier.spec.ts
+++ b/test/scenarios/customSetup/CustomSetupApplier.spec.ts
@@ -1,0 +1,260 @@
+
+const GameStateBuilder = require('../../helpers/GameStateBuilder.js');
+const GameFlowWrapper = require('../../helpers/GameFlowWrapper.js');
+import { UndoMode } from '../../../server/game/core/snapshot/SnapshotManager';
+import { CustomSetupValidationFailure } from '../../../server/game/core/customSetup/CustomSetupTypes';
+
+const builder = new GameStateBuilder();
+
+/**
+ * Minimal router stub. Game's constructor asserts router is non-null and the
+ * engine may invoke handleError on internal failures — re-throwing surfaces
+ * those instead of swallowing. The other callbacks aren't reached on the
+ * applier path under test, so they're no-ops.
+ */
+function makeRouter() {
+    return {
+        gameWon: () => undefined,
+        playerLeft: () => undefined,
+        handleError: (_game: unknown, error: Error) => { throw error; },
+        handleGameEnd: () => undefined,
+        handleUndoGameEnd: () => undefined,
+    };
+}
+
+interface CustomSetupTestOptions {
+    phase?: 'action';
+    player1?: any;
+    player2?: any;
+}
+
+/**
+ * Builds a Game that goes through the production CustomSetupApplier path.
+ *
+ * The test framework's `setupTestAsync` (used by other scenarios) constructs
+ * the same shape of options but applies them via `setupGameStateAsync` —
+ * which manually moves cards via PlayerInteractionWrapper helpers. Here we
+ * pass the options as `customSetupState` in the GameConfiguration so that
+ * `Game.initialiseAsync` invokes the production applier instead.
+ *
+ * Both paths consume the same JSON shape, so these tests double as a
+ * regression check that the production applier produces the same result.
+ */
+async function setupCustomGameAsync(options: CustomSetupTestOptions) {
+    const optionsForBuilder: any = {
+        phase: options.phase ?? 'action',
+        player1: { ...(options.player1 ?? {}) },
+        player2: { ...(options.player2 ?? {}) },
+    };
+
+    const player1OwnedCards = builder.deckBuilder.getOwnedCards(1, optionsForBuilder.player1, optionsForBuilder.player2);
+    const player2OwnedCards = builder.deckBuilder.getOwnedCards(2, optionsForBuilder.player2, optionsForBuilder.player1);
+
+    const [deck1] = builder.deckBuilder.customDeck(1, player1OwnedCards, optionsForBuilder.phase);
+    const [deck2] = builder.deckBuilder.customDeck(2, player2OwnedCards, optionsForBuilder.phase);
+
+    // Give the production applier the cleanest possible JSON: only the keys
+    // the applier knows about. The DeckBuilder mutates its inputs (e.g. pads
+    // the deck list), so we don't share that object with the applier.
+    const customSetupState: any = {
+        phase: options.phase ?? 'action',
+        player1: { ...(options.player1 ?? {}) },
+        player2: { ...(options.player2 ?? {}) },
+    };
+
+    const wrapper = new GameFlowWrapper(
+        builder.cardDataGetter,
+        makeRouter(),
+        { id: '111', username: 'player1', settings: { optionSettings: { autoSingleTarget: false } } },
+        { id: '222', username: 'player2', settings: { optionSettings: { autoSingleTarget: false } } },
+        UndoMode.Disabled,
+        customSetupState,
+    );
+
+    wrapper.player1.selectDeck(deck1);
+    wrapper.player2.selectDeck(deck2);
+    wrapper.game.initialiseTokens(builder.deckBuilder.tokenData);
+
+    await wrapper.startGameAsync();
+
+    return wrapper;
+}
+
+describe('CustomSetupApplier', function () {
+    it('places named cards in each player\'s hand zone', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { hand: ['porg'] },
+            player2: { hand: ['rebel-pathfinder'] },
+        });
+
+        expect(wrapper.player1.player.hand.length).toBe(1);
+        expect(wrapper.player1.player.hand[0].internalName).toBe('porg');
+        expect(wrapper.player2.player.hand.length).toBe(1);
+        expect(wrapper.player2.player.hand[0].internalName).toBe('rebel-pathfinder');
+    });
+
+    it('places multiple copies of the same card when the deck has them', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { hand: ['porg', 'porg'] },
+            player2: {},
+        });
+
+        const handNames = wrapper.player1.player.hand.map((c: { internalName: string }) => c.internalName);
+        expect(handNames).toEqual(['porg', 'porg']);
+    });
+
+    it('places units in groundArena with damage and exhausted state', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: {
+                groundArena: [{ card: 'battlefield-marine', damage: 1, exhausted: true }],
+            },
+            player2: {},
+        });
+
+        const arena = wrapper.player1.player.getArenaCards();
+        expect(arena.length).toBe(1);
+        expect(arena[0].internalName).toBe('battlefield-marine');
+        expect((arena[0] as unknown as { damage: number }).damage).toBe(1);
+        expect((arena[0] as unknown as { exhausted: boolean }).exhausted).toBe(true);
+    });
+
+    it('places units in spaceArena', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: {
+                spaceArena: ['cartel-spacer'],
+            },
+            player2: {},
+        });
+
+        const arena = wrapper.player1.player.getArenaCards();
+        expect(arena.length).toBe(1);
+        expect(arena[0].internalName).toBe('cartel-spacer');
+        expect(arena[0].zoneName).toBe('spaceArena');
+    });
+
+    it('attaches a token upgrade (shield) to an arena unit', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: {
+                groundArena: [{ card: 'battlefield-marine', upgrades: ['shield'] }],
+            },
+            player2: {},
+        });
+
+        const arenaCards = wrapper.player1.player.getArenaCards();
+        const marines = arenaCards.filter((c: { internalName: string }) => c.internalName === 'battlefield-marine');
+        expect(marines.length).toBe(1);
+
+        // The shield should be an upgrade attached to the marine, not free-standing.
+        const shieldsOnMarine = arenaCards.filter((c: { internalName: string; parentCard?: { internalName: string } }) =>
+            c.internalName === 'shield' && c.parentCard?.internalName === 'battlefield-marine'
+        );
+        expect(shieldsOnMarine.length).toBe(1);
+    });
+
+    it('places cards into the discard zone', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { discard: ['porg', 'rebel-pathfinder'] },
+            player2: {},
+        });
+
+        const discardNames = wrapper.player1.player.discard.map((c: { internalName: string }) => c.internalName);
+        // setDiscard reverses so the first-listed ends up on top — order in the resulting array starts with the bottom card.
+        expect(discardNames.sort()).toEqual(['porg', 'rebel-pathfinder']);
+    });
+
+    it('respects hasInitiative', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: {},
+            player2: { hasInitiative: true },
+        });
+
+        expect(wrapper.game.initiativePlayer).toBeTruthy();
+        expect(wrapper.game.initiativePlayer.id).toBe('222');
+    });
+
+    it('skips the SetupPhase entirely and lands directly in the action phase', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { hand: ['porg'] },
+            player2: { hand: ['rebel-pathfinder'], hasInitiative: true },
+        });
+
+        expect(wrapper.game.currentPhase).toBe('action');
+        // No mulligan or resource-2 prompt should be open. Both players land
+        // either with an action prompt or a "waiting" prompt; neither is the
+        // "Choose cards to resource" prompt that SetupPhase would have opened.
+        const prompts = [wrapper.player1.player.currentPrompt(), wrapper.player2.player.currentPrompt()];
+        for (const p of prompts) {
+            const title = (typeof p.menuTitle === 'function' ? p.menuTitle({}) : p.menuTitle) ?? '';
+            expect(title.toLowerCase()).not.toContain('keep');
+            expect(title.toLowerCase()).not.toContain('resource any 2');
+        }
+    });
+
+    it('throws CustomSetupValidationFailure when the applier is given a card not in the deck', async function () {
+        const deck1Options: any = { hand: ['porg'] };
+        const deck2Options: any = {};
+
+        const player1OwnedCards = builder.deckBuilder.getOwnedCards(1, deck1Options, deck2Options);
+        const player2OwnedCards = builder.deckBuilder.getOwnedCards(2, deck2Options, deck1Options);
+        const [deck1] = builder.deckBuilder.customDeck(1, player1OwnedCards, 'action');
+        const [deck2] = builder.deckBuilder.customDeck(2, player2OwnedCards, 'action');
+
+        const wrapper = new GameFlowWrapper(
+            builder.cardDataGetter,
+            makeRouter(),
+            { id: '111', username: 'player1', settings: { optionSettings: { autoSingleTarget: false } } },
+            { id: '222', username: 'player2', settings: { optionSettings: { autoSingleTarget: false } } },
+            UndoMode.Disabled,
+            // Reference a card the deck doesn't contain.
+            { phase: 'action', player1: { hand: ['rebel-pathfinder'] }, player2: {} },
+        );
+
+        wrapper.player1.selectDeck(deck1);
+        wrapper.player2.selectDeck(deck2);
+        wrapper.game.initialiseTokens(builder.deckBuilder.tokenData);
+
+        let caught: unknown = null;
+        try {
+            await wrapper.startGameAsync();
+        } catch (err) {
+            caught = err;
+        }
+        expect(caught).toBeInstanceOf(CustomSetupValidationFailure);
+        if (caught instanceof CustomSetupValidationFailure) {
+            expect(caught.errors.length).toBeGreaterThan(0);
+            expect(caught.errors[0].path).toContain('player1.hand');
+        }
+    });
+
+    it('respects credits', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { credits: 3 },
+            player2: {},
+        });
+
+        expect(wrapper.player1.player.creditTokenCount).toBe(3);
+    });
+
+    it('grants the Force token when hasForceToken is true', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { hasForceToken: true },
+            player2: {},
+        });
+
+        expect(wrapper.player1.player.hasTheForce).toBe(true);
+        expect(wrapper.player2.player.hasTheForce).toBe(false);
+    });
+
+    it('lets the active player play a card immediately after setup', async function () {
+        const wrapper = await setupCustomGameAsync({
+            player1: { hand: ['porg'], hasInitiative: true },
+            player2: {},
+        });
+
+        // Player1 starts with initiative. Click porg to play it.
+        wrapper.player1.clickCard(wrapper.player1.findCardByName('porg'));
+        // After playing, porg moves to ground arena.
+        const arenaNames = wrapper.player1.player.getArenaCards().map((c: { internalName: string }) => c.internalName);
+        expect(arenaNames).toContain('porg');
+    });
+});

--- a/test/scenarios/customSetup/CustomSetupApplier.spec.ts
+++ b/test/scenarios/customSetup/CustomSetupApplier.spec.ts
@@ -1,6 +1,5 @@
-
-const GameStateBuilder = require('../../helpers/GameStateBuilder.js');
-const GameFlowWrapper = require('../../helpers/GameFlowWrapper.js');
+import GameStateBuilder from '../../helpers/GameStateBuilder';
+import GameFlowWrapper from '../../helpers/GameFlowWrapper';
 import { UndoMode } from '../../../server/game/core/snapshot/SnapshotManager';
 import { CustomSetupValidationFailure } from '../../../server/game/core/customSetup/CustomSetupTypes';
 
@@ -16,7 +15,9 @@ function makeRouter() {
     return {
         gameWon: () => undefined,
         playerLeft: () => undefined,
-        handleError: (_game: unknown, error: Error) => { throw error; },
+        handleError: (_game: unknown, error: Error) => {
+            throw error;
+        },
         handleGameEnd: () => undefined,
         handleUndoGameEnd: () => undefined,
     };
@@ -65,15 +66,17 @@ async function setupCustomGameAsync(options: CustomSetupTestOptions) {
     const wrapper = new GameFlowWrapper(
         builder.cardDataGetter,
         makeRouter(),
-        { id: '111', username: 'player1', settings: { optionSettings: { autoSingleTarget: false } } },
-        { id: '222', username: 'player2', settings: { optionSettings: { autoSingleTarget: false } } },
+        { id: '111', username: 'player1' },
+        { id: '222', username: 'player2' },
         UndoMode.Disabled,
         customSetupState,
     );
 
     wrapper.player1.selectDeck(deck1);
     wrapper.player2.selectDeck(deck2);
-    wrapper.game.initialiseTokens(builder.deckBuilder.tokenData);
+
+    // Token data is already initialised by Game's constructor (it pulls from
+    // cardDataGetter.tokenData), so no explicit initialiseTokens call here.
 
     await wrapper.startGameAsync();
 
@@ -202,8 +205,8 @@ describe('CustomSetupApplier', function () {
         const wrapper = new GameFlowWrapper(
             builder.cardDataGetter,
             makeRouter(),
-            { id: '111', username: 'player1', settings: { optionSettings: { autoSingleTarget: false } } },
-            { id: '222', username: 'player2', settings: { optionSettings: { autoSingleTarget: false } } },
+            { id: '111', username: 'player1' },
+            { id: '222', username: 'player2' },
             UndoMode.Disabled,
             // Reference a card the deck doesn't contain.
             { phase: 'action', player1: { hand: ['rebel-pathfinder'] }, player2: {} },
@@ -211,7 +214,6 @@ describe('CustomSetupApplier', function () {
 
         wrapper.player1.selectDeck(deck1);
         wrapper.player2.selectDeck(deck2);
-        wrapper.game.initialiseTokens(builder.deckBuilder.tokenData);
 
         let caught: unknown = null;
         try {


### PR DESCRIPTION
This PR adds the ability for private lobby owners to set up a custom board state for the game to start from, similar to how we do it in tests. Lobby owner applies the json and it is validated before anything starts. A system chat message is made for any setting of this so everyone is aware of whats going on.

This will be a very helpful feature for teaching/playtesting around very specific board states, without having to attempt to engineer them from a random initial state.

Frontend PR: https://github.com/SWU-Karabast/forceteki-client/pull/672

Example player1 starting with only Gungi in hand:
<img width="2544" height="1249" alt="image" src="https://github.com/user-attachments/assets/2350e278-6ee9-4a9b-8201-1f28fa4c11c7" />
<img width="2545" height="1263" alt="image" src="https://github.com/user-attachments/assets/bb6fd67f-5134-48a1-adf6-04863e9a151d" />
