### PR TITLE
Eye Of Sion card implementation

### DIFF
--- a/server/game/cards/08_ASH/units/EyeOfSionDeliveredFromExile.ts
+++ b/server/game/cards/08_ASH/units/EyeOfSionDeliveredFromExile.ts
@@ -15,6 +15,7 @@ export default class EyeOfSionDeliveredFromExile extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper): void {
         registrar.addActionAbility({
             title: 'Search the top 8 cards of your deck for a unit that costs the same as or less than this unit\'s power. Play it for free. It enters play ready.',
+            contextTitle: (context) => `Search the top 8 cards of your deck for a unit that costs ${context.source.getPower()} or less. Play it for free. It enters play ready.`,
             cost: abilityHelper.costs.exhaustSelf(),
             immediateEffect: abilityHelper.immediateEffects.deckSearch({
                 targetMode: TargetMode.Single,

--- a/server/game/cards/08_ASH/units/EyeOfSionDeliveredFromExile.ts
+++ b/server/game/cards/08_ASH/units/EyeOfSionDeliveredFromExile.ts
@@ -1,0 +1,31 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { TargetMode, WildcardCardType } from '../../../core/Constants';
+import { CostAdjustType } from '../../../core/cost/CostAdjuster';
+
+export default class EyeOfSionDeliveredFromExile extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'eye-of-sion#delivered-from-exile-id',
+            internalName: 'eye-of-sion#delivered-from-exile',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper): void {
+        registrar.addActionAbility({
+            title: 'Search the top 8 cards of your deck for a unit that costs the same as or less than this unit\'s power. Play it for free. It enters play ready.',
+            cost: abilityHelper.costs.exhaustSelf(),
+            immediateEffect: abilityHelper.immediateEffects.deckSearch({
+                targetMode: TargetMode.Single,
+                searchCount: 8,
+                cardCondition: (card, context) => card.isUnit() && card.cost <= context.source.getPower(),
+                selectedCardsImmediateEffect: abilityHelper.immediateEffects.playCardFromOutOfPlay({
+                    adjustCost: { costAdjustType: CostAdjustType.Free },
+                    entersReady: true,
+                    playAsType: WildcardCardType.Unit,
+                }),
+            }),
+        });
+    }
+}

--- a/test/server/cards/08_ASH/units/EyeOfSionDeliveredFromExile.spec.ts
+++ b/test/server/cards/08_ASH/units/EyeOfSionDeliveredFromExile.spec.ts
@@ -1,0 +1,156 @@
+describe('Eye of Sion, Delivered From Exile', function() {
+    integration(function(contextRef) {
+        const abilityTitle = 'Search the top 8 cards of your deck for a unit that costs the same as or less than this unit\'s power. Play it for free. It enters play ready.';
+
+        it('should search the top 8 cards for a unit with cost equal to or less than its power, play it for free, and ready it', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['eye-of-sion#delivered-from-exile'],
+                    deck: [
+                        'wampa',
+                        'green-squadron-awing',
+                        'atst',
+                        'repair',
+                        'vanguard-infantry',
+                        'takedown',
+                        'pyke-sentinel',
+                        'battlefield-marine',
+                        'blue-squadron-assault-wing'
+                    ],
+                    resources: 1
+                }
+            });
+
+            const { context } = contextRef;
+            const readyResources = context.player1.readyResourceCount;
+
+            context.player1.clickCard(context.eyeOfSion);
+            expect(context.player1).toHavePrompt('Choose an ability:');
+            context.player1.clickPrompt(abilityTitle);
+
+            expect(context.player1).toHaveExactDisplayPromptCards({
+                selectable: [
+                    context.wampa,
+                    context.greenSquadronAwing,
+                    context.vanguardInfantry,
+                    context.pykeSentinel,
+                    context.battlefieldMarine
+                ],
+                invalid: [
+                    context.atst,
+                    context.repair,
+                    context.takedown
+                ]
+            });
+            expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+            expect(context.player1).not.toHaveEnabledPromptButton('Done');
+
+            context.player1.clickCardInDisplayCardPrompt(context.greenSquadronAwing);
+
+            expect(context.eyeOfSion.exhausted).toBeTrue();
+            expect(context.greenSquadronAwing).toBeInZone('spaceArena', context.player1);
+            expect(context.greenSquadronAwing.exhausted).toBeFalse();
+            expect(context.player1.readyResourceCount).toBe(readyResources);
+            expect([
+                context.wampa,
+                context.atst,
+                context.repair,
+                context.vanguardInfantry,
+                context.takedown,
+                context.pykeSentinel,
+                context.battlefieldMarine
+            ]).toAllBeInBottomOfDeck(context.player1, 7);
+            expect(context.player1.deck[0]).toBe(context.blueSquadronAssaultWing);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should use this unit\'s current power when checking eligible unit costs', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: [{ card: 'eye-of-sion#delivered-from-exile', upgrades: ['experience'] }],
+                    deck: [
+                        'blue-squadron-assault-wing',
+                        'atst',
+                        'repair',
+                        'vanguard-infantry',
+                        'takedown',
+                        'pyke-sentinel',
+                        'battlefield-marine',
+                        'green-squadron-awing'
+                    ],
+                    resources: 1
+                }
+            });
+
+            const { context } = contextRef;
+
+            expect(context.eyeOfSion.getPower()).toBe(5);
+
+            context.player1.clickCard(context.eyeOfSion);
+            context.player1.clickPrompt(abilityTitle);
+
+            expect(context.player1).toHaveExactDisplayPromptCards({
+                selectable: [
+                    context.blueSquadronAssaultWing,
+                    context.vanguardInfantry,
+                    context.pykeSentinel,
+                    context.battlefieldMarine,
+                    context.greenSquadronAwing
+                ],
+                invalid: [
+                    context.atst,
+                    context.repair,
+                    context.takedown
+                ]
+            });
+
+            context.player1.clickCardInDisplayCardPrompt(context.blueSquadronAssaultWing);
+
+            expect(context.blueSquadronAssaultWing).toBeInZone('spaceArena', context.player1);
+            expect(context.blueSquadronAssaultWing.exhausted).toBeFalse();
+            expect(context.player1.readyResourceCount).toBe(1);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should allow taking nothing and move only the searched cards to the bottom of the deck', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['eye-of-sion#delivered-from-exile'],
+                    deck: [
+                        'wampa',
+                        'green-squadron-awing',
+                        'atst',
+                        'repair',
+                        'vanguard-infantry',
+                        'takedown',
+                        'pyke-sentinel',
+                        'battlefield-marine',
+                        'blue-squadron-assault-wing'
+                    ]
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.eyeOfSion);
+            context.player1.clickPrompt(abilityTitle);
+            context.player1.clickPrompt('Take nothing');
+
+            expect([
+                context.wampa,
+                context.greenSquadronAwing,
+                context.atst,
+                context.repair,
+                context.vanguardInfantry,
+                context.takedown,
+                context.pykeSentinel,
+                context.battlefieldMarine
+            ]).toAllBeInBottomOfDeck(context.player1, 8);
+            expect(context.player1.deck[0]).toBe(context.blueSquadronAssaultWing);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/cards/08_ASH/units/EyeOfSionDeliveredFromExile.spec.ts
+++ b/test/server/cards/08_ASH/units/EyeOfSionDeliveredFromExile.spec.ts
@@ -86,7 +86,7 @@ describe('Eye of Sion, Delivered From Exile', function() {
 
             const { context } = contextRef;
 
-            expect(context.eyeOfSion.getPower()).toBe(5);
+            expect(context.eyeOfSion.getPower()).toBe(6);
 
             context.player1.clickCard(context.eyeOfSion);
             context.player1.clickPrompt(abilityTitle);
@@ -94,13 +94,13 @@ describe('Eye of Sion, Delivered From Exile', function() {
             expect(context.player1).toHaveExactDisplayPromptCards({
                 selectable: [
                     context.blueSquadronAssaultWing,
+                    context.atst,
                     context.vanguardInfantry,
                     context.pykeSentinel,
                     context.battlefieldMarine,
                     context.greenSquadronAwing
                 ],
                 invalid: [
-                    context.atst,
                     context.repair,
                     context.takedown
                 ]

--- a/test/server/cards/08_ASH/units/EyeOfSionDeliveredFromExile.spec.ts
+++ b/test/server/cards/08_ASH/units/EyeOfSionDeliveredFromExile.spec.ts
@@ -1,6 +1,6 @@
 describe('Eye of Sion, Delivered From Exile', function() {
     integration(function(contextRef) {
-        const abilityTitle = 'Search the top 8 cards of your deck for a unit that costs the same as or less than this unit\'s power. Play it for free. It enters play ready.';
+        const abilityTitle = (power) => `Search the top 8 cards of your deck for a unit that costs ${power} or less. Play it for free. It enters play ready.`;
 
         it('should search the top 8 cards for a unit with cost equal to or less than its power, play it for free, and ready it', async function() {
             await contextRef.setupTestAsync({
@@ -27,7 +27,7 @@ describe('Eye of Sion, Delivered From Exile', function() {
 
             context.player1.clickCard(context.eyeOfSion);
             expect(context.player1).toHavePrompt('Choose an ability:');
-            context.player1.clickPrompt(abilityTitle);
+            context.player1.clickPrompt(abilityTitle(5));
 
             expect(context.player1).toHaveExactDisplayPromptCards({
                 selectable: [
@@ -89,7 +89,7 @@ describe('Eye of Sion, Delivered From Exile', function() {
             expect(context.eyeOfSion.getPower()).toBe(6);
 
             context.player1.clickCard(context.eyeOfSion);
-            context.player1.clickPrompt(abilityTitle);
+            context.player1.clickPrompt(abilityTitle(6));
 
             expect(context.player1).toHaveExactDisplayPromptCards({
                 selectable: [
@@ -136,7 +136,7 @@ describe('Eye of Sion, Delivered From Exile', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.eyeOfSion);
-            context.player1.clickPrompt(abilityTitle);
+            context.player1.clickPrompt(abilityTitle(5));
             context.player1.clickPrompt('Take nothing');
 
             expect([
@@ -150,6 +150,63 @@ describe('Eye of Sion, Delivered From Exile', function() {
                 context.battlefieldMarine
             ]).toAllBeInBottomOfDeck(context.player1, 8);
             expect(context.player1.deck[0]).toBe(context.blueSquadronAssaultWing);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should play a Piloting unit as a unit and not as an upgrade', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: [
+                        {
+                            card: 'eye-of-sion#delivered-from-exile',
+                            // it has a -2/-2 and a -1/-1 upgrades so power now is 2
+                            upgrades: ['perilous-position', 'kill-switch'],
+                        },
+                        'wing-leader'
+                    ],
+                    deck: [
+                        // luke unit costs 2 but luke pilot costs 3
+                        'luke-skywalker#you-still-with-me',
+                        'repair',
+                        'green-squadron-awing',
+                        'atst',
+                        'vanguard-infantry',
+                        'takedown',
+                        'pyke-sentinel',
+                        'battlefield-marine',
+                        'blue-squadron-assault-wing'
+                    ],
+                    resources: 1
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.eyeOfSion);
+            context.player1.clickPrompt(abilityTitle(2));
+
+            expect(context.player1).toHaveExactDisplayPromptCards({
+                selectable: [
+                    context.lukeSkywalkerYouStillWithMe,
+                    context.greenSquadronAwing,
+                    context.vanguardInfantry,
+                    context.pykeSentinel,
+                    context.battlefieldMarine
+                ],
+                invalid: [
+                    context.repair,
+                    context.atst,
+                    context.takedown
+                ]
+            });
+
+            context.player1.clickCardInDisplayCardPrompt(context.lukeSkywalkerYouStillWithMe);
+
+            expect(context.lukeSkywalkerYouStillWithMe).toBeInZone('groundArena', context.player1);
+            expect(context.lukeSkywalkerYouStillWithMe.exhausted).toBeFalse();
+            expect(context.wingLeader).not.toHaveExactUpgradeNames(['luke-skywalker#you-still-with-me']);
+            expect(context.player1.readyResourceCount).toBe(1);
             expect(context.player2).toBeActivePlayer();
         });
     });


### PR DESCRIPTION
| ⟡ Eye Of Sion |
| :----: |
| Delivered From Exile |
| <img width=450 src="https://github.com/user-attachments/assets/3e661dca-3f73-4c1c-854a-8e3f9475fdad" /> |

Game setup file:
```json
{
    "phase": "action",
    "player1": {
        "spaceArena": ["eye-of-sion#delivered-from-exile"],
        "deck": [
            "wampa",
            "green-squadron-awing",
            "atst",
            "repair",
            "vanguard-infantry",
            "takedown",
            "pyke-sentinel",
            "battlefield-marine",
            "blue-squadron-assault-wing"
        ],
        "resources": 1,
        "base": "echo-base",
        "leader": "luke-skywalker#faithful-friend"
    },
    "player2": {
        "base": "chopper-base",
        "leader": "sabine-wren#galvanized-revolutionary"
    }
}

```