### PR TITLE
Bugfix: add keyword deduping to prevent gain loops

### DIFF
--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -52,6 +52,47 @@ export function parseKeywords(
     return keywords;
 }
 
+/**
+ * Deduplicates keyword instances per CR 7.5.4 stacking rules:
+ * - Non-stacking keywords (Ambush, Grit, Hidden, Overwhelm, Plot, Saboteur, Sentinel, Shielded, Support):
+ *   collapse to a single instance per name.
+ * - Numeric-stacking keywords (Raid, Restore, Exploit): collapse to a single instance per name with summed value.
+ * - Cost-bearing keywords (Smuggle, Piloting) and ability-definition keywords (Bounty, Coordinate):
+ *   each instance is its own independent ability, so all are kept.
+ *
+ * @param card The card whose keyword list is being deduped; used as the owning card for any new instances created here.
+ */
+export function dedupeKeywords(instances: KeywordInstance[], card: Card): KeywordInstance[] {
+    const result: KeywordInstance[] = [];
+    const seenNonStacking = new Set<KeywordName>();
+    const numericTotals = new Map<NumericKeywordName, number>();
+
+    for (const instance of instances) {
+        if (instance.hasNumericValue()) {
+            const existing = numericTotals.get(instance.name);
+            numericTotals.set(instance.name, (existing ?? 0) + instance.value);
+            continue;
+        }
+
+        if (instance.hasCostValue() || instance.hasAbilityDefinition()) {
+            result.push(instance);
+            continue;
+        }
+
+        if (seenNonStacking.has(instance.name)) {
+            continue;
+        }
+        seenNonStacking.add(instance.name);
+        result.push(instance);
+    }
+
+    for (const [name, sum] of numericTotals) {
+        result.push(new KeywordWithNumericValue(name, card, sum));
+    }
+
+    return result;
+}
+
 export function keywordFromProperties(properties: IKeywordProperties, card: Card) {
     switch (properties.keyword) {
         case KeywordName.Restore:

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -717,7 +717,7 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
 
         keywordInstances = keywordInstances.filter((instance) => !instance.isBlank);
 
-        return keywordInstances;
+        return KeywordHelpers.dedupeKeywords(keywordInstances, this);
     }
 
     public getKeywordsWithCostValues(keywordName: KeywordName): KeywordWithCostValues[] {

--- a/test/server/cards/04_JTL/units/TheGhostHeartOfTheFamily.spec.ts
+++ b/test/server/cards/04_JTL/units/TheGhostHeartOfTheFamily.spec.ts
@@ -327,6 +327,43 @@ describe('The Ghost, Heart of the Family', () => {
             });
         });
 
+        describe('ongoing effect loop with Ezra Bridger Support', function() {
+            it('does not infinite loop in the ongoing effect engine when Ezra Bridger uses Support to attack with The Ghost while The Ghost is upgraded', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['ezra-bridger#the-force-is-all-i-need'],
+                        spaceArena: [
+                            { card: 'the-ghost#heart-of-the-family', upgrades: ['experience'] }
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Ezra Bridger — Support triggers, prompting to attack with another unit.
+                // The Ghost is upgraded, so it has Sentinel, which The Ghost's constant ability
+                // grants to Ezra (Spectre). Support's lasting effect then grants Ezra's keywords
+                // (including that Sentinel) back to The Ghost, creating a mutual keyword-grant loop
+                // in the ongoing effect engine. This test ensures that loop does not infinite-loop.
+                context.player1.clickCard(context.ezraBridger);
+
+                // Support: select The Ghost as the attacking unit
+                context.player1.clickCard(context.theGhost);
+
+                // The Ghost attacks p2Base
+                context.player1.clickCard(context.p2Base);
+
+                // Support grants The Ghost Ezra's non-keyword abilities for the attack,
+                // including Ezra's optional "Give a unit -3/-0" on-attack ability. Skip it.
+                context.player1.clickPrompt('Pass');
+
+                // The Ghost (power 5 + 1 from experience = 6) attacks the base
+                expect(context.p2Base.damage).toBe(6);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
         describe('When The Ghost gains', function() {
             it('Hidden, it shares that keyword with other friendly Spectre units', async function() {
                 await contextRef.setupTestAsync({

--- a/test/server/cards/04_JTL/units/TheGhostHeartOfTheFamily.spec.ts
+++ b/test/server/cards/04_JTL/units/TheGhostHeartOfTheFamily.spec.ts
@@ -345,7 +345,7 @@ describe('The Ghost, Heart of the Family', () => {
                 // The Ghost is upgraded, so it has Sentinel, which The Ghost's constant ability
                 // grants to Ezra (Spectre). Support's lasting effect then grants Ezra's keywords
                 // (including that Sentinel) back to The Ghost, creating a mutual keyword-grant loop
-                // in the ongoing effect engine. This test ensures that loop does not infinite-loop.
+                // in the ongoing effect engine. This test ensures that loop does not continue indefinitely.
                 context.player1.clickCard(context.ezraBridger);
 
                 // Support: select The Ghost as the attacking unit
@@ -354,12 +354,12 @@ describe('The Ghost, Heart of the Family', () => {
                 // The Ghost attacks p2Base
                 context.player1.clickCard(context.p2Base);
 
-                // Support grants The Ghost Ezra's non-keyword abilities for the attack,
+                // Support grants The Ghost Ezra's non-Support abilities for the attack,
                 // including Ezra's optional "Give a unit -3/-0" on-attack ability. Skip it.
                 context.player1.clickPrompt('Pass');
 
-                // The Ghost (power 5 + 1 from experience = 6) attacks the base
-                expect(context.p2Base.damage).toBe(6);
+                // Attack completed, it is now P2's action
+                expect(context.p2Base.damage).toBe(6); // 5 base power plus experience token
                 expect(context.player2).toBeActivePlayer();
             });
         });


### PR DESCRIPTION
This PR adds the keyword stacking logic described in CR 7.5.4:

> If a card is given a keyword it already has, those keywords do not “stack” (meaning, the card does not gain any additional effects) unless those keywords are followed by a numeral, a cost, or a dash and ability text. If they are followed by a numeral, the numbers following each keyword are added together. If they are followed by a cost or a dash and ability text, each keyword is considered its own ability.

This takes the form of a de-duping function before returning a card's keywords from `Card.getKeywords()`.

Without this, abilities that gain keywords from other units could create an infinite loop when resolving the keywords, specifically for the case where two units grant their keywords to each other. The only current example in the engine is The Ghost (JTL) and Ezra Bridger (ASH). Scenario:

- The Ghost is upgraded, giving itself sentinel
- The Ghost shares its keywords with other **_Spectre_** units
- Ezra Bridger (**_Spectre_**) is played, gaining the Sentinel keyword, and triggering his support Keyword to initiate an attack with The Ghost
- Support grants a unit's abilities (including keywords other than Support itself) to the attacking unit for the duration of the attack. 

We now have two dynamic `gainKeyword` abilities that depend on each other:

1. Ezra asks Ghost for its keywords
2. Ghost returns it's own Sentinel ability, then asks Ezra for its keywords
3. Ezra asks Ghost for it's keywords again
4. And so on...the list grows indefinitely

With the de-dupe method, the ongoing effect engine sees a stable set of keywords across effect resolution, rather than an ever-growing bag of keywords.