### PR TITLE
Bugfix: Defer damage-based defeat checks to end of event resolution

### DIFF
--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -935,7 +935,16 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
                 this._expiredLastingEffectChangedRemainingHp = false;
             }
 
-            this.checkDefeated(source);
+            // Defer the defeat check so simultaneous effects in the same event window (e.g. an
+            // HP-buffing upgrade being attached at the same time) can resolve first. Running the
+            // check inline would set _pendingDefeat mid-window, which CardTargetSystem treats as
+            // an untargetable card — cancelling the very upgrade attachment that would have saved
+            // the unit. The check is invoked at the end of the window's resolveEvents step.
+            if (damageAdded > 0 && this.game.currentEventWindow) {
+                this.game.currentEventWindow.addPostEventResolutionCallback(() => this.checkDefeated(source));
+            } else {
+                this.checkDefeated(source);
+            }
 
             return damageAdded;
         }

--- a/server/game/core/event/EventWindow.ts
+++ b/server/game/core/event/EventWindow.ts
@@ -27,6 +27,7 @@ export class EventWindow extends BaseStepWithPipeline {
     private subwindowEvents: any[] = [];
     private subAbilityStepFn?: () => AbilityContext = null;
     private windowDepth?: number = null;
+    private postEventResolutionCallbacks: (() => void)[] = [];
 
     public get events() {
         return this._events;
@@ -115,6 +116,17 @@ export class EventWindow extends BaseStepWithPipeline {
      */
     public addSubwindowEvents(events) {
         this.subwindowEvents = this.subwindowEvents.concat(events);
+    }
+
+    /**
+     * Registers a callback to be invoked after every event in this window has finished resolving,
+     * but before {@link resolveGameState} runs. Used to defer work that needs to happen "after the
+     * simultaneous batch" — for example, defeat checks triggered by damage. Deferring lets all
+     * simultaneous events in the same window (such as an HP-buffing upgrade attaching) apply their
+     * effects before the defeat decision is locked in.
+     */
+    public addPostEventResolutionCallback(callback: () => void) {
+        this.postEventResolutionCallbacks.push(callback);
     }
 
     /** Set parent event window and initialize triggering window based on configured rules and parent window settings (if relevant) */
@@ -209,6 +221,15 @@ export class EventWindow extends BaseStepWithPipeline {
 
                 this.resolvedEvents.push(event);
             }
+        }
+
+        // Run any callbacks deferred from event handlers (e.g. damage-driven defeat checks).
+        // These run after every event in this window has resolved so they see the unit's final
+        // HP, damage, and upgrade state for the batch — preserving simultaneous-resolution semantics.
+        const callbacks = this.postEventResolutionCallbacks;
+        this.postEventResolutionCallbacks = [];
+        for (const callback of callbacks) {
+            callback();
         }
     }
 

--- a/test/server/cards/07_TS26/leaders/MaulCollectiveAmbition.spec.ts
+++ b/test/server/cards/07_TS26/leaders/MaulCollectiveAmbition.spec.ts
@@ -210,6 +210,33 @@ describe('Maul, Collective Ambition', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('should not defeat a unit at 1 remaining HP since the Experience token and damage are simultaneous', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'maul#collective-ambition',
+                        resources: 6,
+                        groundArena: [{ card: 'wampa', damage: 4 }],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Wampa is a 4/5 with Overwhelm, at 4 damage it has 1 HP remaining
+                context.player1.clickCard(context.maul);
+
+                expect(context.player1).toHavePrompt(abilityPrompt);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+                context.player1.clickCard(context.wampa);
+
+                // Wampa gets +1/+1 from Experience and 1 damage simultaneously, ending at 6 HP with 5 damage (1 HP remaining)
+                expect(context.maul.exhausted).toBeTrue();
+                expect(context.wampa).toBeInZone('groundArena');
+                expect(context.wampa.damage).toBe(5);
+                expect(context.wampa).toHaveExactUpgradeNames(['experience']);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('should exhaust Maul with no effect when there are no units in play', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
This fixes a bug where simultaneous damage and HP buffs could still result in a unit being defeated when the HP buff should have saved it from defeat.

Fixes #2808