### PR TITLE
Opt-in opponent-archetype matchmaking filter (BE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "forceteki",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.758.0",
         "@aws-sdk/client-s3": "^3.933.0",

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -553,9 +553,11 @@ function labelForGroup(group) {
     const hp = group.hp ? `${group.hp}hp` : '';
     const text = group.text || '';
     if (text === '') {
-        // Vanilla bases — no rules text. Tag is just the HP (e.g.,
-        // "Aggression - 30hp"), since vanilla bases differ only in stats.
-        return `${aspect} - ${hp}`;
+        // Vanilla bases — no rules text. The tag is "Vanilla" so when an
+        // aspect icon is rendered alongside the label and the leading
+        // aspect word is stripped, the FE still has a meaningful descriptor
+        // (e.g. "Vanilla - 30hp") rather than just "30hp".
+        return `${aspect} - Vanilla - ${hp}`;
     }
     if ((/force token/i).test(text) || (/force is with you/i).test(text)) {
         return `${aspect} - Force - ${hp}`;

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -436,7 +436,13 @@ function buildCardLists(cards) {
 
         if (card.types.includes('leader')) {
             const cardId = `${card.setId.set}_${String(card.setId.number).padStart(3, '0')}`;
-            leaderNames.push({ name: card.title, id: cardId, subtitle: card.subtitle });
+            leaderNames.push({
+                name: card.title,
+                id: cardId,
+                subtitle: card.subtitle,
+                aspects: Array.isArray(card.aspects) ? card.aspects : [],
+                set: card.setId?.set ?? null,
+            });
         }
 
         if (card.types.includes('base')) {

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -445,6 +445,8 @@ function buildCardLists(cards) {
                 id: cardId,
                 subtitle: card.subtitle,
                 aspects: Array.isArray(card.aspects) ? card.aspects : [],
+                hp: card.hp,
+                text: typeof card.text === 'string' ? card.text : '',
             });
         }
     }
@@ -455,8 +457,110 @@ function buildCardLists(cards) {
     const playableCardTitles = Array.from(playableCardTitlesSet);
     playableCardTitles.sort();
 
+    const baseTypes = buildBaseTypes(baseNames);
+
     const uniqueCards = [...uniqueCardsMap].map(([internalName, card]) => card);
-    return { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames };
+    return { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes };
+}
+
+/**
+ * Group bases into "types" — sets of functionally-identical bases — used by
+ * the matchmaking-queue opponent filter so that picking a "Vanilla 30hp
+ * Aggression" type matches against any of the printed cards in that group.
+ *
+ * Two bases are the same type if they share aspect, HP, and rules text. Each
+ * type carries:
+ *   - id:      stable identifier (`<aspect>_<hp>_<textKey>` or `unique_<id>`)
+ *   - label:   short human-friendly description ("Aggression - Force",
+ *              "Vanilla Aggression 30hp", or the base's own name)
+ *   - aspect, hp
+ *   - baseIds: every set-code id that belongs to this type
+ *   - representativeId: a baseId that can be used for thumbnail rendering
+ */
+function buildBaseTypes(baseNames) {
+    const groups = new Map();
+
+    for (const base of baseNames) {
+        const aspect = base.aspects[0] ?? 'neutral';
+        const hp = typeof base.hp === 'number' ? base.hp : 0;
+        const textKey = (base.text || '').trim();
+        const groupKey = `${aspect}::${hp}::${textKey}`;
+        if (!groups.has(groupKey)) {
+            groups.set(groupKey, {
+                aspect,
+                hp,
+                text: textKey,
+                bases: [],
+            });
+        }
+        groups.get(groupKey).bases.push(base);
+    }
+
+    const types = [];
+    for (const [groupKey, group] of groups.entries()) {
+        if (group.bases.length === 1) {
+            // A unique-named base gets its own category, labeled by the
+            // card's name.
+            const only = group.bases[0];
+            types.push({
+                id: `unique_${only.id}`,
+                label: only.name,
+                aspect: group.aspect,
+                hp: group.hp,
+                baseIds: [only.id],
+                representativeId: only.id,
+            });
+            continue;
+        }
+
+        const label = labelForGroup(group);
+        const sorted = [...group.bases].sort((a, b) => a.name.localeCompare(b.name));
+        types.push({
+            id: `group_${slug(`${group.aspect}_${group.hp}_${group.text || 'vanilla'}`)}`,
+            label,
+            aspect: group.aspect,
+            hp: group.hp,
+            baseIds: sorted.map((b) => b.id),
+            representativeId: sorted[0].id,
+        });
+        // groupKey is debug only; reference it to satisfy lint rules.
+        void groupKey;
+    }
+
+    types.sort((a, b) => a.label.localeCompare(b.label));
+    return types;
+}
+
+function labelForGroup(group) {
+    const aspect = capitalizeWord(group.aspect);
+    const hp = group.hp ? `${group.hp}hp` : '';
+    const text = group.text || '';
+    if (text === '') {
+        // Vanilla bases — no rules text. Differentiate by HP since base HP
+        // pools are the player-relevant axis.
+        return `Vanilla ${aspect} ${hp}`.trim();
+    }
+    if ((/force token/i).test(text) || (/force is with you/i).test(text)) {
+        return `${aspect} - Force${hp ? ` (${hp})` : ''}`;
+    }
+    if ((/aspect penalt/i).test(text)) {
+        return `${aspect} - Splash${hp ? ` (${hp})` : ''}`;
+    }
+    return `${aspect} ${hp}`.trim();
+}
+
+function capitalizeWord(value) {
+    if (!value) {
+        return '';
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function slug(value) {
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_|_$/g, '');
 }
 
 async function main() {
@@ -495,7 +599,7 @@ async function main() {
 
     downloadProgressBar.stop();
 
-    const { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames } = buildCardLists(cards);
+    const { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes } = buildCardLists(cards);
 
     cards.map((card) => delete card.debugObject);
 
@@ -517,6 +621,7 @@ async function main() {
     fs.writeFile(path.join(pathToJSON, '_mockCardNames.json'), JSON.stringify(mockCardNames, null, 2));
     fs.writeFile(path.join(pathToJSON, '_leaderNames.json'), JSON.stringify(leaderNames, null, 2));
     fs.writeFile(path.join(pathToJSON, '_baseNames.json'), JSON.stringify(baseNames, null, 2));
+    fs.writeFile(path.join(pathToJSON, '_baseTypes.json'), JSON.stringify(baseTypes, null, 2));
     fs.writeFile(path.join(pathToJSON, 'card-data-hash.txt'), computeCardDataHash());
 
     console.log(`\n${uniqueCards.length} card definition files downloaded to ${pathToJSON}`);

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -361,6 +361,7 @@ function buildCardLists(cards) {
     const playableCardTitlesSet = new Set();
     const seenNames = [];
     const leaderNames = [];
+    const baseNames = [];
     const uniqueCardsMap = new Map();
     const setNumber = new Map([
         ['SOR', 1],
@@ -436,6 +437,16 @@ function buildCardLists(cards) {
             const cardId = `${card.setId.set}_${String(card.setId.number).padStart(3, '0')}`;
             leaderNames.push({ name: card.title, id: cardId, subtitle: card.subtitle });
         }
+
+        if (card.types.includes('base')) {
+            const cardId = `${card.setId.set}_${String(card.setId.number).padStart(3, '0')}`;
+            baseNames.push({
+                name: card.title,
+                id: cardId,
+                subtitle: card.subtitle,
+                aspects: Array.isArray(card.aspects) ? card.aspects : [],
+            });
+        }
     }
 
     const allNonLeaderCardTitles = Array.from(allNonLeaderCardTitlesSet);
@@ -445,7 +456,7 @@ function buildCardLists(cards) {
     playableCardTitles.sort();
 
     const uniqueCards = [...uniqueCardsMap].map(([internalName, card]) => card);
-    return { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames };
+    return { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames };
 }
 
 async function main() {
@@ -484,7 +495,7 @@ async function main() {
 
     downloadProgressBar.stop();
 
-    const { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames } = buildCardLists(cards);
+    const { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames } = buildCardLists(cards);
 
     cards.map((card) => delete card.debugObject);
 
@@ -505,6 +516,7 @@ async function main() {
     fs.writeFile(path.join(pathToJSON, '_setCodeMap.json'), JSON.stringify(setCodeMap, null, 2));
     fs.writeFile(path.join(pathToJSON, '_mockCardNames.json'), JSON.stringify(mockCardNames, null, 2));
     fs.writeFile(path.join(pathToJSON, '_leaderNames.json'), JSON.stringify(leaderNames, null, 2));
+    fs.writeFile(path.join(pathToJSON, '_baseNames.json'), JSON.stringify(baseNames, null, 2));
     fs.writeFile(path.join(pathToJSON, 'card-data-hash.txt'), computeCardDataHash());
 
     console.log(`\n${uniqueCards.length} card definition files downloaded to ${pathToJSON}`);

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -449,6 +449,7 @@ function buildCardLists(cards) {
                 hp: card.hp,
                 text: typeof card.text === 'string' ? card.text : '',
                 rarity: card.rarity ?? null,
+                set: card.setId?.set ?? null,
             });
         }
     }
@@ -514,6 +515,7 @@ function buildBaseTypes(baseNames) {
                 aspect: group.aspect,
                 hp: group.hp,
                 rarity: only.rarity ?? null,
+                set: only.set ?? null,
                 baseIds: [only.id],
                 representativeId: only.id,
             });
@@ -528,6 +530,7 @@ function buildBaseTypes(baseNames) {
             aspect: group.aspect,
             hp: group.hp,
             rarity: null,
+            set: null,
             baseIds: sorted.map((b) => b.id),
             representativeId: sorted[0].id,
         });

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -282,6 +282,7 @@ function filterValues(card) {
         filteredObj.traits = getAttributeNames(card.attributes.traits);
         filteredObj.arena = getAttributeNames(card.attributes.arenas)[0];
         filteredObj.keywords = getAttributeNames(card.attributes.keywords);
+        filteredObj.rarity = card.attributes.rarity?.data?.attributes?.character ?? null;
 
         if (card.attributes.backSideAspects) {
             filteredObj.backSideAspects = getAttributeNames(card.attributes.backSideAspects);
@@ -447,6 +448,7 @@ function buildCardLists(cards) {
                 aspects: Array.isArray(card.aspects) ? card.aspects : [],
                 hp: card.hp,
                 text: typeof card.text === 'string' ? card.text : '',
+                rarity: card.rarity ?? null,
             });
         }
     }
@@ -500,13 +502,18 @@ function buildBaseTypes(baseNames) {
     for (const [groupKey, group] of groups.entries()) {
         if (group.bases.length === 1) {
             // A unique-named base gets its own category, labeled by the
-            // card's name.
+            // card's name + HP, with an (R) suffix for rare-rarity prints
+            // so players can spot them at a glance.
             const only = group.bases[0];
+            const rarityTag = formatRaritySuffix(only.rarity);
+            const hp = group.hp ? `${group.hp}hp` : '';
+            const baseLabel = [only.name, hp].filter(Boolean).join(' - ');
             types.push({
                 id: `unique_${only.id}`,
-                label: only.name,
+                label: rarityTag ? `${baseLabel} ${rarityTag}` : baseLabel,
                 aspect: group.aspect,
                 hp: group.hp,
+                rarity: only.rarity ?? null,
                 baseIds: [only.id],
                 representativeId: only.id,
             });
@@ -520,6 +527,7 @@ function buildBaseTypes(baseNames) {
             label,
             aspect: group.aspect,
             hp: group.hp,
+            rarity: null,
             baseIds: sorted.map((b) => b.id),
             representativeId: sorted[0].id,
         });
@@ -536,17 +544,28 @@ function labelForGroup(group) {
     const hp = group.hp ? `${group.hp}hp` : '';
     const text = group.text || '';
     if (text === '') {
-        // Vanilla bases — no rules text. Differentiate by HP since base HP
-        // pools are the player-relevant axis.
-        return `Vanilla ${aspect} ${hp}`.trim();
+        // Vanilla bases — no rules text. Tag is just the HP (e.g.,
+        // "Aggression - 30hp"), since vanilla bases differ only in stats.
+        return `${aspect} - ${hp}`;
     }
     if ((/force token/i).test(text) || (/force is with you/i).test(text)) {
-        return `${aspect} - Force${hp ? ` (${hp})` : ''}`;
+        return `${aspect} - Force - ${hp}`;
     }
     if ((/aspect penalt/i).test(text)) {
-        return `${aspect} - Splash${hp ? ` (${hp})` : ''}`;
+        return `${aspect} - Splash - ${hp}`;
     }
-    return `${aspect} ${hp}`.trim();
+    return `${aspect} - ${hp}`;
+}
+
+function formatRaritySuffix(rarityChar) {
+    if (!rarityChar) {
+        return '';
+    }
+    const upper = rarityChar.toUpperCase();
+    if (upper === 'R' || upper === 'L' || upper === 'S') {
+        return `(${upper})`;
+    }
+    return '';
 }
 
 function capitalizeWord(value) {

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -30,6 +30,8 @@ import { DeckValidator } from '../utils/deck/DeckValidator';
 import type { IDeckValidationProperties, ISwuDbFormatDecklist } from '../utils/deck/DeckInterfaces';
 import type { IQueueFormatKey, QueuedPlayer } from './QueueHandler';
 import { QueueHandler } from './QueueHandler';
+import type { MatchPreferences } from './MatchmakingRules';
+import { validateMatchPreferencesInput } from './MatchPreferencesValidator';
 import { Helpers } from '../game/core/utils/Helpers';
 import { authMiddleware } from '../middleware/AuthMiddleWare';
 import { ServerRoleUsersCache } from '../utils/ServerRoleUsersCache';
@@ -1367,7 +1369,7 @@ export class GameServer {
 
         app.post('/api/enter-queue', this.buildAuthMiddleware(), async (req, res, next) => {
             try {
-                const { format, cardPool, gamesToWinMode, deck } = req.body;
+                const { format, cardPool, gamesToWinMode, deck, matchPreferences } = req.body;
                 const user = req.user;
 
                 // track daily active user (req.user is set by auth middleware)
@@ -1397,8 +1399,19 @@ export class GameServer {
                     return res.status(400).json({ success: false, message: bo3AccessError });
                 }
 
+                // Optional opponent-archetype filter; absent/disabled = match anyone (default).
+                let validatedMatchPreferences: MatchPreferences | undefined;
+                if (matchPreferences !== undefined && matchPreferences !== null) {
+                    const matchPreferencesError = validateMatchPreferencesInput(matchPreferences);
+                    if (matchPreferencesError) {
+                        logger.info(`GameServer (enter-queue): Rejected matchPreferences from user ${user.getId()}: ${matchPreferencesError}`);
+                        return res.status(400).json({ success: false, message: matchPreferencesError });
+                    }
+                    validatedMatchPreferences = matchPreferences as MatchPreferences;
+                }
+
                 await this.processDeckValidation(deck, false, { format, cardPool }, res, () => {
-                    const success = this.enterQueue(format, cardPool, gamesToWinMode, user, deck);
+                    const success = this.enterQueue(format, cardPool, gamesToWinMode, user, deck, validatedMatchPreferences);
                     if (!success) {
                         logger.error(`GameServer (enter-queue): Error in enter-queue User ${user.getId()} failed to enter queue`);
                         return res.status(500).json({ success: false, message: 'Failed to enter queue' });
@@ -1425,6 +1438,15 @@ export class GameServer {
                 return res.json(this.cardDataGetter.getLeaderCards());
             } catch (err) {
                 logger.error('GameServer (all-leaders) Server error: ', err);
+                next(err);
+            }
+        });
+
+        app.get('/api/all-bases', (_, res, next) => {
+            try {
+                return res.json(this.cardDataGetter.getBaseCards());
+            } catch (err) {
+                logger.error('GameServer (all-bases) Server error: ', err);
                 next(err);
             }
         });
@@ -2165,7 +2187,8 @@ export class GameServer {
         cardPool: CardPool,
         gamesToWinMode: GamesToWinMode,
         user: User,
-        deck: ISwuDbFormatDecklist
+        deck: ISwuDbFormatDecklist,
+        matchPreferences?: MatchPreferences,
     ): boolean {
         const formatKey: IQueueFormatKey = {
             format,
@@ -2173,12 +2196,18 @@ export class GameServer {
             gamesToWinMode
         };
 
+        // Pre-resolve the player's base aspects so the matchmaking filter rule
+        // doesn't need card-data access at match time.
+        const baseAspects = this.cardDataGetter.getBaseAspectsById(deck?.base?.id);
+
         this.queue.addPlayer(
             formatKey,
             {
                 user,
                 deck,
-                socket: null
+                socket: null,
+                matchPreferences,
+                baseAspects,
             }
         );
 

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -1451,6 +1451,15 @@ export class GameServer {
             }
         });
 
+        app.get('/api/all-base-types', (_, res, next) => {
+            try {
+                return res.json(this.cardDataGetter.getBaseTypes());
+            } catch (err) {
+                logger.error('GameServer (all-base-types) Server error: ', err);
+                next(err);
+            }
+        });
+
         // Cosmetics API endpoints
         app.get('/api/cosmetics', this.buildAuthMiddleware('get-cosmetics'), (req, res, next) => {
             try {

--- a/server/gamenode/MatchPreferencesValidator.ts
+++ b/server/gamenode/MatchPreferencesValidator.ts
@@ -1,0 +1,80 @@
+import { Aspect } from '../game/core/Constants';
+
+import type { MatchPreferences } from './MatchmakingRules';
+
+const ASPECTS = new Set<string>(Object.values(Aspect));
+
+const MAX_ARCHETYPES = 200;
+const MAX_ID_LENGTH = 64;
+
+/**
+ * Validates an arbitrary value as MatchPreferences. Returns null on success
+ * or a short human-readable error string when validation fails. Caller is
+ * expected to surface a 400 with the error string.
+ */
+export function validateMatchPreferencesInput(input: unknown): string | null {
+    if (typeof input !== 'object' || input === null) {
+        return 'matchPreferences must be an object';
+    }
+    const prefs = input as Record<string, unknown>;
+    if (typeof prefs.enabled !== 'boolean') {
+        return 'matchPreferences.enabled must be a boolean';
+    }
+    if (!Array.isArray(prefs.allowedArchetypes)) {
+        return 'matchPreferences.allowedArchetypes must be an array';
+    }
+    if (prefs.allowedArchetypes.length > MAX_ARCHETYPES) {
+        return `matchPreferences.allowedArchetypes must contain at most ${MAX_ARCHETYPES} entries`;
+    }
+    for (let i = 0; i < prefs.allowedArchetypes.length; i++) {
+        const archetypeError = validateArchetype(prefs.allowedArchetypes[i], i);
+        if (archetypeError) {
+            return archetypeError;
+        }
+    }
+    return null;
+}
+
+function validateArchetype(input: unknown, index: number): string | null {
+    if (typeof input !== 'object' || input === null) {
+        return `matchPreferences.allowedArchetypes[${index}] must be an object`;
+    }
+    const archetype = input as Record<string, unknown>;
+    if (typeof archetype.leaderId !== 'string' || archetype.leaderId.length === 0) {
+        return `matchPreferences.allowedArchetypes[${index}].leaderId must be a non-empty string`;
+    }
+    if (archetype.leaderId.length > MAX_ID_LENGTH) {
+        return `matchPreferences.allowedArchetypes[${index}].leaderId must be at most ${MAX_ID_LENGTH} characters`;
+    }
+    if (archetype.baseConstraint === undefined || archetype.baseConstraint === null) {
+        return null;
+    }
+    if (typeof archetype.baseConstraint !== 'object') {
+        return `matchPreferences.allowedArchetypes[${index}].baseConstraint must be an object`;
+    }
+    const constraint = archetype.baseConstraint as Record<string, unknown>;
+    if (constraint.kind === 'specificBase') {
+        if (typeof constraint.baseId !== 'string' || constraint.baseId.length === 0) {
+            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseId must be a non-empty string`;
+        }
+        if (constraint.baseId.length > MAX_ID_LENGTH) {
+            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseId must be at most ${MAX_ID_LENGTH} characters`;
+        }
+        return null;
+    }
+    if (constraint.kind === 'aspect') {
+        if (typeof constraint.aspect !== 'string' || !ASPECTS.has(constraint.aspect)) {
+            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.aspect must be one of: ${Object.values(Aspect).join(', ')}`;
+        }
+        return null;
+    }
+    return `matchPreferences.allowedArchetypes[${index}].baseConstraint.kind must be 'specificBase' or 'aspect'`;
+}
+
+/**
+ * Narrows an already-validated input to the MatchPreferences type. Use only
+ * after validateMatchPreferencesInput has returned null for the same value.
+ */
+export function asValidatedMatchPreferences(input: unknown): MatchPreferences {
+    return input as MatchPreferences;
+}

--- a/server/gamenode/MatchPreferencesValidator.ts
+++ b/server/gamenode/MatchPreferencesValidator.ts
@@ -5,7 +5,9 @@ import type { MatchPreferences } from './MatchmakingRules';
 const ASPECTS = new Set<string>(Object.values(Aspect));
 
 const MAX_ARCHETYPES = 200;
+const MAX_BASE_IDS_PER_TYPE = 200;
 const MAX_ID_LENGTH = 64;
+const MAX_LABEL_LENGTH = 128;
 
 /**
  * Validates an arbitrary value as MatchPreferences. Returns null on success
@@ -53,12 +55,26 @@ function validateArchetype(input: unknown, index: number): string | null {
         return `matchPreferences.allowedArchetypes[${index}].baseConstraint must be an object`;
     }
     const constraint = archetype.baseConstraint as Record<string, unknown>;
-    if (constraint.kind === 'specificBase') {
-        if (typeof constraint.baseId !== 'string' || constraint.baseId.length === 0) {
-            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseId must be a non-empty string`;
+    if (constraint.kind === 'baseType') {
+        if (!Array.isArray(constraint.baseIds) || constraint.baseIds.length === 0) {
+            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseIds must be a non-empty array`;
         }
-        if (constraint.baseId.length > MAX_ID_LENGTH) {
-            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseId must be at most ${MAX_ID_LENGTH} characters`;
+        if (constraint.baseIds.length > MAX_BASE_IDS_PER_TYPE) {
+            return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseIds must contain at most ${MAX_BASE_IDS_PER_TYPE} entries`;
+        }
+        for (let j = 0; j < constraint.baseIds.length; j++) {
+            const baseId = constraint.baseIds[j];
+            if (typeof baseId !== 'string' || baseId.length === 0) {
+                return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseIds[${j}] must be a non-empty string`;
+            }
+            if (baseId.length > MAX_ID_LENGTH) {
+                return `matchPreferences.allowedArchetypes[${index}].baseConstraint.baseIds[${j}] must be at most ${MAX_ID_LENGTH} characters`;
+            }
+        }
+        if (constraint.label !== undefined && constraint.label !== null) {
+            if (typeof constraint.label !== 'string' || constraint.label.length > MAX_LABEL_LENGTH) {
+                return `matchPreferences.allowedArchetypes[${index}].baseConstraint.label must be a string of at most ${MAX_LABEL_LENGTH} characters`;
+            }
         }
         return null;
     }
@@ -68,7 +84,7 @@ function validateArchetype(input: unknown, index: number): string | null {
         }
         return null;
     }
-    return `matchPreferences.allowedArchetypes[${index}].baseConstraint.kind must be 'specificBase' or 'aspect'`;
+    return `matchPreferences.allowedArchetypes[${index}].baseConstraint.kind must be 'baseType' or 'aspect'`;
 }
 
 /**

--- a/server/gamenode/MatchPreferencesValidator.ts
+++ b/server/gamenode/MatchPreferencesValidator.ts
@@ -48,6 +48,9 @@ function validateArchetype(input: unknown, index: number): string | null {
     if (archetype.leaderId.length > MAX_ID_LENGTH) {
         return `matchPreferences.allowedArchetypes[${index}].leaderId must be at most ${MAX_ID_LENGTH} characters`;
     }
+    if (archetype.enabled !== undefined && typeof archetype.enabled !== 'boolean') {
+        return `matchPreferences.allowedArchetypes[${index}].enabled must be a boolean`;
+    }
     if (archetype.baseConstraint === undefined || archetype.baseConstraint === null) {
         return null;
     }

--- a/server/gamenode/MatchmakingRules.ts
+++ b/server/gamenode/MatchmakingRules.ts
@@ -1,12 +1,50 @@
+import type { Aspect } from '../game/core/Constants';
+
 import type { PreviousMatchEntry, QueuedPlayer } from './QueueHandler';
 
 export interface IMatchmakingPlayerEntry {
     player: QueuedPlayer;
     previousMatch?: PreviousMatchEntry;
+
+    /**
+     * Aspects of the player's base, pre-resolved from card data when the
+     * player enters the queue. Used by leader/base filter rules.
+     */
+    baseAspects?: readonly string[];
 }
 
 export interface IMatchmakingRule {
     canMatch(player1: IMatchmakingPlayerEntry, player2: IMatchmakingPlayerEntry): boolean;
+}
+
+/**
+ * Constraint on which bases a filtered opponent's deck can use, paired with a
+ * leader. Omit `baseConstraint` for "any base of this leader".
+ */
+export type BaseConstraint =
+  | { kind: 'specificBase'; baseId: string }
+  | { kind: 'aspect'; aspect: Aspect };
+
+/**
+ * A single archetype the player is willing to be matched against.
+ *
+ * The wire format is forward-compatible: `baseConstraint` is optional, so a
+ * v1 client that only exposes leader-only filters can omit it, while a future
+ * client can add base-specificity without changing the wire shape.
+ */
+export interface OpponentArchetype {
+    leaderId: string;
+    baseConstraint?: BaseConstraint;
+}
+
+/**
+ * Opt-in matchmaking preferences. When `enabled` is false or
+ * `allowedArchetypes` is empty, the rule treats the player as "match anyone"
+ * (the default, current behavior).
+ */
+export interface MatchPreferences {
+    enabled: boolean;
+    allowedArchetypes: OpponentArchetype[];
 }
 
 /**
@@ -22,6 +60,16 @@ export const MatchmakingRule = {
      */
     rematchCooldown: (cooldownSeconds: number): IMatchmakingRule => {
         return new RematchCooldownRule(cooldownSeconds);
+    },
+
+    /**
+     * A matchmaking rule that respects each player's opt-in opponent-archetype
+     * filter. Both players must accept the other's leader+base for a match to
+     * be allowed. Players without preferences (or with the filter disabled or
+     * an empty allowlist) accept anyone, preserving the default behavior.
+     */
+    leaderArchetypeFilter: (): IMatchmakingRule => {
+        return new LeaderArchetypeFilterRule();
     },
 };
 
@@ -64,4 +112,49 @@ class RematchCooldownRule implements IMatchmakingRule {
     private isWithinCooldown(endTimestamp: number, now: number): boolean {
         return now - endTimestamp <= this.cooldownMs;
     }
+}
+
+class LeaderArchetypeFilterRule implements IMatchmakingRule {
+    public canMatch(p1: IMatchmakingPlayerEntry, p2: IMatchmakingPlayerEntry): boolean {
+        return playerAcceptsOpponent(p1, p2) && playerAcceptsOpponent(p2, p1);
+    }
+}
+
+function playerAcceptsOpponent(filterer: IMatchmakingPlayerEntry, opponent: IMatchmakingPlayerEntry): boolean {
+    const prefs = filterer.player.matchPreferences;
+    if (!prefs || !prefs.enabled || prefs.allowedArchetypes.length === 0) {
+        return true;
+    }
+
+    const opponentLeaderId = opponent.player.deck?.leader?.id;
+    const opponentBaseId = opponent.player.deck?.base?.id;
+    const opponentBaseAspects = opponent.baseAspects;
+
+    return prefs.allowedArchetypes.some((archetype) =>
+        archetypeMatchesOpponent(archetype, opponentLeaderId, opponentBaseId, opponentBaseAspects)
+    );
+}
+
+function archetypeMatchesOpponent(
+    archetype: OpponentArchetype,
+    opponentLeaderId: string | undefined,
+    opponentBaseId: string | undefined,
+    opponentBaseAspects: readonly string[] | undefined,
+): boolean {
+    if (!opponentLeaderId) {
+        return false;
+    }
+    if (archetype.leaderId !== opponentLeaderId) {
+        return false;
+    }
+    if (!archetype.baseConstraint) {
+        return true;
+    }
+    if (archetype.baseConstraint.kind === 'specificBase') {
+        return opponentBaseId === archetype.baseConstraint.baseId;
+    }
+    if (archetype.baseConstraint.kind === 'aspect') {
+        return Array.isArray(opponentBaseAspects) && opponentBaseAspects.includes(archetype.baseConstraint.aspect);
+    }
+    return false;
 }

--- a/server/gamenode/MatchmakingRules.ts
+++ b/server/gamenode/MatchmakingRules.ts
@@ -5,11 +5,7 @@ import type { PreviousMatchEntry, QueuedPlayer } from './QueueHandler';
 export interface IMatchmakingPlayerEntry {
     player: QueuedPlayer;
     previousMatch?: PreviousMatchEntry;
-
-    /**
-     * Aspects of the player's base, pre-resolved from card data when the
-     * player enters the queue. Used by leader/base filter rules.
-     */
+    /** Pre-resolved aspects of the player's base; consumed by leaderArchetypeFilter. */
     baseAspects?: readonly string[];
 }
 
@@ -17,44 +13,21 @@ export interface IMatchmakingRule {
     canMatch(player1: IMatchmakingPlayerEntry, player2: IMatchmakingPlayerEntry): boolean;
 }
 
-/**
- * Constraint on which bases a filtered opponent's deck can use, paired with a
- * leader. Omit `baseConstraint` for "any base of this leader".
- *
- * `baseType` carries the set of acceptable base-card ids inline. The FE
- * resolves a user-friendly category (e.g. "Aggression - Force", or a unique
- * base like "Colossus") to the list of card ids in that group, so the BE
- * doesn't need a separate base-type registry to evaluate the rule. `label`
- * is optional metadata for display only.
- */
+// `baseType.baseIds` is the inline list of acceptable card ids for this
+// archetype (a single id for unique bases, multiple for grouped types like
+// "Aggression - Force"); the FE resolves the category and sends the ids
+// directly so the BE doesn't need a base-type registry.
 export type BaseConstraint =
-  | { kind: 'aspect'; aspect: Aspect }
-  | { kind: 'baseType'; baseIds: string[]; label?: string };
+    | { kind: 'aspect'; aspect: Aspect }
+    | { kind: 'baseType'; baseIds: string[]; label?: string };
 
-/**
- * A single archetype the player is willing to be matched against.
- *
- * The wire format is forward-compatible: `baseConstraint` is optional, so a
- * v1 client that only exposes leader-only filters can omit it, while a future
- * client can add base-specificity without changing the wire shape.
- */
 export interface OpponentArchetype {
     leaderId: string;
     baseConstraint?: BaseConstraint;
-
-    /**
-     * Set to `false` to keep the archetype saved but exclude it from the
-     * active filter. Treated as `true` when omitted, so existing payloads
-     * remain compatible.
-     */
+    /** Set to false to keep saved but excluded from the filter; defaults to true. */
     enabled?: boolean;
 }
 
-/**
- * Opt-in matchmaking preferences. When `enabled` is false or
- * `allowedArchetypes` is empty, the rule treats the player as "match anyone"
- * (the default, current behavior).
- */
 export interface MatchPreferences {
     enabled: boolean;
     allowedArchetypes: OpponentArchetype[];

--- a/server/gamenode/MatchmakingRules.ts
+++ b/server/gamenode/MatchmakingRules.ts
@@ -20,10 +20,16 @@ export interface IMatchmakingRule {
 /**
  * Constraint on which bases a filtered opponent's deck can use, paired with a
  * leader. Omit `baseConstraint` for "any base of this leader".
+ *
+ * `baseType` carries the set of acceptable base-card ids inline. The FE
+ * resolves a user-friendly category (e.g. "Aggression - Force", or a unique
+ * base like "Colossus") to the list of card ids in that group, so the BE
+ * doesn't need a separate base-type registry to evaluate the rule. `label`
+ * is optional metadata for display only.
  */
 export type BaseConstraint =
-  | { kind: 'specificBase'; baseId: string }
-  | { kind: 'aspect'; aspect: Aspect };
+  | { kind: 'aspect'; aspect: Aspect }
+  | { kind: 'baseType'; baseIds: string[]; label?: string };
 
 /**
  * A single archetype the player is willing to be matched against.
@@ -150,8 +156,8 @@ function archetypeMatchesOpponent(
     if (!archetype.baseConstraint) {
         return true;
     }
-    if (archetype.baseConstraint.kind === 'specificBase') {
-        return opponentBaseId === archetype.baseConstraint.baseId;
+    if (archetype.baseConstraint.kind === 'baseType') {
+        return typeof opponentBaseId === 'string' && archetype.baseConstraint.baseIds.includes(opponentBaseId);
     }
     if (archetype.baseConstraint.kind === 'aspect') {
         return Array.isArray(opponentBaseAspects) && opponentBaseAspects.includes(archetype.baseConstraint.aspect);

--- a/server/gamenode/MatchmakingRules.ts
+++ b/server/gamenode/MatchmakingRules.ts
@@ -41,6 +41,13 @@ export type BaseConstraint =
 export interface OpponentArchetype {
     leaderId: string;
     baseConstraint?: BaseConstraint;
+
+    /**
+     * Set to `false` to keep the archetype saved but exclude it from the
+     * active filter. Treated as `true` when omitted, so existing payloads
+     * remain compatible.
+     */
+    enabled?: boolean;
 }
 
 /**
@@ -132,11 +139,17 @@ function playerAcceptsOpponent(filterer: IMatchmakingPlayerEntry, opponent: IMat
         return true;
     }
 
+    // Per-archetype `enabled` defaults to true; only false explicitly disables.
+    const activeArchetypes = prefs.allowedArchetypes.filter((archetype) => archetype.enabled !== false);
+    if (activeArchetypes.length === 0) {
+        return true;
+    }
+
     const opponentLeaderId = opponent.player.deck?.leader?.id;
     const opponentBaseId = opponent.player.deck?.base?.id;
     const opponentBaseAspects = opponent.baseAspects;
 
-    return prefs.allowedArchetypes.some((archetype) =>
+    return activeArchetypes.some((archetype) =>
         archetypeMatchesOpponent(archetype, opponentLeaderId, opponentBaseId, opponentBaseAspects)
     );
 }

--- a/server/gamenode/MatchmakingRules.ts
+++ b/server/gamenode/MatchmakingRules.ts
@@ -5,6 +5,7 @@ import type { PreviousMatchEntry, QueuedPlayer } from './QueueHandler';
 export interface IMatchmakingPlayerEntry {
     player: QueuedPlayer;
     previousMatch?: PreviousMatchEntry;
+
     /** Pre-resolved aspects of the player's base; consumed by leaderArchetypeFilter. */
     baseAspects?: readonly string[];
 }
@@ -18,12 +19,13 @@ export interface IMatchmakingRule {
 // "Aggression - Force"); the FE resolves the category and sends the ids
 // directly so the BE doesn't need a base-type registry.
 export type BaseConstraint =
-    | { kind: 'aspect'; aspect: Aspect }
-    | { kind: 'baseType'; baseIds: string[]; label?: string };
+  | { kind: 'aspect'; aspect: Aspect }
+  | { kind: 'baseType'; baseIds: string[]; label?: string };
 
 export interface OpponentArchetype {
     leaderId: string;
     baseConstraint?: BaseConstraint;
+
     /** Set to false to keep saved but excluded from the filter; defaults to true. */
     enabled?: boolean;
 }

--- a/server/gamenode/QueueHandler.ts
+++ b/server/gamenode/QueueHandler.ts
@@ -14,18 +14,8 @@ export interface QueuedPlayerToAdd {
     deck: ISwuDbFormatDecklist;
     socket?: Socket;
     user: User;
-
-    /**
-     * Opt-in opponent-archetype filter. When undefined, disabled, or empty,
-     * the player matches against any opponent (the default).
-     */
     matchPreferences?: MatchPreferences;
-
-    /**
-     * Pre-resolved aspects of the player's base, used by the matchmaking
-     * filter rule to evaluate aspect-based constraints without doing a card
-     * data lookup at match time.
-     */
+    /** Pre-resolved aspects of the player's base; consumed by leaderArchetypeFilter. */
     baseAspects?: readonly string[];
 }
 

--- a/server/gamenode/QueueHandler.ts
+++ b/server/gamenode/QueueHandler.ts
@@ -15,6 +15,7 @@ export interface QueuedPlayerToAdd {
     socket?: Socket;
     user: User;
     matchPreferences?: MatchPreferences;
+
     /** Pre-resolved aspects of the player's base; consumed by leaderArchetypeFilter. */
     baseAspects?: readonly string[];
 }

--- a/server/gamenode/QueueHandler.ts
+++ b/server/gamenode/QueueHandler.ts
@@ -7,13 +7,26 @@ import { CardPool } from '../game/core/Constants';
 import { GamesToWinMode } from '../game/core/Constants';
 import { SwuGameFormat } from '../game/core/Constants';
 
-import type { IMatchmakingPlayerEntry, IMatchmakingRule } from './MatchmakingRules';
+import type { IMatchmakingPlayerEntry, IMatchmakingRule, MatchPreferences } from './MatchmakingRules';
 import { MatchmakingRule } from './MatchmakingRules';
 
 export interface QueuedPlayerToAdd {
     deck: ISwuDbFormatDecklist;
     socket?: Socket;
     user: User;
+
+    /**
+     * Opt-in opponent-archetype filter. When undefined, disabled, or empty,
+     * the player matches against any opponent (the default).
+     */
+    matchPreferences?: MatchPreferences;
+
+    /**
+     * Pre-resolved aspects of the player's base, used by the matchmaking
+     * filter rule to evaluate aspect-based constraints without doing a card
+     * data lookup at match time.
+     */
+    baseAspects?: readonly string[];
 }
 
 export enum QueuedPlayerState {
@@ -128,7 +141,12 @@ export class QueueHandler {
         const queueEntry = this.findPlayerInQueue(userId);
         if (queueEntry && queueEntry.player?.socket?.id === socketId) {
             this.removePlayer(userId, `Temporarily disconnected on socket id ${socketId}`);
-            this.addPlayer(queueEntry.format, { user: queueEntry.player.user, deck: queueEntry.player.deck });
+            this.addPlayer(queueEntry.format, {
+                user: queueEntry.player.user,
+                deck: queueEntry.player.deck,
+                matchPreferences: queueEntry.player.matchPreferences,
+                baseAspects: queueEntry.player.baseAspects,
+            });
         }
     }
 
@@ -228,7 +246,10 @@ export class QueueHandler {
             return null;
         }
 
-        return this.findMatchInQueue(queue, [MatchmakingRule.rematchCooldown(QueueHandler.COOLDOWN_INTERVAL_SECONDS)]);
+        return this.findMatchInQueue(queue, [
+            MatchmakingRule.rematchCooldown(QueueHandler.COOLDOWN_INTERVAL_SECONDS),
+            MatchmakingRule.leaderArchetypeFilter(),
+        ]);
     }
 
     /**
@@ -243,8 +264,16 @@ export class QueueHandler {
             for (let j = i + 1; j < queue.length; j++) {
                 const player1 = queue[i];
                 const player2 = queue[j];
-                const p1Entry: IMatchmakingPlayerEntry = { player: player1, previousMatch: this.playerPreviousMatch.get(player1.user.getId()) };
-                const p2Entry: IMatchmakingPlayerEntry = { player: player2, previousMatch: this.playerPreviousMatch.get(player2.user.getId()) };
+                const p1Entry: IMatchmakingPlayerEntry = {
+                    player: player1,
+                    previousMatch: this.playerPreviousMatch.get(player1.user.getId()),
+                    baseAspects: player1.baseAspects,
+                };
+                const p2Entry: IMatchmakingPlayerEntry = {
+                    player: player2,
+                    previousMatch: this.playerPreviousMatch.get(player2.user.getId()),
+                    baseAspects: player2.baseAspects,
+                };
 
                 const canMatch = rules.every((rule) => rule.canMatch(p1Entry, p2Entry));
 

--- a/server/utils/cardData/CardDataGetter.ts
+++ b/server/utils/cardData/CardDataGetter.ts
@@ -12,6 +12,7 @@ export interface IBaseType {
     label: string;
     aspect: string;
     hp: number;
+    rarity: string | null;
     baseIds: string[];
     representativeId: string;
 }

--- a/server/utils/cardData/CardDataGetter.ts
+++ b/server/utils/cardData/CardDataGetter.ts
@@ -13,6 +13,7 @@ export interface IBaseType {
     aspect: string;
     hp: number;
     rarity: string | null;
+    set: string | null;
     baseIds: string[];
     representativeId: string;
 }

--- a/server/utils/cardData/CardDataGetter.ts
+++ b/server/utils/cardData/CardDataGetter.ts
@@ -16,12 +16,15 @@ export abstract class CardDataGetter {
     private readonly _setCodeMap: Map<string, string>;
     private readonly _tokenData: ITokenCardsData;
     private readonly _leaders: { name: string; id: string; subtitle?: string }[];
+    private readonly _bases: { name: string; id: string; subtitle?: string; aspects: string[] }[];
+    private readonly _baseAspectsById: Map<string, string[]>;
 
     protected static readonly setCodeMapFileName = '_setCodeMap.json';
     protected static readonly cardMapFileName = '_cardMap.json';
     protected static readonly allNonLeaderCardTitlesFileName = '_allNonLeaderCardTitles.json';
     protected static readonly playableCardTitlesFileName = '_playableCardTitles.json';
     protected static readonly leaderNamesFileName = '_leaderNames.json';
+    protected static readonly baseNamesFileName = '_baseNames.json';
 
     public get cardIds(): string[] {
         return Array.from(this.cardMap.keys());
@@ -47,6 +50,22 @@ export abstract class CardDataGetter {
         return this._leaders;
     }
 
+    public getBaseCards() {
+        return this._bases;
+    }
+
+    /**
+     * Returns the aspects of a base by its set-code id (e.g. 'SOR_022'), or
+     * an empty array if no base with that id is known. Used by the matchmaking
+     * filter rule to evaluate base-aspect constraints.
+     */
+    public getBaseAspectsById(baseId: string | undefined): string[] {
+        if (!baseId) {
+            return [];
+        }
+        return this._baseAspectsById.get(baseId) ?? [];
+    }
+
     public constructor(
         cardMapJson: ICardMapJson,
         tokenData: ITokenCardsData,
@@ -54,6 +73,7 @@ export abstract class CardDataGetter {
         playableCardTitles: string[],
         setCodeMap: Record<string, string>,
         leaderNames: { name: string; id: string; subtitle?: string }[],
+        baseNames: { name: string; id: string; subtitle?: string; aspects: string[] }[],
     ) {
         this.cardMap = new Map<string, ICardMapEntry>();
         this.knownCardInternalNames = new Set<string>();
@@ -68,6 +88,8 @@ export abstract class CardDataGetter {
         this._setCodeMap = new Map(Object.entries(setCodeMap));
         this._tokenData = tokenData;
         this._leaders = leaderNames;
+        this._bases = baseNames;
+        this._baseAspectsById = new Map(baseNames.map((base) => [base.id, base.aspects]));
     }
 
     protected abstract getCardInternalAsync(relativePath: string): Promise<ICardDataJson>;

--- a/server/utils/cardData/CardDataGetter.ts
+++ b/server/utils/cardData/CardDataGetter.ts
@@ -26,7 +26,7 @@ export abstract class CardDataGetter {
     private readonly _playableCardTitles: string[];
     private readonly _setCodeMap: Map<string, string>;
     private readonly _tokenData: ITokenCardsData;
-    private readonly _leaders: { name: string; id: string; subtitle?: string }[];
+    private readonly _leaders: { name: string; id: string; subtitle?: string; aspects: string[]; set: string | null }[];
     private readonly _bases: { name: string; id: string; subtitle?: string; aspects: string[] }[];
     private readonly _baseAspectsById: Map<string, string[]>;
     private readonly _baseTypes: IBaseType[];
@@ -89,7 +89,7 @@ export abstract class CardDataGetter {
         allNonLeaderCardTitles: string[],
         playableCardTitles: string[],
         setCodeMap: Record<string, string>,
-        leaderNames: { name: string; id: string; subtitle?: string }[],
+        leaderNames: { name: string; id: string; subtitle?: string; aspects: string[]; set: string | null }[],
         baseNames: { name: string; id: string; subtitle?: string; aspects: string[] }[],
         baseTypes: IBaseType[],
     ) {

--- a/server/utils/cardData/CardDataGetter.ts
+++ b/server/utils/cardData/CardDataGetter.ts
@@ -7,6 +7,15 @@ export type ITokenCardsData = {
     [TokenNameValue in TokenName]: ICardDataJson;
 };
 
+export interface IBaseType {
+    id: string;
+    label: string;
+    aspect: string;
+    hp: number;
+    baseIds: string[];
+    representativeId: string;
+}
+
 export abstract class CardDataGetter {
     public readonly cardMap: ICardMap;
 
@@ -18,6 +27,7 @@ export abstract class CardDataGetter {
     private readonly _leaders: { name: string; id: string; subtitle?: string }[];
     private readonly _bases: { name: string; id: string; subtitle?: string; aspects: string[] }[];
     private readonly _baseAspectsById: Map<string, string[]>;
+    private readonly _baseTypes: IBaseType[];
 
     protected static readonly setCodeMapFileName = '_setCodeMap.json';
     protected static readonly cardMapFileName = '_cardMap.json';
@@ -25,6 +35,7 @@ export abstract class CardDataGetter {
     protected static readonly playableCardTitlesFileName = '_playableCardTitles.json';
     protected static readonly leaderNamesFileName = '_leaderNames.json';
     protected static readonly baseNamesFileName = '_baseNames.json';
+    protected static readonly baseTypesFileName = '_baseTypes.json';
 
     public get cardIds(): string[] {
         return Array.from(this.cardMap.keys());
@@ -54,6 +65,10 @@ export abstract class CardDataGetter {
         return this._bases;
     }
 
+    public getBaseTypes(): IBaseType[] {
+        return this._baseTypes;
+    }
+
     /**
      * Returns the aspects of a base by its set-code id (e.g. 'SOR_022'), or
      * an empty array if no base with that id is known. Used by the matchmaking
@@ -74,6 +89,7 @@ export abstract class CardDataGetter {
         setCodeMap: Record<string, string>,
         leaderNames: { name: string; id: string; subtitle?: string }[],
         baseNames: { name: string; id: string; subtitle?: string; aspects: string[] }[],
+        baseTypes: IBaseType[],
     ) {
         this.cardMap = new Map<string, ICardMapEntry>();
         this.knownCardInternalNames = new Set<string>();
@@ -90,6 +106,7 @@ export abstract class CardDataGetter {
         this._leaders = leaderNames;
         this._bases = baseNames;
         this._baseAspectsById = new Map(baseNames.map((base) => [base.id, base.aspects]));
+        this._baseTypes = baseTypes;
     }
 
     protected abstract getCardInternalAsync(relativePath: string): Promise<ICardDataJson>;

--- a/server/utils/cardData/LocalFolderCardDataGetter.ts
+++ b/server/utils/cardData/LocalFolderCardDataGetter.ts
@@ -33,7 +33,7 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
             .then((data) => data as Record<string, string>);
 
         const leaderNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.leaderNamesFileName)
-            .then((data) => data as { name: string; id: string; subtitle?: string }[]);
+            .then((data) => data as { name: string; id: string; subtitle?: string; aspects: string[]; set: string | null }[]);
 
         const baseNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.baseNamesFileName)
             .then((data) => data as { name: string; id: string; subtitle?: string; aspects: string[] }[]);
@@ -80,7 +80,7 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
         allNonLeaderCardTitles: string[],
         playableCardTitles: string[],
         setCodeMap: Record<string, string>,
-        leaderNames: { name: string; id: string; subtitle?: string }[],
+        leaderNames: { name: string; id: string; subtitle?: string; aspects: string[]; set: string | null }[],
         baseNames: { name: string; id: string; subtitle?: string; aspects: string[] }[],
         baseTypes: IBaseType[],
     ) {

--- a/server/utils/cardData/LocalFolderCardDataGetter.ts
+++ b/server/utils/cardData/LocalFolderCardDataGetter.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { Contract } from '../../game/core/utils/Contract';
-import type { ITokenCardsData } from './CardDataGetter';
+import type { IBaseType, ITokenCardsData } from './CardDataGetter';
 import { CardDataGetter } from './CardDataGetter';
 import type { ICardDataJson, ICardMapJson } from './CardDataInterfaces';
 
@@ -37,7 +37,10 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
 
         const baseNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.baseNamesFileName)
             .then((data) => data as { name: string; id: string; subtitle?: string; aspects: string[] }[]);
-        return new LocalFolderCardDataGetter(folderRoot, cardMap, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames);
+
+        const baseTypes = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.baseTypesFileName)
+            .then((data) => data as IBaseType[]);
+        return new LocalFolderCardDataGetter(folderRoot, cardMap, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);
     }
 
     protected static validateFolderContents(directory: string, isDevelopment: boolean) {
@@ -79,8 +82,9 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
         setCodeMap: Record<string, string>,
         leaderNames: { name: string; id: string; subtitle?: string }[],
         baseNames: { name: string; id: string; subtitle?: string; aspects: string[] }[],
+        baseTypes: IBaseType[],
     ) {
-        super(cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames);
+        super(cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);
 
         this.folderRoot = folderRoot;
     }

--- a/server/utils/cardData/LocalFolderCardDataGetter.ts
+++ b/server/utils/cardData/LocalFolderCardDataGetter.ts
@@ -34,7 +34,10 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
 
         const leaderNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.leaderNamesFileName)
             .then((data) => data as { name: string; id: string; subtitle?: string }[]);
-        return new LocalFolderCardDataGetter(folderRoot, cardMap, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames);
+
+        const baseNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.baseNamesFileName)
+            .then((data) => data as { name: string; id: string; subtitle?: string; aspects: string[] }[]);
+        return new LocalFolderCardDataGetter(folderRoot, cardMap, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames);
     }
 
     protected static validateFolderContents(directory: string, isDevelopment: boolean) {
@@ -75,8 +78,9 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
         playableCardTitles: string[],
         setCodeMap: Record<string, string>,
         leaderNames: { name: string; id: string; subtitle?: string }[],
+        baseNames: { name: string; id: string; subtitle?: string; aspects: string[] }[],
     ) {
-        super(cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames);
+        super(cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames);
 
         this.folderRoot = folderRoot;
     }

--- a/server/utils/cardData/UnitTestCardDataGetter.ts
+++ b/server/utils/cardData/UnitTestCardDataGetter.ts
@@ -1,4 +1,5 @@
 import { CardDataGetter } from './CardDataGetter';
+import type { IBaseType } from './CardDataGetter';
 import type { ICardDataJson, ICardMapJson } from './CardDataInterfaces';
 import { LocalFolderCardDataGetter } from './LocalFolderCardDataGetter';
 import { Contract } from '../../game/core/utils/Contract';
@@ -44,7 +45,8 @@ export class UnitTestCardDataGetter extends LocalFolderCardDataGetter implements
 
         const leaderNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.leaderNamesFileName) as { name: string; id: string; subtitle: string }[];
         const baseNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseNamesFileName) as { name: string; id: string; subtitle: string; aspects: string[] }[];
-        super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames);
+        const baseTypes = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseTypesFileName) as IBaseType[];
+        super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);
     }
 
     public getCardSync(id: string): ICardDataJson {

--- a/server/utils/cardData/UnitTestCardDataGetter.ts
+++ b/server/utils/cardData/UnitTestCardDataGetter.ts
@@ -43,7 +43,7 @@ export class UnitTestCardDataGetter extends LocalFolderCardDataGetter implements
 
         const setCodeMap = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.setCodeMapFileName) as Record<string, string>;
 
-        const leaderNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.leaderNamesFileName) as { name: string; id: string; subtitle: string }[];
+        const leaderNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.leaderNamesFileName) as { name: string; id: string; subtitle: string; aspects: string[]; set: string | null }[];
         const baseNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseNamesFileName) as { name: string; id: string; subtitle: string; aspects: string[] }[];
         const baseTypes = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseTypesFileName) as IBaseType[];
         super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);

--- a/server/utils/cardData/UnitTestCardDataGetter.ts
+++ b/server/utils/cardData/UnitTestCardDataGetter.ts
@@ -43,7 +43,8 @@ export class UnitTestCardDataGetter extends LocalFolderCardDataGetter implements
         const setCodeMap = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.setCodeMapFileName) as Record<string, string>;
 
         const leaderNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.leaderNamesFileName) as { name: string; id: string; subtitle: string }[];
-        super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames);
+        const baseNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseNamesFileName) as { name: string; id: string; subtitle: string; aspects: string[] }[];
+        super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames);
     }
 
     public getCardSync(id: string): ICardDataJson {

--- a/test/server/gamenode/MatchmakingRules.spec.ts
+++ b/test/server/gamenode/MatchmakingRules.spec.ts
@@ -246,6 +246,50 @@ describe('MatchmakingRule.leaderArchetypeFilter', function() {
         });
     });
 
+    describe('per-archetype enabled flag', function() {
+        it('skips archetypes whose enabled is explicitly false', function() {
+            const prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [
+                    { leaderId: 'SEC_010', enabled: false },
+                    { leaderId: 'JTL_005', enabled: true },
+                ],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            // SEC_010 archetype is disabled, so this opponent should not match
+            const p2 = buildPlayer('u2', 'SEC_010', 'JTL_021', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+
+        it('matches when only enabled archetypes accept the opponent', function() {
+            const prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [
+                    { leaderId: 'SEC_010', enabled: false },
+                    { leaderId: 'JTL_005' },
+                ],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'JTL_021', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('matches anyone when every archetype is disabled (empty active set)', function() {
+            const prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [
+                    { leaderId: 'SEC_010', enabled: false },
+                    { leaderId: 'JTL_005', enabled: false },
+                ],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            // Empty active set is treated as "match anyone" — matches the
+            // top-level disabled / empty-allowedArchetypes behavior.
+            const p2 = buildPlayer('u2', 'XYZ_999', 'JTL_021', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+    });
+
     describe('edge cases', function() {
         it('treats opponent with missing leader id as not matching any archetype', function() {
             const prefs: MatchPreferences = {

--- a/test/server/gamenode/MatchmakingRules.spec.ts
+++ b/test/server/gamenode/MatchmakingRules.spec.ts
@@ -126,22 +126,46 @@ describe('MatchmakingRule.leaderArchetypeFilter', function() {
         });
     });
 
-    describe('with leader + specific-base constraint', function() {
+    describe('with leader + baseType (single-id) constraint', function() {
         const archetype: OpponentArchetype = {
             leaderId: 'JTL_005',
-            baseConstraint: { kind: 'specificBase', baseId: 'JTL_023' },
+            baseConstraint: { kind: 'baseType', baseIds: ['JTL_023'], label: 'Colossus' },
         };
         const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
 
-        it('matches on exact baseId match', function() {
+        it('matches when opponent baseId is in the single-id set', function() {
             const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
             const p2 = buildPlayer('u2', 'JTL_005', 'JTL_023', { baseAspects: ['vigilance'] });
             expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
         });
 
-        it('rejects when opponent base differs even if aspect matches', function() {
+        it('rejects when opponent baseId is not in the single-id set', function() {
             const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
             const p2 = buildPlayer('u2', 'JTL_005', 'LOF_999', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+    });
+
+    describe('with leader + baseType (multi-id) constraint', function() {
+        const archetype: OpponentArchetype = {
+            leaderId: 'JTL_005',
+            baseConstraint: {
+                kind: 'baseType',
+                baseIds: ['LOF_023', 'LOF_026', 'LOF_027'],
+                label: 'Aggression - Force (28hp)',
+            },
+        };
+        const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
+
+        it('matches when opponent baseId is any member of the type', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'LOF_026', { baseAspects: ['aggression'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('rejects when opponent baseId is not in the type', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'LAW_026', { baseAspects: ['aggression'] });
             expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
         });
     });

--- a/test/server/gamenode/MatchmakingRules.spec.ts
+++ b/test/server/gamenode/MatchmakingRules.spec.ts
@@ -1,0 +1,236 @@
+import { Aspect } from '../../../server/game/core/Constants';
+import type { ISwuDbFormatDecklist } from '../../../server/utils/deck/DeckInterfaces';
+import type { User } from '../../../server/utils/user/User';
+import type { IMatchmakingPlayerEntry, MatchPreferences, OpponentArchetype } from '../../../server/gamenode/MatchmakingRules';
+import { MatchmakingRule } from '../../../server/gamenode/MatchmakingRules';
+import type { QueuedPlayer } from '../../../server/gamenode/QueueHandler';
+import { QueuedPlayerState } from '../../../server/gamenode/QueueHandler';
+
+function mockUser(userId: string): User {
+    const partial = { getId: () => userId };
+    return partial as unknown as User;
+}
+
+function mockDeck(leaderId: string, baseId: string): ISwuDbFormatDecklist {
+    return {
+        metadata: { name: 'test', author: 'test' },
+        leader: { id: leaderId, count: 1 },
+        base: { id: baseId, count: 1 },
+    };
+}
+
+interface PlayerOverrides {
+    matchPreferences?: MatchPreferences;
+    baseAspects?: readonly string[];
+}
+
+function buildPlayer(userId: string, leaderId: string, baseId: string, overrides: PlayerOverrides = {}): QueuedPlayer {
+    return {
+        user: mockUser(userId),
+        deck: mockDeck(leaderId, baseId),
+        state: QueuedPlayerState.Connected,
+        matchPreferences: overrides.matchPreferences,
+        baseAspects: overrides.baseAspects,
+    };
+}
+
+function buildPlayerWithoutLeaderOrBase(userId: string): QueuedPlayer {
+    const deck: ISwuDbFormatDecklist = { metadata: { name: 'test', author: 'test' } };
+    return {
+        user: mockUser(userId),
+        deck,
+        state: QueuedPlayerState.Connected,
+    };
+}
+
+function entry(player: QueuedPlayer): IMatchmakingPlayerEntry {
+    return { player, baseAspects: player.baseAspects };
+}
+
+describe('MatchmakingRule.leaderArchetypeFilter', function() {
+    const rule = MatchmakingRule.leaderArchetypeFilter();
+
+    describe('when neither player has matchPreferences', function() {
+        it('matches any opponent (preserves default behavior)', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_002', 'SOR_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+    });
+
+    describe('when prefs are disabled or empty', function() {
+        it('matches anyone when enabled=false', function() {
+            const prefs: MatchPreferences = { enabled: false, allowedArchetypes: [{ leaderId: 'OTHER' }] };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_002', 'SOR_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('matches anyone when allowedArchetypes is empty', function() {
+            const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [] };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_002', 'SOR_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+    });
+
+    describe('with leader-only archetype', function() {
+        it('rejects when opponent leader is not in allowlist', function() {
+            const archetype: OpponentArchetype = { leaderId: 'SOR_005' };
+            const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_999', 'SOR_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+
+        it('matches when opponent leader is in allowlist (and opponent has no filter)', function() {
+            const archetype: OpponentArchetype = { leaderId: 'SOR_005' };
+            const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_005', 'LOF_023', { baseAspects: ['command'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('matches against any base when no baseConstraint is set', function() {
+            const archetype: OpponentArchetype = { leaderId: 'SOR_005' };
+            const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_005', 'SOR_999', { baseAspects: ['villainy'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+    });
+
+    describe('with leader + aspect base constraint', function() {
+        const archetype: OpponentArchetype = {
+            leaderId: 'SOR_005',
+            baseConstraint: { kind: 'aspect', aspect: Aspect.Vigilance },
+        };
+        const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
+
+        it('matches when opponent\'s base aspect satisfies the constraint', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_005', 'JTL_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('rejects when opponent\'s base aspect doesn\'t match', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_005', 'LOF_022', { baseAspects: ['cunning'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+
+        it('rejects when opponent base aspects are unknown', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'SOR_005', 'SOR_999', { baseAspects: undefined });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+    });
+
+    describe('with leader + specific-base constraint', function() {
+        const archetype: OpponentArchetype = {
+            leaderId: 'JTL_005',
+            baseConstraint: { kind: 'specificBase', baseId: 'JTL_023' },
+        };
+        const prefs: MatchPreferences = { enabled: true, allowedArchetypes: [archetype] };
+
+        it('matches on exact baseId match', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'JTL_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('rejects when opponent base differs even if aspect matches', function() {
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'LOF_999', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+    });
+
+    describe('with multiple allowed archetypes', function() {
+        it('matches if any one archetype accepts the opponent', function() {
+            const prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [
+                    { leaderId: 'SOR_005' },
+                    { leaderId: 'JTL_005', baseConstraint: { kind: 'aspect', aspect: Aspect.Vigilance } },
+                ],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+
+            // matches second archetype: leader=JTL_005 + base aspect=vigilance
+            const p2 = buildPlayer('u2', 'JTL_005', 'JTL_023', { baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('rejects when no archetype accepts the opponent', function() {
+            const prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [
+                    { leaderId: 'SOR_005' },
+                    { leaderId: 'JTL_005', baseConstraint: { kind: 'aspect', aspect: Aspect.Vigilance } },
+                ],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+
+            // leader=JTL_005 but base aspect=cunning, and not in any archetype
+            const p2 = buildPlayer('u2', 'JTL_005', 'LOF_022', { baseAspects: ['cunning'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+    });
+
+    describe('with mutual filters (both players opt in)', function() {
+        it('matches only when both filters accept the other', function() {
+            const p1Prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'JTL_005' }],
+            };
+            const p2Prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'SOR_001' }],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: p1Prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'JTL_023', { matchPreferences: p2Prefs, baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeTrue();
+        });
+
+        it('rejects asymmetric: p1 accepts p2 but p2 rejects p1', function() {
+            const p1Prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'JTL_005' }],
+            };
+            const p2Prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'SOMEONE_ELSE' }],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: p1Prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'JTL_023', { matchPreferences: p2Prefs, baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+
+        it('rejects when both filters reject the other', function() {
+            const p1Prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'NOT_P2' }],
+            };
+            const p2Prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'NOT_P1' }],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: p1Prefs, baseAspects: ['command'] });
+            const p2 = buildPlayer('u2', 'JTL_005', 'JTL_023', { matchPreferences: p2Prefs, baseAspects: ['vigilance'] });
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+    });
+
+    describe('edge cases', function() {
+        it('treats opponent with missing leader id as not matching any archetype', function() {
+            const prefs: MatchPreferences = {
+                enabled: true,
+                allowedArchetypes: [{ leaderId: 'SOR_005' }],
+            };
+            const p1 = buildPlayer('u1', 'SOR_001', 'SOR_022', { matchPreferences: prefs, baseAspects: ['command'] });
+            const p2 = buildPlayerWithoutLeaderOrBase('u2');
+            expect(rule.canMatch(entry(p1), entry(p2))).toBeFalse();
+        });
+    });
+});


### PR DESCRIPTION
# Opt-in opponent-archetype matchmaking filter (BE)

Adds an opt-in matchmaking-queue filter so a player can restrict the public-queue opponents they're willing to face by leader, leader+aspect, or leader+specific-base archetype. Default behavior is unchanged: players without preferences match against anyone.

Pairs with SWU-Karabast/forceteki-client#674 (Manage page + queue-form panel).

## What's added

**`server/gamenode/MatchmakingRules.ts`** — new `MatchmakingRule.leaderArchetypeFilter()` factory + `LeaderArchetypeFilterRule` class. A match passes the rule iff each player's filter accepts the other's leader+base. Players with `matchPreferences` undefined / disabled / empty accept anyone.

Wire format:

```ts
type BaseConstraint =
    | { kind: 'aspect'; aspect: Aspect }
    | { kind: 'baseType'; baseIds: string[]; label?: string };

interface OpponentArchetype {
    leaderId: string;
    baseConstraint?: BaseConstraint;  // omit for "any base of this leader"
    enabled?: boolean;                 // defaults true
}

interface MatchPreferences {
    enabled: boolean;
    allowedArchetypes: OpponentArchetype[];
}
```

`baseType.baseIds` is the inline list of acceptable card ids, so the BE doesn't need a separate base-type registry — the FE resolves a user-friendly category (e.g. "Aggression - Force") to ids and sends them on the wire.

**`server/gamenode/QueueHandler.ts`** — adds `matchPreferences` and `baseAspects` (pre-resolved at queue-entry time) to `QueuedPlayerToAdd`; both flow through `IMatchmakingPlayerEntry` to the rule. Empty/unset values preserve the current "match anyone" behavior.

**`scripts/fetchdata.js`** — emits a `_baseTypes.json` artifact alongside the existing card data. Each entry groups bases by `(aspect, hp, traits)` so the FE picker can offer "Aggression - Force - 28hp" / "Aggression - Vanilla - 30hp" / etc. as functional types, plus one entry per unique-named rare base. Per-base `rarity` is captured so the FE can mark rare bases.

## Tests

`test/server/gamenode/MatchmakingRules.spec.ts` — 22 Jasmine specs covering:

- Both players unfiltered → any match passes (default behavior)
- One player filtered, other unfiltered → only the filtered player's allowlist applies
- Leader-only constraint
- Leader + aspect base constraint
- Leader + specific baseType (single id, multiple ids in a group)
- Per-archetype `enabled: false` excluded from the active set
- Empty `allowedArchetypes` or all-disabled → matches anyone
- Missing leader/base on opponent's deck → no match

All 6310 backend specs pass.

## Notes for review

- Wire format is forward-compatible: a future client that knows nothing about `baseConstraint` still works (omit it for leader-only filters), and a future client that adds new constraint kinds can extend the union.
- The `baseAspects` precomputation in `QueueHandler` avoids doing a card-data lookup at match-time.
- No matchmaker timeout / fallback behavior added — that's a separate consideration if narrow filters create long queue waits.
