### PR TITLE
Gar Saxon Coveting Power card implementation

### DIFF
--- a/server/game/cards/08_ASH/units/GarSaxonCovetingPower.ts
+++ b/server/game/cards/08_ASH/units/GarSaxonCovetingPower.ts
@@ -1,0 +1,24 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+
+export default class GarSaxonCovetingPower extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'gar-saxon#coveting-power-id',
+            internalName: 'gar-saxon#coveting-power',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper): void {
+        registrar.addTriggeredAbility({
+            title: 'Create a Mandalorian token',
+            when: {
+                onCardPlayed: (event, context) => event.player === context.player && event.card.isUpgrade() && event.attachTarget === context.source
+            },
+            optional: true,
+            limit: AbilityHelper.limit.perRound(1),
+            immediateEffect: AbilityHelper.immediateEffects.createMandalorian()
+        });
+    }
+}

--- a/test/server/cards/08_ASH/units/GarSaxonCovetingPower.spec.ts
+++ b/test/server/cards/08_ASH/units/GarSaxonCovetingPower.spec.ts
@@ -5,11 +5,11 @@ describe('Gar Saxon, Coveting Power', function () {
                 return contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        hand: ['electrostaff', 'jedi-lightsaber', 'snapshot-reflexes'],
+                        hand: ['electrostaff', 'jedi-lightsaber', 'infiltrators-skill'],
                         groundArena: ['gar-saxon#coveting-power', 'battlefield-marine'],
                     },
                     player2: {
-                        hand: ['academy-training'],
+                        hand: ['academy-training', 'devotion'],
                         groundArena: ['wampa']
                     }
                 });
@@ -45,14 +45,20 @@ describe('Gar Saxon, Coveting Power', function () {
             it('should not trigger when an upgrade is played on another unit or by the opponent', function () {
                 const { context } = contextRef;
 
-                context.player1.clickCard(context.snapshotReflexes);
+                context.player1.clickCard(context.infiltratorsSkill);
                 context.player1.clickCard(context.battlefieldMarine);
-                context.player1.clickPrompt('Pass');
                 expect(context.player2).toBeActivePlayer();
                 expect(context.player1.findCardsByName('mandalorian').length).toBe(0);
 
                 context.player2.clickCard(context.academyTraining);
                 context.player2.clickCard(context.wampa);
+                expect(context.player1).toBeActivePlayer();
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(0);
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.devotion);
+                context.player2.clickCard(context.garSaxon);
                 expect(context.player1).toBeActivePlayer();
                 expect(context.player1.findCardsByName('mandalorian').length).toBe(0);
             });
@@ -67,9 +73,8 @@ describe('Gar Saxon, Coveting Power', function () {
 
                 context.player2.passAction();
 
-                context.player1.clickCard(context.snapshotReflexes);
+                context.player1.clickCard(context.infiltratorsSkill);
                 context.player1.clickCard(context.garSaxon);
-                context.player1.clickPrompt('Pass');
                 expect(context.player2).toBeActivePlayer();
                 expect(context.player1.findCardsByName('mandalorian').length).toBe(1);
 

--- a/test/server/cards/08_ASH/units/GarSaxonCovetingPower.spec.ts
+++ b/test/server/cards/08_ASH/units/GarSaxonCovetingPower.spec.ts
@@ -1,0 +1,88 @@
+describe('Gar Saxon, Coveting Power', function () {
+    integration(function (contextRef) {
+        describe('Gar Saxon\'s ability', function () {
+            beforeEach(function () {
+                return contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['electrostaff', 'jedi-lightsaber', 'snapshot-reflexes'],
+                        groundArena: ['gar-saxon#coveting-power', 'battlefield-marine'],
+                    },
+                    player2: {
+                        hand: ['academy-training'],
+                        groundArena: ['wampa']
+                    }
+                });
+            });
+
+            it('should create a Mandalorian token when an upgrade is played on Gar Saxon', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.electrostaff);
+                context.player1.clickCard(context.garSaxon);
+
+                expect(context.player1).toHaveEnabledPromptButtons(['Create a Mandalorian token', 'Pass']);
+                context.player1.clickPrompt('Trigger');
+
+                const mandalorians = context.player1.findCardsByName('mandalorian');
+                expect(mandalorians.length).toBe(1);
+                expect(mandalorians[0]).toBeInZone('groundArena');
+                expect(mandalorians[0].exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should not create a Mandalorian token when declined', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.electrostaff);
+                context.player1.clickCard(context.garSaxon);
+                context.player1.clickPrompt('Pass');
+
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(0);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should not trigger when an upgrade is played on another unit or by the opponent', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.snapshotReflexes);
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickPrompt('Pass');
+                expect(context.player2).toBeActivePlayer();
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(0);
+
+                context.player2.clickCard(context.academyTraining);
+                context.player2.clickCard(context.wampa);
+                expect(context.player1).toBeActivePlayer();
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(0);
+            });
+
+            it('should only be usable once each round', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.electrostaff);
+                context.player1.clickCard(context.garSaxon);
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(1);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.snapshotReflexes);
+                context.player1.clickCard(context.garSaxon);
+                context.player1.clickPrompt('Pass');
+                expect(context.player2).toBeActivePlayer();
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(1);
+
+                context.moveToNextActionPhase();
+
+                context.player1.clickCard(context.jediLightsaber);
+                context.player1.clickCard(context.garSaxon);
+                expect(context.player1).toHaveEnabledPromptButtons(['Create a Mandalorian token', 'Pass']);
+                context.player1.clickPrompt('Trigger');
+
+                expect(context.player1.findCardsByName('mandalorian').length).toBe(2);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+    });
+});


### PR DESCRIPTION
| ⟡ Gar Saxon |
| :----: |
| Coveting Power |
| <img width=450 src="https://github.com/user-attachments/assets/62a39424-3c10-42ea-a698-0f5ad759f612" /> |

Test file:
```json
{
    "phase": "action",
    "player1": {
        "hand": ["electrostaff", "jedi-lightsaber", "infiltrators-skill"],
        "groundArena": ["gar-saxon#coveting-power", "battlefield-marine"],
        "resources": 10,
        "base": "echo-base",
        "leader": "luke-skywalker#faithful-friend"
    },
    "player2": {
        "hand": ["academy-training", "devotion"],
        "groundArena": ["wampa"],
        "resources": 10,
        "base": "chopper-base",
        "leader": "sabine-wren#galvanized-revolutionary"
    }
}

```

