### PR TITLE
Add screen resolution logging at game start

### DIFF
--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -1260,6 +1260,10 @@ export class Lobby {
                 this.server.registerDisconnect(user.socket, user.id);
             });
 
+            // Ask each player's client for their screen resolution so we can log it for analytics.
+            // Fire-and-forget; clients reply via the `reportScreenResolution` lobby command.
+            this.requestScreenResolutionsForGameStart();
+
             // For each user, if they have a deck, select it in the game
             this.users.forEach((user) => {
                 Contract.assertNotNullLike(user.deck, `User ${user.id} doesn't have a deck assigned at game start for lobby ${this.id}`);
@@ -2248,6 +2252,58 @@ export class Lobby {
 
     private assertSettingType(settingName: string, settingValue: any, expectedType: string): void {
         Contract.assertTrue(typeof settingValue === expectedType, `Invalid setting value for ${settingName}, expected ${expectedType} but received: ` + settingValue);
+    }
+
+    /**
+     * Sends a `requestScreenResolution` socket event to every connected player at game start.
+     * Players reply via the `reportScreenResolution` lobby command, which logs the result.
+     */
+    private requestScreenResolutionsForGameStart(): void {
+        for (const user of this.users) {
+            try {
+                user.socket?.send('requestScreenResolution');
+            } catch (error) {
+                logger.warn('Lobby: failed to send requestScreenResolution to user', {
+                    lobbyId: this.id,
+                    userId: user.id,
+                    error: { message: error?.message, stack: error?.stack },
+                });
+            }
+        }
+    }
+
+    /**
+     * Lobby command handler invoked by clients in response to `requestScreenResolution`.
+     * Logs the player's screen resolution as a structured field for log aggregation.
+     */
+    private reportScreenResolution(socket: Socket, payload: any): void {
+        const userId = socket.user.getId();
+        const user = this.getUser(userId);
+        if (!user || !this.game) {
+            return;
+        }
+
+        const width = payload?.width;
+        const height = payload?.height;
+        if (
+            !Number.isInteger(width) || !Number.isInteger(height) ||
+            width <= 0 || height <= 0
+        ) {
+            logger.warn('Lobby: received invalid screen resolution payload', {
+                lobbyId: this.id,
+                userId,
+                payload,
+            });
+            return;
+        }
+
+        logger.info(`[Lobby] Player screen resolution at game start: ${width}x${height}`, {
+            lobbyId: this.id,
+            gameId: this.game.id,
+            userId,
+            username: user.username,
+            screenResolution: { width, height },
+        });
     }
 
     private async submitReport(socket: Socket, ...args: any[]): Promise<void> {


### PR DESCRIPTION
https://github.com/SWU-Karabast/forceteki-client/pull/695

Hits a new callback on the FE to get the screen resolution for both players when the game starts and log it. This will allow us to grab some aggregate metrics on player device dimensions via the logs on occasion.