### PR TITLE
Include last update to unimplemented cards endpoint

### DIFF
--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -412,8 +412,7 @@ export class GameServer {
 
                 return res.json({
                     cards: this.deckValidator.getUnimplementedCards(),
-                    lastUpdated: cardDataVersionInfo?.lastUpdated ?? null,
-                    cardDataVersion: cardDataVersionInfo?.version ?? null
+                    lastUpdated: cardDataVersionInfo?.lastUpdated ?? null
                 });
             } catch (err) {
                 logger.error('GameServer (get-unimplemented) Server error: ', err);

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -412,7 +412,7 @@ export class GameServer {
 
                 return res.json({
                     cards: this.deckValidator.getUnimplementedCards(),
-                    lastUpdated: cardDataVersionInfo?.lastUpdated ?? null
+                    lastUpdated: cardDataVersionInfo
                 });
             } catch (err) {
                 logger.error('GameServer (get-unimplemented) Server error: ', err);

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -43,6 +43,7 @@ import { EnumHelpers } from '../game/core/utils/EnumHelpers';
 import { DiscordDispatcher } from '../game/core/DiscordDispatcher';
 import { checkServerRoleUserPrivileges } from '../utils/authUtils';
 import { CosmeticsService } from '../utils/cosmetics/CosmeticsService';
+import { getCardDataVersionInfo as fetchCardDataVersionInfo } from '../utils/cardData/CardDataVersion';
 import type { IActiveModActionCacheEntry,
     IDeckDataEntity,
     IModerationAction } from '../services/DynamoDBInterfaces';
@@ -211,6 +212,7 @@ export class GameServer {
     private readonly tokenCleanupInterval: NodeJS.Timeout;
     public readonly serverRoleUsersCache?: ServerRoleUsersCache;
     public readonly modActionService?: ModActionService;
+    private cardDataVersionInfoPromise?: ReturnType<typeof fetchCardDataVersionInfo>;
 
     private constructor(
         cardDataGetter: CardDataGetter,
@@ -398,10 +400,21 @@ export class GameServer {
         }
     }
 
+    private getCardDataVersionInfo(): ReturnType<typeof fetchCardDataVersionInfo> {
+        this.cardDataVersionInfoPromise ??= fetchCardDataVersionInfo();
+        return this.cardDataVersionInfoPromise;
+    }
+
     private setupAppRoutes(app: express.Application) {
-        app.get('/api/get-unimplemented', (req, res, next) => {
+        app.get('/api/get-unimplemented', async (req, res, next) => {
             try {
-                return res.json(this.deckValidator.getUnimplementedCards());
+                const cardDataVersionInfo = await this.getCardDataVersionInfo();
+
+                return res.json({
+                    cards: this.deckValidator.getUnimplementedCards(),
+                    lastUpdated: cardDataVersionInfo?.lastUpdated ?? null,
+                    cardDataVersion: cardDataVersionInfo?.version ?? null
+                });
             } catch (err) {
                 logger.error('GameServer (get-unimplemented) Server error: ', err);
                 next(err);
@@ -2856,4 +2869,3 @@ export class GameServer {
         return { stopped: cpuResult.stopped || heapResult.stopped };
     }
 }
-

--- a/server/utils/cardData/CardDataVersion.ts
+++ b/server/utils/cardData/CardDataVersion.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+import { logger } from '../../logger';
+
+const defaultCardDataVersionUrl = 'https://karabast-data.s3.amazonaws.com/card-data-version.txt';
+
+export interface ICardDataVersionInfo {
+    lastUpdated: string;
+    version: string;
+}
+
+export function parseCardDataVersion(version: string): ICardDataVersionInfo {
+    const trimmedVersion = version.trim();
+    const versionMatch = trimmedVersion.match(/^(\d{4})(\d{2})(\d{2})_/);
+
+    if (!versionMatch) {
+        throw new Error(`Unexpected card data version format: '${trimmedVersion}'`);
+    }
+
+    const [, year, month, day] = versionMatch;
+    return {
+        lastUpdated: `${year}-${month}-${day}`,
+        version: trimmedVersion
+    };
+}
+
+export async function getCardDataVersionInfo(): Promise<ICardDataVersionInfo | null> {
+    const versionUrl = process.env.CARD_DATA_VERSION_URL ?? defaultCardDataVersionUrl;
+
+    try {
+        const response = await fetch(versionUrl);
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${versionUrl}: ${response.status} ${response.statusText}`);
+        }
+
+        return parseCardDataVersion(await response.text());
+    } catch (error) {
+        logger.warn('CardDataVersion: Failed to fetch card data version from S3, falling back to local file.', error);
+    }
+
+    return getLocalCardDataVersionInfo();
+}
+
+function getLocalCardDataVersionInfo(): ICardDataVersionInfo | null {
+    const localVersionPaths = [
+        path.resolve(process.cwd(), 'card-data-version.txt'),
+        path.resolve(__dirname, '../../../card-data-version.txt')
+    ];
+
+    for (const localVersionPath of localVersionPaths) {
+        if (fs.existsSync(localVersionPath)) {
+            return parseCardDataVersion(fs.readFileSync(localVersionPath, 'utf8'));
+        }
+    }
+
+    logger.warn('CardDataVersion: No local card-data-version.txt fallback found.');
+    return null;
+}

--- a/server/utils/cardData/CardDataVersion.ts
+++ b/server/utils/cardData/CardDataVersion.ts
@@ -1,12 +1,7 @@
-import fs from 'fs';
-import path from 'path';
 import { logger } from '../../logger';
-
-const defaultCardDataVersionUrl = 'https://karabast-data.s3.amazonaws.com/card-data-version.txt';
 
 export interface ICardDataVersionInfo {
     lastUpdated: string;
-    version: string;
 }
 
 export function parseCardDataVersion(version: string): ICardDataVersionInfo {
@@ -19,13 +14,16 @@ export function parseCardDataVersion(version: string): ICardDataVersionInfo {
 
     const [, year, month, day] = versionMatch;
     return {
-        lastUpdated: `${year}-${month}-${day}`,
-        version: trimmedVersion
+        lastUpdated: `${year}-${month}-${day}`
     };
 }
 
 export async function getCardDataVersionInfo(): Promise<ICardDataVersionInfo | null> {
-    const versionUrl = process.env.CARD_DATA_VERSION_URL ?? defaultCardDataVersionUrl;
+    const versionUrl = process.env.CARD_DATA_VERSION_URL;
+
+    if (!versionUrl) {
+        return null;
+    }
 
     try {
         const response = await fetch(versionUrl);
@@ -36,24 +34,7 @@ export async function getCardDataVersionInfo(): Promise<ICardDataVersionInfo | n
 
         return parseCardDataVersion(await response.text());
     } catch (error) {
-        logger.warn('CardDataVersion: Failed to fetch card data version from S3, falling back to local file.', error);
+        logger.warn('CardDataVersion: Failed to fetch card data version.', error);
+        return null;
     }
-
-    return getLocalCardDataVersionInfo();
-}
-
-function getLocalCardDataVersionInfo(): ICardDataVersionInfo | null {
-    const localVersionPaths = [
-        path.resolve(process.cwd(), 'card-data-version.txt'),
-        path.resolve(__dirname, '../../../card-data-version.txt')
-    ];
-
-    for (const localVersionPath of localVersionPaths) {
-        if (fs.existsSync(localVersionPath)) {
-            return parseCardDataVersion(fs.readFileSync(localVersionPath, 'utf8'));
-        }
-    }
-
-    logger.warn('CardDataVersion: No local card-data-version.txt fallback found.');
-    return null;
 }

--- a/server/utils/cardData/CardDataVersion.ts
+++ b/server/utils/cardData/CardDataVersion.ts
@@ -1,10 +1,6 @@
 import { logger } from '../../logger';
 
-export interface ICardDataVersionInfo {
-    lastUpdated: string;
-}
-
-export function parseCardDataVersion(version: string): ICardDataVersionInfo {
+export function parseCardDataVersion(version: string): string {
     const trimmedVersion = version.trim();
     const versionMatch = trimmedVersion.match(/^(\d{4})(\d{2})(\d{2})_/);
 
@@ -13,12 +9,10 @@ export function parseCardDataVersion(version: string): ICardDataVersionInfo {
     }
 
     const [, year, month, day] = versionMatch;
-    return {
-        lastUpdated: `${year}-${month}-${day}`
-    };
+    return `${year}-${month}-${day}`;
 }
 
-export async function getCardDataVersionInfo(): Promise<ICardDataVersionInfo | null> {
+export async function getCardDataVersionInfo(): Promise<string | null> {
     const versionUrl = process.env.CARD_DATA_VERSION_URL;
 
     if (!versionUrl) {

--- a/test/server/utils/cardData/CardDataVersion.spec.ts
+++ b/test/server/utils/cardData/CardDataVersion.spec.ts
@@ -1,0 +1,16 @@
+import { parseCardDataVersion } from '../../../../server/utils/cardData/CardDataVersion';
+
+describe('CardDataVersion', function() {
+    it('parses the last updated date from the card data version', function() {
+        const versionInfo = parseCardDataVersion('20260423_00\n');
+
+        expect(versionInfo).toEqual({
+            lastUpdated: '2026-04-23',
+            version: '20260423_00'
+        });
+    });
+
+    it('throws for unexpected card data version formats', function() {
+        expect(() => parseCardDataVersion('not-a-version')).toThrowError('Unexpected card data version format: \'not-a-version\'');
+    });
+});

--- a/test/server/utils/cardData/CardDataVersion.spec.ts
+++ b/test/server/utils/cardData/CardDataVersion.spec.ts
@@ -4,10 +4,7 @@ describe('CardDataVersion', function() {
     it('parses the last updated date from the card data version', function() {
         const versionInfo = parseCardDataVersion('20260423_00\n');
 
-        expect(versionInfo).toEqual({
-            lastUpdated: '2026-04-23',
-            version: '20260423_00'
-        });
+        expect(versionInfo).toEqual({ lastUpdated: '2026-04-23' });
     });
 
     it('throws for unexpected card data version formats', function() {

--- a/test/server/utils/cardData/CardDataVersion.spec.ts
+++ b/test/server/utils/cardData/CardDataVersion.spec.ts
@@ -4,7 +4,7 @@ describe('CardDataVersion', function() {
     it('parses the last updated date from the card data version', function() {
         const versionInfo = parseCardDataVersion('20260423_00\n');
 
-        expect(versionInfo).toEqual({ lastUpdated: '2026-04-23' });
+        expect(versionInfo).toEqual('2026-04-23');
     });
 
     it('throws for unexpected card data version formats', function() {


### PR DESCRIPTION
Waiting for definitions about this ticket https://discord.com/channels/1220057752961814568/1266424023290482812/1508278088289616073 

Work needed for:
https://github.com/SWU-Karabast/forceteki-client/issues/509
https://github.com/SWU-Karabast/forceteki-client/issues/581

It must be merged with https://github.com/SWU-Karabast/forceteki-client/pull/705

Another approach could be computing it at startup time since every new card will trigger a deploy and the value will always get updated.