### PR TITLE
Ensure turn timer resets for both players during all setup prompts

### DIFF
--- a/server/game/core/gameSteps/phases/SetupPhase.ts
+++ b/server/game/core/gameSteps/phases/SetupPhase.ts
@@ -39,7 +39,7 @@ export class SetupPhase extends Phase {
             [
                 ...setupStep,
                 ...mulliganStep,
-                new ResourcePrompt(game, 2)
+                new ResourcePrompt(game, 2, true)
             ],
             initializeMode
         );
@@ -74,6 +74,7 @@ export class SetupPhase extends Phase {
             activePromptTitle,
             source: 'choose initiative player',
             choices: ['Yourself', 'Opponent'],
+            resetActionTimerOnComplete: true,
             handlers: [
                 () => {
                     this.game.initiativePlayer = firstPlayer;

--- a/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
+++ b/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
@@ -21,7 +21,7 @@ const { UiPrompt } = require('./UiPrompt.js');
  */
 class HandlerMenuPrompt extends UiPrompt {
     constructor(game, player, properties) {
-        super(game);
+        super(game, properties.resetActionTimerOnComplete);
         this.player = player;
         if (typeof properties.source === 'string') {
             properties.source = new OngoingEffectSource(game, properties.source);

--- a/server/game/core/gameSteps/prompts/MulliganPrompt.ts
+++ b/server/game/core/gameSteps/prompts/MulliganPrompt.ts
@@ -13,7 +13,8 @@ export class MulliganPrompt extends AllPlayerPrompt {
     protected playersDone = new Map<string, boolean>();
     protected playerMulligan = new Map<string, boolean>();
     public constructor(game: Game) {
-        super(game);
+        super(game, true);
+
         for (const player of game.getPlayers()) {
             this.playersDone[player.name] = false;
             this.playerMulligan[player.name] = false;
@@ -69,9 +70,6 @@ export class MulliganPrompt extends AllPlayerPrompt {
 
     public override complete() {
         for (const player of this.game.getPlayers()) {
-            // force stop both players' action timers to ensure that both players' timers are reset for the next step and don't keep running
-            this.stopPlayerActionTimer(player);
-
             if (this.playerMulligan[player.name]) {
                 // Move the first hand to the bottom of the deck
                 new MoveCardSystem({

--- a/server/game/core/gameSteps/prompts/MulliganPrompt.ts
+++ b/server/game/core/gameSteps/prompts/MulliganPrompt.ts
@@ -69,6 +69,9 @@ export class MulliganPrompt extends AllPlayerPrompt {
 
     public override complete() {
         for (const player of this.game.getPlayers()) {
+            // force stop both players' action timers to ensure that both players' timers are reset for the next step and don't keep running
+            this.stopPlayerActionTimer(player);
+
             if (this.playerMulligan[player.name]) {
                 // Move the first hand to the bottom of the deck
                 new MoveCardSystem({

--- a/server/game/core/gameSteps/prompts/ResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/ResourcePrompt.ts
@@ -8,15 +8,21 @@ import { PromptType, SelectCardMode } from '../PromptInterfaces';
 import { GameCardMetric } from '../../../../gameStatistics/GameStatisticsTracker';
 
 export class ResourcePrompt extends AllPlayerPrompt {
+    private readonly nCardsToResource: number;
+
     protected selectedCards = new Map<string, Card[]>();
     protected selectableCards = new Map<string, Card[]>();
     protected playersDone = new Map<string, boolean>();
 
     public constructor(
         game: Game,
-        private readonly nCardsToResource: number
+        nCardsToResource: number,
+        resetActionTimerOnComplete = false
     ) {
-        super(game);
+        super(game, resetActionTimerOnComplete);
+
+        this.nCardsToResource = nCardsToResource;
+
         for (const player of game.getPlayers()) {
             this.selectedCards[player.name] = [];
             this.playersDone[player.name] = false;

--- a/server/game/core/gameSteps/prompts/UiPrompt.ts
+++ b/server/game/core/gameSteps/prompts/UiPrompt.ts
@@ -100,7 +100,7 @@ export abstract class UiPrompt extends BaseStep {
                 this.playersActiveForPrompt.push(player);
 
                 if ((this.firstContinue && !player.activeForPreviousPrompt) || !player.actionTimer.isRunning) {
-                    this.startActivePlayerActionTimer(player);
+                    this.startPlayerActionTimer(player);
                 }
 
                 player.activeForPreviousPrompt = true;
@@ -108,14 +108,14 @@ export abstract class UiPrompt extends BaseStep {
             } else {
                 player.activeForPreviousPrompt = false;
                 player.setPrompt(this.waitingPrompt());
-                this.stopInactivePlayerActionTimer(player);
+                this.stopPlayerActionTimer(player);
             }
         }
 
         this.highlightSelectableCards();
     }
 
-    public startActivePlayerActionTimer(player: Player) {
+    public startPlayerActionTimer(player: Player) {
         // if the player's timer was paused instead of stop, do a resume so we don't reset their timer
         if (player.actionTimer.isPaused) {
             player.actionTimer.resume();
@@ -124,7 +124,7 @@ export abstract class UiPrompt extends BaseStep {
         }
     }
 
-    public stopInactivePlayerActionTimer(player: Player) {
+    public stopPlayerActionTimer(player: Player) {
         player.actionTimer.stop();
     }
 

--- a/server/game/core/gameSteps/prompts/UiPrompt.ts
+++ b/server/game/core/gameSteps/prompts/UiPrompt.ts
@@ -11,6 +11,8 @@ import type { AllPlayerPrompt } from './AllPlayerPrompt';
 export abstract class UiPrompt extends BaseStep {
     public readonly uuid = uuid();
 
+    private readonly resetActionTimerOnComplete: boolean;
+
     private previousPrompt?: UiPrompt;
     private completed = false;
     private firstContinue = true;
@@ -21,8 +23,10 @@ export abstract class UiPrompt extends BaseStep {
     // this is passed to the FE for the sake of being able to inform the player by e.g. making a sound
     private playerIsNewlyActive = new Map<Player, boolean>();
 
-    public constructor(game: Game) {
+    public constructor(game: Game, resetActionTimerOnComplete = false) {
         super(game);
+
+        this.resetActionTimerOnComplete = resetActionTimerOnComplete;
 
         this.clearPrompts();
     }
@@ -71,6 +75,13 @@ export abstract class UiPrompt extends BaseStep {
 
     public complete(): void {
         this.completed = true;
+
+        if (this.resetActionTimerOnComplete) {
+            for (const player of this.playersActiveForPrompt) {
+                this.stopPlayerActionTimer(player);
+            }
+        }
+
         this.game.setCurrentOpenPrompt(this.previousPrompt);
 
         // if this is an opponent reveal new info prompt, require confirmation to undo for the active player

--- a/server/game/core/gameSteps/prompts/UndoConfirmationPrompt.js
+++ b/server/game/core/gameSteps/prompts/UndoConfirmationPrompt.js
@@ -62,7 +62,7 @@ class UndoConfirmationPrompt extends HandlerMenuPrompt {
      * @override
      * @param {Player} player
      */
-    stopInactivePlayerActionTimer(player) {
+    stopPlayerActionTimer(player) {
         // we pause the requesting player's timer instead of stopping it so that they can't cheat time back
         player.actionTimer.pause();
     }


### PR DESCRIPTION
The turn timer wasn't consistenly resetting after first player selection, mulligan, and first resource during setup. We want to give players lots of breathing room during the setup phase so this adds enforcement and consistency there.