### PR TITLE
⟡ Red Leader, Strike the Reactor

### DIFF
--- a/server/game/abilities/keyword/SupportAbility.ts
+++ b/server/game/abilities/keyword/SupportAbility.ts
@@ -29,10 +29,15 @@ export class SupportAbility extends TriggeredAbilityBase {
                     const keywords = context.source.keywords.filter((instance) => instance.name !== KeywordName.Support);
                     return {
                         attackerCondition: (card) => card !== context.source,
-                        attackerLastingEffects: [
-                            { effect: context.game.abilityHelper.ongoingEffects.gainNonKeywordAbilitiesFromUnit(context.source) },
-                            ...keywords.map((x) => ({ effect: context.game.abilityHelper.ongoingEffects.gainKeyword(x.toProperties()) }))
-                        ]
+                        attackerLastingEffects: {
+                            effect: [
+                                context.game.abilityHelper.ongoingEffects
+                                    .gainNonKeywordAbilitiesFromUnit(context.source),
+                                context.game.abilityHelper.ongoingEffects.gainKeywords(() =>
+                                    keywords.map((keyword) => keyword.toProperties())
+                                )
+                            ]
+                        }
                     };
                 })
             }

--- a/server/game/cards/08_ASH/units/RedLeaderStrikeTheReactor.ts
+++ b/server/game/cards/08_ASH/units/RedLeaderStrikeTheReactor.ts
@@ -1,0 +1,24 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { EffectName } from '../../../core/Constants';
+import { OngoingEffectBuilder } from '../../../core/ongoingEffect/OngoingEffectBuilder';
+
+export default class RedLeaderStrikeTheReactor extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '0770708432',
+            internalName: 'red-leader#strike-the-reactor'
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        registrar.addConstantAbility({
+            title: 'This unit can attack units in either arena',
+            ongoingEffect: [
+                OngoingEffectBuilder.card.static(EffectName.CanAttackGroundArenaFromSpaceArena),
+                OngoingEffectBuilder.card.static(EffectName.CanAttackSpaceArenaFromGroundArena)
+            ]
+        });
+    }
+}

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -23,11 +23,8 @@ import { Helpers } from '../core/utils/Helpers';
 import { ChatHelpers } from '../core/chat/ChatHelpers';
 import type { IAttackableCard } from '../core/card/CardInterfaces';
 import type { IUnitCard } from '../core/card/propertyMixins/UnitProperties';
-import type { IOngoingCardEffectGenerator, KeywordNameOrProperties } from '../Interfaces';
-import { KeywordInstance } from '../core/ability/KeywordInstance';
+import type { IOngoingCardEffectGenerator } from '../Interfaces';
 import type { MustAttackProperties } from '../core/ongoingEffect/effectImpl/MustAttackProperties';
-import type { OngoingCardEffect } from '../core/ongoingEffect/OngoingCardEffect';
-import type { OngoingPlayerEffect } from '../core/ongoingEffect/OngoingPlayerEffect';
 import type { FormatMessage } from '../core/chat/GameChat';
 
 export interface IAttackLastingEffectProperties<TContext extends AbilityContext = AbilityContext> {
@@ -179,9 +176,12 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
             return false; // cannot attack cards with a BeAttacked restriction
         }
 
+        // Per CR 6.3.1.1, abilities granted by a modified "Attack With a Unit" action are active at "Declare Intent",
+        // before this legality check runs. InitiateAttackSystem applies unconditional attacker lasting effects up front,
+        // so we can read them directly off the attacker here.
         const attackerZone = properties.attacker.zoneName === ZoneName.GroundArena ? ZoneName.GroundArena : ZoneName.SpaceArena;
-        const canTargetGround = attackerZone === ZoneName.GroundArena || context.source.hasOngoingEffect(EffectName.CanAttackGroundArenaFromSpaceArena) || this.attackerGainsEffect(targetCard, context, EffectName.CanAttackGroundArenaFromSpaceArena, additionalProperties);
-        const canTargetSpace = attackerZone === ZoneName.SpaceArena || context.source.hasOngoingEffect(EffectName.CanAttackSpaceArenaFromGroundArena) || this.attackerGainsEffect(targetCard, context, EffectName.CanAttackSpaceArenaFromGroundArena, additionalProperties);
+        const canTargetGround = attackerZone === ZoneName.GroundArena || properties.attacker.hasOngoingEffect(EffectName.CanAttackGroundArenaFromSpaceArena);
+        const canTargetSpace = attackerZone === ZoneName.SpaceArena || properties.attacker.hasOngoingEffect(EffectName.CanAttackSpaceArenaFromGroundArena);
         if (
             targetCard.zoneName !== attackerZone &&
             targetCard.zoneName !== ZoneName.Base &&
@@ -192,9 +192,7 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         }
 
         // If not Saboteur, do a Sentinel check
-        const attackerHasSaboteur =
-            properties.attacker.hasSomeKeyword(KeywordName.Saboteur) ||
-            this.attackerGainsSaboteur(targetCard, context, additionalProperties);
+        const attackerHasSaboteur = properties.attacker.hasSomeKeyword(KeywordName.Saboteur);
         if (!attackerHasSaboteur) {
             if (targetCard.controller.hasSomeArenaUnit({ arena: attackerZone, keyword: KeywordName.Sentinel })) {
                 return targetCard.hasSomeKeyword(KeywordName.Sentinel);
@@ -296,10 +294,16 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         defenderLastingEffects: IAttackLastingEffectPropertiesOrFactory<TContext> | IAttackLastingEffectPropertiesOrFactory<TContext>[],
         attack: Attack
     ): { attackerEffects?: CardLastingEffectSystem; defenderEffects: Map<Card, CardLastingEffectSystem> } {
+        // Unconditional, non-factory attacker effects are applied earlier by InitiateAttackSystem so they're
+        // active at "Declare Intent" (CR 6.3.1.1). Only factory-form or conditional entries can be applied here,
+        // because they depend on the chosen target or other attack details that aren't finalized until now.
+        const allAttackerEntries = Helpers.asArray(attackerLastingEffects);
+        const lateAttackerEntries = AttackStepsSystem.partitionLateAttackerLastingEffects(attackerLastingEffects);
+
         // create events for all effects to be generated
         const effectEvents: GameEvent[] = [];
-        const attackerEffects = this.queueCreateLastingEffectsGameSteps(Helpers.asArray(attackerLastingEffects), attack.attacker, context, attack, effectEvents);
-        let effectsRegistered = attackerEffects != null;
+        const lateAttackerEffects = this.queueCreateLastingEffectsGameSteps(lateAttackerEntries, attack.attacker, context, attack, effectEvents);
+        let effectsRegistered = lateAttackerEffects != null;
         const defenderEffectsMap = new Map<Card, CardLastingEffectSystem>();
         for (const target of attack.getAllTargets()) {
             const defenderEffects = this.queueCreateLastingEffectsGameSteps(Helpers.asArray(defenderLastingEffects), target, context, attack, effectEvents);
@@ -311,6 +315,17 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
 
         if (effectsRegistered) {
             context.game.queueSimpleStep(() => context.game.openEventWindow(effectEvents), 'open event window for attack effects');
+        }
+
+        // For the chat summary, build a non-queued system that covers every attacker entry (including the ones
+        // applied early by InitiateAttackSystem) so the message lists the full set of granted effects. Skip when
+        // nothing would apply to the attacker (e.g. blanked) — matching legacy behavior of suppressing the message.
+        let attackerEffects: CardLastingEffectSystem | undefined;
+        if (allAttackerEntries.length > 0) {
+            const messageSystem = this.buildCardLastingEffectSystem(allAttackerEntries, context, attack, attack.attacker);
+            if (messageSystem.getApplicableEffects(attack.attacker, context).length > 0) {
+                attackerEffects = messageSystem;
+            }
         }
 
         return { attackerEffects, defenderEffects: defenderEffectsMap };
@@ -338,58 +353,60 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         return effectSystem;
     }
 
-    private attackerGainsSaboteur(attackTarget: IAttackableCard, context: TContext, additionalProperties?: Partial<IAttackProperties<TContext>>) {
-        const properties = this.generatePropertiesFromContext(context, additionalProperties);
-
-        // If the attacker is blanked or has lost Saboteur, it cannot gain Saboteur
-        const saboteur = new KeywordInstance(KeywordName.Saboteur, properties.attacker);
-        if (saboteur.isBlank) {
-            return false;
-        }
-
-        return this.attackerGains(attackTarget, context, additionalProperties, (effect) => {
-            if (effect.impl.type !== EffectName.GainKeyword) {
-                return false;
-            }
-
-            const keywordProps: KeywordNameOrProperties = effect.impl.getValue(properties.attacker);
-
-            if (!keywordProps) {
-                return false;
-            }
-
-            const keyword = typeof keywordProps === 'string' ? keywordProps : keywordProps.keyword;
-
-            return keyword === KeywordName.Saboteur;
-        });
-    }
-
-    private attackerGainsEffect(attackTarget: IAttackableCard, context: TContext, effect: EffectName, additionalProperties?: Partial<IAttackProperties<TContext>>) {
-        return this.attackerGains(attackTarget, context, additionalProperties, (e) => e.impl.type === effect);
-    }
-
-    /** Checks if there are any lasting effects that would give the attacker Saboteur, for the purposes of targeting */
-    private attackerGains(attackTarget: IAttackableCard, context: TContext, additionalProperties?: Partial<IAttackProperties<TContext>>, predicate: (effect: OngoingCardEffect | OngoingPlayerEffect) => boolean = () => false): boolean {
-        const properties = this.generatePropertiesFromContext(context, additionalProperties);
-
-        const attackerLastingEffects = Helpers.asArray(properties.attackerLastingEffects);
-        if (attackerLastingEffects.length === 0) {
-            return false;
-        }
-
-        // construct a hypothetical attack in case it's required for evaluating a condition on the lasting effect
-        const attack = new Attack(
-            context.game,
-            properties.attacker as IUnitCard,
-            [attackTarget],
-            properties.isAmbush,
-            properties.attackerCombatDamageOverride,
+    /**
+     * Returns the subset of attacker lasting effects that depend on the chosen target or some other aspect of
+     * the attack object itself (factory-form or conditional).
+     *
+     * Used by {@link registerAttackEffects} to skip entries that were applied earlier at Declare Intent.
+     */
+    private static partitionLateAttackerLastingEffects<TContext extends AbilityContext>(
+        attackerLastingEffects: IAttackLastingEffectPropertiesOrFactory<TContext> | IAttackLastingEffectPropertiesOrFactory<TContext>[] | undefined
+    ): IAttackLastingEffectPropertiesOrFactory<TContext>[] {
+        return Helpers.asArray(attackerLastingEffects).filter((entry) =>
+            typeof entry === 'function' || entry.condition != null
         );
+    }
 
-        const effectSystem = this.buildCardLastingEffectSystem(attackerLastingEffects, context, attack, attackTarget);
-        const applicableEffects = effectSystem.getApplicableEffects(properties.attacker, context);
+    /**
+     * Returns the subset of attacker lasting effects that can be applied before target selection — entries
+     * that are neither factory functions nor carry an attack-dependent condition.
+     */
+    private static partitionEarlyAttackerLastingEffects<TContext extends AbilityContext>(
+        attackerLastingEffects: IAttackLastingEffectPropertiesOrFactory<TContext> | IAttackLastingEffectPropertiesOrFactory<TContext>[] | undefined
+    ): IAttackLastingEffectProperties<TContext>[] {
+        return Helpers.asArray(attackerLastingEffects).filter((entry): entry is IAttackLastingEffectProperties<TContext> =>
+            typeof entry !== 'function' && entry.condition == null
+        );
+    }
 
-        return applicableEffects.some((effect) => predicate(effect));
+    /**
+     * Applies attacker lasting effects at "Declare Intent" of a modified attack action (CR 6.3.1.1), so that they're
+     * active during target legality checks performed by {@link canAffectInternal}. Only entries that don't depend on
+     * the chosen target (no factory, no condition) are applied here; the rest run later in {@link registerAttackEffects}.
+     */
+    public static queueEarlyAttackerLastingEffects<TContext extends AbilityContext>(
+        context: TContext,
+        attacker: Card,
+        attackerLastingEffects: IAttackLastingEffectPropertiesOrFactory<TContext> | IAttackLastingEffectPropertiesOrFactory<TContext>[] | undefined
+    ): void {
+        const entries = AttackStepsSystem.partitionEarlyAttackerLastingEffects(attackerLastingEffects);
+        if (entries.length === 0) {
+            return;
+        }
+
+        const effectSystem = new CardLastingEffectSystem<TContext>({
+            duration: Duration.UntilEndOfAttack,
+            target: attacker,
+            effect: entries.flatMap((entry) => Helpers.asArray(entry.effect))
+        });
+
+        if (effectSystem.getApplicableEffects(attacker, context).length === 0) {
+            return;
+        }
+
+        const effectEvents: GameEvent[] = [];
+        effectSystem.queueGenerateEventGameSteps(effectEvents, context);
+        context.game.queueSimpleStep(() => context.game.openEventWindow(effectEvents), 'open event window for early attacker lasting effects');
     }
 
     private buildCardLastingEffectSystem(lastingEffects: IAttackLastingEffectPropertiesOrFactory<TContext>[], context: TContext, attack: Attack, target: Card) {

--- a/server/game/gameSystems/InitiateAttackSystem.ts
+++ b/server/game/gameSystems/InitiateAttackSystem.ts
@@ -5,6 +5,7 @@ import { InitiateAttackAction } from '../actions/InitiateAttackAction';
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import { Contract } from '../core/utils/Contract';
 import type { IAttackProperties } from './AttackStepsSystem';
+import { AttackStepsSystem } from './AttackStepsSystem';
 import { MetaEventName } from '../core/Constants';
 import type { IUnitCard } from '../core/card/propertyMixins/UnitProperties';
 
@@ -38,6 +39,12 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
         const context = event.context as AbilityContext;
         const player = event.player;
         const newContext = (event.attackAbility as InitiateAttackAction).createContext(player);
+
+        // CR 6.3.1.1: Abilities granted to the attacker by a modified "Attack With a Unit" action are active at
+        // "Declare Intent" — before target selection. Apply unconditional attacker lasting effects now so they're
+        // visible to target legality checks inside AttackStepsSystem.canAffectInternal.
+        AttackStepsSystem.queueEarlyAttackerLastingEffects(newContext, newContext.source, event.attackerLastingEffects);
+
         context.game.queueStep(new AbilityResolver(event.context.game, newContext, event.optional));
         context.game.queueSimpleStep(() => {
             if (context.activeAttackId !== undefined) {
@@ -55,6 +62,7 @@ export class InitiateAttackSystem<TContext extends AbilityContext = AbilityConte
 
         event.attackAbility = this.generateAttackAbilityNoTarget(attacker, properties, context.source);
         event.optional = properties.optional ?? context.ability.optional;
+        event.attackerLastingEffects = properties.attackerLastingEffects;
     }
 
     public override canAffectInternal(card: Card, context: TContext, additionalProperties: Partial<IInitiateAttackProperties<TContext>> = {}): boolean {

--- a/test/server/cards/08_ASH/units/RedLeaderStrikeTheReactor.spec.ts
+++ b/test/server/cards/08_ASH/units/RedLeaderStrikeTheReactor.spec.ts
@@ -91,6 +91,189 @@ describe('Red Leader, Strike the Reactor', function() {
                 expect(context.battlefieldMarine).toBeInZone('discard');
             });
 
+            it('should not restrict Red Leader\'s targeting when a Sentinel is only in the other arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: ['red-leader#strike-the-reactor']
+                    },
+                    player2: {
+                        groundArena: ['echo-base-defender', 'battlefield-marine'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Red Leader is in the space arena and there's no Sentinel in space —
+                // the ground Sentinel doesn't restrict targeting from the other arena.
+                context.player1.clickCard(context.redLeader);
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.tielnFighter,
+                    context.p2Base,
+                    context.echoBaseDefender,
+                    context.battlefieldMarine
+                ]);
+
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.battlefieldMarine).toBeInZone('discard');
+            });
+
+            it('should not restrict a ground unit chosen via Support when a Sentinel is only in the space arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['alkenzi-patroller', 'tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support — Wampa is the only friendly unit
+                context.player1.clickCard(context.redLeader);
+                context.player1.clickCard(context.wampa);
+
+                // Wampa is in the ground arena and there's no Sentinel in ground —
+                // the space Sentinel doesn't restrict targeting from the other arena.
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.battlefieldMarine,
+                    context.p2Base,
+                    context.alkenziPatroller,
+                    context.tielnFighter,
+                ]);
+
+                context.player1.clickCard(context.tielnFighter);
+                expect(context.tielnFighter).toBeInZone('discard');
+            });
+
+            it('should restrict Red Leader to attacking only Sentinels in either arena when a Sentinel is in its arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: ['red-leader#strike-the-reactor']
+                    },
+                    player2: {
+                        groundArena: ['echo-base-defender', 'battlefield-marine'],
+                        spaceArena: ['alkenzi-patroller', 'tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Red Leader is in the space arena. A Sentinel in its arena restricts every target
+                // (including cross-arena) to Sentinels only, per the Strafing Gunship dev ruling.
+                context.player1.clickCard(context.redLeader);
+
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.alkenziPatroller,
+                    context.echoBaseDefender
+                ]);
+
+                context.player1.clickCard(context.echoBaseDefender);
+                expect(context.echoBaseDefender).toBeInZone('discard');
+            });
+
+            it('should restrict a ground unit chosen via Support to only Sentinels in either arena when a Sentinel is in the ground arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['echo-base-defender', 'battlefield-marine'],
+                        spaceArena: ['alkenzi-patroller', 'tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support — Wampa is the only friendly unit
+                context.player1.clickCard(context.redLeader);
+                context.player1.clickCard(context.wampa);
+
+                // Wampa is in the ground arena, so the ground Sentinel restricts every target
+                // (including cross-arena to space) to Sentinels only.
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.echoBaseDefender,
+                    context.alkenziPatroller
+                ]);
+
+                context.player1.clickCard(context.alkenziPatroller);
+                expect(context.alkenziPatroller).toBeInZone('discard');
+            });
+
+            it('should allow a Saboteur space unit chosen via Support to attack any enemy unit or the base', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        spaceArena: ['ohnaka-gang-starhopper']
+                    },
+                    player2: {
+                        groundArena: ['echo-base-defender', 'battlefield-marine'],
+                        spaceArena: ['alkenzi-patroller', 'tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support — Ohnaka Gang Starhopper is the only friendly unit
+                context.player1.clickCard(context.redLeader);
+                context.player1.clickCard(context.ohnakaGangStarhopper);
+
+                // Saboteur ignores Sentinel, and Red Leader's ability adds cross-arena attack —
+                // so any enemy unit and the base are valid targets.
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.alkenziPatroller,
+                    context.tielnFighter,
+                    context.echoBaseDefender,
+                    context.battlefieldMarine,
+                    context.p2Base
+                ]);
+
+                context.player1.clickCard(context.p2Base);
+                expect(context.p2Base.damage).toBe(2);
+            });
+
+            it('should allow a Saboteur ground unit chosen via Support to attack any enemy unit or the base', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        groundArena: ['reckless-rebel']
+                    },
+                    player2: {
+                        groundArena: ['echo-base-defender', 'battlefield-marine'],
+                        spaceArena: ['alkenzi-patroller', 'tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support — Reckless Rebel is the only friendly unit
+                context.player1.clickCard(context.redLeader);
+                context.player1.clickCard(context.recklessRebel);
+
+                // Saboteur ignores Sentinel, and Red Leader's ability adds cross-arena attack —
+                // so any enemy unit and the base are valid targets.
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.echoBaseDefender,
+                    context.battlefieldMarine,
+                    context.alkenziPatroller,
+                    context.tielnFighter,
+                    context.p2Base
+                ]);
+
+                context.player1.clickCard(context.p2Base);
+                expect(context.p2Base.damage).toBe(2);
+            });
+
             it('should not grant the supported unit cross-arena attack on subsequent attacks', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',

--- a/test/server/cards/08_ASH/units/RedLeaderStrikeTheReactor.spec.ts
+++ b/test/server/cards/08_ASH/units/RedLeaderStrikeTheReactor.spec.ts
@@ -1,0 +1,128 @@
+describe('Red Leader, Strike the Reactor', function() {
+    integration(function(contextRef) {
+        describe('its cross-arena attack ability', function() {
+            it('should allow Red Leader to attack units in either arena from the space arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        spaceArena: ['red-leader#strike-the-reactor']
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Red Leader can attack both arenas and the base
+                context.player1.clickCard(context.redLeader);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.cartelSpacer, context.p2Base]);
+
+                context.player1.clickCard(context.wampa);
+                expect(context.wampa).toBeInZone('discard');
+            });
+
+            it('should allow a friendly ground unit chosen via Support to attack enemy units in either arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support
+                context.player1.clickCard(context.redLeader);
+
+                // Support: Wampa is the only friendly unit
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+                context.player1.clickCard(context.wampa);
+
+                // Wampa gains cross-arena attack for this attack
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.battlefieldMarine,
+                    context.tielnFighter,
+                    context.p2Base
+                ]);
+
+                // TIE/ln Fighter (1 HP) is defeated by Wampa (4 power)
+                context.player1.clickCard(context.tielnFighter);
+                expect(context.tielnFighter).toBeInZone('discard');
+            });
+
+            it('should allow a friendly space unit chosen via Support to attack enemy units in either arena', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        spaceArena: ['stolen-athauler']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support
+                context.player1.clickCard(context.redLeader);
+
+                // Support: Stolen AT-Hauler is the only friendly unit
+                expect(context.player1).toBeAbleToSelectExactly([context.stolenAthauler]);
+                context.player1.clickCard(context.stolenAthauler);
+
+                // Stolen AT-Hauler gains cross-arena attack for this attack
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.battlefieldMarine,
+                    context.tielnFighter,
+                    context.p2Base
+                ]);
+
+                // Battlefield Marine (3 HP) is defeated by Stolen AT-Hauler (4 power)
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.battlefieldMarine).toBeInZone('discard');
+            });
+
+            it('should not grant the supported unit cross-arena attack on subsequent attacks', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['red-leader#strike-the-reactor'],
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['cartel-spacer', 'tieln-fighter']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Red Leader, triggering Support — Wampa attacks the base to preserve all units
+                context.player1.clickCard(context.redLeader);
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+                context.player1.clickCard(context.wampa);
+                context.player1.clickCard(context.cartelSpacer);
+
+                expect(context.cartelSpacer).toBeInZone('discard');
+
+                // Advance to next action phase so Wampa readies
+                context.moveToNextActionPhase();
+
+                // Wampa (ground) can only attack ground targets — cross-arena was for the Support attack only
+                context.player1.clickCard(context.wampa);
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.p2Base]);
+
+                context.player1.clickCard(context.p2Base);
+            });
+        });
+    });
+});

--- a/test/server/core/abilities/keyword/Support.spec.ts
+++ b/test/server/core/abilities/keyword/Support.spec.ts
@@ -258,30 +258,43 @@ describe('Support keyword', function() {
             });
         });
 
-        it('Supported unit should copy Saboteur keyword immediately', async function () {
+        it('Supported unit should copy Saboteur keyword early enough for attack target selection', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
-                    leader: 'moff-gideon#indomitable-warlord',
-                    discard: ['seventh-sister#implacable-inquisitor', 'rukh#from-the-shadows'],
-                    groundArena: ['wampa']
+                    hand: ['unsanctioned-patrol'],
+                    spaceArena: ['stolen-athauler'],
                 },
                 player2: {
-                    groundArena: ['echo-base-defender']
+                    spaceArena: [{
+                        card: 'alkenzi-patroller',
+                        upgrades: ['shield', 'shield']
+                    }]
                 }
             });
+
             const { context } = contextRef;
 
-            // Deploy Moff Gideon, he gains Saboteur & Support from Imperial units on discard
-            context.player1.clickCard(context.moffGideon);
-            context.player1.clickPrompt('Deploy Moff Gideon');
+            // Initiate an attack with Stolen AT-Hauler; it can only target the space Sentinel
+            context.player1.clickCard(context.stolenAthauler);
+            expect(context.player1).toBeAbleToSelectExactly([context.alkenziPatroller]);
+            context.player1.clickPrompt('Cancel');
 
-            // Attack with Wampa, it can ignore Sentinel because it gains Saboteur from Support
-            context.player1.clickCard(context.wampa);
-            expect(context.player1).toBeAbleToSelectExactly([context.p2Base, context.echoBaseDefender]);
-            context.player1.clickCard(context.p2Base);
+            // Instead, play Unsanctioned Patrol, which should copy Saboteur to Stolen AT-Hauler and initiate an attack with it
+            context.player1.clickCard(context.unsanctionedPatrol);
+            context.player1.clickCard(context.stolenAthauler);
 
-            expect(context.player2).toBeActivePlayer();
+            // Base is targetable because abilities were copied in time for the attack target selection
+            expect(context.player1).toBeAbleToSelectExactly([
+                context.alkenziPatroller,
+                context.p2Base
+            ]);
+
+            context.player1.clickCard(context.alkenziPatroller);
+
+            // Alkenzi Patroller should be defeated because Saboteur allowed Stolen AT-Hauler to defeat Shields on attack
+            expect(context.alkenziPatroller).toBeInZone('discard');
+            expect(context.stolenAthauler.damage).toBe(2);
         });
     });
 });


### PR DESCRIPTION
### Dev notes

Includes some small tweaks to the `AttackStepsSystem` to ensure unconditional non-Attack-dependent abilities are granted in time for targeting, so the supported unit can also choose targets in either arena. This actually ended up cleaning up some Saboteur-specific logic and now works in the general case.

| ⟡ Red Leader |
| :---: |
| Strike the Reactor |
| <img width=350 src="https://github.com/user-attachments/assets/27921405-43ba-4fa1-9312-ba38ae63f9d6" /> |