### PR TITLE
add exportable game format, schema, & validator

### DIFF
--- a/server/game/core/gameStateFormat/GameStateFormatExporter.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatExporter.ts
@@ -144,17 +144,23 @@ function exportPlayerState(player: Player, game: Game, players: [Player, Player]
     }
 
     // Arenas — controlled by this player, excluding attached upgrades and the
-    // deployed leader (which is serialised under `leader` above).
+    // leader card itself (serialised under `leader` above).
+    //
+    // We identify the leader card by object identity rather than `isLeaderUnit()`.
+    // A vehicle hosting a pilot leader also returns `isLeaderUnit() === true` and
+    // overrides `getType()` to `NonTokenLeaderUnit`, so a type-based check would
+    // incorrectly drop the vehicle from the output.
+    const leaderCard = player.leader as unknown as Card;
     const groundCards = game.groundArena
         .getCards({ controller: player })
-        .filter((c) => !c.isAttached() && !c.isLeaderUnit());
+        .filter((c) => !c.isAttached() && c !== leaderCard);
     if (groundCards.length > 0) {
         state.groundArena = groundCards.map((c) => exportCardEntry(c, player, players));
     }
 
     const spaceCards = game.spaceArena
         .getCards({ controller: player })
-        .filter((c) => !c.isAttached() && !c.isLeaderUnit());
+        .filter((c) => !c.isAttached() && c !== leaderCard);
     if (spaceCards.length > 0) {
         state.spaceArena = spaceCards.map((c) => exportCardEntry(c, player, players));
     }
@@ -207,9 +213,17 @@ function exportLeaderState(leader: ILeaderCard, players: [Player, Player]): Card
     const state: IExportedLeaderState = { card: id };
 
     if (leader.isLeaderUnit()) {
+        // Regular deployed leader: in the arena as a standalone unit.
         state.deployed = true;
         exportDeployedLeaderState(leader, state, players);
+    } else if ((leader as any).deployed === true) {
+        // Pilot leader: deployed as an upgrade attached to a vehicle.
+        // `isLeaderUnit()` returns false here because `isAttached()` is true, but
+        // `_deployed` is still set. Damage and upgrades are tracked on the host
+        // vehicle (via `exportCardEntry`), so we only record `deployed: true`.
+        state.deployed = true;
     } else {
+        // Undeployed leader.
         if (leader.exhausted) {
             state.exhausted = true;
         }

--- a/server/game/core/gameStateFormat/GameStateFormatExporter.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatExporter.ts
@@ -1,0 +1,395 @@
+import type { ISetId } from '../../../game/Interfaces';
+import type { Game } from '../Game';
+import type { Player } from '../Player';
+import type { Card } from '../card/Card';
+import type { IBaseCard } from '../card/BaseCard';
+import type { ILeaderCard } from '../card/propertyMixins/LeaderProperties';
+import type { ILeaderUnitCard } from '../card/LeaderUnitCard';
+import type { IUpgradeCard } from '../card/CardInterfaces';
+import type { IUnitCard } from '../card/propertyMixins/UnitProperties';
+import {
+    TOKEN_NAMES,
+    type ActionType,
+    type CardId,
+    type CardEntry,
+    type CapturedEntry,
+    type IActionSummary,
+    type IExportedBaseState,
+    type IExportedCardState,
+    type IExportedGameState,
+    type IExportedLeaderState,
+    type IExportedPlayerState,
+    type IGameHistory,
+    type IGameHistoryAction,
+    type IGameResult,
+    type ResourceEntry,
+    type UpgradeEntry,
+} from './GameStateFormatTypes';
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Exports the current live game position to the portable `IExportedGameState`
+ * format. The result is safe to `JSON.stringify` and can be re-imported (after
+ * schema validation via `validateGameState`) to recreate the board position.
+ *
+ * `player1` in the output corresponds to `game.getPlayers()[0]` (the lobby
+ * owner); `player2` corresponds to `game.getPlayers()[1]` (the opponent).
+ */
+export function exportGameState(game: Game): IExportedGameState {
+    const [p1, p2] = game.getPlayers();
+    const players: [Player, Player] = [p1, p2];
+    return {
+        phase: game.currentPhase ?? undefined,
+        player1: exportPlayerState(p1, game, players),
+        player2: exportPlayerState(p2, game, players),
+    };
+}
+
+// ── Game history ──────────────────────────────────────────────────────────────
+
+/** Creates a new, empty {@link IGameHistory} ready to receive entries. */
+export function createGameHistory(): IGameHistory {
+    return { entries: [] };
+}
+
+/**
+ * Seals a finished history by attaching the game result.
+ * Call once when the game ends (base destroyed, concede, or timeout).
+ */
+export function finalizeGameHistory(history: IGameHistory, result: IGameResult): void {
+    history.result = result;
+}
+
+/**
+ * Builds an {@link IActionSummary} from raw action-dispatch data.
+ *
+ * @param type         The action type (matches `ActionType` vocabulary).
+ * @param game         The live game (used to resolve player order).
+ * @param actingPlayer The player who took the action — omit for engine-driven
+ *                     transitions such as `phaseStart`.
+ * @param sourceCard   The primary card involved (played card, attacker, ability
+ *                     source, resourced card). Omit when not applicable.
+ * @param targetCard   The primary target card (upgrade target, defending unit or
+ *                     base, ability target). Omit when not applicable.
+ */
+export function exportActionSummary(
+    type: ActionType,
+    game: Game,
+    actingPlayer?: Player,
+    sourceCard?: Card,
+    targetCard?: Card,
+): IActionSummary {
+    const players = game.getPlayers() as [Player, Player];
+    const summary: IActionSummary = { type };
+    if (actingPlayer !== undefined) {
+        summary.actingPlayer = playerNumber(actingPlayer, players);
+    }
+    if (sourceCard !== undefined) {
+        summary.sourceCard = cardToId(sourceCard);
+    }
+    if (targetCard !== undefined) {
+        summary.targetCard = cardToId(targetCard);
+    }
+    return summary;
+}
+
+/**
+ * Snapshots the current live game position into an {@link IGameHistoryAction}.
+ *
+ * Internally calls {@link exportGameState} and augments the resulting state
+ * with `round` and `actionNumber` fields (which are omitted from standalone
+ * state exports but required in history entries).
+ *
+ * @param game   The live game to snapshot.
+ * @param seq    Monotonically increasing sequence number across the game (1-based, caller-managed).
+ * @param action The action that produced this state. Omit for the initial
+ *               post-setup entry (seq 1).
+ */
+export function exportHistoryEntry(
+    game: Game,
+    seq: number,
+    action?: IActionSummary,
+): IGameHistoryAction {
+    const state = exportGameState(game);
+    // Augment with history-only fields (omitted in standalone resume payloads).
+    state.round = game.roundNumber;
+    if (game.actionNumber > 0) {
+        state.actionNumber = game.actionNumber;
+    }
+
+    const entry: IGameHistoryAction = {
+        seq,
+        round: game.roundNumber,
+        state,
+    };
+    if (action !== undefined) {
+        entry.action = action;
+    }
+    return entry;
+}
+
+// ── Player ────────────────────────────────────────────────────────────────────
+
+function exportPlayerState(player: Player, game: Game, players: [Player, Player]): IExportedPlayerState {
+    // Leader and base are always present (every player always has one).
+    const state: IExportedPlayerState = {
+        leader: exportLeaderState(player.leader, players),
+        base: exportBaseState(player.base),
+    };
+
+    // Hand — full list, never hidden
+    if (player.handZone.cards.length > 0) {
+        state.hand = player.handZone.cards.map(cardToId);
+    }
+
+    // Arenas — controlled by this player, excluding attached upgrades and the
+    // deployed leader (which is serialised under `leader` above).
+    const groundCards = game.groundArena
+        .getCards({ controller: player })
+        .filter((c) => !c.isAttached() && !c.isLeaderUnit());
+    if (groundCards.length > 0) {
+        state.groundArena = groundCards.map((c) => exportCardEntry(c, player, players));
+    }
+
+    const spaceCards = game.spaceArena
+        .getCards({ controller: player })
+        .filter((c) => !c.isAttached() && !c.isLeaderUnit());
+    if (spaceCards.length > 0) {
+        state.spaceArena = spaceCards.map((c) => exportCardEntry(c, player, players));
+    }
+
+    // Discard
+    if (player.discardZone.count > 0) {
+        state.discard = player.discardZone.cards.map(cardToId);
+    }
+
+    // Full deck, top → bottom order
+    if (player.deckZone.cards.length > 0) {
+        state.deck = player.deckZone.cards.map(cardToId);
+    }
+
+    // Resources
+    if (player.resourceZone.count > 0) {
+        state.resources = player.resourceZone.cards.map((c): ResourceEntry => {
+            const id = cardToId(c);
+            // Only emit the object form when the resource is exhausted;
+            // a bare CardId implies ready.
+            if (c.isUnit() && c.exhausted) {
+                return { card: id, exhausted: true };
+            }
+            return id;
+        });
+    }
+
+    // Initiative
+    if (player.hasInitiative()) {
+        state.hasInitiative = true;
+    }
+
+    // Force token
+    if (player.hasTheForce) {
+        state.hasForceToken = true;
+    }
+
+    // Credit tokens
+    if (player.creditTokenCount > 0) {
+        state.credits = player.creditTokenCount;
+    }
+
+    return state;
+}
+
+// ── Leader ────────────────────────────────────────────────────────────────────
+
+function exportLeaderState(leader: ILeaderCard, players: [Player, Player]): CardId | IExportedLeaderState {
+    const id = cardToId(leader as unknown as Card);
+    const state: IExportedLeaderState = { card: id };
+
+    if (leader.isLeaderUnit()) {
+        state.deployed = true;
+        exportDeployedLeaderState(leader, state, players);
+    } else {
+        if (leader.exhausted) {
+            state.exhausted = true;
+        }
+        // Some leaders expose a "flip" mechanic without being deployed.
+        // The `flipped` property is not part of a public interface, so we access it defensively.
+        const flipped: boolean = (leader as any).flipped ?? false;
+        if (flipped) {
+            state.flipped = true;
+        }
+    }
+
+    // Track whether the deploy epic action has been spent
+    // TODO: expose epicActionSpent on ILeaderCard once the mixin decorator pattern supports getter overrides on composed types.
+    const epicActionSpent: boolean =
+        (leader as any).deployEpicActionLimit?.isAtMax((leader as unknown as Card).owner) ?? false;
+    if (epicActionSpent) {
+        state.epicActionSpent = true;
+    }
+
+    // Collapse to a bare CardId when there's nothing interesting to record
+    // (e.g. un-deployed leader, no damage, no exhausted state).
+    const extraKeys = Object.keys(state).filter((k) => k !== 'card');
+    if (extraKeys.length === 0) {
+        return id;
+    }
+    return state;
+}
+
+function exportDeployedLeaderState(leader: ILeaderUnitCard, state: IExportedLeaderState, players: [Player, Player]): void {
+    if (leader.damage > 0) {
+        state.damage = leader.damage;
+    }
+    if (leader.exhausted) {
+        state.exhausted = true;
+    }
+    const upgrades = exportUpgrades(leader, players);
+    if (upgrades.length > 0) {
+        state.upgrades = upgrades;
+    }
+    const capturedUnits = exportCapturedUnits(leader, players);
+    if (capturedUnits.length > 0) {
+        state.capturedUnits = capturedUnits;
+    }
+}
+
+// ── Base ──────────────────────────────────────────────────────────────────────
+
+function exportBaseState(base: IBaseCard): CardId | IExportedBaseState {
+    const id = cardToId(base as unknown as Card);
+    const hasDamage = base.damage > 0;
+    const epicActionSpent = base.epicActionSpent;
+
+    if (!hasDamage && !epicActionSpent) {
+        return id;
+    }
+
+    const state: IExportedBaseState = { card: id };
+    if (hasDamage) {
+        state.damage = base.damage;
+    }
+    if (epicActionSpent) {
+        state.epicActionSpent = true;
+    }
+    return state;
+}
+
+// ── In-play cards ─────────────────────────────────────────────────────────────
+
+function exportCardEntry(card: Card, controllingPlayer: Player, players: [Player, Player]): CardEntry {
+    if (!card.isUnit()) {
+        // Non-unit in-play cards (shouldn't normally appear in arena, but be safe)
+        return cardToId(card);
+    }
+
+    const unit = card as IUnitCard;
+    const hasDamage = unit.damage > 0;
+    const isExhausted = unit.exhausted;
+    const upgrades = exportUpgrades(unit, players);
+    const capturedUnits = exportCapturedUnits(unit, players);
+    const ownerDiffers = unit.owner !== controllingPlayer;
+
+    if (!hasDamage && !isExhausted && upgrades.length === 0 && capturedUnits.length === 0 && !ownerDiffers) {
+        return cardToId(card);
+    }
+
+    const state: IExportedCardState = { card: cardToId(card) };
+
+    if (hasDamage) {
+        state.damage = unit.damage;
+    }
+    if (isExhausted) {
+        state.exhausted = true;
+    }
+    if (upgrades.length > 0) {
+        state.upgrades = upgrades;
+    }
+    if (capturedUnits.length > 0) {
+        state.capturedUnits = capturedUnits;
+    }
+    // `owner` records who originally owns the card when control has been
+    // transferred (e.g. via a "take control" effect).
+    if (ownerDiffers) {
+        state.owner = playerNumber(unit.owner, players);
+    }
+
+    return state;
+}
+
+// ── Upgrades ──────────────────────────────────────────────────────────────────
+
+function exportUpgrades(card: IUnitCard, players: [Player, Player]): UpgradeEntry[] {
+    if (!card.isUpgraded()) {
+        return [];
+    }
+    return card.upgrades.map((upgrade: IUpgradeCard): UpgradeEntry => {
+        const upgradeCard = upgrade as unknown as Card;
+        const id = cardToId(upgradeCard);
+        const { owner, controller } = upgradeCard;
+        // Emit owner/controller player numbers only when they differ from each
+        // other (e.g. one player's upgrade attached to the other's unit).
+        if (!owner || !controller || owner === controller) {
+            return id;
+        }
+        return {
+            card: id,
+            owner: playerNumber(owner, players),
+            controller: playerNumber(controller, players),
+        };
+    });
+}
+
+// ── Captured units ────────────────────────────────────────────────────────────
+
+function exportCapturedUnits(card: IUnitCard | IBaseCard, players: [Player, Player]): CapturedEntry[] {
+    if (!('capturedUnits' in card) || card.capturedUnits.length === 0) {
+        return [];
+    }
+    return card.capturedUnits.map((captured): CapturedEntry => {
+        const capturedCard = captured as unknown as Card;
+        return {
+            card: cardToId(capturedCard),
+            owner: playerNumber(capturedCard.owner, players),
+        };
+    });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const TOKEN_NAME_SET = new Set<string>(TOKEN_NAMES);
+
+/**
+ * Returns the canonical `CardId` for a card instance.
+ *
+ * - Token cards have no set codes and are returned as their `internalName`
+ *   slug (e.g. `"shield"`, `"clone-trooper"`).
+ * - All other cards are returned as a formatted set-code string derived from
+ *   `card.setId`, which reflects the specific printing used to build this
+ *   card instance (e.g. `"SOR_001"`, `"ASH_209"`).
+ */
+function cardToId(card: Card): CardId {
+    if (card.isToken()) {
+        return card.internalName as CardId;
+    }
+    return formatSetId(card.setId);
+}
+
+/**
+ * Formats an `ISetId` as the canonical set-code string.
+ * Numbers are zero-padded to at least three digits: `{ set: "SOR", number: 1 }`
+ * → `"SOR_001"`.
+ */
+function formatSetId(setId: ISetId): string {
+    return `${setId.set}_${String(setId.number).padStart(3, '0')}`;
+}
+
+/**
+ * Returns the player number (1 or 2) for a given player, based on the ordered
+ * pair from `game.getPlayers()`. Player 1 is the lobby owner; player 2 is the
+ * opponent.
+ */
+function playerNumber(player: Player, players: [Player, Player]): 1 | 2 {
+    return player === players[0] ? 1 : 2;
+}

--- a/server/game/core/gameStateFormat/GameStateFormatSchema.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatSchema.ts
@@ -168,8 +168,12 @@ const ExportedPlayerStateSchema = z
 export const ExportedGameStateSchema = z
     .object({
         phase: z.string().optional(),
-        round: z.number().int().positive().optional(),
-        actionNumber: z.number().int().positive().optional(),
+        round: z.number().int()
+            .positive()
+            .optional(),
+        actionNumber: z.number().int()
+            .positive()
+            .optional(),
         player1: ExportedPlayerStateSchema,
         player2: ExportedPlayerStateSchema,
     })
@@ -226,8 +230,10 @@ const ActionSummarySchema = z
 
 const GameHistoryActionSchema = z
     .object({
-        seq: z.number().int().positive(),
-        round: z.number().int().positive(),
+        seq: z.number().int()
+            .positive(),
+        round: z.number().int()
+            .positive(),
         action: ActionSummarySchema.optional(),
         state: ExportedGameStateSchema,
     })

--- a/server/game/core/gameStateFormat/GameStateFormatSchema.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatSchema.ts
@@ -1,0 +1,278 @@
+import { z, type ZodIssue } from 'zod';
+import { TOKEN_NAMES, type IGameStateValidationError } from './GameStateFormatTypes';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Card identifier schemas
+//
+// A CardId is either:
+//   (a) A token name from the fixed TOKEN_NAMES enum, or
+//   (b) A set-code string matching the pattern <SET>_<NUMBER>[<SUFFIX>]
+//       e.g. "SOR_001", "JTL_042b", "ASH_209"
+//
+// Token names are checked first in the union so that slugs like "shield"
+// don't accidentally fail the set-code regex and surface a confusing error.
+// ──────────────────────────────────────────────────────────────────────────────
+
+const TokenNameSchema = z.enum(TOKEN_NAMES);
+
+/** Accepts only the literal integers 1 or 2 (player numbers). */
+const PlayerNumberSchema = z.union([z.literal(1), z.literal(2)]);
+
+const SetCodeSchema = z
+    .string()
+    .regex(
+        /^[A-Z0-9]{2,5}_\d+[a-zA-Z]?$/,
+        'Must be a set-code string (e.g. "SOR_001") or a known token name'
+    );
+
+/**
+ * Validates any CardId: a known token slug or a set-code string.
+ * Error messages from this schema point to the first branch that is "closest"
+ * — zod will surface the set-code regex message for unknown strings.
+ */
+const CardIdSchema = z.union([TokenNameSchema, SetCodeSchema]);
+
+// ── Upgrade ───────────────────────────────────────────────────────────────────
+
+const ExportedUpgradeStateSchema = z
+    .object({
+        card: CardIdSchema,
+        owner: PlayerNumberSchema.optional(),
+        controller: PlayerNumberSchema.optional(),
+    })
+    .strict();
+
+const UpgradeEntrySchema = z.union([CardIdSchema, ExportedUpgradeStateSchema]);
+
+// ── Captured units ────────────────────────────────────────────────────────────
+
+const ExportedCapturedCardStateSchema = z
+    .object({
+        card: CardIdSchema,
+        owner: PlayerNumberSchema,
+    })
+    .strict();
+
+const CapturedEntrySchema = z.union([CardIdSchema, ExportedCapturedCardStateSchema]);
+
+// ── In-play card ──────────────────────────────────────────────────────────────
+
+const ExportedCardStateSchema = z
+    .object({
+        card: CardIdSchema,
+        damage: z.number()
+            .int()
+            .nonnegative()
+            .optional(),
+        exhausted: z.boolean().optional(),
+        upgrades: z.array(UpgradeEntrySchema).optional(),
+        capturedUnits: z.array(CapturedEntrySchema).optional(),
+        owner: PlayerNumberSchema.optional(),
+    })
+    .strict();
+
+const CardEntrySchema = z.union([CardIdSchema, ExportedCardStateSchema]);
+
+// ── Leader ────────────────────────────────────────────────────────────────────
+
+const ExportedLeaderStateSchema = z
+    .object({
+        card: CardIdSchema,
+        deployed: z.boolean().optional(),
+        damage: z.number()
+            .int()
+            .nonnegative()
+            .optional(),
+        exhausted: z.boolean().optional(),
+        upgrades: z.array(UpgradeEntrySchema).optional(),
+        capturedUnits: z.array(CapturedEntrySchema).optional(),
+        flipped: z.boolean().optional(),
+        epicActionSpent: z.boolean().optional(),
+    })
+    .strict()
+    .superRefine((leader, ctx) => {
+        if (leader.deployed === false) {
+            if (typeof leader.damage === 'number' && leader.damage > 0) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['damage'],
+                    message: 'Leader cannot have damage when not deployed',
+                });
+            }
+            if (Array.isArray(leader.upgrades) && leader.upgrades.length > 0) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['upgrades'],
+                    message: 'Leader cannot have upgrades when not deployed',
+                });
+            }
+        }
+    });
+
+// ── Base ──────────────────────────────────────────────────────────────────────
+
+const ExportedBaseStateSchema = z
+    .object({
+        card: CardIdSchema,
+        damage: z.number()
+            .int()
+            .nonnegative()
+            .optional(),
+        epicActionSpent: z.boolean().optional(),
+    })
+    .strict();
+
+// ── Resources ─────────────────────────────────────────────────────────────────
+
+const ExportedResourceStateSchema = z
+    .object({
+        card: CardIdSchema,
+        exhausted: z.boolean().optional(),
+    })
+    .strict();
+
+const ResourceEntrySchema = z.union([CardIdSchema, ExportedResourceStateSchema]);
+
+// ── Player state ──────────────────────────────────────────────────────────────
+
+const ExportedPlayerStateSchema = z
+    .object({
+        hand: z.array(CardIdSchema).optional(),
+        groundArena: z.array(CardEntrySchema).optional(),
+        spaceArena: z.array(CardEntrySchema).optional(),
+        discard: z.array(CardIdSchema).optional(),
+        deck: z.array(CardIdSchema).optional(),
+        resources: z
+            .union([z.number()
+                .int()
+                .nonnegative(), z.array(ResourceEntrySchema)])
+            .optional(),
+        base: z.union([CardIdSchema, ExportedBaseStateSchema]),
+        leader: z.union([CardIdSchema, ExportedLeaderStateSchema]),
+        hasInitiative: z.boolean().optional(),
+        hasForceToken: z.boolean().optional(),
+        credits: z.number()
+            .int()
+            .nonnegative()
+            .optional(),
+    })
+    .strict();
+
+// ── Top-level game state ──────────────────────────────────────────────────────
+
+/**
+ * The root Zod schema for `IExportedGameState`. Exported so that callers can
+ * compose it (e.g. in an API request body validator) without going through the
+ * `validateGameState` helper.
+ */
+export const ExportedGameStateSchema = z
+    .object({
+        phase: z.string().optional(),
+        round: z.number().int().positive().optional(),
+        actionNumber: z.number().int().positive().optional(),
+        player1: ExportedPlayerStateSchema,
+        player2: ExportedPlayerStateSchema,
+    })
+    .strict()
+    .superRefine((state, ctx) => {
+        if (state.player1.hasInitiative && state.player2.hasInitiative) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['hasInitiative'],
+                message: 'Only one player can have initiative',
+            });
+        }
+    });
+
+// ── Game history ──────────────────────────────────────────────────────────────
+
+const ACTION_TYPES = [
+    'playCard',
+    'attack',
+    'useAbility',
+    'pass',
+    'claimInitiative',
+    'resource',
+    'mulligan',
+    'keepHand',
+    'concede',
+    'phaseStart',
+] as const;
+
+const ActionSummarySchema = z
+    .object({
+        type: z.enum(ACTION_TYPES),
+        actingPlayer: PlayerNumberSchema.optional(),
+        sourceCard: CardIdSchema.optional(),
+        targetCard: CardIdSchema.optional(),
+    })
+    .strict()
+    .superRefine((action, ctx) => {
+        if (action.type === 'phaseStart' && action.actingPlayer !== undefined) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['actingPlayer'],
+                message: 'phaseStart actions are engine-driven and must not have an actingPlayer',
+            });
+        }
+        if (action.type !== 'phaseStart' && action.actingPlayer === undefined) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['actingPlayer'],
+                message: 'Player-initiated actions must have an actingPlayer',
+            });
+        }
+    });
+
+const GameHistoryActionSchema = z
+    .object({
+        seq: z.number().int().positive(),
+        round: z.number().int().positive(),
+        action: ActionSummarySchema.optional(),
+        state: ExportedGameStateSchema,
+    })
+    .strict();
+
+const GameEndReasonSchema = z.enum(['baseDestroyed', 'concede', 'timeout']);
+
+const GameResultSchema = z
+    .object({
+        winner: PlayerNumberSchema,
+        reason: GameEndReasonSchema,
+    })
+    .strict();
+
+export const GameHistorySchema = z
+    .object({
+        entries: z.array(GameHistoryActionSchema),
+        result: GameResultSchema.optional(),
+    })
+    .strict();
+
+// ── Error formatting ──────────────────────────────────────────────────────────
+
+/** Converts a Zod issue into the project's `IGameStateValidationError` shape. */
+export function zodIssueToValidationError(issue: ZodIssue): IGameStateValidationError {
+    return {
+        path: formatZodPath(issue.path),
+        message: issue.message,
+    };
+}
+
+/**
+ * Formats a Zod path array into a human-readable dot/bracket string,
+ * e.g. `['player1', 'groundArena', 2, 'card']` → `"player1.groundArena[2].card"`.
+ */
+function formatZodPath(parts: (string | number)[]): string {
+    let out = '';
+    for (const part of parts) {
+        if (typeof part === 'number') {
+            out += `[${part}]`;
+        } else if (out === '') {
+            out = part;
+        } else {
+            out += `.${part}`;
+        }
+    }
+    return out;
+}

--- a/server/game/core/gameStateFormat/GameStateFormatTypes.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatTypes.ts
@@ -216,16 +216,16 @@ export interface IExportedGameState {
  *   phaseStart      — "Round: {round} – {phase} Phase"
  */
 export type ActionType =
-    | 'playCard'
-    | 'attack'
-    | 'useAbility'
-    | 'pass'
-    | 'claimInitiative'
-    | 'resource'
-    | 'mulligan'
-    | 'keepHand'
-    | 'concede'
-    | 'phaseStart';
+  | 'playCard'
+  | 'attack'
+  | 'useAbility'
+  | 'pass'
+  | 'claimInitiative'
+  | 'resource'
+  | 'mulligan'
+  | 'keepHand'
+  | 'concede'
+  | 'phaseStart';
 
 export interface IActionSummary {
     type: ActionType;
@@ -255,6 +255,7 @@ export interface IActionSummary {
 }
 
 export interface IGameHistoryAction {
+
     /** Monotonically increasing sequence number across the whole game (1-based). */
     seq: number;
 
@@ -276,6 +277,7 @@ export interface IGameResult {
 }
 
 export interface IGameHistory {
+
     /** Ordered list of action entries. Entry at index 0 is the post-setup
      *  initial state (seq 1, no `action` field). */
     entries: IGameHistoryAction[];

--- a/server/game/core/gameStateFormat/GameStateFormatTypes.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatTypes.ts
@@ -1,0 +1,298 @@
+/**
+ * Types for the SWU portable game-state format.
+ *
+ * This format serves two purposes:
+ *   - **Export** — capturing a live game position as a JSON document that can
+ *     be stored, shared, or replayed.
+ *   - **Import** — re-applying a saved position to a fresh game (validated
+ *     before apply; see `GameStateFormatValidator`).
+ *
+ */
+
+// ── Card identifiers ──────────────────────────────────────────────────────────
+
+/**
+ * A set-code string identifying a specific printing of a card.
+ * Format: `<SET>_<NUMBER>[<SUFFIX>]`
+ *   - SET: 2–5 uppercase alphanumeric characters (e.g. `SOR`, `JTL`, `ASH`)
+ *   - NUMBER: one or more digits, typically zero-padded to three places
+ *   - SUFFIX: optional lowercase letter for variant printings (e.g. `b`)
+ *
+ * Examples: `"SOR_001"`, `"JTL_042b"`, `"ASH_209"`
+ */
+export type SetCodeId = string;
+
+/**
+ * InternalName slugs for token cards. Tokens are generated during play and
+ * have no set code — they are always identified by these fixed names.
+ */
+export const TOKEN_NAMES = [
+    // Upgrade tokens
+    'shield',
+    'experience',
+    'advantage',
+    // Unit tokens
+    'clone-trooper',
+    'battle-droid',
+    'tie-fighter',
+    'xwing',
+    'mandalorian',
+    'spy',
+    // Other
+    'the-force',
+    'credit',
+] as const;
+
+export type TokenName = (typeof TOKEN_NAMES)[number];
+
+/**
+ * Any card identifier: a set-code string for deck cards, or a token slug for
+ * generated tokens. The Zod schema (`GameStateFormatSchema`) validates that
+ * strings conform to one of these two patterns.
+ */
+export type CardId = SetCodeId | TokenName;
+
+// ── Upgrade state ─────────────────────────────────────────────────────────────
+
+export interface IExportedUpgradeState {
+    card: CardId;
+
+    /**
+     * Player number (1 or 2) of the upgrade's owner — present only when the
+     * upgrade's owner and controller differ (e.g. one player's upgrade attached
+     * to the other player's unit).
+     */
+    owner?: 1 | 2;
+
+    /**
+     * Player number (1 or 2) of the upgrade's controller — present only when
+     * the upgrade's owner and controller differ.
+     */
+    controller?: 1 | 2;
+}
+
+/** An upgrade entry: either a bare `CardId` or a full upgrade state object. */
+export type UpgradeEntry = CardId | IExportedUpgradeState;
+
+// ── Captured units ────────────────────────────────────────────────────────────
+
+export interface IExportedCapturedCardState {
+    card: CardId;
+
+    /** Player number (1 or 2) of the captured unit's original owner. */
+    owner: 1 | 2;
+}
+
+/** A captured-unit entry: bare `CardId` or full captured state object. */
+export type CapturedEntry = CardId | IExportedCapturedCardState;
+
+// ── In-play card state ────────────────────────────────────────────────────────
+
+export interface IExportedCardState {
+    card: CardId;
+    damage?: number;
+    exhausted?: boolean;
+    upgrades?: UpgradeEntry[];
+    capturedUnits?: CapturedEntry[];
+
+    /**
+     * Player number (1 or 2) of the card's owner — present only when the
+     * card's controller differs from its owner (e.g. after a control-switch
+     * effect).
+     */
+    owner?: 1 | 2;
+}
+
+/** An arena or hand card entry: bare `CardId` or full card state object. */
+export type CardEntry = CardId | IExportedCardState;
+
+// ── Leader state ──────────────────────────────────────────────────────────────
+
+export interface IExportedLeaderState {
+    card: CardId;
+    deployed?: boolean;
+    damage?: number;
+    exhausted?: boolean;
+    upgrades?: UpgradeEntry[];
+    capturedUnits?: CapturedEntry[];
+
+    /** True when the leader's non-leader side is face-up (flip ability, ex: TWI Palp). */
+    flipped?: boolean;
+
+    /**
+     * True once the leader's deploy epic action has been used, even if the
+     * leader has subsequently been returned to the non-deployed zone.
+     * Omitted (falsy) when the epic action has not yet been used.
+     */
+    epicActionSpent?: boolean;
+}
+
+// ── Base state ────────────────────────────────────────────────────────────────
+
+export interface IExportedBaseState {
+    card: CardId;
+    damage?: number;
+
+    /**
+     * True once the base's epic action has been used.
+     * Omitted (falsy) when the epic action has not yet been used.
+     */
+    epicActionSpent?: boolean;
+}
+
+// ── Resource entries ──────────────────────────────────────────────────────────
+
+export interface IExportedResourceState {
+    card: CardId;
+    exhausted?: boolean;
+}
+
+/** A resource entry: bare `CardId` (ready) or a full resource state object. */
+export type ResourceEntry = CardId | IExportedResourceState;
+
+// ── Player state ──────────────────────────────────────────────────────────────
+
+export interface IExportedPlayerState {
+    hand?: CardId[];
+    groundArena?: CardEntry[];
+    spaceArena?: CardEntry[];
+    discard?: CardId[];
+    deck?: CardId[];
+    resources?: ResourceEntry[];
+    base: CardId | IExportedBaseState;
+    leader: CardId | IExportedLeaderState;
+    hasInitiative?: boolean;
+    hasForceToken?: boolean;
+    credits?: number;
+}
+
+// ── Top-level game state ──────────────────────────────────────────────────────
+
+export type PhaseName = 'setup' | 'action' | 'regroup';
+
+export interface IExportedGameState {
+    phase?: PhaseName;
+
+    /**
+     * The current round number (1-based). Present in history entries; omitted
+     * when the state is used as a standalone resume-game payload.
+     */
+    round?: number;
+
+    /**
+     * The ordinal of the action within the current round (1-based). Increments
+     * once per resolved player action. Present in history entries only.
+     */
+    actionNumber?: number;
+
+    /** Lobby owner's state. */
+    player1: IExportedPlayerState;
+
+    /** Opponent's state. */
+    player2: IExportedPlayerState;
+}
+
+// ── Game history ──────────────────────────────────────────────────────────────
+
+/**
+ * All discrete action types that generate a top-level message in the game
+ * chat log. The list mirrors the chat-log vocabulary exactly so that a
+ * replayer can reconstruct the same log entry from an `IActionSummary` alone.
+ *
+ * Player-initiated actions (always carry `actingPlayer`):
+ *   playCard        — "{player} plays {card} [attaching it to {target}]"
+ *   attack          — "{player} attacks {target} with {card}"
+ *   useAbility      — "{player} uses {card}'s ability"
+ *   pass            — "{player} passes"
+ *   claimInitiative — "{player} claims initiative and passes"
+ *   resource        — "{player} has resourced {card} from hand"
+ *                     (sourceCard absent when the player declined to resource:
+ *                      "{player} has not resourced any cards")
+ *   mulligan        — "{player} will mulligan"
+ *   keepHand        — "{player} will keep their hand"
+ *   concede         — "{player} concedes the game"
+ *
+ * Engine-driven transitions (no `actingPlayer`):
+ *   phaseStart      — "Round: {round} – {phase} Phase"
+ */
+export type ActionType =
+    | 'playCard'
+    | 'attack'
+    | 'useAbility'
+    | 'pass'
+    | 'claimInitiative'
+    | 'resource'
+    | 'mulligan'
+    | 'keepHand'
+    | 'concede'
+    | 'phaseStart';
+
+export interface IActionSummary {
+    type: ActionType;
+
+    /**
+     * The player who took the action (1 = lobby owner, 2 = opponent).
+     * Absent for engine-driven transitions (`type: 'phaseStart'`).
+     */
+    actingPlayer?: 1 | 2;
+
+    /**
+     * The primary card involved in the action:
+     * - `playCard`    — the card played from hand
+     * - `attack`      — the attacking unit
+     * - `useAbility`  — the card whose ability was activated
+     * - `resource`    — the card resourced (absent when player declined to resource)
+     */
+    sourceCard?: CardId;
+
+    /**
+     * The primary target of the action:
+     * - `playCard` (upgrade / pilot) — the unit the card attached to
+     * - `attack`                     — the defending unit or base
+     * - `useAbility`                 — the primary target, if any
+     */
+    targetCard?: CardId;
+}
+
+export interface IGameHistoryAction {
+    /** Monotonically increasing sequence number across the whole game (1-based). */
+    seq: number;
+
+    /** Game round this action occurred in (1-based). */
+    round: number;
+
+    /** What happened. Absent for the synthetic seq-1 initial-state entry. */
+    action?: IActionSummary;
+
+    /** Full board state *after* this action resolved. */
+    state: IExportedGameState;
+}
+
+export type GameEndReason = 'baseDestroyed' | 'concede' | 'timeout';
+
+export interface IGameResult {
+    winner: 1 | 2;
+    reason: GameEndReason;
+}
+
+export interface IGameHistory {
+    /** Ordered list of action entries. Entry at index 0 is the post-setup
+     *  initial state (seq 1, no `action` field). */
+    entries: IGameHistoryAction[];
+
+    /** Populated once the game ends. */
+    result?: IGameResult;
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+export interface IGameStateValidationError {
+
+    /**
+     * Dot/bracket path into the JSON document pointing to the offending value,
+     * e.g. `"player1.groundArena[2].card"`. Empty string means the top-level
+     * object itself is invalid.
+     */
+    path: string;
+    message: string;
+}

--- a/server/game/core/gameStateFormat/GameStateFormatValidator.ts
+++ b/server/game/core/gameStateFormat/GameStateFormatValidator.ts
@@ -1,0 +1,88 @@
+import type { IExportedGameState, IGameHistory, IGameStateValidationError } from './GameStateFormatTypes';
+import { ExportedGameStateSchema, GameHistorySchema, zodIssueToValidationError } from './GameStateFormatSchema';
+
+/**
+ * Validates an unknown value against the exported game-state schema.
+ *
+ * Returns an empty array if the value is structurally valid; otherwise returns
+ * every validation error found (all issues are collected before returning, so
+ * the caller sees the full picture at once).
+ *
+ * ## What this validates
+ * - Object shape and unknown-key rejection (`.strict()`)
+ * - Field types (strings, numbers, booleans, arrays)
+ * - Card identifier format: each `CardId` must be a known token slug or a
+ *   set-code string matching `<SET>_<NUMBER>[<SUFFIX>]`
+ * - Cross-field constraints:
+ *   - A leader with `deployed: false` cannot carry `damage` or `upgrades`
+ *   - Both players cannot simultaneously hold `hasInitiative: true`
+ *
+ * ## What this does NOT validate
+ * Semantic / runtime checks — e.g. verifying that a named card exists in a
+ * player's loaded deck, or that an arena unit belongs to the correct arena —
+ * are the responsibility of the import layer after a successful parse. Those
+ * checks depend on runtime deck data and belong closer to the applier.
+ */
+export function validateGameState(input: unknown): IGameStateValidationError[] {
+    const result = ExportedGameStateSchema.safeParse(input);
+    if (result.success) {
+        return [];
+    }
+    return result.error.issues.map(zodIssueToValidationError);
+}
+
+/**
+ * Parses and validates an unknown value, returning the typed `IExportedGameState`
+ * on success or `null` on failure.
+ *
+ * @param input   - The raw (e.g. `JSON.parse`'d) value to validate.
+ * @param onError - Optional callback invoked with the full list of errors when
+ *                  validation fails. Useful for logging or surfacing errors to
+ *                  the caller without a separate `validateGameState` call.
+ */
+export function parseGameState(
+    input: unknown,
+    onError?: (errors: IGameStateValidationError[]) => void
+): IExportedGameState | null {
+    const result = ExportedGameStateSchema.safeParse(input);
+    if (result.success) {
+        return result.data as IExportedGameState;
+    }
+    const errors = result.error.issues.map(zodIssueToValidationError);
+    onError?.(errors);
+    return null;
+}
+
+/**
+ * Validates an unknown value against the game-history schema.
+ *
+ * Returns an empty array if valid; otherwise returns every validation error
+ * found (all issues collected before returning).
+ */
+export function validateGameHistory(input: unknown): IGameStateValidationError[] {
+    const result = GameHistorySchema.safeParse(input);
+    if (result.success) {
+        return [];
+    }
+    return result.error.issues.map(zodIssueToValidationError);
+}
+
+/**
+ * Parses and validates an unknown value as an `IGameHistory`, returning the
+ * typed object on success or `null` on failure.
+ *
+ * @param input   - The raw (e.g. `JSON.parse`'d) value to validate.
+ * @param onError - Optional callback invoked with the full error list on failure.
+ */
+export function parseGameHistory(
+    input: unknown,
+    onError?: (errors: IGameStateValidationError[]) => void
+): IGameHistory | null {
+    const result = GameHistorySchema.safeParse(input);
+    if (result.success) {
+        return result.data as IGameHistory;
+    }
+    const errors = result.error.issues.map(zodIssueToValidationError);
+    onError?.(errors);
+    return null;
+}

--- a/test/scenarios/gameStateFormat/GameStateFormatValidator.spec.ts
+++ b/test/scenarios/gameStateFormat/GameStateFormatValidator.spec.ts
@@ -1,0 +1,373 @@
+import { validateGameState, parseGameState, validateGameHistory, parseGameHistory } from '../../../server/game/core/gameStateFormat/GameStateFormatValidator';
+import type { IGameStateValidationError } from '../../../server/game/core/gameStateFormat/GameStateFormatTypes';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Minimal structurally-valid player state — leader and base are always required. */
+const MINIMAL_PLAYER = {
+    leader: 'SOR_001',
+    base: 'SOR_229',
+};
+
+/** Returns a player state object with the required fields plus any overrides. */
+function playerWith(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return { ...MINIMAL_PLAYER, ...overrides };
+}
+
+/** A structurally-valid game state with no optional fields set. */
+function minimalState(overrides: Record<string, unknown> = {}): unknown {
+    return {
+        player1: MINIMAL_PLAYER,
+        player2: MINIMAL_PLAYER,
+        ...overrides,
+    };
+}
+
+function errorPaths(errors: IGameStateValidationError[]): string[] {
+    return errors.map((e) => e.path);
+}
+
+function errorMessages(errors: IGameStateValidationError[]): string[] {
+    return errors.map((e) => e.message);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GameStateFormatValidator', function () {
+    // ── Smoke test ────────────────────────────────────────────────────────────
+
+    describe('smoke', function () {
+        it('accepts a minimal valid state', function () {
+            expect(validateGameState(minimalState())).toEqual([]);
+        });
+
+        it('accepts a fully-populated state', function () {
+            const errors = validateGameState({
+                phase: 'action',
+                player1: {
+                    leader: { card: 'SOR_001', deployed: true, damage: 3, exhausted: true, upgrades: ['shield'] },
+                    base: { card: 'SOR_229', damage: 10 },
+                    groundArena: [
+                        {
+                            card: 'SOR_010',
+                            damage: 2,
+                            exhausted: true,
+                            upgrades: [{ card: 'SOR_050', owner: 2, controller: 1 }],
+                            capturedUnits: [{ card: 'SOR_020', owner: 2 }],
+                        },
+                    ],
+                    spaceArena: [{ card: 'JTL_042b', owner: 2 }],
+                    hand: ['SOR_011', 'SOR_012'],
+                    deck: ['SOR_013', 'SOR_014'],
+                    discard: ['SOR_015'],
+                    resources: [{ card: 'SOR_016', exhausted: true }, 'SOR_017'],
+                    hasInitiative: true,
+                    hasForceToken: true,
+                    credits: 2,
+                },
+                player2: {
+                    leader: 'SOR_002',
+                    base: 'SOR_230',
+                    resources: [],
+                },
+            });
+            expect(errors).toEqual([]);
+        });
+    });
+
+    // ── Card identifiers ──────────────────────────────────────────────────────
+    //
+    // The regex and token list could have typos — a few acceptance/rejection
+    // cases are worth keeping to catch those.
+
+    describe('card identifiers', function () {
+        function stateWithHandCard(cardId: unknown): unknown {
+            return { player1: playerWith({ hand: [cardId] }), player2: MINIMAL_PLAYER };
+        }
+
+        it('accepts valid set-code strings', function () {
+            expect(validateGameState(stateWithHandCard('SOR_001'))).toEqual([]);
+            expect(validateGameState(stateWithHandCard('JTL_042b'))).toEqual([]);
+            expect(validateGameState(stateWithHandCard('TS26_010'))).toEqual([]);
+        });
+
+        it('accepts all known token names', function () {
+            const tokens = [
+                'shield', 'experience', 'advantage',
+                'clone-trooper', 'battle-droid', 'tie-fighter',
+                'xwing', 'mandalorian', 'spy',
+                'the-force', 'credit',
+            ];
+            for (const token of tokens) {
+                expect(validateGameState(stateWithHandCard(token))).toEqual([], `"${token}" should be a valid card id`);
+            }
+        });
+
+        it('rejects a lowercase set abbreviation', function () {
+            expect(validateGameState(stateWithHandCard('sor_001')).length).toBeGreaterThan(0);
+        });
+
+        it('rejects an unknown slug that is not a token name', function () {
+            expect(validateGameState(stateWithHandCard('battlefield-marine')).length).toBeGreaterThan(0);
+        });
+    });
+
+    // ── Cross-field constraints ───────────────────────────────────────────────
+
+    describe('cross-field constraints', function () {
+        it('rejects both players having hasInitiative: true', function () {
+            const errors = validateGameState(minimalState({
+                player1: playerWith({ hasInitiative: true }),
+                player2: playerWith({ hasInitiative: true }),
+            }));
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errorMessages(errors).some((m) => m.toLowerCase().includes('initiative'))).toBeTrue();
+        });
+
+        it('accepts one player having hasInitiative: true', function () {
+            expect(validateGameState(minimalState({
+                player1: playerWith({ hasInitiative: true }),
+                player2: MINIMAL_PLAYER,
+            }))).toEqual([]);
+        });
+
+        it('rejects a leader with damage > 0 when deployed: false', function () {
+            const errors = validateGameState({
+                player1: playerWith({ leader: { card: 'SOR_001', deployed: false, damage: 2 } }),
+                player2: MINIMAL_PLAYER,
+            });
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errorMessages(errors).some((m) => m.toLowerCase().includes('damage'))).toBeTrue();
+        });
+
+        it('rejects a leader with upgrades when deployed: false', function () {
+            const errors = validateGameState({
+                player1: playerWith({ leader: { card: 'SOR_001', deployed: false, upgrades: ['shield'] } }),
+                player2: MINIMAL_PLAYER,
+            });
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errorMessages(errors).some((m) => m.toLowerCase().includes('upgrade'))).toBeTrue();
+        });
+
+        it('accepts a leader with damage: 0 when deployed: false', function () {
+            expect(validateGameState({
+                player1: playerWith({ leader: { card: 'SOR_001', deployed: false, damage: 0 } }),
+                player2: MINIMAL_PLAYER,
+            })).toEqual([]);
+        });
+    });
+
+    // ── Error path formatting ─────────────────────────────────────────────────
+    //
+    // formatZodPath is custom logic — verify it produces readable dot/bracket paths.
+
+    describe('error path formatting', function () {
+        it('formats a path into a hand array element', function () {
+            const errors = validateGameState({
+                player1: playerWith({ hand: ['SOR_001', 'bad-id'] }),
+                player2: MINIMAL_PLAYER,
+            });
+            expect(errorPaths(errors)).toContain('player1.hand[1]');
+        });
+
+        it('formats a nested path into a groundArena card', function () {
+            const errors = validateGameState({
+                player1: playerWith({ groundArena: [{ card: 'bad-id' }] }),
+                player2: MINIMAL_PLAYER,
+            });
+            expect(errorPaths(errors).some((p) => p.startsWith('player1.groundArena[0]'))).toBeTrue();
+        });
+
+        it('formats a path for a superRefine constraint violation', function () {
+            const errors = validateGameState({
+                player1: playerWith({ leader: { card: 'SOR_001', deployed: false, damage: 5 } }),
+                player2: MINIMAL_PLAYER,
+            });
+            expect(errorPaths(errors).some((p) => p.includes('leader'))).toBeTrue();
+        });
+    });
+
+    // ── parseGameState ────────────────────────────────────────────────────────
+
+    describe('parseGameState', function () {
+        it('returns the typed game state on success', function () {
+            const result = parseGameState(minimalState({ phase: 'action' }));
+            expect(result).not.toBeNull();
+            if (result !== null) {
+                expect(result.phase).toBe('action');
+                expect(result.player1).toEqual(MINIMAL_PLAYER);
+            }
+        });
+
+        it('returns null on failure', function () {
+            expect(parseGameState({ player1: playerWith({ hand: ['bad-id'] }), player2: MINIMAL_PLAYER })).toBeNull();
+        });
+
+        it('calls onError with the full error list on failure', function () {
+            let capturedErrors: IGameStateValidationError[] = [];
+            parseGameState(
+                { player1: playerWith({ hand: ['bad-id'] }), player2: MINIMAL_PLAYER },
+                (errors) => {
+                    capturedErrors = errors;
+                }
+            );
+            expect(capturedErrors.length).toBeGreaterThan(0);
+        });
+
+        it('does not call onError when the input is valid', function () {
+            let callCount = 0;
+            parseGameState(minimalState(), () => {
+                callCount++;
+            });
+            expect(callCount).toBe(0);
+        });
+    });
+
+    // ── round and actionNumber ────────────────────────────────────────────────
+    //
+    // Only structural acceptance is tested here — the numeric constraints
+    // (int, positive) are standard Zod primitives and not re-tested.
+
+    describe('round and actionNumber', function () {
+        it('accepts a state with both round and actionNumber', function () {
+            expect(validateGameState(minimalState({ round: 3, actionNumber: 7 }))).toEqual([]);
+        });
+
+        it('accepts a state with only round (actionNumber is optional)', function () {
+            expect(validateGameState(minimalState({ round: 1 }))).toEqual([]);
+        });
+    });
+});
+
+// ── validateGameHistory / parseGameHistory ────────────────────────────────────
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const MINIMAL_STATE = { player1: MINIMAL_PLAYER, player2: MINIMAL_PLAYER };
+
+/** A minimal valid history entry with no action (e.g. the initial-state entry). */
+function historyEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return { seq: 1, round: 1, state: MINIMAL_STATE, ...overrides };
+}
+
+/** A minimal valid history object. */
+function minimalHistory(overrides: Record<string, unknown> = {}): unknown {
+    return { entries: [], ...overrides };
+}
+
+/** A valid player-initiated action summary. */
+function playerAction(type: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return { type, actingPlayer: 1, ...overrides };
+}
+
+describe('validateGameHistory', function () {
+    // ── Smoke ─────────────────────────────────────────────────────────────────
+
+    describe('smoke', function () {
+        it('accepts an empty entries list', function () {
+            expect(validateGameHistory(minimalHistory())).toEqual([]);
+        });
+
+        it('accepts a history with a no-action initial entry', function () {
+            expect(validateGameHistory(minimalHistory({ entries: [historyEntry()] }))).toEqual([]);
+        });
+
+        it('accepts a fully-populated history', function () {
+            const errors = validateGameHistory({
+                entries: [
+                    historyEntry({ seq: 1, round: 1 }),
+                    historyEntry({ seq: 2, round: 1, action: playerAction('playCard', { sourceCard: 'SOR_010' }) }),
+                    historyEntry({ seq: 3, round: 1, action: playerAction('attack', { sourceCard: 'SOR_010', targetCard: 'SOR_229' }) }),
+                    historyEntry({ seq: 4, round: 1, action: { type: 'phaseStart' } }),
+                ],
+                result: { winner: 1, reason: 'baseDestroyed' },
+            });
+            expect(errors).toEqual([]);
+        });
+    });
+
+    // ── Action types ──────────────────────────────────────────────────────────
+    //
+    // One acceptance test per ActionType value confirms the complete enum.
+    // The phaseStart ↔ actingPlayer constraint is the custom cross-field rule.
+
+    describe('action types', function () {
+        const PLAYER_TYPES = [
+            'playCard', 'attack', 'useAbility', 'pass', 'claimInitiative',
+            'resource', 'mulligan', 'keepHand', 'concede',
+        ] as const;
+
+        for (const type of PLAYER_TYPES) {
+            it(`accepts player action type "${type}" with actingPlayer`, function () {
+                const entry = historyEntry({ action: playerAction(type) });
+                expect(validateGameHistory(minimalHistory({ entries: [entry] }))).toEqual([]);
+            });
+        }
+
+        it('accepts phaseStart without actingPlayer', function () {
+            const entry = historyEntry({ action: { type: 'phaseStart' } });
+            expect(validateGameHistory(minimalHistory({ entries: [entry] }))).toEqual([]);
+        });
+
+        it('rejects phaseStart with actingPlayer', function () {
+            const entry = historyEntry({ action: { type: 'phaseStart', actingPlayer: 1 } });
+            const errors = validateGameHistory(minimalHistory({ entries: [entry] }));
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors.some((e) => e.path.includes('actingPlayer'))).toBe(true);
+        });
+
+        it('rejects a player-initiated action without actingPlayer', function () {
+            const entry = historyEntry({ action: { type: 'playCard', sourceCard: 'SOR_010' } });
+            const errors = validateGameHistory(minimalHistory({ entries: [entry] }));
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors.some((e) => e.path.includes('actingPlayer'))).toBe(true);
+        });
+
+        it('accepts resource with no sourceCard (player declined to resource)', function () {
+            const entry = historyEntry({ action: playerAction('resource') });
+            expect(validateGameHistory(minimalHistory({ entries: [entry] }))).toEqual([]);
+        });
+    });
+
+    // ── Error path formatting ─────────────────────────────────────────────────
+
+    it('reports an error path that traverses into the entries array', function () {
+        const errors = validateGameHistory(minimalHistory({ entries: [historyEntry({ seq: 0 })] }));
+        expect(errors.some((e) => e.path.startsWith('entries[0]'))).toBe(true);
+    });
+
+    // ── result ────────────────────────────────────────────────────────────────
+
+    it('accepts a valid result', function () {
+        expect(validateGameHistory(minimalHistory({ result: { winner: 1, reason: 'baseDestroyed' } }))).toEqual([]);
+    });
+});
+
+// ── parseGameHistory ──────────────────────────────────────────────────────────
+
+describe('parseGameHistory', function () {
+    it('returns the typed history on success', function () {
+        const result = parseGameHistory(minimalHistory({ entries: [historyEntry()] }));
+        expect(result).not.toBeNull();
+        expect(result?.entries.length).toBe(1);
+    });
+
+    it('returns null on failure', function () {
+        expect(parseGameHistory({ entries: [historyEntry({ seq: 0 })] })).toBeNull();
+    });
+
+    it('calls onError with the full error list on failure', function () {
+        let capturedErrors: IGameStateValidationError[] = [];
+        parseGameHistory(
+            { entries: [historyEntry({ seq: -1 })] },
+            (errors) => { capturedErrors = errors; }
+        );
+        expect(capturedErrors.length).toBeGreaterThan(0);
+    });
+
+    it('does not call onError when the input is valid', function () {
+        let callCount = 0;
+        parseGameHistory(minimalHistory(), () => { callCount++; });
+        expect(callCount).toBe(0);
+    });
+});

--- a/test/scenarios/gameStateFormat/GameStateFormatValidator.spec.ts
+++ b/test/scenarios/gameStateFormat/GameStateFormatValidator.spec.ts
@@ -360,14 +360,18 @@ describe('parseGameHistory', function () {
         let capturedErrors: IGameStateValidationError[] = [];
         parseGameHistory(
             { entries: [historyEntry({ seq: -1 })] },
-            (errors) => { capturedErrors = errors; }
+            (errors) => {
+                capturedErrors = errors;
+            }
         );
         expect(capturedErrors.length).toBeGreaterThan(0);
     });
 
     it('does not call onError when the input is valid', function () {
         let callCount = 0;
-        parseGameHistory(minimalHistory(), () => { callCount++; });
+        parseGameHistory(minimalHistory(), () => {
+            callCount++;
+        });
         expect(callCount).toBe(0);
     });
 });

--- a/test/scenarios/gameStateFormat/GameStateFormatValidator.spec.ts
+++ b/test/scenarios/gameStateFormat/GameStateFormatValidator.spec.ts
@@ -157,6 +157,62 @@ describe('GameStateFormatValidator', function () {
         });
     });
 
+    // ── Pilot leaders ─────────────────────────────────────────────────────────
+    //
+    // A pilot leader is deployed as an upgrade on a vehicle rather than as a
+    // standalone unit. The correct export shape is:
+    //   - `leader` state carries `deployed: true` (and `epicActionSpent: true`)
+    //   - the host vehicle is in the arena with the leader's card ID in `upgrades`
+    //   - no damage or upgrades directly on the leader state; those belong to
+    //     the host vehicle
+    //
+    // This documents the intended format for import/export round-trips involving
+    // pilot leaders.
+
+    describe('pilot leaders deployed as upgrades', function () {
+        const PILOT_LEADER = 'JTL_001';
+        const HOST_VEHICLE = 'JTL_042b';
+
+        it('accepts a pilot leader: deployed: true with the leader in a vehicle upgrade slot', function () {
+            expect(validateGameState({
+                player1: {
+                    leader: { card: PILOT_LEADER, deployed: true, epicActionSpent: true },
+                    base: 'SOR_229',
+                    spaceArena: [{ card: HOST_VEHICLE, upgrades: [PILOT_LEADER] }],
+                },
+                player2: MINIMAL_PLAYER,
+            })).toEqual([]);
+        });
+
+        it('accepts a pilot leader with epicActionSpent omitted when the epic action has not been used', function () {
+            expect(validateGameState({
+                player1: {
+                    leader: { card: PILOT_LEADER, deployed: true },
+                    base: 'SOR_229',
+                    spaceArena: [{ card: HOST_VEHICLE, upgrades: [PILOT_LEADER] }],
+                },
+                player2: MINIMAL_PLAYER,
+            })).toEqual([]);
+        });
+
+        it('accepts damage and upgrades on the host vehicle, not on the leader state', function () {
+            // The pilot leader card has no separate HP — damage belongs to the vehicle.
+            // Upgrades on the vehicle (e.g. an experience token) are also on the vehicle.
+            expect(validateGameState({
+                player1: {
+                    leader: { card: PILOT_LEADER, deployed: true, epicActionSpent: true },
+                    base: 'SOR_229',
+                    spaceArena: [{
+                        card: HOST_VEHICLE,
+                        damage: 3,
+                        upgrades: [PILOT_LEADER, 'experience'],
+                    }],
+                },
+                player2: MINIMAL_PLAYER,
+            })).toEqual([]);
+        });
+    });
+
     // ── Error path formatting ─────────────────────────────────────────────────
     //
     // formatZodPath is custom logic — verify it produces readable dot/bracket paths.


### PR DESCRIPTION
The purpose of this PR is to provide a schema of game state & action history to be used for export/replay/initialState. This purposefully does not provide any hooks into the game life cycle yet to provide recording functionality.

I considered building the action history as deltas to preserve size, but the savings really aren't worth the increased complexity and potential desync. Recording the full game state after every action gives us full reliability and an average game would be still be far less than the size of a card image.

The design looks very similar to our current test schema, but uses set codes instead of name slugs. Ex:

```
                phase: 'action',
                player1: {
                    leader: { card: 'SOR_001', deployed: true, damage: 3, exhausted: true, upgrades: ['shield'] },
                    base: { card: 'SOR_229', damage: 10 },
                    groundArena: [
                        {
                            card: 'SOR_010',
                            damage: 2,
                            exhausted: true,
                            upgrades: [{ card: 'SOR_050', owner: 2, controller: 1 }],
                            capturedUnits: [{ card: 'SOR_020', owner: 2 }],
                        },
                    ],
                    spaceArena: [{ card: 'JTL_042b', owner: 2 }],
                    hand: ['SOR_011', 'SOR_012'],
                    deck: ['SOR_013', 'SOR_014'],
                    discard: ['SOR_015'],
                    resources: [{ card: 'SOR_016', exhausted: true }, 'SOR_017'],
                    hasInitiative: true,
                    hasForceToken: true,
                    credits: 2,
                },
                player2: {
                    leader: 'SOR_002',
                    base: 'SOR_230',
                    resources: [],
                },
            });
```        
    
