### PR TITLE
Bugfix: TS Anakin and Padme leader abilities

### DIFF
--- a/server/game/cards/07_TS26/leaders/AnakinSkywalkerProtectHerAtAllCosts.ts
+++ b/server/game/cards/07_TS26/leaders/AnakinSkywalkerProtectHerAtAllCosts.ts
@@ -1,7 +1,6 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
-import type { IInPlayCard } from '../../../core/card/baseClasses/InPlayCard';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
@@ -31,9 +30,13 @@ export default class AnakinSkywalkerProtectHerAtAllCosts extends LeaderUnitCard 
                 controller: RelativePlayer.Self,
                 cardCondition: (card, context) =>
                     card.canBeInPlay() &&
-                    this.friendlyUnitsThatEnteredPlayThisPhase(context).includes(card),
+                    this.unitsEnteredPlayThisPhaseWatcher.getCardsEnteredPlay((entry) =>
+                        entry.card.controller === context.player &&
+                        entry.playedBy === context.player &&
+                        entry.card.isInPlay()
+                    ).includes(card),
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => this.friendlyUnitsThatEnteredPlayThisPhase(context).length >= 2,
+                    condition: (context) => this.friendlyUnitsEnteredPlayThisPhaseCount(context) >= 2,
                     onTrue: AbilityHelper.immediateEffects.giveShield()
                 })
             }
@@ -50,16 +53,17 @@ export default class AnakinSkywalkerProtectHerAtAllCosts extends LeaderUnitCard 
                 cardCondition: (card, context) =>
                     card !== context.source &&
                     card.canBeInPlay() &&
-                    this.friendlyUnitsThatEnteredPlayThisPhase(context).includes(card),
+                    this.unitsEnteredPlayThisPhaseWatcher.getCardsEnteredPlay((entry) =>
+                        entry.card.controller === context.player
+                    ).includes(card),
                 immediateEffect: AbilityHelper.immediateEffects.giveShield()
             }
         });
     }
 
-    private friendlyUnitsThatEnteredPlayThisPhase(context: AbilityContext): IInPlayCard[] {
+    private friendlyUnitsEnteredPlayThisPhaseCount(context: AbilityContext): number {
         return this.unitsEnteredPlayThisPhaseWatcher.getCardsEnteredPlay((entry) =>
-            entry.card.controller === context.player &&
-            entry.card.isInPlay()
-        );
+            entry.playedBy === context.player
+        ).length;
     }
 }

--- a/server/game/cards/07_TS26/leaders/PadmeAmidalaFollowMyLead.ts
+++ b/server/game/cards/07_TS26/leaders/PadmeAmidalaFollowMyLead.ts
@@ -1,8 +1,8 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
-import type { IInPlayCard } from '../../../core/card/baseClasses/InPlayCard';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
+import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsEnteredPlayThisPhaseWatcher } from '../../../stateWatchers/CardsEnteredPlayThisPhaseWatcher';
 
@@ -25,9 +25,13 @@ export default class PadmeAmidalaFollowMyLead extends LeaderUnitCard {
             title: 'Attack with a friendly unit that entered play this phase even if it\'s exhausted. It can\'t attack bases for this attack',
             cost: abilityHelper.costs.exhaustSelf(),
             immediateEffect: abilityHelper.immediateEffects.conditional({
-                condition: (context) => this.friendlyUnitsThatEnteredPlayThisPhase(context).length >= 2,
+                condition: (context) => this.friendlyUnitsEnteredPlayThisPhaseCount(context) >= 2,
                 onTrue: abilityHelper.immediateEffects.selectCard({
-                    cardCondition: (card, context) => card.isUnit() && this.friendlyUnitsThatEnteredPlayThisPhase(context).includes(card),
+                    cardCondition: (card, context) => card.isUnit() && this.unitsEnteredPlayThisPhaseWatcher.getCardsEnteredPlay((entry) =>
+                        entry.card.controller === context.player &&
+                        entry.playedBy === context.player &&
+                        entry.card.isInPlay()
+                    ).includes(card),
                     immediateEffect: abilityHelper.immediateEffects.attack({
                         targetCondition: (target) => target.isUnit(),
                         allowExhaustedAttacker: true,
@@ -42,9 +46,14 @@ export default class PadmeAmidalaFollowMyLead extends LeaderUnitCard {
             title: 'Attack with a friendly unit that entered play this phase even if it\'s exhausted. It can\'t attack bases for this attack',
             optional: true,
             targetResolver: {
+                cardTypeFilter: WildcardCardType.Unit,
+                controller: RelativePlayer.Self,
                 cardCondition: (card, context) =>
-                    card.isUnit() && card !== context.source &&
-                    this.friendlyUnitsThatEnteredPlayThisPhase(context).includes(card),
+                    card !== context.source &&
+                    card.canBeInPlay() &&
+                    this.unitsEnteredPlayThisPhaseWatcher.getCardsEnteredPlay((entry) =>
+                        entry.card.controller === context.player
+                    ).includes(card),
                 immediateEffect: abilityHelper.immediateEffects.attack({
                     targetCondition: (target) => target.isUnit(),
                     allowExhaustedAttacker: true,
@@ -53,10 +62,9 @@ export default class PadmeAmidalaFollowMyLead extends LeaderUnitCard {
         });
     }
 
-    private friendlyUnitsThatEnteredPlayThisPhase(context: AbilityContext): IInPlayCard[] {
+    private friendlyUnitsEnteredPlayThisPhaseCount(context: AbilityContext): number {
         return this.unitsEnteredPlayThisPhaseWatcher.getCardsEnteredPlay((entry) =>
-            entry.card.controller === context.player &&
-            entry.card.isInPlay()
-        );
+            entry.playedBy === context.player
+        ).length;
     }
 }

--- a/test/server/cards/07_TS26/leaders/AnakinSkywalkerProtectHerAtAllCosts.spec.ts
+++ b/test/server/cards/07_TS26/leaders/AnakinSkywalkerProtectHerAtAllCosts.spec.ts
@@ -92,7 +92,7 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
                 context.player1.clickCard(context.lothwolf);
                 context.player2.passAction();
 
-                // Use Anakin's leader ability - shows no effect since < 2 units entered play
+                // Use Anakin's leader ability — condition not met, no Shield is given
                 context.player1.clickCard(context.anakinSkywalker);
                 expect(context.player1).toHaveNoEffectAbilityPrompt('Give a Shield token to a friendly unit that entered play this phase');
                 context.player1.clickPrompt('Use it anyway');
@@ -102,7 +102,7 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
                 expect(context.lothwolf).toHaveExactUpgradeNames([]);
             });
 
-            it('does not give a Shield token when 2 units entered play but one was defeated', async function() {
+            it('gives a Shield token to the surviving unit when 2 units entered play but one was defeated', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -123,18 +123,53 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.restoredArc170);
 
-                // Opponent defeats Lothwolf
+                // Opponent defeats Lothwolf — count remains 2 (entered under friendly control)
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.lothwolf);
 
-                // Use Anakin's leader ability - shows no effect since only 1 unit that entered this phase is still in play
+                // Use Anakin's leader ability — condition is met; only ARC-170 is a valid target
+                context.player1.clickCard(context.anakinSkywalker);
+                expect(context.player1).toHavePrompt('Give a Shield token to a unit that entered play this phase');
+                expect(context.player1).toBeAbleToSelectExactly([context.restoredArc170]);
+                context.player1.clickCard(context.restoredArc170);
+
+                expect(context.anakinSkywalker.exhausted).toBeTrue();
+                expect(context.restoredArc170).toHaveExactUpgradeNames(['shield']);
+            });
+
+            it('has no effect when 2 units entered play but both were defeated', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'anakin-skywalker#protect-her-at-all-costs',
+                        resources: 4,
+                        hand: ['lothwolf', 'porg'],
+                        groundArena: ['battlefield-marine']
+                    },
+                    player2: {
+                        resources: 10,
+                        hand: ['vanquish', 'vanquish']
+                    }
+                });
+
+                const { context } = contextRef;
+                const vanquishes = context.player2.findCardsByName('vanquish');
+
+                // Play two units; opponent vanquishes each immediately
+                context.player1.clickCard(context.lothwolf);
+                context.player2.clickCard(vanquishes[0]);
+                context.player2.clickCard(context.lothwolf);
+                context.player1.clickCard(context.porg);
+                context.player2.clickCard(vanquishes[1]);
+                context.player2.clickCard(context.porg);
+
+                // Use Anakin's leader ability — condition is met (2 entered under friendly control)
+                // but no valid targets remain (both defeated)
                 context.player1.clickCard(context.anakinSkywalker);
                 expect(context.player1).toHaveNoEffectAbilityPrompt('Give a Shield token to a friendly unit that entered play this phase');
                 context.player1.clickPrompt('Use it anyway');
 
-                // Anakin is exhausted but no Shield is given (only 1 unit currently in play that entered this phase)
                 expect(context.anakinSkywalker.exhausted).toBeTrue();
-                expect(context.restoredArc170).toHaveExactUpgradeNames([]);
             });
 
             it('has no effect when no units have entered play this phase', async function() {
@@ -149,16 +184,15 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
 
                 const { context } = contextRef;
 
-                // Use Anakin's leader ability - shows no effect since no units entered play
+                // Use Anakin's leader ability — condition not met, no Shield is given
                 context.player1.clickCard(context.anakinSkywalker);
                 expect(context.player1).toHaveNoEffectAbilityPrompt('Give a Shield token to a friendly unit that entered play this phase');
                 context.player1.clickPrompt('Use it anyway');
 
-                // Anakin is exhausted but no Shield is given
                 expect(context.anakinSkywalker.exhausted).toBeTrue();
             });
 
-            it('does not count a unit that entered play under friendly control but is now under enemy control', async function() {
+            it('counts a unit that entered play under friendly control even if it is now under enemy control', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -172,26 +206,28 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
 
                 const { context } = contextRef;
 
-                // Play Galen Erso and give control to opponent
+                // Play Galen Erso and give control to opponent (count = 1 under friendly control)
                 context.player1.clickCard(context.galenErso);
                 context.player1.clickPrompt('Trigger');
                 context.player2.passAction();
 
-                // Play Populist Advisor
+                // Play Populist Advisor (count = 2 under friendly control)
                 context.player1.clickCard(context.populistAdvisor);
                 context.player2.passAction();
 
-                // Use Anakin's leader ability - shows no effect since only 1 friendly unit entered play
+                // Use Anakin's leader ability — condition is met (2 units entered under friendly control)
+                // Only Populist Advisor is a valid target (Galen is now controlled by opponent)
                 context.player1.clickCard(context.anakinSkywalker);
-                expect(context.player1).toHaveNoEffectAbilityPrompt('Give a Shield token to a friendly unit that entered play this phase');
-                context.player1.clickPrompt('Use it anyway');
+                expect(context.player1).toHavePrompt('Give a Shield token to a unit that entered play this phase');
+                expect(context.player1).toBeAbleToSelectExactly([context.populistAdvisor]);
+                context.player1.clickCard(context.populistAdvisor);
 
-                // Anakin is exhausted but no Shield is given
                 expect(context.anakinSkywalker.exhausted).toBeTrue();
-                expect(context.populistAdvisor).toHaveExactUpgradeNames([]);
+                expect(context.populistAdvisor).toHaveExactUpgradeNames(['shield']);
+                expect(context.galenErso).toHaveExactUpgradeNames([]);
             });
 
-            it('counts a unit that entered play under enemy control but is now under friendly control', async function() {
+            it('does not count a unit that entered play under enemy control even if it is now under friendly control', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -208,24 +244,22 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
 
                 const { context } = contextRef;
 
-                // Play Populist Advisor
+                // Play Populist Advisor (count = 1 under friendly control)
                 context.player1.clickCard(context.populistAdvisor);
 
-                // Opponent plays Galen Erso and gives control to P1
+                // Opponent plays Galen Erso and transfers control to P1
+                // (Galen entered under enemy control so it does not count)
                 context.player2.clickCard(context.galenErso);
                 context.player2.clickPrompt('Trigger');
 
-                // Use Anakin's leader ability
+                // Use Anakin's leader ability — condition NOT met (only 1 unit entered under friendly control)
                 context.player1.clickCard(context.anakinSkywalker);
+                expect(context.player1).toHaveNoEffectAbilityPrompt('Give a Shield token to a friendly unit that entered play this phase');
+                context.player1.clickPrompt('Use it anyway');
 
-                // Can target both Populist Advisor and Galen Erso (now under P1's control)
-                expect(context.player1).toHavePrompt('Give a Shield token to a unit that entered play this phase');
-                expect(context.player1).toBeAbleToSelectExactly([context.populistAdvisor, context.galenErso]);
-                context.player1.clickCard(context.galenErso);
-
-                // Anakin is exhausted and Galen has a Shield
                 expect(context.anakinSkywalker.exhausted).toBeTrue();
-                expect(context.galenErso).toHaveExactUpgradeNames(['shield']);
+                expect(context.populistAdvisor).toHaveExactUpgradeNames([]);
+                expect(context.galenErso).toHaveExactUpgradeNames([]);
             });
         });
 
@@ -255,11 +289,9 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
                 context.player1.clickPrompt('Deploy Anakin Skywalker');
                 context.player2.passAction();
 
-                // Attack with Anakin
+                // Attack with Anakin — can only target Lothwolf (not Battlefield Marine, not Anakin himself)
                 context.player1.clickCard(context.anakinSkywalker);
                 context.player1.clickCard(context.p2Base);
-
-                // Can only target Lothwolf (not Battlefield Marine, not Anakin himself)
                 expect(context.player1).toBeAbleToSelectExactly([context.lothwolf]);
                 context.player1.clickCard(context.lothwolf);
 
@@ -282,11 +314,11 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
 
                 const { context } = contextRef;
 
-                // Play Veteran Fleet Officer, which creates an X-Wing token
+                // Play Veteran Fleet Officer — its When Played creates an X-Wing token
                 context.player1.clickCard(context.veteranFleetOfficer);
                 context.player2.passAction();
 
-                // Attack with Anakin
+                // Attack with Anakin — can target Veteran Fleet Officer or the X-Wing token
                 context.player1.clickCard(context.anakinSkywalker);
                 context.player1.clickCard(context.p2Base);
 
@@ -335,18 +367,15 @@ describe('Anakin Skywalker, Protect Her at All Costs', function() {
 
                 const { context } = contextRef;
 
-                // Play a unit
+                // Play a unit, opponent defeats it immediately
                 context.player1.clickCard(context.lothwolf);
-
-                // Opponent defeats Lothwolf
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.lothwolf);
 
-                // Attack with Anakin - ability fizzles (no prompt, just continues)
+                // Attack with Anakin — ability fizzles (no valid targets), no prompt shown
                 context.player1.clickCard(context.anakinSkywalker);
                 context.player1.clickCard(context.p2Base);
 
-                // No prompt, ability just skipped
                 expect(context.player2).toBeActivePlayer();
             });
 

--- a/test/server/cards/07_TS26/leaders/PadmeAmidalaFollowMyLead.spec.ts
+++ b/test/server/cards/07_TS26/leaders/PadmeAmidalaFollowMyLead.spec.ts
@@ -1,9 +1,9 @@
 describe('Padme Amidala, Follow My Lead', function() {
     integration(function(contextRef) {
-        describe('Padme Amidala\'s undeployed ability', function() {
+        describe('Undeployed leader-side action ability', function() {
             const abilityText = 'Attack with a friendly unit that entered play this phase even if it\'s exhausted. It can\'t attack bases for this attack';
 
-            it('should attack with a friendly unit that entered play this phase even it it is exhausted. It cannot attack base for this attack. (only if 2 or more friendly units have entered play this phase)', async function() {
+            it('attacks with a unit that entered play this phase, and cannot attack the base', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -20,17 +20,19 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play two units (interleaved with opponent)
                 context.player1.clickCard(context.atst);
                 context.player2.clickCard(context.consularSecurityForce);
-
                 context.player1.clickCard(context.restoredArc170);
                 context.player2.passAction();
 
+                // Use Padmé's leader ability — can select either unit that entered play this phase
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickPrompt(abilityText);
-
                 expect(context.player1).toBeAbleToSelectExactly([context.atst, context.restoredArc170]);
                 context.player1.clickCard(context.atst);
+
+                // AT-ST can attack enemy units but not the enemy base
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.consularSecurityForce]);
                 context.player1.clickCard(context.wampa);
 
@@ -38,7 +40,7 @@ describe('Padme Amidala, Follow My Lead', function() {
                 expect(context.wampa).toBeInZone('discard', context.player2);
             });
 
-            it('should attack with a friendly unit that entered play this phase even it it is exhausted. It cannot attack base for this attack. (token unit)', async function() {
+            it('attacks with a token unit that entered play this phase', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -55,11 +57,12 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play Veteran Fleet Officer — its When Played creates an X-Wing token (2 units enter play)
                 context.player1.clickCard(context.veteranFleetOfficer);
                 context.player2.passAction();
 
+                // Use Padmé's leader ability — can select Veteran Fleet Officer or the X-Wing token
                 context.player1.clickCard(context.padmeAmidala);
-
                 const xwing = context.player1.findCardByName('xwing');
                 expect(context.player1).toBeAbleToSelectExactly([context.veteranFleetOfficer, xwing]);
                 context.player1.clickCard(xwing);
@@ -84,9 +87,11 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play one unit
                 context.player1.clickCard(context.awing);
                 context.player2.passAction();
 
+                // Use Padmé's leader ability — condition not met, no attack is granted
                 context.player1.clickCard(context.padmeAmidala);
                 expect(context.player1).toHaveNoEffectAbilityPrompt(abilityText);
                 context.player1.clickPrompt('Use it anyway');
@@ -95,7 +100,7 @@ describe('Padme Amidala, Follow My Lead', function() {
                 expect(context.padmeAmidala.exhausted).toBeTrue();
             });
 
-            it('does not attack when 2 units entered play but one was defeated', async function() {
+            it('attacks with the surviving unit when 2 units entered play but one was defeated', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -105,24 +110,64 @@ describe('Padme Amidala, Follow My Lead', function() {
                         groundArena: ['battlefield-marine']
                     },
                     player2: {
-                        hand: ['vanquish']
+                        hand: ['vanquish'],
+                        groundArena: ['wampa']
                     }
                 });
 
                 const { context } = contextRef;
 
+                // Play two units; opponent defeats Lothwolf
                 context.player1.clickCard(context.lothwolf);
                 context.player2.passAction();
                 context.player1.clickCard(context.porg);
-
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.lothwolf);
 
+                // Use Padmé's leader ability — condition is met (2 units entered under friendly control);
+                // only the surviving Porg is a valid attacker
+                context.player1.clickCard(context.padmeAmidala);
+                expect(context.player1).toBeAbleToSelectExactly([context.porg]);
+                context.player1.clickCard(context.porg);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+                context.player1.clickCard(context.wampa);
+
+                expect(context.padmeAmidala.exhausted).toBeTrue();
+                expect(context.porg).toBeInZone('discard', context.player1);
+            });
+
+            it('has no effect when 2 units entered play but both were defeated', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'padme-amidala#follow-my-lead',
+                        resources: 4,
+                        hand: ['lothwolf', 'porg'],
+                        groundArena: ['battlefield-marine']
+                    },
+                    player2: {
+                        resources: 10,
+                        hand: ['vanquish', 'vanquish']
+                    }
+                });
+
+                const { context } = contextRef;
+                const vanquishes = context.player2.findCardsByName('vanquish');
+
+                // Play two units; opponent vanquishes each immediately
+                context.player1.clickCard(context.lothwolf);
+                context.player2.clickCard(vanquishes[0]);
+                context.player2.clickCard(context.lothwolf);
+                context.player1.clickCard(context.porg);
+                context.player2.clickCard(vanquishes[1]);
+                context.player2.clickCard(context.porg);
+
+                // Use Padmé's leader ability — condition is met (2 entered under friendly control)
+                // but no valid attackers remain (both defeated)
                 context.player1.clickCard(context.padmeAmidala);
                 expect(context.player1).toHaveNoEffectAbilityPrompt(abilityText);
                 context.player1.clickPrompt('Use it anyway');
 
-                expect(context.player2).toBeActivePlayer();
                 expect(context.padmeAmidala.exhausted).toBeTrue();
             });
 
@@ -138,6 +183,7 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Use Padmé's leader ability — condition not met, no attack is granted
                 context.player1.clickCard(context.padmeAmidala);
                 expect(context.player1).toHaveNoEffectAbilityPrompt(abilityText);
                 context.player1.clickPrompt('Use it anyway');
@@ -146,7 +192,7 @@ describe('Padme Amidala, Follow My Lead', function() {
                 expect(context.padmeAmidala.exhausted).toBeTrue();
             });
 
-            it('does not count a unit that entered play under friendly control but is now under enemy control', async function() {
+            it('counts a unit that entered play under friendly control even if it is now under enemy control', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -155,32 +201,42 @@ describe('Padme Amidala, Follow My Lead', function() {
                         resources: 4,
                         hand: ['galen-erso#destroying-his-creation', 'porg'],
                         groundArena: ['battlefield-marine']
+                    },
+                    player2: {
+                        groundArena: ['wampa']
                     }
                 });
 
                 const { context } = contextRef;
 
+                // Play Galen Erso and give control to opponent (count = 1 under friendly control)
                 context.player1.clickCard(context.galenErso);
                 context.player1.clickPrompt('Trigger');
                 context.player2.passAction();
 
+                // Play Porg (count = 2 under friendly control)
                 context.player1.clickCard(context.porg);
                 context.player2.passAction();
 
+                // Use Padmé's leader ability — condition is met (2 units entered under friendly control);
+                // only Porg is a valid attacker (Galen is now controlled by opponent)
                 context.player1.clickCard(context.padmeAmidala);
-                expect(context.player1).toHaveNoEffectAbilityPrompt(abilityText);
-                context.player1.clickPrompt('Use it anyway');
+                expect(context.player1).toBeAbleToSelectExactly([context.porg]);
+                context.player1.clickCard(context.porg);
+                context.player1.clickCard(context.wampa);
 
                 expect(context.padmeAmidala.exhausted).toBeTrue();
+                expect(context.porg).toBeInZone('discard', context.player1);
             });
 
-            it('counts a unit that entered play under enemy control but is now under friendly control', async function() {
+            it('does not count a unit that entered play under enemy control even if it is now under friendly control', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         leader: 'padme-amidala#follow-my-lead',
                         hand: ['populist-advisor'],
-                        groundArena: ['battlefield-marine']
+                        groundArena: ['battlefield-marine'],
+                        resources: 5 // So we dont get deploy prompt
                     },
                     player2: {
                         base: 'chopper-base',
@@ -191,25 +247,26 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play Populist Advisor (count = 1 under friendly control)
                 context.player1.clickCard(context.populistAdvisor);
 
+                // Opponent plays Galen Erso and transfers control to P1
+                // (Galen entered under enemy control so it does not count)
                 context.player2.clickCard(context.galenErso);
                 context.player2.clickPrompt('Trigger');
 
+                // Use Padmé's leader ability — condition NOT met (only 1 unit entered under friendly control).
                 context.player1.clickCard(context.padmeAmidala);
-                context.player1.clickPrompt(abilityText);
-
-                expect(context.player1).toBeAbleToSelectExactly([context.populistAdvisor, context.galenErso]);
-                context.player1.clickCard(context.galenErso);
-                context.player1.clickCard(context.yoda);
+                expect(context.player1).toHaveNoEffectAbilityPrompt(abilityText);
+                context.player1.clickPrompt('Use it anyway');
 
                 expect(context.padmeAmidala.exhausted).toBeTrue();
-                expect(context.galenErso.damage).toBe(2);
+                expect(context.galenErso.damage).toBe(0);
             });
         });
 
-        describe('Padme Amidala\'s deployed ability', function() {
-            it('should attack with a friendly unit that entered play this phase even it it is exhausted. It cannot attack base for this attack', async function() {
+        describe('Deployed unit-side On Attack ability', function() {
+            it('attacks with a friendly unit that entered play this phase, and cannot attack the base', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -224,16 +281,18 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play a unit
                 context.player1.clickCard(context.yoda);
                 context.player2.passAction();
 
+                // Deploy Padmé
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickPrompt('Deploy Padmé Amidala');
                 context.player2.passAction();
 
+                // Attack with Padmé — ability targets Yoda; Yoda attacks Porg (cannot attack base)
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickCard(context.p2Base);
-
                 expect(context.player1).toBeAbleToSelectExactly([context.yoda]);
                 context.player1.clickCard(context.yoda);
                 expect(context.player1).toBeAbleToSelectExactly([context.porg]);
@@ -244,7 +303,7 @@ describe('Padme Amidala, Follow My Lead', function() {
                 expect(context.yoda.damage).toBe(1);
             });
 
-            it('should attack with a friendly unit that entered play this phase even it it is exhausted. It cannot attack base for this attack (token unit)', async function() {
+            it('attacks with a token unit that entered play this phase', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -260,12 +319,13 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play Veteran Fleet Officer — its When Played creates an X-Wing token
                 context.player1.clickCard(context.veteranFleetOfficer);
                 context.player2.passAction();
 
+                // Attack with Padmé — can target Veteran Fleet Officer or the X-Wing token
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickCard(context.p2Base);
-
                 const xwing = context.player1.findCardByName('xwing');
                 expect(context.player1).toBeAbleToSelectExactly([context.veteranFleetOfficer, xwing]);
                 context.player1.clickCard(xwing);
@@ -291,6 +351,7 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Attack with Padmé — ability fizzles, no prompt shown
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickCard(context.p2Base);
 
@@ -312,11 +373,12 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play a unit, opponent defeats it immediately
                 context.player1.clickCard(context.lothwolf);
-
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.lothwolf);
 
+                // Attack with Padmé — ability fizzles (no valid targets), no prompt shown
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickCard(context.p2Base);
 
@@ -338,10 +400,12 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 const { context } = contextRef;
 
+                // Play Galen Erso and give control to opponent — no other units entered play
                 context.player1.clickCard(context.galenErso);
                 context.player1.clickPrompt('Trigger');
                 context.player2.passAction();
 
+                // Attack with Padmé — ability fizzles (no currently friendly units that entered play), no prompt shown
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickCard(context.p2Base);
 
@@ -366,12 +430,13 @@ describe('Padme Amidala, Follow My Lead', function() {
 
                 context.player1.passAction();
 
+                // Opponent plays Galen Erso and transfers control to P1
                 context.player2.clickCard(context.galenErso);
                 context.player2.clickPrompt('Trigger');
 
+                // Attack with Padmé — Galen is now friendly, so it is a valid attacker
                 context.player1.clickCard(context.padmeAmidala);
                 context.player1.clickCard(context.p2Base);
-
                 expect(context.player1).toBeAbleToSelectExactly([context.galenErso]);
                 context.player1.clickCard(context.galenErso);
                 expect(context.player1).toBeAbleToSelectExactly([context.yoda]);


### PR DESCRIPTION
The abilities should be able to work if 2 friendly units entered play in the phase, but 1 was defeated.

Previous interpretation was that at least 2 units needed to have entered play and survived, but current consensus is that "2 units entered play as friendly units" is sufficient. So token-creating units will count if the token unit is removed.