### PR TITLE
Add aspect penalties to cards in hand

### DIFF
--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -1391,6 +1391,9 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
         const selectionState = activePlayer.getCardSelectionState(this);
         const shouldBeHidden = this.zone.hiddenForPlayers === WildcardRelativePlayer.Any ||
           (!isActivePlayer && this.zone.hiddenForPlayers === RelativePlayer.Opponent);
+        const aspectPenaltyCost = this.zoneName === ZoneName.Hand && isActivePlayer
+            ? activePlayer.getPenaltyAspects(this.aspects).length * 2
+            : 0;
 
         // Check if card is blocked from play by opponent effect (for lock icon display)
         const context = new AbilityContext({
@@ -1418,6 +1421,7 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
                 printedType: this.printedType,
                 isBlanked: this.isBlank(),
                 blockedFromPlayReason,
+                aspectPenaltyCost: aspectPenaltyCost || undefined,
                 ...selectionState
             };
 
@@ -1535,4 +1539,3 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
         return this.internalName;
     }
 }
-

--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -1391,9 +1391,9 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
         const selectionState = activePlayer.getCardSelectionState(this);
         const shouldBeHidden = this.zone.hiddenForPlayers === WildcardRelativePlayer.Any ||
           (!isActivePlayer && this.zone.hiddenForPlayers === RelativePlayer.Opponent);
-        const aspectPenaltyCost = this.zoneName === ZoneName.Hand && isActivePlayer
-            ? activePlayer.getPenaltyAspects(this.aspects).length * 2
-            : 0;
+        const aspectPenaltyAspects = this.zoneName === ZoneName.Hand && isActivePlayer
+            ? activePlayer.getPenaltyAspects(this.aspects)
+            : [];
 
         // Check if card is blocked from play by opponent effect (for lock icon display)
         const context = new AbilityContext({
@@ -1421,7 +1421,7 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
                 printedType: this.printedType,
                 isBlanked: this.isBlank(),
                 blockedFromPlayReason,
-                aspectPenaltyCost: aspectPenaltyCost || undefined,
+                aspectPenaltyAspects: aspectPenaltyAspects.length > 0 ? aspectPenaltyAspects : undefined,
                 ...selectionState
             };
 

--- a/test/server/actions/PlayUnitFromHand.spec.ts
+++ b/test/server/actions/PlayUnitFromHand.spec.ts
@@ -49,5 +49,36 @@ describe('Play unit from hand', function() {
                 expect(context.player1.exhaustedResourceCount).toBe(6);
             });
         });
+
+        describe('When a unit in hand has aspect penalties', function() {
+            it('should include the specific missing aspects in the active player summary', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: [
+                            // villainy, cunning
+                            'cartel-spacer',
+                            // double cunning
+                            'zuckuss#the-findsman',
+                            // heroism
+                            'alliance-xwing',
+                            // heroism, command
+                            'battlefield-marine'
+                        ],
+                        // villainy, cunning
+                        leader: 'boba-fett#collecting-the-bounty',
+                        // aggression
+                        base: 'kestro-city'
+                    }
+                });
+
+                const { context } = contextRef;
+
+                expect(context.cartelSpacer.getSummary(context.player1Object).aspectPenaltyAspects).toBeUndefined();
+                expect(context.zuckuss.getSummary(context.player1Object).aspectPenaltyAspects).toEqual(['cunning']);
+                expect(context.allianceXwing.getSummary(context.player1Object).aspectPenaltyAspects).toEqual(['heroism']);
+                expect(context.battlefieldMarine.getSummary(context.player1Object).aspectPenaltyAspects).toEqual(['command', 'heroism']);
+            });
+        });
     });
 });


### PR DESCRIPTION
Add aspect penalties to cards in active player's cards in hand.

Needed for https://github.com/SWU-Karabast/forceteki-client/issues/154