### PR TITLE
ASH Tatooine Repulsor Train card implementation

### DIFF
--- a/server/game/cards/08_ASH/units/TatooineRepulsorTrain.ts
+++ b/server/game/cards/08_ASH/units/TatooineRepulsorTrain.ts
@@ -1,0 +1,39 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { AbilityRestriction, WildcardCardType, ZoneName } from '../../../core/Constants';
+
+export default class TatooineRepulsorTrain extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: '9629363501',
+            internalName: 'tatooine-repulsor-train',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addConstantAbility({
+            title: 'This unit can\'t be attacked while you control 2 or more exhausted units',
+            condition: (context) => this.getFriendlyExhaustedUnitCount(context) >= 2,
+            ongoingEffect: abilityHelper.ongoingEffects.cardCannot(AbilityRestriction.BeAttacked)
+        });
+
+        registrar.addOnAttackAbility({
+            title: 'Deal 2 damage to a ground unit for each friendly exhausted unit',
+            targetResolver: {
+                activePromptTitle: (context) => `Choose a ground unit to deal ${this.getAttackDamage(context)} damage to`,
+                cardTypeFilter: WildcardCardType.Unit,
+                zoneFilter: ZoneName.GroundArena,
+                immediateEffect: abilityHelper.immediateEffects.damage((context) => ({ amount: this.getAttackDamage(context) })),
+            }
+        });
+    }
+
+    private getFriendlyExhaustedUnitCount(context): number {
+        return context.player.getArenaUnits({ condition: (card) => card.exhausted }).length;
+    }
+
+    private getAttackDamage(context): number {
+        return 2 * this.getFriendlyExhaustedUnitCount(context);
+    }
+}

--- a/test/server/cards/08_ASH/units/TatooineRepulsorTrain.spec.ts
+++ b/test/server/cards/08_ASH/units/TatooineRepulsorTrain.spec.ts
@@ -92,6 +92,7 @@ describe('Tatooine Repulsor Train', function () {
                 context.player1.clickCard(context.tatooineRepulsorTrain);
                 context.player1.clickCard(context.p2Base);
 
+                expect(context.player1).toHavePrompt('Choose a ground unit to deal 6 damage to');
                 expect(context.player1).toBeAbleToSelectExactly([
                     context.tatooineRepulsorTrain,
                     context.battlefieldMarine,

--- a/test/server/cards/08_ASH/units/TatooineRepulsorTrain.spec.ts
+++ b/test/server/cards/08_ASH/units/TatooineRepulsorTrain.spec.ts
@@ -1,0 +1,111 @@
+describe('Tatooine Repulsor Train', function () {
+    integration(function (contextRef) {
+        const cannotBeAttacked = (card: Card, game: Game) => {
+            return card.getSummary(game.actionPhaseActivePlayer).cannotBeAttacked;
+        };
+
+        describe('Tatooine Repulsor Train\'s constant ability', function () {
+            it('cannot be attacked while its controller controls 2 or more exhausted units', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'tatooine-repulsor-train',
+                            'battlefield-marine'
+                        ],
+                        spaceArena: [
+                            { card: 'awing', exhausted: true },
+                            { card: 'green-squadron-awing', exhausted: true }
+                        ],
+                    },
+                    player2: {
+                        hasInitiative: true,
+                        groundArena: ['wampa']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.wampa);
+
+                expect(context.player2).toBeAbleToSelectExactly([
+                    context.battlefieldMarine,
+                    context.p1Base
+                ]);
+                expect(context.player2).not.toBeAbleToSelect(context.tatooineRepulsorTrain);
+                expect(cannotBeAttacked(context.tatooineRepulsorTrain, context.game)).toBeTrue();
+
+                context.player2.clickCard(context.battlefieldMarine);
+            });
+
+            it('can be attacked while its controller controls fewer than 2 exhausted units', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'tatooine-repulsor-train',
+                            'battlefield-marine'
+                        ],
+                        spaceArena: [{ card: 'awing', exhausted: true }],
+                    },
+                    player2: {
+                        hasInitiative: true,
+                        groundArena: ['wampa']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.wampa);
+
+                expect(context.player2).toBeAbleToSelectExactly([
+                    context.tatooineRepulsorTrain,
+                    context.battlefieldMarine,
+                    context.p1Base
+                ]);
+                expect(cannotBeAttacked(context.tatooineRepulsorTrain, context.game)).toBeFalse();
+
+                context.player2.clickCard(context.tatooineRepulsorTrain);
+            });
+        });
+
+        describe('Tatooine Repulsor Train\'s on attack ability', function () {
+            it('deals 2 damage to a ground unit for each friendly exhausted unit', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'tatooine-repulsor-train',
+                            { card: 'battlefield-marine', exhausted: true },
+                            { card: 'wilderness-fighter', exhausted: true },
+                            'echo-base-defender'
+                        ],
+                    },
+                    player2: {
+                        groundArena: ['wampa', 'atst'],
+                        spaceArena: ['cartel-spacer']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.tatooineRepulsorTrain);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.tatooineRepulsorTrain,
+                    context.battlefieldMarine,
+                    context.wildernessFighter,
+                    context.echoBaseDefender,
+                    context.wampa,
+                    context.atst
+                ]);
+                expect(context.player1).not.toBeAbleToSelect(context.cartelSpacer);
+
+                context.player1.clickCard(context.atst);
+
+                expect(context.atst.damage).toBe(6);
+            });
+        });
+    });
+});


### PR DESCRIPTION
<img width="716" height="1000" alt="035" src="https://github.com/user-attachments/assets/b719c7b6-3799-4141-9741-3c471483c6cf" />

Game setup file for proper testing:
```json
{
    "phase": "action",
    "player1": {
        "hand": [
            "nowhere-to-hide",
            "force-illusion"
        ],
        "groundArena": [
            "tatooine-repulsor-train",
            { "card": "battlefield-marine", "exhausted": true },
            { "card": "wilderness-fighter", "exhausted": true },
            "echo-base-defender"
        ],
        "resources": 10,
        "base": "echo-base",
        "leader": "luke-skywalker#faithful-friend",
        "hasInitiative": true
    },
    "player2": {
        "groundArena": [
            "wampa",
            "pyke-sentinel",
            "atst"
        ],
        "spaceArena": [
            "cartel-spacer"
        ],
        "resources": 10,
        "base": "kestro-city",
        "leader": "sabine-wren#galvanized-revolutionary"
    }
}

```