### PR TITLE
BE changes for supporting card language preference

### DIFF
--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -495,6 +495,7 @@ export class GameServer {
                     username: user.getUsername(),
                     showWelcomeMessage: user.getShowWelcomeMessage(),
                     undoPopupSeenDate: user.getUndoPopupSeenDate(),
+                    timerPopupSeenDate: user.getTimerPopupSeenDate(),
                     preferences: user.getPreferences(),
                     mustRequestUsernameChange: user.mustRequestUsernameChange(),
                     reportingDisabled: user.reportingDisabled(),
@@ -636,6 +637,27 @@ export class GameServer {
                 });
             } catch (err) {
                 logger.error('GameServer (undo-popup-seen) Server Error: ', err);
+                next(err);
+            }
+        });
+
+        app.put('/api/user/:userId/timer-popup-seen', this.buildAuthMiddleware(), async (req, res, next) => {
+            try {
+                const user = req.user as User;
+                // Check if user is authenticated (not an anonymous user)
+                if (user.isAnonymousUser()) {
+                    logger.error(`GameServer (timer-popup-seen): Anonymous user ${user.getId()} is attempting to retrieve timer-popup-seen info`);
+                    return res.status(401).json({
+                        success: false,
+                        message: 'Authentication required to retrieve timer-popup-seen info'
+                    });
+                }
+                const result = await this.userFactory.setTimerPopupSeenStatus(user.getId());
+                return res.status(200).json({
+                    success: result,
+                });
+            } catch (err) {
+                logger.error('GameServer (timer-popup-seen) Server Error: ', err);
                 next(err);
             }
         });

--- a/server/services/DynamoDBInterfaces.ts
+++ b/server/services/DynamoDBInterfaces.ts
@@ -35,6 +35,7 @@ export interface IUserDataEntity {
     reportingDisabled?: ModerationFieldState;
     moderation?: IModerationAction;
     undoPopupSeenDate?: string;
+    timerPopupSeenDate?: string;
 }
 
 export interface IFeMatchupStatEntity extends IMatchupStatEntity {

--- a/server/services/DynamoDBInterfaces.ts
+++ b/server/services/DynamoDBInterfaces.ts
@@ -8,6 +8,14 @@ export enum ModerationFieldState {
     EnabledAndSeen = 'enabledAndSeen',
 }
 
+export enum CardImageLocale {
+    English = 'en',
+    French = 'fr',
+    German = 'de',
+    Spanish = 'es',
+    Italian = 'it',
+}
+
 export interface IModerationAction {
     daysRemaining: number;
     endDate?: string;
@@ -67,6 +75,7 @@ export interface IUserPreferences {
     };
     gameOptions?: {
         muteChat?: boolean;
+        cardLanguage?: CardImageLocale;
     };
 }
 

--- a/server/utils/user/User.ts
+++ b/server/utils/user/User.ts
@@ -40,6 +40,11 @@ export abstract class User {
     public abstract getUndoPopupSeenDate(): Date | null;
 
     /**
+     * Gets the date the user last saw the timer tutorial popup
+     */
+    public abstract getTimerPopupSeenDate(): Date | null;
+
+    /**
      * Gets the user's preferences
      */
     public abstract getPreferences(): IUserPreferences;
@@ -107,6 +112,10 @@ export class AuthenticatedUser extends User {
 
     public getUndoPopupSeenDate(): Date | null {
         return this.userData.undoPopupSeenDate ? new Date(this.userData.undoPopupSeenDate) : null;
+    }
+
+    public getTimerPopupSeenDate(): Date | null {
+        return this.userData.timerPopupSeenDate ? new Date(this.userData.timerPopupSeenDate) : null;
     }
 
     public getUsername(): string {
@@ -216,6 +225,10 @@ export class AnonymousUser extends User {
     }
 
     public override getUndoPopupSeenDate(): Date | null {
+        return null;
+    }
+
+    public override getTimerPopupSeenDate(): Date | null {
         return null;
     }
 

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -134,6 +134,21 @@ export class UserFactory {
         }
     }
 
+    public async setTimerPopupSeenStatus(userId: string): Promise<boolean> {
+        try {
+            const dbService = await this.dbServicePromise;
+            const userProfile = await dbService.getUserProfileAsync(userId);
+            Contract.assertNotNullLike(userProfile, `No user profile found for userId ${userId}`);
+            await dbService.updateUserProfileAsync(userId, {
+                timerPopupSeenDate: new Date().toISOString()
+            });
+            return true;
+        } catch (error) {
+            logger.error('Error setting timerPopupSeen status:', { error: { message: error.message, stack: error.stack } });
+            throw error;
+        }
+    }
+
     /**
      * • Unlimited username changes during the first week (7 days) after account creation.
      * • After that, a 1‑month (30‑days) cooldown between changes.
@@ -380,6 +395,7 @@ export class UserFactory {
                 swubaseRefreshToken: null,
                 moderation: null,
                 undoPopupSeenDate: null,
+                timerPopupSeenDate: null,
             };
 
             // Create OAuth link

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -7,7 +7,7 @@ import { getDynamoDbServiceAsync } from '../../services/DynamoDBService';
 import { Contract } from '../../game/core/utils/Contract';
 import type { ParsedUrlQuery } from 'node:querystring';
 import type { IUserDataEntity, IUserPreferences, IUserProfileDataEntity, IModActionEntity } from '../../services/DynamoDBInterfaces';
-import { ModerationFieldState, ModerationType } from '../../services/DynamoDBInterfaces';
+import { CardImageLocale, ModerationFieldState, ModerationType } from '../../services/DynamoDBInterfaces';
 import { RefreshTokenSource } from '../statHandlers/StatHandlerTypes';
 
 
@@ -26,6 +26,7 @@ const getDefaultCosmeticsPreferences = () => ({
 
 const getDefaultGameOptionsPreferences = () => ({
     muteChat: false,
+    cardLanguage: CardImageLocale.English,
 });
 
 export const getDefaultPreferences = (): IUserPreferences => ({


### PR DESCRIPTION
Adds two properties to the DB related to supporting card languages:
- A new preference option for the selected card language (defaults to EN)
- A tracking date for having seen the timer tutorial popup, same as we do for the undo tutorial popup