### PR TITLE
When using Scramble Fighters and Moff Jerjerrod, my TIE fighters did not ready

### DIFF
--- a/server/game/cards/02_SHD/upgrades/Jetpack.ts
+++ b/server/game/cards/02_SHD/upgrades/Jetpack.ts
@@ -21,14 +21,18 @@ export default class Jetpack extends UpgradeCard {
                     target: context.source.parentCard,
                     highPriorityRemoval: true
                 })),
-                AbilityHelper.immediateEffects.delayedCardEffect((context) => ({
-                    title: 'Defeat the Jetpack Shield token',
-                    when: {
-                        onPhaseStarted: (context) => context.phase === PhaseName.Regroup
-                    },
-                    immediateEffect: AbilityHelper.immediateEffects.defeat(),
-                    target: context.events?.[0]?.generatedTokens?.[0]
-                }))
+                AbilityHelper.immediateEffects.simultaneous((context) =>
+                    context.resolvedEvents[0]?.generatedTokens?.map((token) =>
+                        AbilityHelper.immediateEffects.delayedCardEffect({
+                            title: 'Defeat the Jetpack Shield token',
+                            when: {
+                                onPhaseStarted: (context) => context.phase === PhaseName.Regroup
+                            },
+                            immediateEffect: AbilityHelper.immediateEffects.defeat(),
+                            target: token
+                        })
+                    ) ?? []
+                )
             ])
         });
     }

--- a/server/game/cards/04_JTL/events/CoveringTheWing.ts
+++ b/server/game/cards/04_JTL/events/CoveringTheWing.ts
@@ -20,11 +20,10 @@ export default class CoveringTheWing extends EventCard {
                 optional: true,
                 immediateEffect: AbilityHelper.immediateEffects.selectCard({
                     cardTypeFilter: WildcardCardType.Unit,
-                    cardCondition: (card) => card !== thenContext.events[0]?.generatedTokens[0],
+                    cardCondition: (card) => !thenContext.resolvedEvents[0]?.generatedTokens?.includes(card),
                     immediateEffect: AbilityHelper.immediateEffects.giveShield(),
                 })
             })
         });
     }
 }
-

--- a/server/game/cards/04_JTL/events/ScrambleFighters.ts
+++ b/server/game/cards/04_JTL/events/ScrambleFighters.ts
@@ -17,7 +17,7 @@ export default class ScrambleFighters extends EventCard {
                 AbilityHelper.immediateEffects.createTieFighter({ amount: 8, entersReady: true }),
                 AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     effect: AbilityHelper.ongoingEffects.cannotAttackBase(),
-                    target: context.events[0]?.generatedTokens
+                    target: context.resolvedEvents[0]?.generatedTokens
                 }))
             ])
         });

--- a/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
+++ b/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
@@ -5,8 +5,10 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { TokenName } from '../../../core/Constants';
 import { TokenCardName, TokenUnitName, TokenUpgradeName } from '../../../core/Constants';
 import type { GameSystem } from '../../../core/gameSystem/GameSystem';
+import type { IPlayerTargetSystemProperties } from '../../../core/gameSystem/PlayerTargetSystem';
 import { Contract } from '../../../core/utils/Contract';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
+import type { ICreateTokenUnitRequiredProperties } from '../../../gameSystems/CreateTokenUnitSystem';
 
 export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -48,7 +50,11 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
         AbilityHelper: IAbilityHelper
     ): GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>> {
         const { tokenType, amount, player, card } = context.event;
-        const doubledUnitTokenProperties = { amount: amount * 2, target: player, entersReady: context.event.entersReady };
+        const doubledUnitTokenProperties: ICreateTokenUnitRequiredProperties & Pick<IPlayerTargetSystemProperties, 'target'> = {
+            amount: amount * 2,
+            entersReady: context.event.entersReady,
+            target: player
+        };
 
         const systemForToken: Record<TokenName, GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>>> = {
             // Units

--- a/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
+++ b/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
@@ -37,13 +37,14 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
             // Replacement only happens if Jerjerrod is defeated
             onlyIfYouDoEffect: AbilityHelper.immediateEffects.defeat(),
             replaceWith: (context) => ({
-                replacementImmediateEffect: this.buildDoubledTokenSystem(context, AbilityHelper),
+                replacementImmediateEffect: this.buildAdditionalTokenSystem(context, AbilityHelper),
+                cancelOriginalEvent: false,
                 effect: `create ${context.event.amount * 2} ${EnumHelpers.tokenTitle[context.event.tokenType]} tokens instead`
             }),
         });
     }
 
-    private buildDoubledTokenSystem(
+    private buildAdditionalTokenSystem(
         context: TriggeredAbilityContext<NonLeaderUnitCard>,
         AbilityHelper: IAbilityHelper
     ): GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>> {
@@ -51,18 +52,18 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
 
         const systemForToken: Record<TokenName, GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>>> = {
             // Units
-            [TokenUnitName.BattleDroid]: AbilityHelper.immediateEffects.createBattleDroid({ amount: amount * 2, target: player }),
-            [TokenUnitName.CloneTrooper]: AbilityHelper.immediateEffects.createCloneTrooper({ amount: amount * 2, target: player }),
-            [TokenUnitName.XWing]: AbilityHelper.immediateEffects.createXWing({ amount: amount * 2, target: player }),
-            [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter({ amount: amount * 2, target: player }),
-            [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy({ amount: amount * 2, target: player }),
-            [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian({ amount: amount * 2, target: player }),
+            [TokenUnitName.BattleDroid]: AbilityHelper.immediateEffects.createBattleDroid({ amount, target: player }),
+            [TokenUnitName.CloneTrooper]: AbilityHelper.immediateEffects.createCloneTrooper({ amount, target: player }),
+            [TokenUnitName.XWing]: AbilityHelper.immediateEffects.createXWing({ amount, target: player }),
+            [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter({ amount, target: player }),
+            [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy({ amount, target: player }),
+            [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian({ amount, target: player }),
             // Upgrades
-            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount: amount * 2, target: card }),
-            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount: amount * 2, target: card }),
-            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount: amount * 2, target: card }),
+            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount, target: card }),
+            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount, target: card }),
+            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount, target: card }),
             // Miscellaneous
-            [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount: amount * 2, target: player }),
+            [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount, target: player }),
             [TokenCardName.Force]: AbilityHelper.immediateEffects.theForceIsWithYou({ target: player }),
         };
 

--- a/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
+++ b/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
@@ -38,7 +38,6 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
             onlyIfYouDoEffect: AbilityHelper.immediateEffects.defeat(),
             replaceWith: (context) => ({
                 replacementImmediateEffect: this.buildAdditionalTokenSystem(context, AbilityHelper),
-                cancelOriginalEvent: false,
                 effect: `create ${context.event.amount * 2} ${EnumHelpers.tokenTitle[context.event.tokenType]} tokens instead`
             }),
         });
@@ -49,21 +48,23 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
         AbilityHelper: IAbilityHelper
     ): GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>> {
         const { tokenType, amount, player, card } = context.event;
+        const doubledAmount = amount * 2;
+        const tokenUnitProperties = { amount: doubledAmount, target: player, entersReady: context.event.entersReady };
 
         const systemForToken: Record<TokenName, GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>>> = {
             // Units
-            [TokenUnitName.BattleDroid]: AbilityHelper.immediateEffects.createBattleDroid({ amount, target: player }),
-            [TokenUnitName.CloneTrooper]: AbilityHelper.immediateEffects.createCloneTrooper({ amount, target: player }),
-            [TokenUnitName.XWing]: AbilityHelper.immediateEffects.createXWing({ amount, target: player }),
-            [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter({ amount, target: player }),
-            [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy({ amount, target: player }),
-            [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian({ amount, target: player }),
+            [TokenUnitName.BattleDroid]: AbilityHelper.immediateEffects.createBattleDroid(tokenUnitProperties),
+            [TokenUnitName.CloneTrooper]: AbilityHelper.immediateEffects.createCloneTrooper(tokenUnitProperties),
+            [TokenUnitName.XWing]: AbilityHelper.immediateEffects.createXWing(tokenUnitProperties),
+            [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter(tokenUnitProperties),
+            [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy(tokenUnitProperties),
+            [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian(tokenUnitProperties),
             // Upgrades
-            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount, target: card }),
-            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount, target: card }),
-            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount, target: card }),
+            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount: doubledAmount, target: card }),
+            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount: doubledAmount, target: card }),
+            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount: doubledAmount, target: card }),
             // Miscellaneous
-            [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount, target: player }),
+            [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount: doubledAmount, target: player }),
             [TokenCardName.Force]: AbilityHelper.immediateEffects.theForceIsWithYou({ target: player }),
         };
 

--- a/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
+++ b/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
@@ -37,34 +37,33 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
             // Replacement only happens if Jerjerrod is defeated
             onlyIfYouDoEffect: AbilityHelper.immediateEffects.defeat(),
             replaceWith: (context) => ({
-                replacementImmediateEffect: this.buildAdditionalTokenSystem(context, AbilityHelper),
+                replacementImmediateEffect: this.buildDoubledTokenSystem(context, AbilityHelper),
                 effect: `create ${context.event.amount * 2} ${EnumHelpers.tokenTitle[context.event.tokenType]} tokens instead`
             }),
         });
     }
 
-    private buildAdditionalTokenSystem(
+    private buildDoubledTokenSystem(
         context: TriggeredAbilityContext<NonLeaderUnitCard>,
         AbilityHelper: IAbilityHelper
     ): GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>> {
         const { tokenType, amount, player, card } = context.event;
-        const doubledAmount = amount * 2;
-        const tokenUnitProperties = { amount: doubledAmount, target: player, entersReady: context.event.entersReady };
+        const doubledUnitTokenProperties = { amount: amount * 2, target: player, entersReady: context.event.entersReady };
 
         const systemForToken: Record<TokenName, GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>>> = {
             // Units
-            [TokenUnitName.BattleDroid]: AbilityHelper.immediateEffects.createBattleDroid(tokenUnitProperties),
-            [TokenUnitName.CloneTrooper]: AbilityHelper.immediateEffects.createCloneTrooper(tokenUnitProperties),
-            [TokenUnitName.XWing]: AbilityHelper.immediateEffects.createXWing(tokenUnitProperties),
-            [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter(tokenUnitProperties),
-            [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy(tokenUnitProperties),
-            [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian(tokenUnitProperties),
+            [TokenUnitName.BattleDroid]: AbilityHelper.immediateEffects.createBattleDroid(doubledUnitTokenProperties),
+            [TokenUnitName.CloneTrooper]: AbilityHelper.immediateEffects.createCloneTrooper(doubledUnitTokenProperties),
+            [TokenUnitName.XWing]: AbilityHelper.immediateEffects.createXWing(doubledUnitTokenProperties),
+            [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter(doubledUnitTokenProperties),
+            [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy(doubledUnitTokenProperties),
+            [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian(doubledUnitTokenProperties),
             // Upgrades
-            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount: doubledAmount, target: card }),
-            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount: doubledAmount, target: card }),
-            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount: doubledAmount, target: card }),
+            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount: amount * 2, target: card }),
+            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount: amount * 2, target: card }),
+            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount: amount * 2, target: card }),
             // Miscellaneous
-            [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount: doubledAmount, target: player }),
+            [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount: amount * 2, target: player }),
             [TokenCardName.Force]: AbilityHelper.immediateEffects.theForceIsWithYou({ target: player }),
         };
 

--- a/server/game/gameSystems/CreateTokenUnitSystem.ts
+++ b/server/game/gameSystems/CreateTokenUnitSystem.ts
@@ -9,9 +9,12 @@ import { PutIntoPlaySystem } from './PutIntoPlaySystem';
 import { Helpers } from '../core/utils/Helpers';
 import type { FormatMessage } from '../core/chat/GameChat';
 
-export interface ICreateTokenUnitProperties extends IPlayerTargetSystemProperties {
-    amount?: number;
-    entersReady?: boolean;
+export interface ICreateTokenUnitRequiredProperties {
+    amount: number;
+    entersReady: boolean;
+}
+
+export interface ICreateTokenUnitProperties extends IPlayerTargetSystemProperties, Partial<ICreateTokenUnitRequiredProperties> {
 }
 
 /** Base class for managing the logic for creating token units and putting them into play */

--- a/server/game/gameSystems/ReplacementEffectSystem.ts
+++ b/server/game/gameSystems/ReplacementEffectSystem.ts
@@ -14,9 +14,6 @@ export interface IReplacementEffectSystemProperties<TContext extends TriggeredAb
 
     /** The immediate effect to replace the original effect with or `null` to indicate that the original effect should be cancelled with no replacement */
     replacementImmediateEffect?: GameSystem<TContext>;
-
-    /** Whether the original event should be cancelled after creating the replacement event. */
-    cancelOriginalEvent?: boolean;
 }
 
 export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = TriggeredAbilityContext, TProperties extends IReplacementEffectSystemProperties<TContext> = IReplacementEffectSystemProperties<TContext>> extends GameSystem<TContext, TProperties> {
@@ -36,7 +33,6 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
         }
 
         const eventBeingReplaced = event.context.event;
-        const { cancelOriginalEvent } = this.generatePropertiesFromContext(event.context, additionalProperties);
         const replacementImmediateEffect = event.replacementImmediateEffect;
         if (replacementImmediateEffect) {
             const eventWindow = eventBeingReplaced.window;
@@ -54,11 +50,7 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
                 events.forEach((replacementEvent) => {
                     replacementEvent.order = eventBeingReplaced.order;
                     event.context.game.queueSimpleStep(() => {
-                        if (cancelOriginalEvent !== false) {
-                            eventBeingReplaced.setReplacementEvent(replacementEvent);
-                        } else {
-                            replacementEvent.setReplacesEvent(eventBeingReplaced);
-                        }
+                        eventBeingReplaced.setReplacementEvent(replacementEvent);
                         eventWindow.addEvent(replacementEvent);
                         triggerWindow.addReplacementEffectEvent(replacementEvent);
                     }, 'replacementEffect: replace window event');
@@ -66,9 +58,7 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
             }, 'replacementEffect: add replacement event to window');
         }
 
-        if (cancelOriginalEvent !== false) {
-            event.context.cancel();
-        }
+        event.context.cancel();
     }
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<TProperties> = {}) {

--- a/server/game/gameSystems/ReplacementEffectSystem.ts
+++ b/server/game/gameSystems/ReplacementEffectSystem.ts
@@ -14,6 +14,9 @@ export interface IReplacementEffectSystemProperties<TContext extends TriggeredAb
 
     /** The immediate effect to replace the original effect with or `null` to indicate that the original effect should be cancelled with no replacement */
     replacementImmediateEffect?: GameSystem<TContext>;
+
+    /** Whether the original event should be cancelled after creating the replacement event. */
+    cancelOriginalEvent?: boolean;
 }
 
 export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = TriggeredAbilityContext, TProperties extends IReplacementEffectSystemProperties<TContext> = IReplacementEffectSystemProperties<TContext>> extends GameSystem<TContext, TProperties> {
@@ -33,6 +36,7 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
         }
 
         const eventBeingReplaced = event.context.event;
+        const { cancelOriginalEvent } = this.generatePropertiesFromContext(event.context, additionalProperties);
         const replacementImmediateEffect = event.replacementImmediateEffect;
         if (replacementImmediateEffect) {
             const eventWindow = eventBeingReplaced.window;
@@ -50,7 +54,11 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
                 events.forEach((replacementEvent) => {
                     replacementEvent.order = eventBeingReplaced.order;
                     event.context.game.queueSimpleStep(() => {
-                        eventBeingReplaced.setReplacementEvent(replacementEvent);
+                        if (cancelOriginalEvent !== false) {
+                            eventBeingReplaced.setReplacementEvent(replacementEvent);
+                        } else {
+                            replacementEvent.setReplacesEvent(eventBeingReplaced);
+                        }
                         eventWindow.addEvent(replacementEvent);
                         triggerWindow.addReplacementEffectEvent(replacementEvent);
                     }, 'replacementEffect: replace window event');
@@ -58,7 +66,9 @@ export class ReplacementEffectSystem<TContext extends TriggeredAbilityContext = 
             }, 'replacementEffect: add replacement event to window');
         }
 
-        event.context.cancel();
+        if (cancelOriginalEvent !== false) {
+            event.context.cancel();
+        }
     }
 
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<TProperties> = {}) {

--- a/test/server/cards/02_SHD/upgrades/Jetpack.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/Jetpack.spec.ts
@@ -168,5 +168,31 @@ describe('Jetpack', function() {
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['jetpack']);
             });
         });
+
+        describe('with Moff Jerjerrod', function() {
+            it('creates 2 shields and defeats both at the beginning of the regroup phase', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['jetpack'],
+                        groundArena: ['battlefield-marine', 'moff-jerjerrod#we-shall-redouble-our-efforts'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.jetpack);
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Shield tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames(['jetpack', 'shield', 'shield']);
+
+                context.moveToRegroupPhase();
+
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames(['jetpack']);
+            });
+        });
     });
 });

--- a/test/server/cards/04_JTL/events/CoveringTheWing.spec.ts
+++ b/test/server/cards/04_JTL/events/CoveringTheWing.spec.ts
@@ -36,5 +36,44 @@ describe('Covering The Wing', function() {
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['shield']);
             });
         });
+
+        describe('with Moff Jerjerrod', function() {
+            it('should create 2 X-wing tokens and not allow either to be shielded', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['covering-the-wing'],
+                        groundArena: ['wampa', 'moff-jerjerrod#we-shall-redouble-our-efforts'],
+                        spaceArena: ['alliance-xwing']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['red-three#unstoppable']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.coveringTheWing);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 X-Wing tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                const xwings = context.player1.findCardsByName('xwing', 'spaceArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(xwings.length).toBe(2);
+                expect(xwings).toAllBeInZone('spaceArena');
+
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePrompt('Give a Shield token to another unit');
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine, context.redThree, context.allianceXwing]);
+                expect(context.player1).not.toBeAbleToSelect(xwings[0]);
+                expect(context.player1).not.toBeAbleToSelect(xwings[1]);
+                context.player1.clickCard(context.battlefieldMarine);
+
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames(['shield']);
+                expect(xwings[0]).not.toHaveExactUpgradeNames(['shield']);
+                expect(xwings[1]).not.toHaveExactUpgradeNames(['shield']);
+            });
+        });
     });
 });

--- a/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
+++ b/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
@@ -20,7 +20,7 @@ describe('Scramble Fighters', function() {
                 expect(context.player2.getArenaCards().length).toBe(0);
             });
 
-            it('should create 8 readied restricted TIE fighters and 8 exhausted unrestricted TIE fighters when doubled by Moff Jerjerrod', async function() {
+            it('should create 16 readied restricted TIE fighters when doubled by Moff Jerjerrod', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -45,27 +45,17 @@ describe('Scramble Fighters', function() {
                 expect(context.moffJerjerrod).toBeInZone('discard');
                 expect(tieFighters.length).toBe(16);
                 expect(tieFighters).toAllBeInZone('spaceArena');
-
-                const readyTieFighters = tieFighters.filter((tieFighter) => !tieFighter.exhausted);
-                const exhaustedTieFighters = tieFighters.filter((tieFighter) => tieFighter.exhausted);
-                expect(readyTieFighters.length).toBe(8);
-                expect(exhaustedTieFighters.length).toBe(8);
+                expect(tieFighters.every((tieFighter) => !tieFighter.exhausted)).toBeTrue();
 
                 context.player2.passAction();
-                context.player1.clickCard(readyTieFighters[0]);
+                context.player1.clickCard(tieFighters[0]);
                 expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer]);
                 context.player1.clickCard(context.cartelSpacer);
 
                 context.player2.passAction();
-                context.player1.clickCard(context.governorPryce);
-                context.player1.clickPrompt('Ready a token unit');
-                context.player1.clickCard(exhaustedTieFighters[0]);
-                expect(exhaustedTieFighters[0].exhausted).toBeFalse();
-
-                context.player2.passAction();
-                context.player1.clickCard(exhaustedTieFighters[0]);
-                expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer, context.p2Base]);
-                context.player1.clickCard(context.p2Base);
+                context.player1.clickCard(tieFighters[1]);
+                expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer]);
+                context.player1.clickCard(context.cartelSpacer);
             });
 
             it('should create TIE fighters that cannot attack the base the phase they were created', async function() {

--- a/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
+++ b/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
@@ -20,12 +20,18 @@ describe('Scramble Fighters', function() {
                 expect(context.player2.getArenaCards().length).toBe(0);
             });
 
-            it('should create 16 readied TIE fighters when doubled by Moff Jerjerrod', async function() {
+            it('should create 8 readied restricted TIE fighters and 8 exhausted unrestricted TIE fighters when doubled by Moff Jerjerrod', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         hand: ['scramble-fighters'],
-                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts']
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
+                        base: 'data-vault',
+                        leader: 'governor-pryce#tyrant-of-lothal',
+                        resources: 8
+                    },
+                    player2: {
+                        spaceArena: ['cartel-spacer']
                     }
                 });
 
@@ -39,7 +45,27 @@ describe('Scramble Fighters', function() {
                 expect(context.moffJerjerrod).toBeInZone('discard');
                 expect(tieFighters.length).toBe(16);
                 expect(tieFighters).toAllBeInZone('spaceArena');
-                expect(tieFighters.every((tieFighter) => tieFighter.exhausted)).toBeFalse();
+
+                const readyTieFighters = tieFighters.filter((tieFighter) => !tieFighter.exhausted);
+                const exhaustedTieFighters = tieFighters.filter((tieFighter) => tieFighter.exhausted);
+                expect(readyTieFighters.length).toBe(8);
+                expect(exhaustedTieFighters.length).toBe(8);
+
+                context.player2.passAction();
+                context.player1.clickCard(readyTieFighters[0]);
+                expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer]);
+                context.player1.clickCard(context.cartelSpacer);
+
+                context.player2.passAction();
+                context.player1.clickCard(context.governorPryce);
+                context.player1.clickPrompt('Ready a token unit');
+                context.player1.clickCard(exhaustedTieFighters[0]);
+                expect(exhaustedTieFighters[0].exhausted).toBeFalse();
+
+                context.player2.passAction();
+                context.player1.clickCard(exhaustedTieFighters[0]);
+                expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
             });
 
             it('should create TIE fighters that cannot attack the base the phase they were created', async function() {

--- a/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
+++ b/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
@@ -25,10 +25,7 @@ describe('Scramble Fighters', function() {
                     phase: 'action',
                     player1: {
                         hand: ['scramble-fighters'],
-                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
-                        base: 'data-vault',
-                        leader: 'governor-pryce#tyrant-of-lothal',
-                        resources: 8
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts']
                     },
                     player2: {
                         spaceArena: ['cartel-spacer']

--- a/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
+++ b/test/server/cards/04_JTL/events/ScrambleFighters.spec.ts
@@ -20,6 +20,28 @@ describe('Scramble Fighters', function() {
                 expect(context.player2.getArenaCards().length).toBe(0);
             });
 
+            it('should create 16 readied TIE fighters when doubled by Moff Jerjerrod', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['scramble-fighters'],
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.scrambleFighters);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 16 TIE Fighter tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                const tieFighters = context.player1.findCardsByName('tie-fighter', 'spaceArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(tieFighters.length).toBe(16);
+                expect(tieFighters).toAllBeInZone('spaceArena');
+                expect(tieFighters.every((tieFighter) => tieFighter.exhausted)).toBeFalse();
+            });
+
             it('should create TIE fighters that cannot attack the base the phase they were created', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
## Bug report

**Message:** When using Scramble Fighters and Moff Jerjerrod, my TIE fighters did not ready
**File:**
[bug-report-0ce29c51-0b06-46d4-ac35-e5a0c8c20414-1779462375855.json](https://github.com/user-attachments/files/28157987/bug-report-0ce29c51-0b06-46d4-ac35-e5a0c8c20414-1779462375855.json)

<img width="277" height="394" alt="Screenshot 2026-05-22 at 2 54 53 PM" src="https://github.com/user-attachments/assets/fe13261d-dc6d-4f70-8bcf-f8c38ea6314e" />
<img width="278" height="393" alt="Screenshot 2026-05-22 at 2 55 08 PM" src="https://github.com/user-attachments/assets/c7d9dffb-95ee-44b7-826b-a6afd3681522" />


## Scenario
Use the follow game setup file to check `Scramble Fighters` do not ready them
```json
{
    "phase": "action",
    "player1": {
        "hand": ["scramble-fighters"],
        "groundArena": ["moff-jerjerrod#we-shall-redouble-our-efforts"],
        "resources": 10,
        "base": "data-vault",
        "leader": "governor-pryce#tyrant-of-lothal",
        "hasInitiative": true
    },
    "player2": {
        "base": "city-in-the-clouds",
        "leader": "ahsoka-tano#trust-in-the-force"
    }
}

```

Testing with Covering the Wing

```json
{
    "phase": "action",
    "player1": {
        "hand": ["covering-the-wing"],
        "groundArena": ["wampa", "moff-jerjerrod#we-shall-redouble-our-efforts"],
        "spaceArena": ["alliance-xwing"],
        "resources": 10,
        "base": "data-vault",
        "leader": "governor-pryce#tyrant-of-lothal",
        "hasInitiative": true
    },
    "player2": {
        "groundArena": ["battlefield-marine"],
        "spaceArena": ["red-three#unstoppable"],
        "base": "city-in-the-clouds",
        "leader": "ahsoka-tano#trust-in-the-force"
    }
}
```

Testing with Jetpack (should create 2 shield tokens and both shields should be removed at the end of the phase)

```json
{
    "phase": "action",
    "player1": {
        "hand": ["jetpack"],
        "groundArena": ["battlefield-marine", "moff-jerjerrod#we-shall-redouble-our-efforts"],
        "resources": 10,
        "base": "data-vault",
        "leader": "governor-pryce#tyrant-of-lothal",
        "hasInitiative": true
    },
    "player2": {
        "base": "city-in-the-clouds",
        "leader": "ahsoka-tano#trust-in-the-force"
    }
}
```


## Proposed solution
Moff Jerjerrod was replacing the original event which I think it's not right since it could have multiple implications (in this case TIE fighters are ready and can't attack bases but not the ones created by Moff). I went for a solution to avoid replacing the original event and just "add the same amount of tokens with their default behavior"


