### PR TITLE
Shin Hati's Fiend Fighter card implementation

### DIFF
--- a/server/game/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.ts
+++ b/server/game/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.ts
@@ -1,0 +1,33 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { WildcardCardType } from '../../../core/Constants';
+import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
+
+export default class ShinHatisFiendFighterCompactAndAgile extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'shin-hatis-fiend-fighter#compact-and-agile-id',
+            internalName: 'shin-hatis-fiend-fighter#compact-and-agile',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addWhenDefeatedAbility({
+            title: 'Give 2 Advantage tokens to a unit, or 3 instead if this unit wasn\'t defeated by combat damage',
+            contextTitle: (context) => `Give ${this.getAdvantageTokenAmount(context)} Advantage tokens to a unit`,
+            optional: true,
+            targetResolver: {
+                cardTypeFilter: WildcardCardType.Unit,
+                immediateEffect: abilityHelper.immediateEffects.giveAdvantage((context) => ({
+                    amount: this.getAdvantageTokenAmount(context)
+                }))
+            }
+        });
+    }
+
+    private getAdvantageTokenAmount(context: TriggeredAbilityContext) {
+        return context.event.defeatSource.type === DefeatSourceType.Attack ? 2 : 3;
+    }
+}

--- a/test/server/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.spec.ts
+++ b/test/server/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.spec.ts
@@ -56,6 +56,35 @@ describe('Shin Hati\'s Fiend Fighter, Compact and Agile', function() {
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['advantage', 'advantage', 'advantage']);
             });
 
+            it('may give 3 Advantage tokens to an enemy unit when defeated by No Glory Only Results', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['shin-hatis-fiend-fighter#compact-and-agile']
+                    },
+                    player2: {
+                        hand: ['no-glory-only-results'],
+                        groundArena: ['wampa'],
+                        resources: 10,
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.noGloryOnlyResults);
+                context.player2.clickCard(context.shinHatisFiendFighter);
+
+                expect(context.player2).toHavePrompt('Give 3 Advantage tokens to a unit');
+                expect(context.player2).toBeAbleToSelectExactly([context.battlefieldMarine, context.wampa]);
+                expect(context.player2).toHavePassAbilityButton();
+                context.player2.clickCard(context.wampa);
+
+                expect(context.wampa).toHaveExactUpgradeNames(['advantage', 'advantage', 'advantage']);
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames([]);
+            });
+
             it('may be passed', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',

--- a/test/server/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.spec.ts
+++ b/test/server/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.spec.ts
@@ -1,0 +1,83 @@
+describe('Shin Hati\'s Fiend Fighter, Compact and Agile', function() {
+    integration(function(contextRef) {
+        describe('When Defeated ability', function() {
+            it('may give 2 Advantage tokens to a unit when defeated by combat damage', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['shin-hatis-fiend-fighter#compact-and-agile']
+                    },
+                    player2: {
+                        spaceArena: ['green-squadron-awing']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.shinHatisFiendFighter);
+                context.player1.clickCard(context.greenSquadronAwing);
+
+                expect(context.shinHatisFiendFighter).toBeInZone('discard');
+                expect(context.greenSquadronAwing).toBeInZone('discard');
+                expect(context.player1).toHavePrompt('Give 2 Advantage tokens to a unit');
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
+                expect(context.player1).toHavePassAbilityButton();
+
+                context.player1.clickCard(context.battlefieldMarine);
+
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames(['advantage', 'advantage']);
+            });
+
+            it('may give 3 Advantage tokens to a unit instead when not defeated by combat damage', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['shin-hatis-fiend-fighter#compact-and-agile']
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        resources: 10
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.passAction();
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.shinHatisFiendFighter);
+
+                expect(context.player1).toHavePrompt('Give 3 Advantage tokens to a unit');
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickCard(context.battlefieldMarine);
+
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames(['advantage', 'advantage', 'advantage']);
+            });
+
+            it('may be passed', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['shin-hatis-fiend-fighter#compact-and-agile']
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        resources: 10
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.passAction();
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.shinHatisFiendFighter);
+                context.player1.clickPrompt('Pass');
+
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames([]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
| ⟡ Shin Hati's Fiend Fighter |
| :----: |
| Compact And Agile |
| <img width=450 src="https://github.com/user-attachments/assets/05220c3f-c9e2-4369-a950-a5ab63588dff" /> |

Game setup for proper testing (enemy with one defeat card and one space unit to test both defeats)

```json 
{
    "phase": "action",
    "player1": {
        "groundArena": ["battlefield-marine", "scarif-lieutenant"],
        "spaceArena": ["shin-hatis-fiend-fighter#compact-and-agile"],
        "base": "echo-base",
        "leader": "luke-skywalker#faithful-friend"
    },
    "player2": {
        "hand": ["vanquish"],
        "spaceArena": ["green-squadron-awing"],
        "resources": 10,
        "base": "chopper-base",
        "leader": "sabine-wren#galvanized-revolutionary",
        "hasInitiative": true
    }
}

```

Test NGOR behavior (advantage tokens go to the enemy):
```json
{
    "phase": "action",
    "player1": {
        "groundArena": ["battlefield-marine"],
        "spaceArena": ["shin-hatis-fiend-fighter#compact-and-agile"],
        "base": "echo-base",
        "leader": "luke-skywalker#faithful-friend"
    },
    "player2": {
        "hand": ["no-glory-only-results"],
        "groundArena": ["wampa"],
        "resources": 10,
        "base": "chopper-base",
        "leader": "sabine-wren#galvanized-revolutionary",
        "hasInitiative": true
    }
}

```