### PR TITLE
Filtered lobbies (BE) — opponent-archetype filter on public lobbies

### DIFF
--- a/scripts/buildBaseTypes.js
+++ b/scripts/buildBaseTypes.js
@@ -1,0 +1,92 @@
+/**
+ * Group bases into "types" — sets of functionally-identical bases — for the
+ * matchmaking-queue opponent filter. Two bases share a type iff they share
+ * aspects, HP, and rules text; otherwise each base is its own single-card
+ * type. The FE picks a type and sends its `baseIds` on the wire, so the BE
+ * rule just compares ids.
+ */
+function buildBaseTypes(baseNames) {
+    const groups = new Map();
+
+    for (const base of baseNames) {
+        if (typeof base.hp !== 'number') {
+            continue;
+        }
+        const aspects = base.aspects.length === 0 ? null : [...base.aspects].sort();
+        const textKey = normalizeText(base.text);
+        const groupKey = `${aspects ? aspects.join('+') : ''}::${base.hp}::${textKey}`;
+        if (!groups.has(groupKey)) {
+            groups.set(groupKey, { aspects, hp: base.hp, text: textKey, bases: [] });
+        }
+        groups.get(groupKey).bases.push(base);
+    }
+
+    const types = [];
+    for (const group of groups.values()) {
+        if (group.bases.length === 1) {
+            const only = group.bases[0];
+            types.push({
+                id: only.id,
+                kind: 'unique',
+                name: only.name,
+                aspects: group.aspects,
+                baseIds: [only.id],
+            });
+            continue;
+        }
+
+        const sorted = [...group.bases].sort((a, b) => a.name.localeCompare(b.name));
+        types.push({
+            id: sorted[0].id,
+            kind: classifyGroup(group),
+            aspects: group.aspects,
+            baseIds: sorted.map((b) => b.id),
+        });
+    }
+
+    types.sort((a, b) => {
+        const aspectCmp = (a.aspects ?? []).join('+').localeCompare((b.aspects ?? []).join('+'));
+        if (aspectCmp !== 0) {
+            return aspectCmp;
+        }
+        return a.id.localeCompare(b.id);
+    });
+    return types;
+}
+
+// SWU has shipped two "themed common base" archetypes so far — Force bases
+// and Splash bases — each with two printings in every aspect (Aggression,
+// Command, Cunning, Vigilance). classifyGroup tags a group by checking
+// these id sets; matching on a full sentence of rules text would be fragile.
+//
+// If a future set introduces another themed-base archetype, define a new
+// id set + classifyGroup branch alongside these.
+const FORCE_BASE_IDS = new Set([
+    'LOF_020', 'LOF_021', 'LOF_023', 'LOF_024',
+    'LOF_026', 'LOF_027', 'LOF_029', 'LOF_030',
+]);
+const SPLASH_BASE_IDS = new Set([
+    'LAW_020', 'LAW_021', 'LAW_022', 'LAW_024',
+    'LAW_025', 'LAW_027', 'LAW_028', 'LAW_030',
+]);
+
+function normalizeText(text) {
+    return (text || '').replace(/\s+/g, ' ').trim()
+        .toLowerCase();
+}
+
+function classifyGroup(group) {
+    if (group.text === '') {
+        return 'standard';
+    }
+    if (group.bases.some((b) => FORCE_BASE_IDS.has(b.id))) {
+        return 'force';
+    }
+    if (group.bases.some((b) => SPLASH_BASE_IDS.has(b.id))) {
+        return 'splash';
+    }
+    // Multi-card group with unrecognised text — doesn't fire on current data.
+    return 'unknown';
+}
+
+module.exports = { buildBaseTypes };

--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -8,6 +8,7 @@ const path = require('path');
 const cliProgress = require('cli-progress');
 const { addMockCards } = require('./mockdata');
 const { computeCardDataHash } = require('./cardDataHash');
+const { buildBaseTypes } = require('./buildBaseTypes');
 
 // ############################################################################
 // #################                 IMPORTANT              ###################
@@ -361,6 +362,11 @@ function buildCardLists(cards) {
     const playableCardTitlesSet = new Set();
     const seenNames = [];
     const leaderNames = [];
+    const baseNames = [];
+    // Parallel to baseNames, but carrying the extra fields (hp + rules text)
+    // that buildBaseTypes uses for grouping. Not persisted — those fields are
+    // not needed at runtime once base types are computed.
+    const baseGroupingInputs = [];
     const uniqueCardsMap = new Map();
     const setNumber = new Map([
         ['SOR', 1],
@@ -436,6 +442,24 @@ function buildCardLists(cards) {
             const cardId = `${card.setId.set}_${String(card.setId.number).padStart(3, '0')}`;
             leaderNames.push({ name: card.title, id: cardId, subtitle: card.subtitle });
         }
+
+        if (card.types.includes('base')) {
+            const cardId = `${card.setId.set}_${String(card.setId.number).padStart(3, '0')}`;
+            const aspects = Array.isArray(card.aspects) ? card.aspects : [];
+            baseNames.push({
+                name: card.title,
+                id: cardId,
+                subtitle: card.subtitle,
+                aspects,
+            });
+            baseGroupingInputs.push({
+                name: card.title,
+                id: cardId,
+                aspects,
+                hp: card.hp,
+                text: typeof card.text === 'string' ? card.text : '',
+            });
+        }
     }
 
     const allNonLeaderCardTitles = Array.from(allNonLeaderCardTitlesSet);
@@ -444,8 +468,10 @@ function buildCardLists(cards) {
     const playableCardTitles = Array.from(playableCardTitlesSet);
     playableCardTitles.sort();
 
+    const baseTypes = buildBaseTypes(baseGroupingInputs);
+
     const uniqueCards = [...uniqueCardsMap].map(([internalName, card]) => card);
-    return { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames };
+    return { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes };
 }
 
 async function main() {
@@ -484,7 +510,7 @@ async function main() {
 
     downloadProgressBar.stop();
 
-    const { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames } = buildCardLists(cards);
+    const { uniqueCards, cardMap, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes } = buildCardLists(cards);
 
     cards.map((card) => delete card.debugObject);
 
@@ -505,6 +531,8 @@ async function main() {
     fs.writeFile(path.join(pathToJSON, '_setCodeMap.json'), JSON.stringify(setCodeMap, null, 2));
     fs.writeFile(path.join(pathToJSON, '_mockCardNames.json'), JSON.stringify(mockCardNames, null, 2));
     fs.writeFile(path.join(pathToJSON, '_leaderNames.json'), JSON.stringify(leaderNames, null, 2));
+    fs.writeFile(path.join(pathToJSON, '_baseNames.json'), JSON.stringify(baseNames, null, 2));
+    fs.writeFile(path.join(pathToJSON, '_baseTypes.json'), JSON.stringify(baseTypes, null, 2));
     fs.writeFile(path.join(pathToJSON, 'card-data-hash.txt'), computeCardDataHash());
 
     console.log(`\n${uniqueCards.length} card definition files downloaded to ${pathToJSON}`);

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -30,6 +30,8 @@ import { DeckValidator } from '../utils/deck/DeckValidator';
 import type { IDeckValidationProperties, ISwuDbFormatDecklist } from '../utils/deck/DeckInterfaces';
 import type { IQueueFormatKey, QueuedPlayer } from './QueueHandler';
 import { QueueHandler } from './QueueHandler';
+import type { OpponentArchetype } from '../utils/archetypeFilter';
+import { deckMatchesArchetypeFilter } from '../utils/archetypeFilter';
 import { Helpers } from '../game/core/utils/Helpers';
 import { authMiddleware } from '../middleware/AuthMiddleWare';
 import { ServerRoleUsersCache } from '../utils/ServerRoleUsersCache';
@@ -75,6 +77,7 @@ enum UserRole {
 interface ILobbyMapping {
     lobbyId: string;
     role: UserRole;
+    preValidatedDeck?: ISwuDbFormatDecklist;
 }
 
 export interface IToken {
@@ -1211,7 +1214,7 @@ export class GameServer {
 
         app.post('/api/create-lobby', this.buildAuthMiddleware(), async (req, res, next) => {
             try {
-                const { deck, format, isPrivate, gamesToWinMode, lobbyName, cardPool } = req.body;
+                const { deck, format, isPrivate, gamesToWinMode, lobbyName, cardPool, archetypeFilter } = req.body;
                 const user = req.user;
 
                 // track daily active user (req.user is set by auth middleware)
@@ -1265,8 +1268,22 @@ export class GameServer {
                     return res.status(400).json({ success: false, message: bo3AccessError });
                 }
 
+                let validatedArchetypeFilter: OpponentArchetype[] | null = null;
+                if (archetypeFilter != null) {
+                    if (isPrivate) {
+                        return res.status(400).json({ success: false, message: 'Archetype filter is not allowed for private lobbies' });
+                    }
+                    if (!Array.isArray(archetypeFilter) || archetypeFilter.length === 0) {
+                        return res.status(400).json({ success: false, message: 'Archetype filter must be a non-empty array' });
+                    }
+                    if (!archetypeFilter.every((a: unknown) => typeof (a as { leaderId?: unknown })?.leaderId === 'string')) {
+                        return res.status(400).json({ success: false, message: 'Each archetype must have a leaderId' });
+                    }
+                    validatedArchetypeFilter = archetypeFilter as OpponentArchetype[];
+                }
+
                 await this.processDeckValidation(deck, true, { format, cardPool }, res, () => {
-                    this.createLobby(lobbyName, user, deck, format, gamesToWinMode, isPrivate, cardPool);
+                    this.createLobby(lobbyName, user, deck, format, gamesToWinMode, isPrivate, cardPool, validatedArchetypeFilter);
                     res.status(200).json({ success: true });
                 });
             } catch (err) {
@@ -1287,6 +1304,7 @@ export class GameServer {
                         format: lobby.format,
                         cardPool: lobby.cardPool,
                         gamesToWinMode: lobby.gamesToWinMode,
+                        archetypeFilter: lobby.archetypeFilter,
                         host: lobbyOwnerUser?.deck ? {
                             leader: lobbyOwnerUser.deck.leader,
                             base: lobbyOwnerUser.deck.base
@@ -1300,9 +1318,9 @@ export class GameServer {
             }
         });
 
-        app.post('/api/join-lobby', this.buildAuthMiddleware(), (req, res, next) => {
+        app.post('/api/join-lobby', this.buildAuthMiddleware(), async (req, res, next) => {
             try {
-                const { lobbyId } = req.body;
+                const { lobbyId, deck } = req.body;
                 const user = req.user;
 
                 // track daily active user (req.user is set by auth middleware)
@@ -1333,6 +1351,22 @@ export class GameServer {
                 if (bo3AccessError) {
                     logger.info(`GameServer (join-lobby): Anonymous user ${user.getId()} blocked from joining public Bo3 lobby ${lobbyId}`);
                     return res.status(400).json({ success: false, message: bo3AccessError });
+                }
+
+                if (lobby.archetypeFilter) {
+                    if (!deck) {
+                        return res.status(400).json({ success: false, message: 'A deck is required to join this lobby' });
+                    }
+                    await this.processDeckValidation(deck, true, { format: lobby.format, cardPool: lobby.cardPool }, res, () => {
+                        const baseAspects = this.cardDataGetter.getBaseAspectsById(deck?.base?.id);
+                        if (!deckMatchesArchetypeFilter(lobby.archetypeFilter, deck?.leader?.id, deck?.base?.id, baseAspects)) {
+                            res.status(400).json({ success: false, message: 'Your deck does not match any of this lobby\'s allowed leader/base archetypes' });
+                            return;
+                        }
+                        this.userLobbyMap.set(user.getId(), { lobbyId: lobby.id, role: UserRole.Player, preValidatedDeck: deck });
+                        res.status(200).json({ success: true });
+                    });
+                    return;
                 }
 
                 // Add the user to the lobby
@@ -1425,6 +1459,15 @@ export class GameServer {
                 return res.json(this.cardDataGetter.getLeaderCards());
             } catch (err) {
                 logger.error('GameServer (all-leaders) Server error: ', err);
+                next(err);
+            }
+        });
+
+        app.get('/api/all-base-types', (_, res, next) => {
+            try {
+                return res.json(this.cardDataGetter.getBaseTypes());
+            } catch (err) {
+                logger.error('GameServer (all-base-types) Server error: ', err);
                 next(err);
             }
         });
@@ -1888,7 +1931,8 @@ export class GameServer {
         format: SwuGameFormat,
         gamesToWinMode: GamesToWinMode,
         isPrivate: boolean,
-        cardPool: CardPool = CardPool.Current
+        cardPool: CardPool = CardPool.Current,
+        archetypeFilter: OpponentArchetype[] | null = null
     ) {
         if (!user) {
             throw new Error('User must be provided to create a lobby');
@@ -1908,6 +1952,7 @@ export class GameServer {
             this.deckValidator,
             this,
             this.discordDispatcher,
+            archetypeFilter,
             this.testGameBuilder
         );
         this.lobbies.set(lobby.id, lobby);
@@ -1927,6 +1972,7 @@ export class GameServer {
             this.deckValidator,
             this,
             this.discordDispatcher,
+            null,
             this.testGameBuilder
         );
         this.lobbies.set(lobby.id, lobby);
@@ -2054,7 +2100,7 @@ export class GameServer {
             const socket = new Socket(ioSocket);
 
             try {
-                await lobby.addLobbyUserAsync(user, socket);
+                await lobby.addLobbyUserAsync(user, socket, lobbyUserEntry.preValidatedDeck);
             } catch (err) {
                 this.userLobbyMap.delete(user.getId());
                 ioSocket.emit('connection_error', 'Error connecting to lobby');
@@ -2107,6 +2153,14 @@ export class GameServer {
             if (bo3AccessError) {
                 logger.info(`GameServer (onConnectionAsync): Anonymous user ${user.getId()} blocked from joining public Bo3 lobby ${lobby.id} via link`);
                 ioSocket.emit('connection_error', bo3AccessError);
+                ioSocket.disconnect();
+                return Promise.resolve();
+            }
+
+            // Filtered lobbies require the deck-pre-check at /api/join-lobby; link-based joins bypass it.
+            if (lobby.archetypeFilter) {
+                logger.info(`GameServer (onConnectionAsync): User ${user.getId()} attempted link-based join to filtered lobby ${lobby.id}`);
+                ioSocket.emit('connection_error', 'This lobby requires you to join from the lobby browser');
                 ioSocket.disconnect();
                 return Promise.resolve();
             }
@@ -2165,7 +2219,7 @@ export class GameServer {
         cardPool: CardPool,
         gamesToWinMode: GamesToWinMode,
         user: User,
-        deck: ISwuDbFormatDecklist
+        deck: ISwuDbFormatDecklist,
     ): boolean {
         const formatKey: IQueueFormatKey = {
             format,
@@ -2178,7 +2232,7 @@ export class GameServer {
             {
                 user,
                 deck,
-                socket: null
+                socket: null,
             }
         );
 

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -10,10 +10,11 @@ import { GameChat } from '../game/core/chat/GameChat';
 import type { User } from '../utils/user/User';
 import type { IUser } from '../Settings';
 import { getUserWithDefaultsSet } from '../Settings';
+import type { OpponentArchetype } from '../utils/archetypeFilter';
 import type { CardDataGetter } from '../utils/cardData/CardDataGetter';
 import { Deck } from '../utils/deck/Deck';
 import { DeckValidator } from '../utils/deck/DeckValidator';
-import type { IDeckValidationFailures, IDeckValidationProperties } from '../utils/deck/DeckInterfaces';
+import type { IDeckValidationFailures, IDeckValidationProperties, ISwuDbFormatDecklist } from '../utils/deck/DeckInterfaces';
 import { DeckSource, ScoreType } from '../utils/deck/DeckInterfaces';
 import type { GameConfiguration } from '../game/core/GameInterfaces';
 import { GameMode } from '../GameMode';
@@ -149,6 +150,7 @@ export class Lobby {
     private readonly discordDispatcher: DiscordDispatcher;
     private readonly previousAuthenticatedStatusByUser = new Map<string, boolean>();
     public readonly cardPool: CardPool;
+    public readonly archetypeFilter: OpponentArchetype[] | null;
 
     // configurable lobby properties
     private undoMode: UndoMode = UndoMode.Disabled;
@@ -185,6 +187,7 @@ export class Lobby {
         deckValidator: DeckValidator,
         gameServer: GameServer,
         discordDispatcher: DiscordDispatcher,
+        archetypeFilter: OpponentArchetype[] | null = null,
         testGameBuilder?: any
     ) {
         Contract.assertTrue(
@@ -206,6 +209,7 @@ export class Lobby {
         this.discordDispatcher = discordDispatcher;
         this.undoMode = matchmakingType === MatchmakingType.PrivateLobby ? UndoMode.Free : UndoMode.Request;
         this.cardPool = cardPool;
+        this.archetypeFilter = archetypeFilter;
 
         switch (gamesToWinMode) {
             case GamesToWinMode.BestOfOne:
@@ -519,7 +523,7 @@ export class Lobby {
         this.sendLobbyState();
     }
 
-    public async addLobbyUserAsync(user: User, socket: Socket): Promise<void> {
+    public async addLobbyUserAsync(user: User, socket: Socket, preValidatedDeck?: ISwuDbFormatDecklist | null): Promise<void> {
         const existingUser = this.users.find((u) => u.id === user.getId());
         const existingSpectator = this.spectators.find((s) => s.id === user.getId());
         if (existingSpectator) {
@@ -544,6 +548,7 @@ export class Lobby {
             this.checkUpdateSocket(existingUser, socket);
             logger.info(`Lobby: setting state to connected for existing user ${user.getId()} with socket id ${socket.id}`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
         } else {
+            const deck = preValidatedDeck ? new Deck(preValidatedDeck, this.cardDataGetter) : undefined;
             this.users.push({
                 id: user.getId(),
                 username: user.getUsername(),
@@ -551,6 +556,10 @@ export class Lobby {
                 ready: false,
                 socket,
                 user: socket.user,
+                deck,
+                deckValidationErrors: deck
+                    ? this.deckValidator.validateInternalDeck(deck.getDecklist(), { format: this.gameFormat, cardPool: this.cardPool })
+                    : {},
                 reportedBugs: 0
             });
             logger.info(`Lobby: adding username: ${user.getUsername()}, id: ${user.getId()}, socket id: ${socket.id} to users list (${this.users.length} user(s))`, { lobbyId: this.id, userName: user.getUsername(), userId: user.getId() });
@@ -863,7 +872,7 @@ export class Lobby {
 
         // If there's an active game that hasn't finished and no winner has been determined yet, concede it first
         // (Skip if game already has a winner, e.g., from timeout - endGame guard will prevent double-recording)
-        if (this.game && this.game.finishedAt == null && !this.game.isEnded) {
+        if (this.game && this.game.finishedAt == null && this.game.winnerNames.length === 0) {
             this.game.concede(userId);
         }
 
@@ -1777,8 +1786,8 @@ export class Lobby {
             const player2Score = isDraw ? ScoreType.Draw : winner === player1 ? ScoreType.Lose : ScoreType.Win;
 
             // Only update stats if the game has a winner and made it into the second round at least
-            if (!game.isEnded || !game.finishedAt) {
-                throw new Error(`Lobby ${this.id}: Cannot update stats for game with: ${!game.isEnded
+            if (game.winnerNames.length === 0 || !game.finishedAt) {
+                throw new Error(`Lobby ${this.id}: Cannot update stats for game with: ${game.winnerNames.length === 0
                     ? `winnerNames length being ${game.winnerNames.length}` : ''}
                     ${!game.finishedAt ? 'game finishedAt missing' : ''} `);
             }

--- a/server/utils/archetypeFilter.ts
+++ b/server/utils/archetypeFilter.ts
@@ -1,0 +1,49 @@
+import type { Aspect } from '../game/core/Constants';
+
+export type BaseConstraint =
+  | { kind: 'aspect'; aspect: Aspect }
+  | { kind: 'baseType'; baseIds: string[] };
+
+export interface OpponentArchetype {
+    leaderId: string;
+    baseConstraint?: BaseConstraint;
+
+    /** Defaults to true; `false` keeps the archetype saved but excluded from the filter. */
+    enabled?: boolean;
+}
+
+/**
+ * Lobby-side check: does the joiner's deck satisfy any of the host's allowed
+ * archetypes? Disabled archetypes are skipped; an empty active list returns
+ * false (fail-closed — opposite of the queue-side filter behavior).
+ */
+export function deckMatchesArchetypeFilter(
+    filter: readonly OpponentArchetype[],
+    deckLeaderId: string | undefined,
+    deckBaseId: string | undefined,
+    deckBaseAspects: readonly Aspect[] | undefined,
+): boolean {
+    const active = filter.filter((a) => a.enabled !== false);
+    return active.some((a) => archetypeMatchesOpponent(a, deckLeaderId, deckBaseId, deckBaseAspects));
+}
+
+export function archetypeMatchesOpponent(
+    archetype: OpponentArchetype,
+    opponentLeaderId: string | undefined,
+    opponentBaseId: string | undefined,
+    opponentBaseAspects: readonly Aspect[] | undefined,
+): boolean {
+    if (archetype.leaderId !== opponentLeaderId) {
+        return false;
+    }
+    const constraint = archetype.baseConstraint;
+    if (!constraint) {
+        return true;
+    }
+    switch (constraint.kind) {
+        case 'baseType':
+            return opponentBaseId !== undefined && constraint.baseIds.includes(opponentBaseId);
+        case 'aspect':
+            return opponentBaseAspects?.includes(constraint.aspect) ?? false;
+    }
+}

--- a/server/utils/cardData/CardDataGetter.ts
+++ b/server/utils/cardData/CardDataGetter.ts
@@ -1,4 +1,4 @@
-import type { TokenName } from '../../game/core/Constants';
+import type { Aspect, TokenName } from '../../game/core/Constants';
 import { TokenCardName, TokenUnitName, TokenUpgradeName } from '../../game/core/Constants';
 import { Contract } from '../../game/core/utils/Contract';
 import type { ICardDataJson, ICardMap, ICardMapEntry, ICardMapJson } from './CardDataInterfaces';
@@ -6,6 +6,16 @@ import type { ICardDataJson, ICardMap, ICardMapEntry, ICardMapJson } from './Car
 export type ITokenCardsData = {
     [TokenNameValue in TokenName]: ICardDataJson;
 };
+
+interface IBaseTypeCommon {
+    id: string;
+    aspects: Aspect[] | null;
+    baseIds: string[];
+}
+
+export type IBaseType =
+    | (IBaseTypeCommon & { kind: 'unique'; name: string })
+    | (IBaseTypeCommon & { kind: 'standard' | 'force' | 'splash' | 'unknown' });
 
 export abstract class CardDataGetter {
     public readonly cardMap: ICardMap;
@@ -16,12 +26,16 @@ export abstract class CardDataGetter {
     private readonly _setCodeMap: Map<string, string>;
     private readonly _tokenData: ITokenCardsData;
     private readonly _leaders: { name: string; id: string; subtitle?: string }[];
+    private readonly _baseAspectsById: Map<string, Aspect[]>;
+    private readonly _baseTypes: IBaseType[];
 
     protected static readonly setCodeMapFileName = '_setCodeMap.json';
     protected static readonly cardMapFileName = '_cardMap.json';
     protected static readonly allNonLeaderCardTitlesFileName = '_allNonLeaderCardTitles.json';
     protected static readonly playableCardTitlesFileName = '_playableCardTitles.json';
     protected static readonly leaderNamesFileName = '_leaderNames.json';
+    protected static readonly baseNamesFileName = '_baseNames.json';
+    protected static readonly baseTypesFileName = '_baseTypes.json';
 
     public get cardIds(): string[] {
         return Array.from(this.cardMap.keys());
@@ -47,6 +61,18 @@ export abstract class CardDataGetter {
         return this._leaders;
     }
 
+    public getBaseTypes(): IBaseType[] {
+        return this._baseTypes;
+    }
+
+    /** Empty array if the id is unknown or undefined. */
+    public getBaseAspectsById(baseId: string | undefined): Aspect[] {
+        if (!baseId) {
+            return [];
+        }
+        return this._baseAspectsById.get(baseId) ?? [];
+    }
+
     public constructor(
         cardMapJson: ICardMapJson,
         tokenData: ITokenCardsData,
@@ -54,6 +80,8 @@ export abstract class CardDataGetter {
         playableCardTitles: string[],
         setCodeMap: Record<string, string>,
         leaderNames: { name: string; id: string; subtitle?: string }[],
+        baseNames: { name: string; id: string; subtitle?: string; aspects: Aspect[] }[],
+        baseTypes: IBaseType[],
     ) {
         this.cardMap = new Map<string, ICardMapEntry>();
         this.knownCardInternalNames = new Set<string>();
@@ -68,6 +96,8 @@ export abstract class CardDataGetter {
         this._setCodeMap = new Map(Object.entries(setCodeMap));
         this._tokenData = tokenData;
         this._leaders = leaderNames;
+        this._baseAspectsById = new Map(baseNames.map((base) => [base.id, base.aspects]));
+        this._baseTypes = baseTypes;
     }
 
     protected abstract getCardInternalAsync(relativePath: string): Promise<ICardDataJson>;

--- a/server/utils/cardData/LocalFolderCardDataGetter.ts
+++ b/server/utils/cardData/LocalFolderCardDataGetter.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import { Contract } from '../../game/core/utils/Contract';
-import type { ITokenCardsData } from './CardDataGetter';
+import type { Aspect } from '../../game/core/Constants';
+import type { IBaseType, ITokenCardsData } from './CardDataGetter';
 import { CardDataGetter } from './CardDataGetter';
 import type { ICardDataJson, ICardMapJson } from './CardDataInterfaces';
 
@@ -34,7 +35,13 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
 
         const leaderNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.leaderNamesFileName)
             .then((data) => data as { name: string; id: string; subtitle?: string }[]);
-        return new LocalFolderCardDataGetter(folderRoot, cardMap, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames);
+
+        const baseNames = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.baseNamesFileName)
+            .then((data) => data as { name: string; id: string; subtitle?: string; aspects: Aspect[] }[]);
+
+        const baseTypes = await LocalFolderCardDataGetter.readFileAsync(folderRoot, CardDataGetter.baseTypesFileName)
+            .then((data) => data as IBaseType[]);
+        return new LocalFolderCardDataGetter(folderRoot, cardMap, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);
     }
 
     protected static validateFolderContents(directory: string, isDevelopment: boolean) {
@@ -75,8 +82,10 @@ export class LocalFolderCardDataGetter extends CardDataGetter {
         playableCardTitles: string[],
         setCodeMap: Record<string, string>,
         leaderNames: { name: string; id: string; subtitle?: string }[],
+        baseNames: { name: string; id: string; subtitle?: string; aspects: Aspect[] }[],
+        baseTypes: IBaseType[],
     ) {
-        super(cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames);
+        super(cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);
 
         this.folderRoot = folderRoot;
     }

--- a/server/utils/cardData/UnitTestCardDataGetter.ts
+++ b/server/utils/cardData/UnitTestCardDataGetter.ts
@@ -1,4 +1,6 @@
+import type { Aspect } from '../../game/core/Constants';
 import { CardDataGetter } from './CardDataGetter';
+import type { IBaseType } from './CardDataGetter';
 import type { ICardDataJson, ICardMapJson } from './CardDataInterfaces';
 import { LocalFolderCardDataGetter } from './LocalFolderCardDataGetter';
 import { Contract } from '../../game/core/utils/Contract';
@@ -43,7 +45,9 @@ export class UnitTestCardDataGetter extends LocalFolderCardDataGetter implements
         const setCodeMap = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.setCodeMapFileName) as Record<string, string>;
 
         const leaderNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.leaderNamesFileName) as { name: string; id: string; subtitle: string }[];
-        super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames);
+        const baseNames = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseNamesFileName) as { name: string; id: string; subtitle: string; aspects: Aspect[] }[];
+        const baseTypes = UnitTestCardDataGetter.readFileSync(folderRoot, CardDataGetter.baseTypesFileName) as IBaseType[];
+        super(folderRoot, cardMapJson, tokenData, allNonLeaderCardTitles, playableCardTitles, setCodeMap, leaderNames, baseNames, baseTypes);
     }
 
     public getCardSync(id: string): ICardDataJson {

--- a/test/server/utils/archetypeFilter.spec.ts
+++ b/test/server/utils/archetypeFilter.spec.ts
@@ -1,0 +1,91 @@
+import { Aspect } from '../../../server/game/core/Constants';
+import type { OpponentArchetype } from '../../../server/utils/archetypeFilter';
+import { deckMatchesArchetypeFilter } from '../../../server/utils/archetypeFilter';
+
+describe('deckMatchesArchetypeFilter', function() {
+    describe('empty filter', function() {
+        it('rejects (fail-closed: no active archetypes = no joiner accepted)', function() {
+            expect(deckMatchesArchetypeFilter([], 'SOR_001', 'SOR_022', [Aspect.Command])).toBeFalse();
+        });
+
+        it('rejects when every archetype is explicitly disabled', function() {
+            const filter: OpponentArchetype[] = [{ leaderId: 'SOR_001', enabled: false }];
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_001', 'SOR_022', [Aspect.Command])).toBeFalse();
+        });
+    });
+
+    describe('leader-only archetype', function() {
+        it('matches when leader id matches (any base)', function() {
+            const filter: OpponentArchetype[] = [{ leaderId: 'SOR_005' }];
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'SOR_999', [Aspect.Villainy])).toBeTrue();
+        });
+
+        it('rejects when leader id mismatches', function() {
+            const filter: OpponentArchetype[] = [{ leaderId: 'SOR_005' }];
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_001', 'SOR_022', [Aspect.Command])).toBeFalse();
+        });
+
+        it('rejects when joiner has no leader', function() {
+            const filter: OpponentArchetype[] = [{ leaderId: 'SOR_005' }];
+            expect(deckMatchesArchetypeFilter(filter, undefined, 'SOR_022', [Aspect.Command])).toBeFalse();
+        });
+    });
+
+    describe('leader + aspect base constraint', function() {
+        const filter: OpponentArchetype[] = [{
+            leaderId: 'SOR_005',
+            baseConstraint: { kind: 'aspect', aspect: Aspect.Command },
+        }];
+
+        it('matches when joiner base carries the required aspect', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'SOR_022', [Aspect.Command])).toBeTrue();
+        });
+
+        it('rejects when joiner base lacks the required aspect', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'SOR_022', [Aspect.Vigilance])).toBeFalse();
+        });
+
+        it('rejects when joiner base aspects are unknown', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'SOR_022', undefined)).toBeFalse();
+        });
+    });
+
+    describe('leader + specific baseType constraint', function() {
+        const filter: OpponentArchetype[] = [{
+            leaderId: 'SOR_005',
+            baseConstraint: { kind: 'baseType', baseIds: ['SOR_022', 'LOF_023'] },
+        }];
+
+        it('matches when joiner base is in the allowlist', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'LOF_023', [Aspect.Vigilance])).toBeTrue();
+        });
+
+        it('rejects when joiner base is not in the allowlist', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'SOR_999', [Aspect.Vigilance])).toBeFalse();
+        });
+    });
+
+    describe('multiple archetypes', function() {
+        const filter: OpponentArchetype[] = [
+            { leaderId: 'SOR_001' },
+            { leaderId: 'SOR_005', baseConstraint: { kind: 'aspect', aspect: Aspect.Command } },
+        ];
+
+        it('matches when any archetype matches', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_005', 'SOR_022', [Aspect.Command])).toBeTrue();
+        });
+
+        it('rejects when no archetype matches', function() {
+            expect(deckMatchesArchetypeFilter(filter, 'SOR_999', 'SOR_022', [Aspect.Command])).toBeFalse();
+        });
+
+        it('skips disabled archetypes when evaluating', function() {
+            const partiallyDisabled: OpponentArchetype[] = [
+                { leaderId: 'SOR_001', enabled: false },
+                { leaderId: 'SOR_005' },
+            ];
+            expect(deckMatchesArchetypeFilter(partiallyDisabled, 'SOR_001', 'SOR_022', [Aspect.Command])).toBeFalse();
+            expect(deckMatchesArchetypeFilter(partiallyDisabled, 'SOR_005', 'SOR_022', [Aspect.Command])).toBeTrue();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

> Draft — paired with FE draft at https://github.com/SWU-Karabast/forceteki-client/pull/677.

Add an opponent-archetype filter to public lobbies. The host of a public lobby declares which leader / base combinations they're willing to face; the server validates a joiner's deck against that filter at `/api/join-lobby` and rejects mismatches with a clear error. Private and unfiltered public lobbies are unchanged.

**Walkthrough (screenshots + flow):** https://pmossman.github.io/karabast-filtered-lobbies-walkthrough/

## What changed

- **`server/utils/archetypeFilter.ts` (new)** — `OpponentArchetype` / `BaseConstraint` types, `archetypeMatchesOpponent`, and the lobby-side `deckMatchesArchetypeFilter` helper.
- **`server/gamenode/Lobby.ts`** — gains `archetypeFilter: OpponentArchetype[] | null`; threaded through the constructor.
- **`server/gamenode/GameServer.ts`**:
  - `/api/create-lobby` accepts an optional `archetypeFilter` body field; validates shape + rejects for private lobbies.
  - `/api/available-lobbies` surfaces the filter on each lobby so the FE can render rules.
  - `/api/join-lobby` requires a `deck` when the target lobby is filtered, runs `processDeckValidation`, checks `deckMatchesArchetypeFilter`, and stashes the validated deck on the user's `userLobbyMap` entry.
  - `addLobbyUserAsync` picks up the stashed deck on first socket connect — no follow-up `changeDeck` message needed.
  - Link-based lobby joins (the `?lobbyId=…` URL) are rejected for filtered lobbies; they bypass the deck pre-check.
- **`scripts/buildBaseTypes.js` + `scripts/fetchdata.js`** — base-type grouping pipeline (groups bases by aspect + HP + rules text into "types" the host can pick from).
- **`server/utils/cardData/CardDataGetter.ts`** — `IBaseType` discriminated union (`unique` vs `standard | force | splash | unknown`) + `_baseAspectsById` map used at join-time validation.
- **`test/server/utils/archetypeFilter.spec.ts` (new)** — 13 specs covering leader-only / aspect / specific-baseType / disabled-archetype branches.

