### PR TITLE
Add support for fetching SWUDB decks directly from the BE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/gameSetups/*.json
 *.zip
 Dockerfile.test
 .claude/settings.local.json
+*.code-workspace

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -28,6 +28,7 @@ import { Contract } from '../game/core/utils/Contract';
 import { LocalFolderCardDataGetter } from '../utils/cardData/LocalFolderCardDataGetter';
 import { DeckValidator } from '../utils/deck/DeckValidator';
 import type { IDeckValidationProperties, ISwuDbFormatDecklist } from '../utils/deck/DeckInterfaces';
+import { SwuDbDeckFetcher, SwuDbFetchError } from '../utils/deck/SwuDbDeckFetcher';
 import type { IQueueFormatKey, QueuedPlayer } from './QueueHandler';
 import { QueueHandler } from './QueueHandler';
 import { Helpers } from '../game/core/utils/Helpers';
@@ -43,6 +44,7 @@ import { DiscordDispatcher } from '../game/core/DiscordDispatcher';
 import { checkServerRoleUserPrivileges } from '../utils/authUtils';
 import { CosmeticsService } from '../utils/cosmetics/CosmeticsService';
 import type { IActiveModActionCacheEntry,
+    IDeckDataEntity,
     IModerationAction } from '../services/DynamoDBInterfaces';
 import { ModActionType } from '../services/DynamoDBInterfaces';
 import {
@@ -204,6 +206,7 @@ export class GameServer {
     public readonly cosmeticsService?: CosmeticsService;
     public readonly swuStatsHandler: SwuStatsHandler;
     public readonly swuBaseHandler: SwuBaseHandler;
+    public readonly swuDbDeckFetcher: SwuDbDeckFetcher = new SwuDbDeckFetcher();
     private readonly discordDispatcher = new DiscordDispatcher();
     private readonly tokenCleanupInterval: NodeJS.Timeout;
     public readonly serverRoleUsersCache?: ServerRoleUsersCache;
@@ -1108,17 +1111,49 @@ export class GameServer {
 
         app.post('/api/save-deck', this.buildAuthMiddleware(), async (req, res, next) => {
             try {
-                const { deck } = req.body;
+                const { deck, swudbLink } = req.body;
                 const user = req.user as User;
                 if (user.isAnonymousUser()) {
-                    logger.error(`GameServer (save-deck): A anonymous user ${user.getId()} attempted to save deck ${deck.id}`);
+                    logger.error(`GameServer (save-deck): A anonymous user ${user.getId()} attempted to save deck`);
                     return res.status(401).json({
                         success: false,
                         message: 'Authentication error'
                     });
                 }
+
+                let deckEntity: IDeckDataEntity;
+                if (typeof swudbLink === 'string' && swudbLink.trim().length > 0) {
+                    let resolved;
+                    try {
+                        resolved = await this.swuDbDeckFetcher.fetchAsync(swudbLink);
+                    } catch (err) {
+                        if (err instanceof SwuDbFetchError) {
+                            return res.status(err.status).json({ success: false, error: err.message });
+                        }
+                        logger.error('GameServer (save-deck): unexpected error resolving swudbLink', err);
+                        return res.status(500).json({ success: false, error: 'Failed to resolve swudb deck link' });
+                    }
+                    deckEntity = {
+                        id: '',
+                        userId: user.getId(),
+                        deck: {
+                            leader: { id: resolved.leader?.id ?? '' },
+                            base: { id: resolved.base?.id ?? '' },
+                            name: resolved.metadata?.name || 'Untitled Deck',
+                            favourite: false,
+                            deckLink: swudbLink,
+                            deckLinkID: resolved.deckID ?? '',
+                            source: 'SWUDB',
+                        },
+                    };
+                } else if (deck) {
+                    deckEntity = deck;
+                } else {
+                    return res.status(400).json({ success: false, error: 'No deck or swudbLink provided' });
+                }
+
                 // we save the deck
-                const newDeck = await this.deckService.saveDeckAsync(deck, user);
+                const newDeck = await this.deckService.saveDeckAsync(deckEntity, user);
                 return res.status(200).json({
                     success: true,
                     message: 'Deck saved successfully',
@@ -1200,6 +1235,77 @@ export class GameServer {
             }
         });
 
+        // Resolves a swudb.com deck-share URL into a full decklist payload.
+        // Used by the FE to preview decks before submitting them to other
+        // endpoints (create-lobby, enter-queue, save-deck) and to re-render
+        // saved decks on the deck view page.
+        app.post('/api/resolve-deck-link', this.buildAuthMiddleware('resolve-deck-link'), async (req, res, next) => {
+            try {
+                const { deckLink } = req.body;
+                if (typeof deckLink !== 'string' || deckLink.trim().length === 0) {
+                    return res.status(400).json({ success: false, error: 'Missing deckLink' });
+                }
+                if (!deckLink.includes('swudb.com')) {
+                    return res.status(400).json({ success: false, error: 'Only swudb.com links are supported by this endpoint' });
+                }
+
+                try {
+                    const resolvedDeck = await this.swuDbDeckFetcher.fetchAsync(deckLink);
+                    return res.status(200).json({ success: true, deck: resolvedDeck });
+                } catch (err) {
+                    if (err instanceof SwuDbFetchError) {
+                        return res.status(err.status).json({ success: false, error: err.message });
+                    }
+                    throw err;
+                }
+            } catch (err) {
+                logger.error('GameServer (resolve-deck-link) Server error :', err);
+                next(err);
+            }
+        });
+
+        // Lobby-scoped deck change. Mirrors the `changeDeck` socket message
+        // but accepts an optional `swudbLink` for server-side deck resolution.
+        // The caller must be a Player currently in `:lobbyId`.
+        app.post('/api/lobby/:lobbyId/change-deck', this.buildAuthMiddleware('lobby-change-deck'), async (req, res, next) => {
+            try {
+                const { lobbyId } = req.params;
+                const { deck, swudbLink } = req.body;
+                const user = req.user as User;
+
+                const mapping = this.userLobbyMap.get(user.getId());
+                if (!mapping || mapping.lobbyId !== lobbyId || mapping.role !== UserRole.Player) {
+                    return res.status(403).json({
+                        success: false,
+                        error: 'Not a player in this lobby',
+                        errorCode: 'NotLobbyMember',
+                    });
+                }
+
+                const lobby = this.lobbies.get(lobbyId);
+                if (!lobby) {
+                    return res.status(404).json({ success: false, error: 'Lobby not found' });
+                }
+
+                const resolvedDeck = await this.resolveDeckInputAsync({ deck, swudbLink }, res);
+                if (!resolvedDeck) {
+                    return;
+                }
+
+                try {
+                    const importDeckErrors = lobby.changeDeckForUser(user.getId(), resolvedDeck);
+                    lobby.sendLobbyState();
+                    return res.status(200).json({ success: true, importDeckErrors });
+                } catch (err) {
+                    const message = err instanceof Error ? err.message : 'Failed to change deck';
+                    return res.status(400).json({ success: false, error: message });
+                }
+            } catch (err) {
+                logger.error('GameServer (lobby-change-deck) Server error :', err);
+                next(err);
+            }
+        });
+
         app.get('/api/ongoing-games', (_, res, next) => {
             try {
                 return res.json(this.getOngoingGamesData());
@@ -1211,7 +1317,7 @@ export class GameServer {
 
         app.post('/api/create-lobby', this.buildAuthMiddleware(), async (req, res, next) => {
             try {
-                const { deck, format, isPrivate, gamesToWinMode, lobbyName, cardPool } = req.body;
+                const { deck, swudbLink, format, isPrivate, gamesToWinMode, lobbyName, cardPool } = req.body;
                 const user = req.user;
 
                 // track daily active user (req.user is set by auth middleware)
@@ -1265,8 +1371,15 @@ export class GameServer {
                     return res.status(400).json({ success: false, message: bo3AccessError });
                 }
 
-                await this.processDeckValidation(deck, true, { format, cardPool }, res, () => {
-                    this.createLobby(lobbyName, user, deck, format, gamesToWinMode, isPrivate, cardPool);
+                const resolvedDeck = await this.resolveDeckInputAsync({ deck, swudbLink }, res);
+                if (!resolvedDeck) {
+                    return;
+                }
+
+                await this.processDeckValidation(resolvedDeck, true, { format, cardPool }, res, () => {
+                    // createLobby's `deck` parameter is mistyped as `Deck` but receives the raw
+                    // decklist at runtime; cast preserves the pre-existing behavior.
+                    this.createLobby(lobbyName, user, resolvedDeck as any, format, gamesToWinMode, isPrivate, cardPool);
                     res.status(200).json({ success: true });
                 });
             } catch (err) {
@@ -1367,7 +1480,7 @@ export class GameServer {
 
         app.post('/api/enter-queue', this.buildAuthMiddleware(), async (req, res, next) => {
             try {
-                const { format, cardPool, gamesToWinMode, deck } = req.body;
+                const { format, cardPool, gamesToWinMode, deck, swudbLink } = req.body;
                 const user = req.user;
 
                 // track daily active user (req.user is set by auth middleware)
@@ -1397,8 +1510,13 @@ export class GameServer {
                     return res.status(400).json({ success: false, message: bo3AccessError });
                 }
 
-                await this.processDeckValidation(deck, false, { format, cardPool }, res, () => {
-                    const success = this.enterQueue(format, cardPool, gamesToWinMode, user, deck);
+                const resolvedDeck = await this.resolveDeckInputAsync({ deck, swudbLink }, res);
+                if (!resolvedDeck) {
+                    return;
+                }
+
+                await this.processDeckValidation(resolvedDeck, false, { format, cardPool }, res, () => {
+                    const success = this.enterQueue(format, cardPool, gamesToWinMode, user, resolvedDeck);
                     if (!success) {
                         logger.error(`GameServer (enter-queue): Error in enter-queue User ${user.getId()} failed to enter queue`);
                         return res.status(500).json({ success: false, message: 'Failed to enter queue' });
@@ -1778,6 +1896,43 @@ export class GameServer {
 
     public getUserLobbyId(userId: string): string | undefined {
         return this.userLobbyMap.get(userId)?.lobbyId;
+    }
+
+    /**
+     * Resolves the deck input for endpoints that accept either a pre-resolved
+     * `deck` payload or a `swudbLink` to be fetched server-side.
+     *
+     * If `swudbLink` is provided, fetches the deck from swudb.com via
+     * {@link SwuDbDeckFetcher}. On failure, writes the appropriate error
+     * response to `res` and returns `null` so the caller can short-circuit.
+     *
+     * If only `deck` is provided, returns it unchanged. If neither is
+     * provided, writes a 400 to `res` and returns `null`.
+     */
+    private async resolveDeckInputAsync(
+        body: { deck?: ISwuDbFormatDecklist; swudbLink?: string },
+        res: express.Response
+    ): Promise<ISwuDbFormatDecklist | null> {
+        if (typeof body.swudbLink === 'string' && body.swudbLink.trim().length > 0) {
+            try {
+                return await this.swuDbDeckFetcher.fetchAsync(body.swudbLink);
+            } catch (err) {
+                if (err instanceof SwuDbFetchError) {
+                    res.status(err.status).json({ success: false, error: err.message });
+                    return null;
+                }
+                logger.error('GameServer (resolveDeckInputAsync): unexpected error resolving swudbLink', err);
+                res.status(500).json({ success: false, error: 'Failed to resolve swudb deck link' });
+                return null;
+            }
+        }
+
+        if (body.deck) {
+            return body.deck;
+        }
+
+        res.status(400).json({ success: false, error: 'No deck or swudbLink provided' });
+        return null;
     }
 
     // method for validating the deck via API

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -13,7 +13,7 @@ import { getUserWithDefaultsSet } from '../Settings';
 import type { CardDataGetter } from '../utils/cardData/CardDataGetter';
 import { Deck } from '../utils/deck/Deck';
 import { DeckValidator } from '../utils/deck/DeckValidator';
-import type { IDeckValidationFailures, IDeckValidationProperties } from '../utils/deck/DeckInterfaces';
+import type { IDeckValidationFailures, IDeckValidationProperties, ISwuDbFormatDecklist } from '../utils/deck/DeckInterfaces';
 import { DeckSource, ScoreType } from '../utils/deck/DeckInterfaces';
 import type { GameConfiguration } from '../game/core/GameInterfaces';
 import { GameMode } from '../GameMode';
@@ -947,22 +947,33 @@ export class Lobby {
     }
 
     private changeDeck(socket: Socket, ...args) {
-        // Changing decks is not allowed after game 1 in a Bo3 set
-        Contract.assertFalse(
-            this.winHistory.gamesToWinMode === GamesToWinMode.BestOfThree && this.winHistory.currentGameNumber >= 2,
-            'Changing decks is not allowed after game 1 in a Bo3 set'
-        );
+        this.changeDeckForUser(socket.user.getId(), args[0]);
+    }
 
-        const activeUser = this.users.find((u) => u.id === socket.user.getId());
+    /**
+     * Applies a deck-change for the given user in this lobby. Used by both the
+     * `changeDeck` socket handler and the lobby-scoped REST endpoint
+     * (`POST /api/lobby/:lobbyId/change-deck`). Throws if the lobby is in a
+     * Bo3 game ≥ 2 state where deck-changes are disallowed; callers should
+     * translate that to an appropriate user-facing error.
+     */
+    public changeDeckForUser(userId: string, deck: ISwuDbFormatDecklist): IDeckValidationFailures | undefined {
+        // Changing decks is not allowed after game 1 in a Bo3 set
+        if (this.winHistory.gamesToWinMode === GamesToWinMode.BestOfThree && this.winHistory.currentGameNumber >= 2) {
+            throw new Error('Changing decks is not allowed after game 1 in a Bo3 set');
+        }
+
+        const activeUser = this.users.find((u) => u.id === userId);
+        Contract.assertNotNullLike(activeUser, `Lobby.changeDeckForUser: user ${userId} not found in lobby ${this.id}`);
 
         // we check if the deck is valid.
         const validationProperties: IDeckValidationProperties = { format: this.gameFormat, cardPool: this.cardPool };
-        activeUser.importDeckValidationErrors = this.deckValidator.validateSwuDbDeck(args[0], validationProperties);
+        activeUser.importDeckValidationErrors = this.deckValidator.validateSwuDbDeck(deck, validationProperties);
 
         // if the deck doesn't have any errors that block import, set it as active
         const filteredErrors = DeckValidator.filterOutSideboardingErrors(activeUser.importDeckValidationErrors);
         if (Object.keys(filteredErrors).length === 0) {
-            activeUser.deck = new Deck(args[0], this.cardDataGetter);
+            activeUser.deck = new Deck(deck, this.cardDataGetter);
             activeUser.deckValidationErrors = this.deckValidator.validateInternalDeck(
                 activeUser.deck.getDecklist(),
                 validationProperties
@@ -976,6 +987,8 @@ export class Lobby {
         logger.info(`Lobby: user ${activeUser.username} changing deck`, { lobbyId: this.id, userName: activeUser.username, userId: activeUser.id });
 
         this.updateUserLastActivity(activeUser.id);
+
+        return activeUser.importDeckValidationErrors;
     }
 
     private updateDeck(socket: Socket, ...args) {

--- a/server/utils/deck/SwuDbDeckFetcher.ts
+++ b/server/utils/deck/SwuDbDeckFetcher.ts
@@ -1,0 +1,130 @@
+import { logger } from '../../logger';
+import type { ISwuDbFormatDecklist } from './DeckInterfaces';
+
+/**
+ * Typed error returned from {@link SwuDbDeckFetcher.fetchAsync}. The HTTP
+ * `status` and user-facing `message` are designed to be passed through to the
+ * client unchanged so the existing FE error-handling UX is preserved.
+ */
+export class SwuDbFetchError extends Error {
+    public readonly status: number;
+
+    public constructor(status: number, message: string) {
+        super(message);
+        this.name = 'SwuDbFetchError';
+        this.status = status;
+    }
+}
+
+interface ISwuDbApiResponse {
+    metadata?: { name?: string; author?: string };
+    leader?: { id?: string; count?: number };
+    secondleader?: { id?: string; count?: number } | null;
+    base?: { id?: string; count?: number };
+    deck?: { id?: string; count?: number }[];
+    sideboard?: { id?: string; count?: number }[];
+}
+
+/**
+ * Resolves a swudb.com deck-share URL into an {@link ISwuDbFormatDecklist} by
+ * calling swudb's public deck-export API. Mirrors the upstream-error to
+ * client-error mapping previously implemented in the Amplify Next.js route at
+ * `forceteki-client/src/app/api/swudbdeck/route.ts` so the FE messaging is
+ * preserved when the call is moved to the backend.
+ */
+export class SwuDbDeckFetcher {
+    private static readonly TIMEOUT_MS = 8000;
+    private static readonly MAX_ATTEMPTS = 2; // 1 initial + 1 retry on 5xx / network
+
+    public async fetchAsync(deckLink: string): Promise<ISwuDbFormatDecklist> {
+        if (typeof deckLink !== 'string' || deckLink.trim().length === 0) {
+            throw new SwuDbFetchError(400, 'Invalid deckLink format');
+        }
+
+        if (!deckLink.includes('swudb.com')) {
+            throw new SwuDbFetchError(400, 'Invalid deckLink format');
+        }
+
+        const match = deckLink.match(/\/([^\/]+)\/?$/);
+        const deckId = match ? match[1] : null;
+        if (!deckId) {
+            throw new SwuDbFetchError(400, 'Invalid deckLink format');
+        }
+
+        const apiUrl = `https://swudb.com/api/getDeckJson/${deckId}`;
+        const response = await this.fetchWithRetryAsync(apiUrl);
+
+        if (!response.ok) {
+            if (response.status === 403) {
+                throw new SwuDbFetchError(403, 'Deck is set to Private. Change deck to unlisted on swudb');
+            }
+            if (response.status === 404) {
+                throw new SwuDbFetchError(404, 'Deck not found. Make sure the deck exists on swudb.com.');
+            }
+            logger.error(`SwuDbDeckFetcher: SWUDB API error: ${response.status} ${response.statusText}`);
+            throw new SwuDbFetchError(502, `SWUDB API error: ${response.statusText || response.status}`);
+        }
+
+        let raw: ISwuDbApiResponse;
+        try {
+            raw = await response.json() as ISwuDbApiResponse;
+        } catch (err) {
+            logger.error('SwuDbDeckFetcher: Failed to parse SWUDB API response as JSON', err);
+            throw new SwuDbFetchError(502, 'SWUDB API error: invalid response body');
+        }
+
+        return {
+            metadata: {
+                name: raw.metadata?.name ?? '',
+                author: raw.metadata?.author ?? '',
+            },
+            leader: raw.leader as ISwuDbFormatDecklist['leader'],
+            secondleader: raw.secondleader as ISwuDbFormatDecklist['secondleader'],
+            base: raw.base as ISwuDbFormatDecklist['base'],
+            deck: raw.deck as ISwuDbFormatDecklist['deck'],
+            sideboard: raw.sideboard as ISwuDbFormatDecklist['sideboard'],
+            deckID: deckId,
+            deckLink,
+        };
+    }
+
+    private async fetchWithRetryAsync(apiUrl: string): Promise<Response> {
+        let lastNetworkError: unknown = null;
+        for (let attempt = 1; attempt <= SwuDbDeckFetcher.MAX_ATTEMPTS; attempt++) {
+            try {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), SwuDbDeckFetcher.TIMEOUT_MS);
+                try {
+                    const response = await fetch(apiUrl, {
+                        method: 'GET',
+                        signal: controller.signal,
+                    });
+
+                    // retry on 5xx
+                    if (response.status >= 500 && response.status < 600 && attempt < SwuDbDeckFetcher.MAX_ATTEMPTS) {
+                        logger.warn(`SwuDbDeckFetcher: SWUDB API returned ${response.status}, retrying (attempt ${attempt})`);
+                        continue;
+                    }
+
+                    return response;
+                } finally {
+                    clearTimeout(timeout);
+                }
+            } catch (err) {
+                lastNetworkError = err;
+                const isAbort = err instanceof Error && err.name === 'AbortError';
+                if (attempt < SwuDbDeckFetcher.MAX_ATTEMPTS && !isAbort) {
+                    logger.warn(`SwuDbDeckFetcher: network error on attempt ${attempt}, retrying`, err);
+                    continue;
+                }
+                if (isAbort) {
+                    throw new SwuDbFetchError(504, 'SWUDB API request timed out');
+                }
+                break;
+            }
+        }
+
+        logger.error('SwuDbDeckFetcher: Failed to fetch from SWUDB API', lastNetworkError);
+        throw new SwuDbFetchError(502, 'SWUDB API error: network failure');
+    }
+}


### PR DESCRIPTION
FE PR: https://github.com/SWU-Karabast/forceteki-client/pull/679

We are migrating the SWUDB decklist fetching out of the Amplify server directly into the BE. This PR adds a "swudbLink" parameter on relevant APIs so that when a swudb list is being used, the FE can directly populate the link and then it will be retrieved as part of the BE request processing.

Other deckbuilders will continue to be supported via the existing setup (passing in the actual decklist contents) since all other deckbuilder calls will be moved to the client code.

Also added some additional logic to support the Decks and Lobby pages in the FE in order to be able to interact with swudb decks and get the contents for rendering.