### PR TITLE
[Bugfix] Cassian/Condemn timing + Anakin's Podracer attacking condition

### DIFF
--- a/server/game/cards/07_LAW/units/AnakinsPodracerSoWizard.ts
+++ b/server/game/cards/07_LAW/units/AnakinsPodracerSoWizard.ts
@@ -21,10 +21,12 @@ export default class AnakinsPodracerSoWizard extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
             title: 'While attacking, if no other units have attacked this phase, this unit deals combat damage before the defender.',
-            condition: (context) => this.attacksThisPhaseWatcher.getAttackers((attackEvent) =>
-                attackEvent.attacker !== context.source ||
-                attackEvent.attackerInPlayId !== context.source.inPlayId
-            ).length === 0,
+            condition: (context) =>
+                context.source.isAttacking() &&
+                this.attacksThisPhaseWatcher.getAttackers((attackEvent) =>
+                    attackEvent.attacker !== context.source ||
+                    attackEvent.attackerInPlayId !== context.source.inPlayId
+                ).length === 0,
             ongoingEffect: AbilityHelper.ongoingEffects.dealsCombatDamageFirst(),
         });
     }

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -26,7 +26,6 @@ export class AttackFlow extends BaseStepWithPipeline {
         this.attack = attack;
 
         this.pipeline.initialise([
-            new SimpleStep(this.game, () => this.setCurrentAttack(), 'setCurrentAttack'),
             new SimpleStep(this.game, () => this.declareAttack(), 'declareAttack'),
             new SimpleStep(this.game, () => this.dealDamageAndCompleteAttack(), 'dealDamageAndCompleteAttack'),
             new SimpleStep(this.game, () => this.cleanUpAttack(), 'cleanUpAttack'),
@@ -43,7 +42,13 @@ export class AttackFlow extends BaseStepWithPipeline {
     }
 
     private declareAttack() {
-        const event = this.game.createEventAndOpenWindow(EventName.OnAttackDeclared, this.context, { attack: this.attack }, TriggerHandlingMode.ResolvesTriggers);
+        const event = this.game.createEventAndOpenWindow(
+            EventName.OnAttackDeclared,
+            this.context,
+            { attack: this.attack },
+            TriggerHandlingMode.ResolvesTriggers,
+            () => this.setCurrentAttack()
+        );
 
         // Capture the attacker and defender's LKI on the event itself, before any "On Attack" / "On Defense"
         // abilities can mutate or defeat the attacker. Read by triggers that resolve during the

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -213,6 +213,10 @@ export class AttackFlow extends BaseStepWithPipeline {
 
             this.context.game.openEventWindow(damageEvents);
         } else {
+            // Every legal target has left play (e.g. defeated by a debuff from "While this unit
+            // is attacking..." abilities) and the attacker has no Overwhelm to redirect damage
+            // to the base, so no combat damage will be dealt.
+            this.context.game.addMessage('The attack does not resolve because there is no longer a legal target');
             this.context.game.openEventWindow(attackCompleteEvent);
         }
     }

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -5,7 +5,7 @@ import { BaseStepWithPipeline } from '../gameSteps/BaseStepWithPipeline';
 import { SimpleStep } from '../gameSteps/SimpleStep';
 import { EnumHelpers } from '../utils/EnumHelpers';
 import { GameEvent } from '../event/GameEvent';
-import { addAttackLastKnownInformationToEvent } from '../event/LastKnownInformation';
+import { addAttackLastKnownInformationToEvent, buildAttackLastKnownInformationEffect } from '../event/LastKnownInformation';
 import type { Card } from '../card/Card';
 import { TriggerHandlingMode } from '../event/EventWindow';
 import { DamageSystem } from '../../gameSystems/DamageSystem';
@@ -48,14 +48,17 @@ export class AttackFlow extends BaseStepWithPipeline {
             { attack: this.attack }
         );
 
-        declareAttackEvent.setPreResolutionEffect((_event) => this.setCurrentAttack());
-
-        this.context.game.openEventWindow([declareAttackEvent], TriggerHandlingMode.ResolvesTriggers);
-
         // Capture the attacker and defender's LKI on the event itself, before any "On Attack" / "On Defense"
         // abilities can mutate or defeat the attacker. Read by triggers that resolve during the
         // OnAttackDeclared window (e.g. Kragan Gorr's target resolver).
-        addAttackLastKnownInformationToEvent(declareAttackEvent, this.attack);
+        const captureLastKnownInformation = buildAttackLastKnownInformationEffect(this.attack);
+
+        declareAttackEvent.setPreResolutionEffect((event) => {
+            this.setCurrentAttack();
+            captureLastKnownInformation(event);
+        });
+
+        this.context.game.openEventWindow([declareAttackEvent], TriggerHandlingMode.ResolvesTriggers);
     }
 
     private dealDamageAndCompleteAttack(): void {

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -15,15 +15,18 @@ import { Contract } from '../utils/Contract';
 export class AttackFlow extends BaseStepWithPipeline {
     private context: AbilityContext;
     private attack: Attack;
+    private onAttackDeclared?: () => void;
 
     public constructor(
         context: AbilityContext,
-        attack: Attack
+        attack: Attack,
+        onAttackDeclared?: () => void
     ) {
         super(context.game);
 
         this.context = context;
         this.attack = attack;
+        this.onAttackDeclared = onAttackDeclared;
 
         this.pipeline.initialise([
             new SimpleStep(this.game, () => this.declareAttack(), 'declareAttack'),
@@ -56,6 +59,7 @@ export class AttackFlow extends BaseStepWithPipeline {
         declareAttackEvent.setPreResolutionEffect((event) => {
             this.setCurrentAttack();
             captureLastKnownInformation(event);
+            this.onAttackDeclared?.();
         });
 
         this.context.game.openEventWindow([declareAttackEvent], TriggerHandlingMode.ResolvesTriggers);

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -5,7 +5,7 @@ import { BaseStepWithPipeline } from '../gameSteps/BaseStepWithPipeline';
 import { SimpleStep } from '../gameSteps/SimpleStep';
 import { EnumHelpers } from '../utils/EnumHelpers';
 import { GameEvent } from '../event/GameEvent';
-import { addAttackLastKnownInformationToEvent, buildAttackLastKnownInformationEffect } from '../event/LastKnownInformation';
+import { addAttackLastKnownInformationToEvent, buildAttackLastKnownInformationHandler } from '../event/LastKnownInformation';
 import type { Card } from '../card/Card';
 import { TriggerHandlingMode } from '../event/EventWindow';
 import { DamageSystem } from '../../gameSystems/DamageSystem';
@@ -54,7 +54,7 @@ export class AttackFlow extends BaseStepWithPipeline {
         // Capture the attacker and defender's LKI on the event itself, before any "On Attack" / "On Defense"
         // abilities can mutate or defeat the attacker. Read by triggers that resolve during the
         // OnAttackDeclared window (e.g. Kragan Gorr's target resolver).
-        const captureLastKnownInformation = buildAttackLastKnownInformationEffect(this.attack);
+        const captureLastKnownInformation = buildAttackLastKnownInformationHandler(this.attack);
 
         declareAttackEvent.setPreResolutionEffect((event) => {
             this.setCurrentAttack();

--- a/server/game/core/attack/AttackFlow.ts
+++ b/server/game/core/attack/AttackFlow.ts
@@ -42,18 +42,20 @@ export class AttackFlow extends BaseStepWithPipeline {
     }
 
     private declareAttack() {
-        const event = this.game.createEventAndOpenWindow(
+        const declareAttackEvent = new GameEvent(
             EventName.OnAttackDeclared,
             this.context,
-            { attack: this.attack },
-            TriggerHandlingMode.ResolvesTriggers,
-            () => this.setCurrentAttack()
+            { attack: this.attack }
         );
+
+        declareAttackEvent.setPreResolutionEffect((_event) => this.setCurrentAttack());
+
+        this.context.game.openEventWindow([declareAttackEvent], TriggerHandlingMode.ResolvesTriggers);
 
         // Capture the attacker and defender's LKI on the event itself, before any "On Attack" / "On Defense"
         // abilities can mutate or defeat the attacker. Read by triggers that resolve during the
         // OnAttackDeclared window (e.g. Kragan Gorr's target resolver).
-        addAttackLastKnownInformationToEvent(event, this.attack);
+        addAttackLastKnownInformationToEvent(declareAttackEvent, this.attack);
     }
 
     private dealDamageAndCompleteAttack(): void {

--- a/server/game/core/event/LastKnownInformation.ts
+++ b/server/game/core/event/LastKnownInformation.ts
@@ -93,15 +93,16 @@ export function addLastKnownInformationToEvent(event: GameEvent, card: Card): vo
  * and defender immediately before any in-window changes (e.g. defeat from damage events sharing the same window).
  */
 export function addAttackLastKnownInformationToEvent(event: GameEvent, attack: Attack): void {
-    event.setPreResolutionEffect(buildAttackLastKnownInformationEffect(attack));
+    event.setPreResolutionEffect(buildAttackLastKnownInformationHandler(attack));
 }
 
 /**
- * Builds a pre-resolution effect that captures the attacker's and defender's last known information onto
- * `event.attackerLastKnownInformation` and `event.defendersLastKnownInformation`. Intended for cases where the
- * capture needs to be composed with other logic inside a single pre-resolution hook.
+ * Builds a handler that captures the attacker's and defender's last known information onto
+ * `event.attackerLastKnownInformation` and `event.defendersLastKnownInformation`. Intended
+ * for cases where the capture needs to be composed with other logic inside a single pre-resolution
+ * hook.
  */
-export function buildAttackLastKnownInformationEffect(attack: Attack): (event) => void {
+export function buildAttackLastKnownInformationHandler(attack: Attack): (event) => void {
     return (event) => {
         event.attackerLastKnownInformation = buildLastKnownInformation(attack.attacker);
         event.defendersLastKnownInformation = attack.getLegalTargets().map((target) => buildLastKnownInformation(target));

--- a/server/game/core/event/LastKnownInformation.ts
+++ b/server/game/core/event/LastKnownInformation.ts
@@ -93,8 +93,17 @@ export function addLastKnownInformationToEvent(event: GameEvent, card: Card): vo
  * and defender immediately before any in-window changes (e.g. defeat from damage events sharing the same window).
  */
 export function addAttackLastKnownInformationToEvent(event: GameEvent, attack: Attack): void {
-    event.setPreResolutionEffect((event) => {
+    event.setPreResolutionEffect(buildAttackLastKnownInformationEffect(attack));
+}
+
+/**
+ * Builds a pre-resolution effect that captures the attacker's and defender's last known information onto
+ * `event.attackerLastKnownInformation` and `event.defendersLastKnownInformation`. Intended for cases where the
+ * capture needs to be composed with other logic inside a single pre-resolution hook.
+ */
+export function buildAttackLastKnownInformationEffect(attack: Attack): (event) => void {
+    return (event) => {
         event.attackerLastKnownInformation = buildLastKnownInformation(attack.attacker);
         event.defendersLastKnownInformation = attack.getLegalTargets().map((target) => buildLastKnownInformation(target));
-    });
+    };
 }

--- a/server/game/gameSystems/AttackStepsSystem.ts
+++ b/server/game/gameSystems/AttackStepsSystem.ts
@@ -96,12 +96,26 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
 
         const attack: Attack = event.attack;
 
+        // The chat log emission is deferred to AttackFlow so it runs after `setCurrentAttack`
+        // has marked the attacker as attacking. This lets constant abilities gated on
+        // `isAttacking()` (e.g. Anakin's Podracer) contribute their ongoing effects to
+        // `attackerDealsCombatDamageFirst()` in time for the chat log to reflect them.
+        const emitChatLog = () => this.emitAttackChatLog(context, attack, attackerEffects, defenderEffects);
+        context.game.queueStep(new AttackFlow(context, attack, emitChatLog));
+    }
+
+    private emitAttackChatLog(
+        context: TContext,
+        attack: Attack,
+        attackerEffects: CardLastingEffectSystem | undefined,
+        defenderEffects: Map<Card, CardLastingEffectSystem>
+    ): void {
         const attackMessage: FormatMessage[] = [
             {
                 format: '{0} attacks {1} with {2}{3}',
                 args: [
                     attack.attackingPlayer,
-                    this.getTargetMessage(attack.getAllTargets(), event.context),
+                    this.getTargetMessage(attack.getAllTargets(), context),
                     attack.attacker,
                     attack.attackerDealsCombatDamageFirst() ? ' (dealing damage before the defender)' : ''
                 ]
@@ -131,7 +145,6 @@ export class AttackStepsSystem<TContext extends AbilityContext = AbilityContext>
         }
 
         context.game.addMessage(ChatHelpers.formatWithLength(attackMessage.length), ...attackMessage);
-        context.game.queueStep(new AttackFlow(context, attack));
     }
 
     public override generatePropertiesFromContext(context: TContext, additionalProperties: Partial<IAttackProperties<TContext>> = {}) {

--- a/test/server/cards/02_SHD/units/IncineratorTrooper.spec.ts
+++ b/test/server/cards/02_SHD/units/IncineratorTrooper.spec.ts
@@ -23,6 +23,7 @@ describe('Incinerator Trooper', function() {
                 // check board state
                 expect(context.incineratorTrooper.damage).toBe(0);
                 expect(context.jedhaAgitator).toBeInZone('discard');
+                expect(context.getChatLogs(2)).toContain('player1 attacks Jedha Agitator with Incinerator Trooper (dealing damage before the defender)');
 
                 // Case 2 attacking wampa should defeat incinerator-trooper and give 2 damage to wampa
                 context.player2.passAction();
@@ -33,6 +34,7 @@ describe('Incinerator Trooper', function() {
                 // check board state
                 expect(context.incineratorTrooper).toBeInZone('discard');
                 expect(context.wampa.damage).toBe(2);
+                expect(context.getChatLogs(3)).toContain('player1 attacks Wampa with Incinerator Trooper (dealing damage before the defender)');
             });
 
             it('does not deal damage first when defending.', function () {
@@ -47,6 +49,7 @@ describe('Incinerator Trooper', function() {
                 // Both units are defeated, since damage was dealt simultaneously
                 expect(context.incineratorTrooper).toBeInZone('discard');
                 expect(context.jedhaAgitator).toBeInZone('discard');
+                expect(context.getChatLogs(3)).toContain('player2 attacks Incinerator Trooper with Jedha Agitator');
             });
         });
     });

--- a/test/server/cards/06_SEC/leaders/CassianAndorClimb.spec.ts
+++ b/test/server/cards/06_SEC/leaders/CassianAndorClimb.spec.ts
@@ -1,7 +1,7 @@
 describe('Cassian Andor, Climb!', function() {
     integration(function(contextRef) {
         describe('Cassian Andor\'s leader side constant ability', function() {
-            const cannotBeAttacked = (card: Card, game: Game) => {
+            const cannotBeAttacked = (card, game) => {
                 return card.getSummary(game.actionPhaseActivePlayer).cannotBeAttacked;
             };
 
@@ -496,6 +496,41 @@ describe('Cassian Andor, Climb!', function() {
                 expect(context.cassianAndor).toBeInZone('base');
                 expect(context.cassianAndor.exhausted).toBeTrue();
             });
+        });
+
+        it('Cassian is immediately defeated if an effect causes him to lose all abilities', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hasInitiative: true,
+                    leader: {
+                        card: 'cassian-andor#climb',
+                        deployed: true,
+                        damage: 3,
+                        upgrades: [
+                            'condemn'
+                        ]
+                    }
+                },
+                player2: {
+                    groundArena: [
+                        'darth-tyranus#servant-of-sidious'
+                    ]
+                }
+            });
+
+            const { context } = contextRef;
+
+            // Cassian attacks Darth Tyranus and is immediately defeated before the attack resolves
+            context.player1.clickCard(context.cassianAndor);
+            context.player1.clickCard(context.darthTyranus);
+
+            // Darth Tyranus should be in play and Cassian should be defeated
+            expect(context.darthTyranus).toBeInZone('groundArena');
+            expect(context.darthTyranus.damage).toBe(0);
+            expect(context.cassianAndor).toBeInZone('base');
+            expect(context.cassianAndor.exhausted).toBeTrue();
+            expect(context.getChatLog()).toEqual('The attack does not resolve because the attacker is no longer valid');
         });
     });
 });

--- a/test/server/cards/06_SEC/upgrades/Condemn.spec.ts
+++ b/test/server/cards/06_SEC/upgrades/Condemn.spec.ts
@@ -1,6 +1,6 @@
 describe('Condemn', function () {
     integration(function (contextRef) {
-        const disclosePrompt = (attackerTitle: string) => `Disclose Vigilance, Villainy to give ${attackerTitle} -6/-0 for this attack`;
+        const disclosePrompt = (attackerTitle) => `Disclose Vigilance, Villainy to give ${attackerTitle} -6/-0 for this attack`;
 
         describe('The gained On Attack ability targeting attached unit', function () {
             it('should allow the defending player to disclose Vigilance & Villainy to give attached unit -6/-0 for the attack', async function () {

--- a/test/server/cards/08_ASH/units/ScionShuttleAtMorgansBidding.spec.ts
+++ b/test/server/cards/08_ASH/units/ScionShuttleAtMorgansBidding.spec.ts
@@ -21,6 +21,30 @@ describe('Scion Shuttle, At Morgan\'s Bidding', function() {
             expect(context.player2).toBeActivePlayer();
         });
 
+        it('should defeat a 1 HP defender from the -1 HP debuff before any combat damage is dealt', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['scion-shuttle#at-morgans-bidding']
+                },
+                player2: {
+                    spaceArena: ['exegol-patroller']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.scionShuttle);
+            context.player1.clickCard(context.exegolPatroller);
+
+            // Exegol Patroller (3/1) is defeated by the -1 HP debuff before any combat damage
+            // can be dealt, so Scion Shuttle takes no damage despite Exegol's 3 power.
+            expect(context.scionShuttle.damage).toBe(0);
+            expect(context.exegolPatroller).toBeInZone('discard', context.player2);
+            expect(context.getChatLogs(3)).toContain('The attack does not resolve because there is no longer a legal target');
+            expect(context.player2).toBeActivePlayer();
+        });
+
         it('should give the defending unit -1/-1 during the attack initiated by Support', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',

--- a/test/server/cards/08_ASH/units/ScionShuttleAtMorgansBidding.spec.ts
+++ b/test/server/cards/08_ASH/units/ScionShuttleAtMorgansBidding.spec.ts
@@ -45,6 +45,32 @@ describe('Scion Shuttle, At Morgan\'s Bidding', function() {
             expect(context.player2).toBeActivePlayer();
         });
 
+        it('should defeat a 1 HP defender from the -1 HP debuff during a Support-initiated attack', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['scion-shuttle#at-morgans-bidding'],
+                    spaceArena: ['awing']
+                },
+                player2: {
+                    spaceArena: ['exegol-patroller']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.scionShuttle);
+            context.player1.clickCard(context.awing);
+            context.player1.clickCard(context.exegolPatroller);
+
+            // A-Wing gains Scion's ability for this attack, so Exegol Patroller (3/1) is defeated
+            // by the -1 HP debuff before combat damage — A-Wing takes no damage from Exegol's 3 power.
+            expect(context.awing.damage).toBe(0);
+            expect(context.exegolPatroller).toBeInZone('discard', context.player2);
+            expect(context.getChatLogs(3)).toContain('The attack does not resolve because there is no longer a legal target');
+            expect(context.player2).toBeActivePlayer();
+        });
+
         it('should give the defending unit -1/-1 during the attack initiated by Support', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',


### PR DESCRIPTION
Supersedes #2252.

## Changes

- **Cassian/Condemn timing**: setCurrentAttack runs as a preResolutionEffect of OnAttackDeclared so Condemn blanks post-attack triggers too (per the [Judge ruling](https://discord.com/channels/1265343874105081856/1430299428106928249/1431293825673986190)).
- **Anakin's Podracer**: constant ability now requires `isAttacking()` so the "deals damage first" effect doesn't apply while defending.
- **Attack chat log**: deferred from AttackStepsSystem into AttackFlow's preResolutionEffect so abilities gated on `isAttacking()` are active in time for the `(dealing damage before the defender)` suffix to render.
- **Missing log in `dealDamage`**: when every legal target leaves play mid-attack and there's no Overwhelm, emit "The attack does not resolve because there is no longer a legal target" instead of silently completing.

## Tests

- Anakin's Podracer chat-log assertions
- Incinerator Trooper chat-log assertions (non-conditional case)
- Scion Shuttle: defender (Exegol Patroller, 3/1) defeated by the -1 HP debuff before combat — asserts Scion takes 0 damage despite Exegol's 3 power
- Cassian Andor Climb + Condemn test for the new post-attack blanking behavior

## Test plan
- [x] `npm run test-parallel` — 7,183 specs pass
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)