### PR TITLE
Mockdata today's updates

### DIFF
--- a/scripts/mockdata.js
+++ b/scripts/mockdata.js
@@ -940,6 +940,75 @@ const mockCards = [
         unique: false,
         internalName: 'hold-them-off',
     }),
+    buildMockCard({
+        title: 'The Mandalorian',
+        subtitle: 'We Can\'t Keep Running',
+        cost: 6,
+        power: 4,
+        hp: 6,
+        hasNonKeywordAbility: true,
+        aspects: ['aggression', 'heroism'],
+        types: ['leader'],
+        traits: ['mandalorian'],
+        keywords: ['support'],
+        setId: {
+            set: 'ASH',
+            number: 14
+        },
+        unique: true,
+        arena: 'ground',
+        internalName: 'the-mandalorian#we-cant-keep-running',
+    }),
+    buildMockCard({
+        title: 'Green Leader',
+        subtitle: 'Crynyd\'s Sacrifice',
+        cost: 2,
+        power: 3,
+        hp: 1,
+        hasNonKeywordAbility: true,
+        aspects: ['aggression', 'heroism'],
+        types: ['unit'],
+        traits: ['rebel', 'vehicle', 'fighter'],
+        setId: {
+            set: 'ASH',
+            number: 153
+        },
+        unique: true,
+        arena: 'space',
+        internalName: 'green-leader#crynys-sacrifice',
+    }),
+    buildMockCard({
+        title: 'Zeb Orrelios',
+        subtitle: 'Fists Work Every Time',
+        cost: 7,
+        power: 5,
+        hp: 7,
+        hasNonKeywordAbility: true,
+        aspects: ['aggression', 'heroism'],
+        types: ['unit'],
+        traits: ['rebel', 'spectre'],
+        setId: {
+            set: 'ASH',
+            number: 161
+        },
+        unique: true,
+        arena: 'ground',
+        internalName: 'zeb-orrelios#fists-work-every-time',
+    }),
+    buildMockCard({
+        title: 'Reckless Sacrifice',
+        cost: 2,
+        hasNonKeywordAbility: true,
+        aspects: ['aggression', 'heroism'],
+        types: ['event'],
+        traits: ['gambit'],
+        setId: {
+            set: 'ASH',
+            number: 163
+        },
+        unique: false,
+        internalName: 'reckless-sacrifice',
+    }),
 ];
 
 /** @param {{ title: string, subtitle: string?, hasNonKeywordAbility: boolean, cost: number?, hp: number?, arena?: string, unique: boolean, upgradeHp: number?, upgradePower: number?, aspects: string[]?, traits: string[]?, keywords: string[]?, types: string[], setId: { set: string, number: number }, internalName: string }} cardData */

--- a/scripts/mockdata.js
+++ b/scripts/mockdata.js
@@ -975,7 +975,7 @@ const mockCards = [
         },
         unique: true,
         arena: 'space',
-        internalName: 'green-leader#crynys-sacrifice',
+        internalName: 'green-leader#crynyds-sacrifice',
     }),
     buildMockCard({
         title: 'Zeb Orrelios',


### PR DESCRIPTION
Updating the `mockdata.js` file with today's updates.

<img width="1407" height="1004" alt="image1" src="https://github.com/user-attachments/assets/28a35ed7-950c-471c-b352-3e550bfa0b43" />
<img width="982" height="1376" alt="image2" src="https://github.com/user-attachments/assets/4b33e5df-fbcc-4efb-a776-4e5a64af7bfe" />
<img width="892" height="1254" alt="image3" src="https://github.com/user-attachments/assets/f3f84fe7-d714-4ee0-ab93-0780cc69b9c8" />
<img width="987" height="1356" alt="image4" src="https://github.com/user-attachments/assets/b3cefe87-1808-4761-9c2c-5ac53a4de85f" />
<img width="968" height="1356" alt="image5" src="https://github.com/user-attachments/assets/2e48bbb0-bf90-497f-91ca-8423b01a01a6" />
