### PR TITLE
ASH Rancor Keeper card implementation

### DIFF
--- a/server/game/cards/08_ASH/units/RancorKeeper.ts
+++ b/server/game/cards/08_ASH/units/RancorKeeper.ts
@@ -1,0 +1,33 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { CardType, TargetMode } from '../../../core/Constants';
+
+export default class RancorKeeper extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '1069133190',
+            internalName: 'rancor-keeper',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addTriggeredAbility({
+            title: 'Deal 1 damage to any number of bases',
+            when: {
+                onDamageDealt: (event, context) =>
+                    !event.willDefeat &&
+                    event.card.isUnit() &&
+                    event.card.controller === context.player
+            },
+            limit: abilityHelper.limit.perRound(1),
+            targetResolver: {
+                activePromptTitle: 'Choose bases to deal 1 damage to',
+                mode: TargetMode.Unlimited,
+                canChooseNoCards: true,
+                cardTypeFilter: CardType.Base,
+                immediateEffect: abilityHelper.immediateEffects.damage({ amount: 1 })
+            }
+        });
+    }
+}

--- a/test/server/cards/08_ASH/units/RancorKeeper.spec.ts
+++ b/test/server/cards/08_ASH/units/RancorKeeper.spec.ts
@@ -1,0 +1,155 @@
+describe('Rancor Keeper', function() {
+    integration(function(contextRef) {
+        it('deals 1 damage to any number of bases when a friendly unit is dealt damage and survives', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['daring-raid'],
+                    groundArena: ['rancor-keeper', 'wampa']
+                },
+                player2: {
+                    groundArena: ['battlefield-marine']
+                }
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.daringRaid);
+            context.player1.clickCard(context.wampa);
+
+            expect(context.player1).toHavePrompt('Choose bases to deal 1 damage to');
+            expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+
+            context.player1.clickCard(context.p1Base);
+            context.player1.clickCard(context.p2Base);
+            context.player1.clickPrompt('Done');
+
+            expect(context.wampa.damage).toBe(2);
+            expect(context.p1Base.damage).toBe(1);
+            expect(context.p2Base.damage).toBe(1);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('can choose no bases', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['daring-raid'],
+                    groundArena: ['rancor-keeper', 'wampa']
+                }
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.daringRaid);
+            context.player1.clickCard(context.wampa);
+            context.player1.clickPrompt('Choose nothing');
+
+            expect(context.wampa.damage).toBe(2);
+            expect(context.p1Base.damage).toBe(0);
+            expect(context.p2Base.damage).toBe(0);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('can trigger when Rancor Keeper is dealt damage and survives', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['daring-raid'],
+                    groundArena: ['rancor-keeper']
+                }
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.daringRaid);
+            context.player1.clickCard(context.rancorKeeper);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+            context.player1.clickCard(context.p2Base);
+            context.player1.clickPrompt('Done');
+
+            expect(context.rancorKeeper.damage).toBe(2);
+            expect(context.p2Base.damage).toBe(1);
+        });
+
+        it('does not trigger if the damaged friendly unit is defeated', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['open-fire'],
+                    groundArena: ['rancor-keeper', 'battlefield-marine']
+                }
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.openFire);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.battlefieldMarine).toBeInZone('discard', context.player1);
+            expect(context.p1Base.damage).toBe(0);
+            expect(context.p2Base.damage).toBe(0);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('does not trigger when an enemy unit is dealt damage', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['daring-raid'],
+                    groundArena: ['rancor-keeper']
+                },
+                player2: {
+                    groundArena: ['wampa']
+                }
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.daringRaid);
+            context.player1.clickCard(context.wampa);
+
+            expect(context.wampa.damage).toBe(2);
+            expect(context.p1Base.damage).toBe(0);
+            expect(context.p2Base.damage).toBe(0);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('uses the ability only once each round', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['daring-raid', 'daring-raid', 'daring-raid'],
+                    groundArena: ['rancor-keeper', 'wampa', 'atst']
+                }
+            });
+            const { context } = contextRef;
+            const daringRaids = context.player1.findCardsByName('daring-raid', 'hand');
+
+            context.player1.clickCard(daringRaids[0]);
+            context.player1.clickCard(context.wampa);
+            context.player1.clickCard(context.p2Base);
+            context.player1.clickPrompt('Done');
+
+            expect(context.p2Base.damage).toBe(1);
+            expect(context.player2).toBeActivePlayer();
+
+            context.player2.passAction();
+            context.player1.clickCard(daringRaids[1]);
+            context.player1.clickCard(context.atst);
+
+            expect(context.atst.damage).toBe(2);
+            expect(context.p2Base.damage).toBe(1);
+            expect(context.player2).toBeActivePlayer();
+
+            context.moveToNextActionPhase();
+
+            context.player1.clickCard(daringRaids[2]);
+            context.player1.clickCard(context.atst);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+            context.player1.clickCard(context.p2Base);
+            context.player1.clickPrompt('Done');
+
+            expect(context.atst.damage).toBe(4);
+            expect(context.p2Base.damage).toBe(2);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});


### PR DESCRIPTION
<img width="716" height="1000" alt="032" src="https://github.com/user-attachments/assets/7d48f88e-aab0-48e5-bf20-7d5a7ba83c50" />

Test file 
```json
{
  "phase": "action",
  "player1": {
    "leader": "iden-versio#inferno-squad-commander",
    "base": "kestro-city",
    "hand": [
      "daring-raid",
      "daring-raid",
      "open-fire"
    ],
    "groundArena": [
      "rancor-keeper",
      "wampa",
      "battlefield-marine"
    ],
    "resources": 10,
    "hasInitiative": true
  },
  "player2": {
    "leader": "luke-skywalker#faithful-friend",
    "base": "echo-base",
    "groundArena": [
      "wampa"
    ],
    "resources": 10
  }
}

```