### PR TITLE
Grand Admiral Sloane ASH leader implementation

### DIFF
--- a/server/game/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.ts
+++ b/server/game/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.ts
@@ -20,8 +20,8 @@ export default class GrandAdmiralSloaneHoldingTheEmpireTogether extends LeaderUn
                 mode: TargetMode.Select,
                 activePromptTitle: 'Choose an arena',
                 choices: {
-                    ['Ground']: this.giveArenaUnitsKeywordsForThisPhase(ZoneName.GroundArena, abilityHelper),
                     ['Space']: this.giveArenaUnitsKeywordsForThisPhase(ZoneName.SpaceArena, abilityHelper),
+                    ['Ground']: this.giveArenaUnitsKeywordsForThisPhase(ZoneName.GroundArena, abilityHelper),
                 }
             }
         });

--- a/server/game/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.ts
+++ b/server/game/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.ts
@@ -1,0 +1,50 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
+import type { Arena } from '../../../core/Constants';
+import { KeywordName, TargetMode, ZoneName } from '../../../core/Constants';
+
+export default class GrandAdmiralSloaneHoldingTheEmpireTogether extends LeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '6779170431',
+            internalName: 'grand-admiral-sloane#holding-the-empire-together',
+        };
+    }
+
+    protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addActionAbility({
+            title: 'Choose an arena. Give each unit in that arena Sentinel and Overwhelm for this phase',
+            cost: abilityHelper.costs.exhaustSelf(),
+            targetResolver: {
+                mode: TargetMode.Select,
+                activePromptTitle: 'Choose an arena',
+                choices: {
+                    ['Ground']: this.giveArenaUnitsKeywordsForThisPhase(ZoneName.GroundArena, abilityHelper),
+                    ['Space']: this.giveArenaUnitsKeywordsForThisPhase(ZoneName.SpaceArena, abilityHelper),
+                }
+            }
+        });
+    }
+
+    protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addConstantAbility({
+            title: 'Each other friendly unit gains Overwhelm and Sentinel',
+            matchTarget: (card, context) => card.isUnit() && card.controller === context.player && card !== context.source,
+            ongoingEffect: [
+                abilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm),
+                abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel),
+            ]
+        });
+    }
+
+    private giveArenaUnitsKeywordsForThisPhase(arena: Arena, abilityHelper: IAbilityHelper) {
+        return abilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
+            target: context.game.getArenaUnits({ arena }),
+            effect: [
+                abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel),
+                abilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm),
+            ]
+        }));
+    }
+}

--- a/test/server/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.spec.ts
+++ b/test/server/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.spec.ts
@@ -1,0 +1,119 @@
+describe('Grand Admiral Sloane, Holding the Empire Together', function() {
+    integration(function(contextRef) {
+        describe('leader side ability', function() {
+            it('should exhaust to give each ground unit Sentinel and Overwhelm for this phase', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'grand-admiral-sloane#holding-the-empire-together',
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['awing']
+                    },
+                    player2: {
+                        groundArena: ['battle-droid', 'wampa'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.grandAdmiralSloane);
+                context.player1.clickPrompt('Choose an arena. Give each unit in that arena Sentinel and Overwhelm for this phase');
+
+                expect(context.player1).toHavePrompt('Choose an arena');
+                expect(context.player1).toHaveExactPromptButtons(['Ground', 'Space']);
+                context.player1.clickPrompt('Ground');
+
+                expect(context.grandAdmiralSloane.exhausted).toBeTrue();
+                expect(context.battlefieldMarine.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.battlefieldMarine.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.battleDroid.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.battleDroid.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.wampa.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.wampa.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.awing.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.awing.hasSomeKeyword('overwhelm')).toBeFalse();
+                expect(context.tielnFighter.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.tielnFighter.hasSomeKeyword('overwhelm')).toBeFalse();
+
+                context.player2.passAction();
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.battleDroid);
+                expect(context.p2Base.damage).toBe(2);
+
+                context.moveToNextActionPhase();
+
+                expect(context.battlefieldMarine.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.battlefieldMarine.hasSomeKeyword('overwhelm')).toBeFalse();
+                expect(context.battleDroid.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.battleDroid.hasSomeKeyword('overwhelm')).toBeFalse();
+            });
+
+            it('should exhaust to give each space unit Sentinel and Overwhelm for this phase', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'grand-admiral-sloane#holding-the-empire-together',
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['awing']
+                    },
+                    player2: {
+                        groundArena: ['battle-droid'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.grandAdmiralSloane);
+                context.player1.clickPrompt('Choose an arena. Give each unit in that arena Sentinel and Overwhelm for this phase');
+                context.player1.clickPrompt('Space');
+
+                expect(context.awing.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.awing.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.tielnFighter.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.tielnFighter.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.battlefieldMarine.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.battlefieldMarine.hasSomeKeyword('overwhelm')).toBeFalse();
+                expect(context.battleDroid.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.battleDroid.hasSomeKeyword('overwhelm')).toBeFalse();
+            });
+        });
+
+        describe('leader unit side ability', function() {
+            it('should give each other friendly unit Overwhelm and Sentinel', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'grand-admiral-sloane#holding-the-empire-together', deployed: true },
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['awing']
+                    },
+                    player2: {
+                        groundArena: ['battle-droid', 'wampa'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                expect(context.battlefieldMarine.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.battlefieldMarine.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.awing.hasSomeKeyword('sentinel')).toBeTrue();
+                expect(context.awing.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.grandAdmiralSloane.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.grandAdmiralSloane.hasSomeKeyword('overwhelm')).toBeTrue();
+                expect(context.battleDroid.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.battleDroid.hasSomeKeyword('overwhelm')).toBeFalse();
+                expect(context.wampa.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.tielnFighter.hasSomeKeyword('sentinel')).toBeFalse();
+                expect(context.tielnFighter.hasSomeKeyword('overwhelm')).toBeFalse();
+
+                context.player1.passAction();
+                context.player2.clickCard(context.wampa);
+                expect(context.player2).toBeAbleToSelectExactly([context.battlefieldMarine]);
+                context.player2.clickCard(context.battlefieldMarine);
+            });
+        });
+    });
+});

--- a/test/server/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.spec.ts
+++ b/test/server/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.spec.ts
@@ -38,6 +38,7 @@ describe('Grand Admiral Sloane, Holding the Empire Together', function() {
 
                 context.player2.passAction();
                 context.player1.clickCard(context.battlefieldMarine);
+                expect(context.player1).toBeAbleToSelectExactly([context.battleDroid, context.wampa]);
                 context.player1.clickCard(context.battleDroid);
                 expect(context.p2Base.damage).toBe(2);
 


### PR DESCRIPTION
One important thing to notice about the side ability is that gives ALSO affects enemy units 

<img width="700" height="501" alt="007" src="https://github.com/user-attachments/assets/7f5754aa-44f0-41c0-a373-145af778d1f0" />
<img width="501" height="700" alt="007-back" src="https://github.com/user-attachments/assets/d91a0e2c-c66b-47af-8e8e-403e0a8ff556" />

Test leader action
```json
{
  "phase": "action",
  "player1": {
    "hasInitiative": true,
    "resources": 5,
    "base": "echo-base",
    "leader": "grand-admiral-sloane#holding-the-empire-together",
    "groundArena": [
      "battlefield-marine"
    ],
    "spaceArena": [
      "awing"
    ]
  },
  "player2": {
    "resources": 5,
    "base": "chopper-base",
    "leader": "luke-skywalker#faithful-friend",
    "groundArena": [
      "battle-droid",
      "wampa"
    ],
    "spaceArena": [
      "tieln-fighter"
    ]
  }
}

```

Deployed (your units with sentinel and saboteur but not the enemy's)
```json
{
  "phase": "action",
  "player1": {
    "resources": 5,
    "base": "echo-base",
    "leader": {
      "card": "grand-admiral-sloane#holding-the-empire-together",
      "deployed": true,
      "exhausted": false
    },
    "groundArena": [
      "battlefield-marine",
      "battle-droid"
    ],
    "spaceArena": [
      "awing"
    ]
  },
  "player2": {
    "hasInitiative": true,
    "resources": 5,
    "base": "chopper-base",
    "leader": "luke-skywalker#faithful-friend",
    "groundArena": [
      "wampa"
    ],
    "spaceArena": [
      "tieln-fighter"
    ]
  }
}

```