### PR TITLE
Bugfix: capture Support unit's keywords at the start of the attack

### DIFF
--- a/server/game/abilities/keyword/SupportAbility.ts
+++ b/server/game/abilities/keyword/SupportAbility.ts
@@ -23,20 +23,23 @@ export class SupportAbility extends TriggeredAbilityBase {
             zoneFilter: WildcardZoneName.AnyArena,
             targetResolver: {
                 activePromptTitle: `Attack with another unit. It gains ${source.title}'s abilities for this attack.`,
-                immediateEffect: new InitiateAttackSystem((context) => ({
-                    attackerCondition: (card) => card !== context.source,
-                    attackerLastingEffects: {
-                        effect: [
-                            context.game.abilityHelper.ongoingEffects
-                                .gainNonKeywordAbilitiesFromUnit(context.source),
-                            context.game.abilityHelper.ongoingEffects.gainKeywords(() =>
-                                context.source.keywords
-                                    .filter((instance) => instance.name !== KeywordName.Support)
-                                    .map((keyword) => keyword.toProperties())
-                            )
-                        ]
-                    }
-                }))
+                immediateEffect: new InitiateAttackSystem((context) => {
+                    // Snapshot keywords at the time of attack so dynamically gained keywords don't continue to update
+                    // after the attack is initiated.
+                    const keywords = context.source.keywords.filter((instance) => instance.name !== KeywordName.Support);
+                    return {
+                        attackerCondition: (card) => card !== context.source,
+                        attackerLastingEffects: {
+                            effect: [
+                                context.game.abilityHelper.ongoingEffects
+                                    .gainNonKeywordAbilitiesFromUnit(context.source),
+                                context.game.abilityHelper.ongoingEffects.gainKeywords(() =>
+                                    keywords.map((keyword) => keyword.toProperties())
+                                )
+                            ]
+                        }
+                    };
+                })
             }
         };
     }

--- a/test/server/core/abilities/keyword/Support.spec.ts
+++ b/test/server/core/abilities/keyword/Support.spec.ts
@@ -191,6 +191,30 @@ describe('Support keyword', function() {
             });
         });
 
+        it('the Raid value is captured when the attack is initiated, not updated dynamically during the attack', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['ezra-bridger#the-force-is-all-i-need'],
+                    spaceArena: ['the-ghost#heart-of-the-family', 'red-three#unstoppable']
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Play Ezra (Raid 2: 1 from Red Three, 1 from Ghost)
+            context.player1.clickCard(context.ezraBridger);
+
+            // Select The Ghost
+            expect(context.player1).toBeAbleToSelectExactly([context.theGhost, context.redThree]);
+            context.player1.clickCard(context.theGhost);
+            context.player1.clickCard(context.p2Base);
+
+            // The Ghost should gain Raid 3 (1 from Red Three, 2 from Ezra via Support)
+            expect(context.p2Base.damage).toBe(8);
+            expect(context.player2).toBeActivePlayer();
+        });
+
         describe('When the Support unit gains triggered abilities from another source', function() {
             it('the Support target gains the triggered ability for the attack', async function() {
                 await contextRef.setupTestAsync({


### PR DESCRIPTION
This prevents infinite loops in dynamically updating gained keyword abilities that depend on each other.