### PR TITLE
Remove ASH card mocks in favor of official data

### DIFF
--- a/scripts/fetchdata.js
+++ b/scripts/fetchdata.js
@@ -40,6 +40,10 @@ function populateMissingData(attributes, id) {
             attributes.upgradeHp = 0;
             attributes.upgradePower = 0;
             break;
+        case '5844562972': // advantage
+            attributes.upgradeHp = 0;
+            attributes.upgradePower = 1;
+            break;
         case '8015500527': // Credit token
         case '4571900905': // The Force
             attributes.cost = 0;

--- a/scripts/mockdata.js
+++ b/scripts/mockdata.js
@@ -18,61 +18,6 @@ const mockCards = [
         arena: 'ground',
         internalName: 'mandalorian',
     }),
-    // Advantage
-    buildMockCard({
-        title: 'Advantage',
-        cost: 0,
-        hp: 0,
-        power: 0,
-        upgradePower: 1,
-        upgradeHp: 0,
-        hasNonKeywordAbility: true,
-        types: ['token', 'upgrade'],
-        traits: ['innate'],
-        setId: {
-            set: 'ASH'
-        },
-        unique: false,
-        internalName: 'advantage'
-    }),
-    // Luke Skywalker, I Can Save Him
-    buildMockCard({
-        title: 'Luke Skywalker',
-        subtitle: 'I Can Save Him',
-        power: 6,
-        hp: 7,
-        cost: 7,
-        hasNonKeywordAbility: true,
-        aspects: ['vigilance', 'heroism'],
-        types: ['leader'],
-        traits: ['force', 'jedi', 'rebel'],
-        setId: {
-            set: 'ASH',
-            number: 5
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'luke-skywalker#i-can-save-him',
-    }),
-    // Emperor Palpatine, According to My Design
-    buildMockCard({
-        title: 'Emperor Palpatine',
-        subtitle: 'According to My Design',
-        power: 4,
-        hp: 8,
-        cost: 7,
-        hasNonKeywordAbility: true,
-        aspects: ['cunning', 'villainy'],
-        types: ['leader'],
-        traits: ['force', 'imperial', 'sith', 'official'],
-        setId: {
-            set: 'ASH',
-            number: 15
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'emperor-palpatine#according-to-my-design',
-    }),
     // Grogu, Charming Companion
     buildMockCard({
         title: 'Grogu',
@@ -131,26 +76,6 @@ const mockCards = [
         unique: true,
         internalName: 'blade-of-talzin#a-gift-of-shadows',
     }),
-    // Leia Organa, Vigilant for Danger
-    buildMockCard({
-        title: 'Leia Organa',
-        subtitle: 'Vigilant for Danger',
-        power: 3,
-        hp: 4,
-        cost: 3,
-        hasNonKeywordAbility: true,
-        aspects: ['vigilance', 'heroism'],
-        types: ['unit'],
-        traits: ['rebel', 'official'],
-        keywords: ['support'],
-        setId: {
-            set: 'ASH',
-            number: 59
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'leia-organa#vigilant-for-danger',
-    }),
     // The Armorer, Secrecy is Our Survival
     buildMockCard({
         title: 'The Armorer',
@@ -171,162 +96,6 @@ const mockCards = [
         arena: 'ground',
         internalName: 'the-armorer#secrecy-is-our-survival',
     }),
-    // Luke's Jedi Lightsaber, Constructed by Hand
-    buildMockCard({
-        title: 'Luke\'s Jedi Lightsaber',
-        subtitle: 'Constructed by Hand',
-        power: 0,
-        hp: 0,
-        upgradePower: 3,
-        upgradeHp: 3,
-        cost: 3,
-        hasNonKeywordAbility: true,
-        aspects: ['vigilance', 'heroism'],
-        types: ['upgrade'],
-        traits: ['item', 'weapon', 'lightsaber'],
-        setId: {
-            set: 'ASH',
-            number: 66
-        },
-        unique: true,
-        internalName: 'lukes-jedi-lightsaber#constructed-by-hand',
-    }),
-    // Moff Jerjerrod, We Shall Redouble Our Efforts
-    buildMockCard({
-        title: 'Moff Jerjerrod',
-        subtitle: 'We Shall Redouble Our Efforts',
-        power: 1,
-        hp: 3,
-        cost: 2,
-        hasNonKeywordAbility: true,
-        aspects: ['command', 'villainy'],
-        types: ['unit'],
-        traits: ['imperial', 'official'],
-        setId: {
-            set: 'ASH',
-            number: 94
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'moff-jerjerrod#we-shall-redouble-our-efforts',
-    }),
-    // Forest Patroller
-    buildMockCard({
-        title: 'Forest Patroller',
-        power: 3,
-        hp: 4,
-        cost: 3,
-        hasNonKeywordAbility: false,
-        aspects: ['command', 'villainy'],
-        types: ['unit'],
-        traits: ['imperial', 'trooper'],
-        keywords: ['overwhelm', 'restore 1'],
-        setId: {
-            set: 'ASH',
-            number: 96
-        },
-        unique: false,
-        arena: 'ground',
-        internalName: 'forest-patroller',
-    }),
-    // Moff Gideon, Remnant Commander
-    buildMockCard({
-        title: 'Moff Gideon',
-        subtitle: 'Remnant Commander',
-        power: 2,
-        hp: 5,
-        cost: 3,
-        hasNonKeywordAbility: true,
-        aspects: ['command', 'villainy'],
-        types: ['unit'],
-        traits: ['imperial', 'official'],
-        keywords: ['sentinel'],
-        setId: {
-            set: 'ASH',
-            number: 97
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'moff-gideon#remnant-commander',
-    }),
-    // R5-D4, Built For Adventure
-    buildMockCard({
-        title: 'R5-D4',
-        subtitle: 'Built For Adventure',
-        power: 3,
-        hp: 4,
-        cost: 3,
-        hasNonKeywordAbility: true,
-        aspects: ['aggression', 'heroism'],
-        types: ['unit'],
-        traits: ['droid'],
-        keywords: ['support'],
-        setId: {
-            set: 'ASH',
-            number: 156
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'r5d4#built-for-adventure',
-    }),
-    // Han Solo, It'll Work
-    buildMockCard({
-        title: 'Han Solo',
-        subtitle: 'It\'ll Work',
-        power: 3,
-        hp: 7,
-        cost: 4,
-        hasNonKeywordAbility: true,
-        aspects: ['aggression', 'heroism'],
-        types: ['unit'],
-        traits: ['rebel', 'official'],
-        keywords: ['saboteur'],
-        setId: {
-            set: 'ASH',
-            number: 158
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'han-solo#itll-work',
-    }),
-    // Executor, Final Destruction of the Alliance
-    buildMockCard({
-        title: 'Executor',
-        subtitle: 'Final Destruction of the Alliance',
-        power: 5,
-        hp: 12,
-        cost: 8,
-        hasNonKeywordAbility: true,
-        aspects: ['cunning', 'villainy'],
-        types: ['unit'],
-        traits: ['imperial', 'vehicle', 'capital ship'],
-        setId: {
-            set: 'ASH',
-            number: 197
-        },
-        unique: true,
-        arena: 'space',
-        internalName: 'executor#final-destruction-of-the-alliance',
-    }),
-    // There Is No Conflict
-    buildMockCard({
-        title: 'There Is No Conflict',
-        power: 0,
-        hp: 0,
-        upgradePower: 2,
-        upgradeHp: 2,
-        cost: 2,
-        hasNonKeywordAbility: true,
-        aspects: ['cunning', 'villainy'],
-        types: ['upgrade'],
-        traits: ['innate'],
-        setId: {
-            set: 'ASH',
-            number: 199
-        },
-        unique: false,
-        internalName: 'there-is-no-conflict',
-    }),
     // Ezra Bridger, The Force Is All I Need
     buildMockCard({
         title: 'Ezra Bridger',
@@ -346,64 +115,6 @@ const mockCards = [
         unique: true,
         arena: 'ground',
         internalName: 'ezra-bridger#the-force-is-all-i-need',
-    }),
-    // Helix Starfighter
-    buildMockCard({
-        title: 'Helix Starfighter',
-        power: 3,
-        hp: 3,
-        cost: 4,
-        hasNonKeywordAbility: true,
-        aspects: ['cunning'],
-        types: ['unit'],
-        traits: ['underworld', 'vehicle', 'fighter'],
-        setId: {
-            set: 'ASH',
-            number: 221
-        },
-        unique: false,
-        arena: 'space',
-        internalName: 'helix-starfighter',
-    }),
-    // Darth Vader, Meet Your Destiny
-    buildMockCard({
-        title: 'Darth Vader',
-        subtitle: 'Meet Your Destiny',
-        power: 4,
-        hp: 6,
-        cost: 5,
-        hasNonKeywordAbility: true,
-        aspects: ['villainy'],
-        types: ['unit'],
-        traits: ['force', 'imperial', 'sith'],
-        keywords: ['shielded'],
-        setId: {
-            set: 'ASH',
-            number: 243
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'darth-vader#meet-your-destiny',
-    }),
-    // Anakin Skywalker, You Were Right About Me
-    buildMockCard({
-        title: 'Anakin Skywalker',
-        subtitle: 'You Were Right About Me',
-        power: 6,
-        hp: 4,
-        cost: 5,
-        hasNonKeywordAbility: true,
-        aspects: ['heroism'],
-        types: ['unit'],
-        traits: ['force', 'jedi'],
-        keywords: ['hidden', 'saboteur'],
-        setId: {
-            set: 'ASH',
-            number: 255
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'anakin-skywalker#you-were-right-about-me',
     }),
     buildMockCard({
         title: 'Jod Na Nawood',
@@ -572,25 +283,6 @@ const mockCards = [
         internalName: 't6-shuttle-1974#with-a-mentors-dedication',
     }),
     buildMockCard({
-        title: 'Cobb Vanth',
-        subtitle: 'Let Me Handle This',
-        cost: 4,
-        power: 2,
-        hp: 6,
-        hasNonKeywordAbility: true,
-        aspects: ['vigilance', 'heroism'],
-        types: ['unit'],
-        traits: ['official'],
-        keywords: ['grit'],
-        setId: {
-            set: 'ASH',
-            number: 60
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'cobb-vanth#let-me-handle-this',
-    }),
-    buildMockCard({
         title: 'Ahsoka Tano',
         subtitle: 'Trust in The Force',
         cost: 6,
@@ -644,25 +336,6 @@ const mockCards = [
         unique: true,
         arena: 'space',
         internalName: 'chimaera#a-frightening-reality',
-    }),
-    buildMockCard({
-        title: 'Home One',
-        subtitle: 'Heart of the Fleet',
-        cost: 8,
-        power: 7,
-        hp: 10,
-        hasNonKeywordAbility: true,
-        aspects: ['vigilance', 'heroism'],
-        types: ['unit'],
-        traits: ['rebel', 'vehicle', 'capital ship'],
-        keywords: ['sentinel'],
-        setId: {
-            set: 'ASH',
-            number: 65
-        },
-        unique: true,
-        arena: 'space',
-        internalName: 'home-one#heart-of-the-fleet',
     }),
     buildMockCard({
         title: 'Protectorate Fighter',
@@ -817,43 +490,6 @@ const mockCards = [
         internalName: 'scion-shuttle#at-morgans-bidding',
     }),
     buildMockCard({
-        title: 'Shin Hati\'s Fiend Fighter',
-        subtitle: 'Compact and Agile',
-        cost: 2,
-        power: 3,
-        hp: 1,
-        hasNonKeywordAbility: true,
-        aspects: ['cunning', 'villainy'],
-        types: ['unit'],
-        traits: ['vehicle', 'fighter'],
-        setId: {
-            set: 'ASH',
-            number: 191
-        },
-        unique: true,
-        arena: 'space',
-        internalName: 'shin-hatis-fiend-fighter#compact-and-agile',
-    }),
-    buildMockCard({
-        title: 'Doctor Pershing',
-        subtitle: 'Dedicated to Research',
-        cost: 2,
-        power: 0,
-        hp: 4,
-        hasNonKeywordAbility: true,
-        keywords: ['support'],
-        aspects: ['vigilance'],
-        types: ['unit'],
-        traits: ['new republic'],
-        setId: {
-            set: 'ASH',
-            number: 72
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'doctor-pershing#dedicated-to-research',
-    }),
-    buildMockCard({
         title: 'Gar Saxon',
         subtitle: 'Coveting Power',
         cost: 3,
@@ -890,25 +526,6 @@ const mockCards = [
         internalName: 'grogu#yes-yes-yes',
     }),
     buildMockCard({
-        title: 'The Great Mothers',
-        subtitle: 'With Strange Magicks',
-        cost: 7,
-        power: 6,
-        hp: 7,
-        hasNonKeywordAbility: true,
-        keywords: ['support'],
-        aspects: ['command', 'villainy'],
-        types: ['unit'],
-        traits: ['force', 'night'],
-        setId: {
-            set: 'ASH',
-            number: 101
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'the-great-mothers#with-strange-magicks',
-    }),
-    buildMockCard({
         title: 'Eye of Sion',
         subtitle: 'Delivered from Exile',
         cost: 7,
@@ -925,20 +542,6 @@ const mockCards = [
         unique: true,
         arena: 'space',
         internalName: 'eye-of-sion#delivered-from-exile',
-    }),
-    buildMockCard({
-        title: 'Hold Them Off',
-        cost: 4,
-        hasNonKeywordAbility: true,
-        aspects: ['command'],
-        types: ['event'],
-        traits: ['tactic'],
-        setId: {
-            set: 'ASH',
-            number: 139
-        },
-        unique: false,
-        internalName: 'hold-them-off',
     }),
     buildMockCard({
         title: 'The Mandalorian',
@@ -960,24 +563,6 @@ const mockCards = [
         internalName: 'the-mandalorian#we-cant-keep-running',
     }),
     buildMockCard({
-        title: 'Green Leader',
-        subtitle: 'Crynyd\'s Sacrifice',
-        cost: 2,
-        power: 3,
-        hp: 1,
-        hasNonKeywordAbility: true,
-        aspects: ['aggression', 'heroism'],
-        types: ['unit'],
-        traits: ['rebel', 'vehicle', 'fighter'],
-        setId: {
-            set: 'ASH',
-            number: 153
-        },
-        unique: true,
-        arena: 'space',
-        internalName: 'green-leader#crynyds-sacrifice',
-    }),
-    buildMockCard({
         title: 'Zeb Orrelios',
         subtitle: 'Fists Work Every Time',
         cost: 7,
@@ -994,20 +579,6 @@ const mockCards = [
         unique: true,
         arena: 'ground',
         internalName: 'zeb-orrelios#fists-work-every-time',
-    }),
-    buildMockCard({
-        title: 'Reckless Sacrifice',
-        cost: 2,
-        hasNonKeywordAbility: true,
-        aspects: ['aggression', 'heroism'],
-        types: ['event'],
-        traits: ['gambit'],
-        setId: {
-            set: 'ASH',
-            number: 163
-        },
-        unique: false,
-        internalName: 'reckless-sacrifice',
     }),
     buildMockCard({
         title: 'Sabine Wren',
@@ -1092,61 +663,6 @@ const mockCards = [
         },
         unique: false,
         internalName: 'far-far-away',
-    }),
-    buildMockCard({
-        title: 'Bothan-5',
-        subtitle: 'New Republic Prison Ship',
-        cost: 5,
-        power: 4,
-        hp: 5,
-        hasNonKeywordAbility: true,
-        aspects: ['command'],
-        types: ['unit'],
-        traits: ['new republic', 'vehicle', 'transport'],
-        setId: {
-            set: 'ASH',
-            number: 128
-        },
-        unique: true,
-        arena: 'space',
-        internalName: 'bothan5#new-republic-prison-ship',
-    }),
-    buildMockCard({
-        title: 'Rukh',
-        subtitle: 'From the Shadows',
-        cost: 3,
-        power: 1,
-        hp: 5,
-        hasNonKeywordAbility: true,
-        aspects: ['command', 'cunning', 'villainy'],
-        types: ['unit'],
-        traits: ['imperial'],
-        keywords: ['support'],
-        setId: {
-            set: 'ASH',
-            number: 36
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'rukh#from-the-shadows',
-    }),
-    buildMockCard({
-        title: 'Hera Syndulla',
-        subtitle: 'Renegade General',
-        cost: 3,
-        power: 3,
-        hp: 4,
-        hasNonKeywordAbility: true,
-        aspects: ['vigilance', 'aggression', 'heroism'],
-        types: ['unit'],
-        traits: ['new republic', 'twi\'lek', 'spectre'],
-        setId: {
-            set: 'ASH',
-            number: 31
-        },
-        unique: true,
-        arena: 'ground',
-        internalName: 'hera-syndulla#renegade-general',
     }),
     buildMockCard({
         title: 'Moff Gideon',

--- a/server/game/cards/08_ASH/events/HoldThemOff.ts
+++ b/server/game/cards/08_ASH/events/HoldThemOff.ts
@@ -6,7 +6,7 @@ import { RelativePlayer, WildcardCardType, WildcardRelativePlayer } from '../../
 export default class HoldThemOff extends EventCard {
     protected override getImplementationId () {
         return {
-            id: 'hold-them-off-id',
+            id: '0912750156',
             internalName: 'hold-them-off',
         };
     }

--- a/server/game/cards/08_ASH/events/RecklessSacrifice.ts
+++ b/server/game/cards/08_ASH/events/RecklessSacrifice.ts
@@ -6,7 +6,7 @@ import { WildcardCardType } from '../../../core/Constants';
 export default class RecklessSacrifice extends EventCard {
     protected override getImplementationId() {
         return {
-            id: 'reckless-sacrifice-id',
+            id: '8814113279',
             internalName: 'reckless-sacrifice',
         };
     }

--- a/server/game/cards/08_ASH/leaders/EmperorPalpatineAccordingToMyDesign.ts
+++ b/server/game/cards/08_ASH/leaders/EmperorPalpatineAccordingToMyDesign.ts
@@ -9,7 +9,7 @@ import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 export default class EmperorPalpatineAccordingToMyDesign extends LeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'emperor-palpatine#according-to-my-design-id',
+            id: '9261531867',
             internalName: 'emperor-palpatine#according-to-my-design',
         };
     }

--- a/server/game/cards/08_ASH/leaders/LukeSkywalkerICanSaveHim.ts
+++ b/server/game/cards/08_ASH/leaders/LukeSkywalkerICanSaveHim.ts
@@ -13,7 +13,7 @@ export default class LukeSkywalkerICanSaveHim extends LeaderUnitCard {
 
     protected override getImplementationId() {
         return {
-            id: 'luke-skywalker#i-can-save-him-id',
+            id: '6397550626',
             internalName: 'luke-skywalker#i-can-save-him',
         };
     }

--- a/server/game/cards/08_ASH/tokens/Advantage.ts
+++ b/server/game/cards/08_ASH/tokens/Advantage.ts
@@ -5,7 +5,7 @@ import { TokenUpgradeCard } from '../../../core/card/TokenCards';
 export default class Advantage extends TokenUpgradeCard {
     protected override getImplementationId() {
         return {
-            id: 'advantage-id',
+            id: '5844562972',
             internalName: 'advantage',
         };
     }

--- a/server/game/cards/08_ASH/units/AnakinSkywalkerYouWereRightAboutMe.ts
+++ b/server/game/cards/08_ASH/units/AnakinSkywalkerYouWereRightAboutMe.ts
@@ -6,7 +6,7 @@ import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 export default class AnakinSkywalkerYouWereRightAboutMe extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'anakin-skywalker#you-were-right-about-me-id',
+            id: '6510578496',
             internalName: 'anakin-skywalker#you-were-right-about-me',
         };
     }

--- a/server/game/cards/08_ASH/units/CobbVanthLetMeHandleThis.ts
+++ b/server/game/cards/08_ASH/units/CobbVanthLetMeHandleThis.ts
@@ -6,7 +6,7 @@ import { CardType } from '../../../core/Constants';
 export default class CobbVanthLetMeHandleThis extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'cobb-vanth#let-me-handle-this-id',
+            id: '2100091585',
             internalName: 'cobb-vanth#let-me-handle-this',
         };
     }

--- a/server/game/cards/08_ASH/units/DarthVaderMeetYourDestiny.ts
+++ b/server/game/cards/08_ASH/units/DarthVaderMeetYourDestiny.ts
@@ -6,7 +6,7 @@ import { KeywordName } from '../../../core/Constants';
 export default class DarthVaderMeetYourDestiny extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'darth-vader#meet-your-destiny-id',
+            id: '2759135991',
             internalName: 'darth-vader#meet-your-destiny',
         };
     }

--- a/server/game/cards/08_ASH/units/DoctorPershingDedicatedToResearch.ts
+++ b/server/game/cards/08_ASH/units/DoctorPershingDedicatedToResearch.ts
@@ -5,7 +5,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 export default class DoctorPershingDedicatedToResearch extends NonLeaderUnitCard {
     protected override getImplementationId () {
         return {
-            id: 'doctor-pershing#dedicated-to-research-id',
+            id: '2812074334',
             internalName: 'doctor-pershing#dedicated-to-research',
         };
     }

--- a/server/game/cards/08_ASH/units/ExecutorFinalDestructionOfTheAlliance.ts
+++ b/server/game/cards/08_ASH/units/ExecutorFinalDestructionOfTheAlliance.ts
@@ -5,7 +5,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 export default class ExecutorFinalDestructionOfTheAlliance extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'executor#final-destruction-of-the-alliance-id',
+            id: '6139617442',
             internalName: 'executor#final-destruction-of-the-alliance',
         };
     }

--- a/server/game/cards/08_ASH/units/GreenLeaderCrynydsSacrifice.ts
+++ b/server/game/cards/08_ASH/units/GreenLeaderCrynydsSacrifice.ts
@@ -6,7 +6,7 @@ import { WildcardCardType } from '../../../core/Constants';
 export default class GreenLeaderCrynydsSacrifice extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'green-leader#crynyds-sacrifice-id',
+            id: '7688684269',
             internalName: 'green-leader#crynyds-sacrifice',
         };
     }

--- a/server/game/cards/08_ASH/units/HanSoloItllWork.ts
+++ b/server/game/cards/08_ASH/units/HanSoloItllWork.ts
@@ -6,7 +6,7 @@ import { WildcardCardType } from '../../../core/Constants';
 export default class HanSoloItllWork extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'han-solo#itll-work-id',
+            id: '8474739433',
             internalName: 'han-solo#itll-work',
         };
     }

--- a/server/game/cards/08_ASH/units/HelixStarfighter.ts
+++ b/server/game/cards/08_ASH/units/HelixStarfighter.ts
@@ -6,7 +6,7 @@ import { ZoneName } from '../../../core/Constants';
 export default class HelixStarfighter extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'helix-starfighter-id',
+            id: '4212933603',
             internalName: 'helix-starfighter',
         };
     }

--- a/server/game/cards/08_ASH/units/HeraSyndullaRenegadeGeneral.ts
+++ b/server/game/cards/08_ASH/units/HeraSyndullaRenegadeGeneral.ts
@@ -9,7 +9,7 @@ export default class HeraSyndullaRenegadeGeneral extends NonLeaderUnitCard {
 
     protected override getImplementationId() {
         return {
-            id: 'hera-syndulla#renegade-general-id',
+            id: '5557320306',
             internalName: 'hera-syndulla#renegade-general',
         };
     }

--- a/server/game/cards/08_ASH/units/HomeOneHeartOfTheFleet.ts
+++ b/server/game/cards/08_ASH/units/HomeOneHeartOfTheFleet.ts
@@ -5,7 +5,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 export default class HomeOneHeartOfTheFleet extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'home-one#heart-of-the-fleet-id',
+            id: '0334778925',
             internalName: 'home-one#heart-of-the-fleet',
         };
     }

--- a/server/game/cards/08_ASH/units/LeiaOrganaVigilantForDanger.ts
+++ b/server/game/cards/08_ASH/units/LeiaOrganaVigilantForDanger.ts
@@ -5,7 +5,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 export default class LeiaOrganaVigilantForDanger extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'leia-organa#vigilant-for-danger-id',
+            id: '8288798287',
             internalName: 'leia-organa#vigilant-for-danger',
         };
     }

--- a/server/game/cards/08_ASH/units/MoffGideonRemnantCommander.ts
+++ b/server/game/cards/08_ASH/units/MoffGideonRemnantCommander.ts
@@ -6,7 +6,7 @@ import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core
 export default class MoffGideonRemnantCommander extends NonLeaderUnitCard {
     protected override getImplementationId () {
         return {
-            id: 'moff-gideon#remnant-commander-id',
+            id: '4641653534',
             internalName: 'moff-gideon#remnant-commander'
         };
     }

--- a/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
+++ b/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
@@ -11,7 +11,7 @@ import { EnumHelpers } from '../../../core/utils/EnumHelpers';
 export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'moff-jerjerrod#we-shall-redouble-our-efforts-id',
+            id: '9995040018',
             internalName: 'moff-jerjerrod#we-shall-redouble-our-efforts',
         };
     }

--- a/server/game/cards/08_ASH/units/R5D4BuiltForAdventure.ts
+++ b/server/game/cards/08_ASH/units/R5D4BuiltForAdventure.ts
@@ -5,7 +5,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 export default class R5D4BuiltForAdventure extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'r5d4#built-for-adventure-id',
+            id: '3708951358',
             internalName: 'r5d4#built-for-adventure',
         };
     }

--- a/server/game/cards/08_ASH/units/RukhFromTheShadows.ts
+++ b/server/game/cards/08_ASH/units/RukhFromTheShadows.ts
@@ -11,7 +11,7 @@ export default class RukhFromTheShadows extends NonLeaderUnitCard {
 
     protected override getImplementationId() {
         return {
-            id: 'rukh#from-the-shadows-id',
+            id: '5334076199',
             internalName: 'rukh#from-the-shadows',
         };
     }

--- a/server/game/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.ts
+++ b/server/game/cards/08_ASH/units/ShinHatisFiendFighterCompactAndAgile.ts
@@ -8,7 +8,7 @@ import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 export default class ShinHatisFiendFighterCompactAndAgile extends NonLeaderUnitCard {
     protected override getImplementationId() {
         return {
-            id: 'shin-hatis-fiend-fighter#compact-and-agile-id',
+            id: '0834554190',
             internalName: 'shin-hatis-fiend-fighter#compact-and-agile',
         };
     }

--- a/server/game/cards/08_ASH/units/TheGreatMothersWithStrangeMagicks.ts
+++ b/server/game/cards/08_ASH/units/TheGreatMothersWithStrangeMagicks.ts
@@ -12,7 +12,7 @@ export default class TheGreatMothersWithStrangeMagicks extends NonLeaderUnitCard
 
     protected override getImplementationId() {
         return {
-            id: 'the-great-mothers#with-strange-magicks-id',
+            id: '5392982470',
             internalName: 'the-great-mothers#with-strange-magicks',
         };
     }

--- a/server/game/cards/08_ASH/upgrades/LukesJediLightsaberConstructedByHand.ts
+++ b/server/game/cards/08_ASH/upgrades/LukesJediLightsaberConstructedByHand.ts
@@ -6,7 +6,7 @@ import { KeywordName, Trait } from '../../../core/Constants';
 export default class LukesJediLightsaberConstructedByHand extends UpgradeCard {
     protected override getImplementationId() {
         return {
-            id: 'lukes-jedi-lightsaber#constructed-by-hand-id',
+            id: '4924242543',
             internalName: 'lukes-jedi-lightsaber#constructed-by-hand',
         };
     }

--- a/server/game/cards/08_ASH/upgrades/ThereIsNoConflict.ts
+++ b/server/game/cards/08_ASH/upgrades/ThereIsNoConflict.ts
@@ -6,7 +6,7 @@ import { TargetMode } from '../../../core/Constants';
 export default class ThereIsNoConflict extends UpgradeCard {
     protected override getImplementationId() {
         return {
-            id: 'there-is-no-conflict-id',
+            id: '8773190295',
             internalName: 'there-is-no-conflict',
         };
     }


### PR DESCRIPTION
The publisher added 43 ASH cards to the official API. Remove the now-redundant
mocks from mockdata.js and swap the placeholder `-id` strings in each
implementation file for the real card IDs.

Advantage's official entry publishes its modifier as `power/hp` instead of
`upgradePower/upgradeHp`, so add an entry to `populateMissingData` mirroring the
existing Shield token fix; otherwise UpgradeCard's null-check fires at
construction time and every Shin Hati's Fiend Fighter spec blows up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
