### PR TITLE
Improve resourcing prompts

### DIFF
--- a/server/game/core/gameSteps/prompts/ResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/ResourcePrompt.ts
@@ -57,6 +57,9 @@ export class ResourcePrompt extends AllPlayerPrompt {
 
     public override activePromptInternal(player: Player): IPlayerPromptStateProperties {
         let promptText = null;
+        const selectedCount = this.selectedCards[player.name].length;
+        const selectCardMode = this.nCardsToResource === 1 ? SelectCardMode.Single : SelectCardMode.Multiple;
+
         if (this.nCardsToResource !== 1) {
             promptText = `Select ${this.nCardsToResource} cards to resource`;
         } else {
@@ -66,9 +69,13 @@ export class ResourcePrompt extends AllPlayerPrompt {
         const hasEnoughSelected = this.hasEnoughSelected(player);
 
         return {
-            selectCardMode: this.nCardsToResource === 1 ? SelectCardMode.Single : SelectCardMode.Multiple,
+            selectCardMode,
             menuTitle: promptText,
-            buttons: [{ text: 'Done', arg: 'done', disabled: !hasEnoughSelected }],
+            buttons: [{
+                text: selectedCount === 0 && selectCardMode === SelectCardMode.Single ? 'Skip Resourcing' : 'Confirm Resources',
+                arg: 'done',
+                disabled: !hasEnoughSelected,
+            }],
             promptTitle: 'Resource Step',
             promptUuid: this.uuid,
             promptType: PromptType.Resource

--- a/server/game/core/gameSteps/prompts/VariableResourcePrompt.ts
+++ b/server/game/core/gameSteps/prompts/VariableResourcePrompt.ts
@@ -24,11 +24,16 @@ export class VariableResourcePrompt extends ResourcePrompt {
         const promptText = `Select between ${this.minCardsToResource} and ${this.maxCardsToResource} cards to resource`;
 
         const hasEnoughSelected = this.hasEnoughSelected(player);
+        const selectedCount = this.selectedCards[player.name].length;
 
         return {
             selectCardMode: SelectCardMode.Multiple,
             menuTitle: promptText,
-            buttons: [{ text: 'Done', arg: 'done', disabled: !hasEnoughSelected }],
+            buttons: [{
+                text: selectedCount === 0 ? 'Skip Resourcing' : 'Confirm Resources',
+                arg: 'done',
+                disabled: !hasEnoughSelected,
+            }],
             promptTitle: VariableResourcePrompt.title,
             promptUuid: this.uuid,
             promptType: PromptType.Resource

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -84,7 +84,7 @@ class GameFlowWrapper {
         this.guardCurrentPhase('setup');
         for (const player of this.allPlayersInInitiativeOrder()) {
             player.clickAnyOfSelectableCards(2);
-            player.clickPrompt('Done');
+            player.clickDone();
         }
 
         this.game.continue();
@@ -144,7 +144,7 @@ class GameFlowWrapper {
     skipRegroupPhase() {
         this.guardCurrentPhase('regroup');
         var playersInPromptedOrder = [...this.allPlayers].sort((player) => player.hasPrompt('Waiting for opponent to choose cards to resource'));
-        playersInPromptedOrder.forEach((player) => player.clickPrompt('Done'));
+        playersInPromptedOrder.forEach((player) => player.clickDone());
         this.guardCurrentPhase('action');
     }
 

--- a/test/helpers/PlayerInteractionWrapper.ts
+++ b/test/helpers/PlayerInteractionWrapper.ts
@@ -638,9 +638,13 @@ export class PlayerInteractionWrapper {
     public clickPrompt(text: string) {
         text = text.toString();
         const currentPrompt = this.player.currentPrompt();
-        const promptButton = currentPrompt.buttons.find(
+        let promptButton = currentPrompt.buttons.find(
             (button: { text: { toString: () => string } }) => button.text.toString().toLowerCase() === text.toLowerCase()
         );
+
+        if (!promptButton && text.toLowerCase() === 'done') {
+            promptButton = currentPrompt.buttons.find((button: { arg: string }) => button.arg === 'done');
+        }
 
         if (!promptButton || promptButton.disabled) {
             throw new TestSetupError(
@@ -914,10 +918,17 @@ export class PlayerInteractionWrapper {
      * Player clicks Done prompt
      */
     public clickDone() {
-        if (!this.currentButtons.includes('Done')) {
-            throw new TestSetupError(`${this.name} can't click Done, because it is not present in the prompt`);
+        const currentPrompt = this.player.currentPrompt();
+        const doneButton = currentPrompt.buttons.find((button: { arg: string; text: { toString: () => string } }) =>
+            button.arg === 'done' || button.text.toString().toLowerCase() === 'done'
+        );
+
+        if (!doneButton || doneButton.disabled) {
+            throw new TestSetupError(`${this.name} can't click Done, because it is not present in the prompt:\n${Util.formatBothPlayerPrompts(this.testContext)}`);
         }
-        this.clickPrompt('Done');
+
+        this.game.menuButton(this.player.id, doneButton.arg, doneButton.uuid, doneButton.method);
+        this.game.continue();
     }
 
     /**

--- a/test/server/core/gameSteps/actionWindow/Initiative.spec.ts
+++ b/test/server/core/gameSteps/actionWindow/Initiative.spec.ts
@@ -52,8 +52,8 @@ describe('Claiming initiative', function() {
 
                 // Regroup phase
                 expect(context.ardentSympathizer.getPower()).toBe(3);
-                expect(context.player2).toHaveExactPromptButtons(['Done']);
-                expect(context.player1).toHaveExactPromptButtons(['Done']);
+                expect(context.player2).toHaveExactPromptButtons(['Skip Resourcing']);
+                expect(context.player1).toHaveExactPromptButtons(['Skip Resourcing']);
 
                 context.player2.clickDone();
                 context.player1.clickDone();
@@ -70,8 +70,8 @@ describe('Claiming initiative', function() {
                 context.player2.passAction();
 
                 // Regroup phase
-                expect(context.player2).toHaveExactPromptButtons(['Done']);
-                expect(context.player1).toHaveExactPromptButtons(['Done']);
+                expect(context.player2).toHaveExactPromptButtons(['Skip Resourcing']);
+                expect(context.player1).toHaveExactPromptButtons(['Skip Resourcing']);
 
                 context.player2.clickDone();
                 context.player1.clickDone();

--- a/test/server/core/gameSteps/phases/SetupPhase.spec.ts
+++ b/test/server/core/gameSteps/phases/SetupPhase.spec.ts
@@ -104,16 +104,16 @@ describe('Setup Phase', function() {
 
                 // We check if player1's hand has the only selectable cards
                 expect(context.player1).toBeAbleToSelectExactly(context.player1.hand);
-                expect(context.player1).toHaveExactPromptButtons(['Done']);
-                expect(context.player2).toHaveExactPromptButtons(['Done']);
-                expect(context.player1).toHaveDisabledPromptButton('Done');
-                expect(context.player2).toHaveDisabledPromptButton('Done');
+                expect(context.player1).toHaveExactPromptButtons(['Confirm Resources']);
+                expect(context.player2).toHaveExactPromptButtons(['Confirm Resources']);
+                expect(context.player1).toHaveDisabledPromptButton('Confirm Resources');
+                expect(context.player2).toHaveDisabledPromptButton('Confirm Resources');
 
                 context.player1.clickCard(context.player1.hand[1]);
-                expect(context.player1).toHaveExactPromptButtons(['Done']);
-                expect(context.player2).toHaveExactPromptButtons(['Done']);
-                expect(context.player1).toHaveEnabledPromptButton('Done');
-                expect(context.player2).toHaveDisabledPromptButton('Done');
+                expect(context.player1).toHaveExactPromptButtons(['Confirm Resources']);
+                expect(context.player2).toHaveExactPromptButtons(['Confirm Resources']);
+                expect(context.player1).toHaveEnabledPromptButton('Confirm Resources');
+                expect(context.player2).toHaveDisabledPromptButton('Confirm Resources');
 
                 // Check that player1 cannot select any additional cards
                 context.player1.clickCardNonChecking(context.player1.hand[2]);
@@ -143,8 +143,8 @@ describe('Setup Phase', function() {
                 context.player2.clickFirstCardInHand();
                 expect(context.player2.selectedCards.length).toBe(1);
                 expect(context.player1).toHavePrompt('Waiting for opponent to choose cards to resource');
-                expect(context.player2).toHaveExactPromptButtons(['Done']);
-                expect(context.player2).toHaveDisabledPromptButton('Done');
+                expect(context.player2).toHaveExactPromptButtons(['Confirm Resources']);
+                expect(context.player2).toHaveDisabledPromptButton('Confirm Resources');
 
                 // we check if player2's hand has the only selectable cards
                 expect(context.player2).toBeAbleToSelectExactly(context.player2.hand);
@@ -152,8 +152,8 @@ describe('Setup Phase', function() {
                 // click the second card to resource
                 context.player2.clickCard(context.player2.hand[1]);
                 expect(context.player1).toHavePrompt('Waiting for opponent to choose cards to resource');
-                expect(context.player2).toHaveExactPromptButtons(['Done']);
-                expect(context.player2).toHaveEnabledPromptButton('Done');
+                expect(context.player2).toHaveExactPromptButtons(['Confirm Resources']);
+                expect(context.player2).toHaveEnabledPromptButton('Confirm Resources');
 
                 // Check that player2 cannot select any additional cards
                 context.player2.clickCardNonChecking(context.player2.hand[2]);

--- a/test/server/core/gameSteps/regroupWindow/RegroupPhase.spec.ts
+++ b/test/server/core/gameSteps/regroupWindow/RegroupPhase.spec.ts
@@ -75,12 +75,12 @@ describe('Regroup phase', function() {
                     oldResourcesPlayer1.push(context.wroshyrTreeTender);
 
                     // we check that both players have the correct prompt
-                    expect(context.player1).toHaveExactPromptButtons(['Done']);
-                    expect(context.player2).toHaveExactPromptButtons(['Done']);
+                    expect(context.player1).toHaveExactPromptButtons(['Confirm Resources']);
+                    expect(context.player2).toHaveExactPromptButtons(['Skip Resourcing']);
 
                     context.player1.clickDone();
                     expect(context.player1).toHavePrompt('Waiting for opponent to choose cards to resource');
-                    expect(context.player2).toHaveExactPromptButtons(['Done']);
+                    expect(context.player2).toHaveExactPromptButtons(['Skip Resourcing']);
                     context.player2.clickDone();
 
                     expect(context.getChatLogs(4)).toContain('player1 has resourced 1 card from hand');


### PR DESCRIPTION
Issue was [reported on the FE](https://github.com/SWU-Karabast/forceteki-client/issues/448) but I think this could be an easy solution for it.

Initial sourcing phase:
<img width="1888" height="934" alt="Screenshot 2026-05-26 at 10 22 35 AM" src="https://github.com/user-attachments/assets/80deb4e0-da19-432c-83ca-5c50a158daba" />
<img width="1874" height="938" alt="Screenshot 2026-05-26 at 10 22 46 AM" src="https://github.com/user-attachments/assets/43258e84-fe6a-443c-b054-9e1b015474f3" />


Later on

<img width="1826" height="953" alt="Screenshot 2026-05-26 at 10 21 04 AM" src="https://github.com/user-attachments/assets/4785b1ab-0579-48a0-b323-7bdfc81ddc04" />
<img width="1876" height="942" alt="Screenshot 2026-05-26 at 10 21 25 AM" src="https://github.com/user-attachments/assets/ce746c14-50ca-4c13-8196-b0ed2de43df5" />
