### PR TITLE
Fix upgrade conditional targeting

### DIFF
--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -27,6 +27,8 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
 
     private readonly onSelectionSetChanged?: (selected: Card | Card[], context: AbilityContext) => void;
 
+    private _inAffordabilityCheck = false;
+
     private static readonly choosingFromHiddenPrompt = '\n(because you are choosing from a hidden zone you may choose nothing)';
 
     public static allZonesAreHidden(zoneFilter: ZoneFilter | ZoneFilter[], controller: RelativePlayer): boolean {
@@ -72,6 +74,25 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
             if (context.stage === Stage.PreTarget && this.dependentCost && !this.dependentCost.canPay(contextCopy)) {
                 return false;
             }
+
+            // Check whether the resource cost can be paid for this specific target. This ensures that
+            // when cost adjusters are target-dependent (e.g. Mastery only discounts on unique units),
+            // targets that the player cannot afford are excluded from the selectable list rather than
+            // appearing selectable and thencancelling the action after selection.
+            if (context.stage === Stage.PreTarget && !this._inAffordabilityCheck) {
+                // Guard against re-entry: some cost adjusters (e.g. Exploit) call hasLegalTarget on their own CardTargetResolver from within canPay,
+                // which would invoke this same check recursively. Setting __inAffordabilityCheck prevents that inner resolver from entering this block
+                this._inAffordabilityCheck = true;
+                try {
+                    const resourceCost = contextCopy.ability?.getCosts(contextCopy).find((cost) => cost.isResourceCost());
+                    if (resourceCost != null && !resourceCost.canPay(contextCopy)) {
+                        return false;
+                    }
+                } finally {
+                    this._inAffordabilityCheck = false;
+                }
+            }
+
             return (this.immediateEffect || !this.dependentTarget || this.dependentTarget.properties.optional || this.dependentTarget.hasLegalTarget(contextCopy)) &&
               (!properties.cardCondition || properties.cardCondition(card, contextCopy)) &&
               (properties.immediateEffect == null || properties.immediateEffect.hasLegalTarget(contextCopy, {}, this.properties.mustChangeGameState));

--- a/server/game/core/cost/CostAdjuster.ts
+++ b/server/game/core/cost/CostAdjuster.ts
@@ -2,7 +2,7 @@ import type { AbilityContext } from '../ability/AbilityContext';
 import type { AbilityLimit } from '../ability/AbilityLimit';
 import type { Card } from '../card/Card';
 import type { Aspect, CardTypeFilter } from '../Constants';
-import { CardType, PlayType, Stage, WildcardCardType } from '../Constants';
+import { CardType, PlayType, WildcardCardType } from '../Constants';
 import type { Game } from '../Game';
 import type { Player } from '../Player';
 import { Contract } from '../../core/utils/Contract';
@@ -378,11 +378,14 @@ export abstract class CostAdjuster extends GameObjectBase {
         const upgrade = context.source;
         Contract.assertTrue(upgrade.isUpgrade(), `attachTargetCondition can only be used with upgrade cards, attempting to use with '${upgrade.title}'`);
 
-        if (context.stage === Stage.Cost && context.target != null) {
+        // If a specific attach target is available in the context (e.g., during actual cost payment or
+        // during per-card affordability checks in target selection), evaluate the condition against it.
+        if (context.target != null) {
             return this.attachTargetCondition(context.target, context, this.sourceCard);
         }
 
-        // if we're not yet at the "pay cost" stage, evaluate whether any unit on the field meets the attach condition
+        // if no specific target is set, evaluate whether any unit on the field meets the attach condition
+        // (used when checking whether the card is playable at all, before a target is selected)
         for (const unit of context.game.getArenaUnits()) {
             if (
                 upgrade.canAttach(unit, context, context.player) &&

--- a/test/server/cards/01_SOR/units/GuardianOfTheWhills.spec.ts
+++ b/test/server/cards/01_SOR/units/GuardianOfTheWhills.spec.ts
@@ -135,19 +135,13 @@ describe('Guardian of the Whills', function () {
                 expect(context.player1).toBeAbleToSelect(context.constructedLightsaber);
                 context.player1.clickCard(context.constructedLightsaber);
 
-                expect(context.player1).toBeAbleToSelectExactly([
-                    context.guardianOfTheWhills,
-                    // TODO: Jedi Guardian should not even be selectable in this scenario
-                    // https://github.com/SWU-Karabast/forceteki/issues/1970
-                    context.jediGuardian
-                ]);
+                // Only Guardian of the Whills is selectable — Jedi Guardian cannot be afforded at full cost
+                expect(context.player1).toBeAbleToSelectExactly([context.guardianOfTheWhills]);
+                context.player1.clickCard(context.guardianOfTheWhills);
 
-                context.player1.clickCard(context.jediGuardian);
-
-                // Action is cancelled because player cannot pay full cost
-                expect(context.player1.exhaustedResourceCount).toBe(0);
-                expect(context.jediGuardian).toHaveExactUpgradeNames([]);
-                expect(context.player1).toBeActivePlayer();
+                expect(context.guardianOfTheWhills).toHaveExactUpgradeNames(['constructed-lightsaber']);
+                expect(context.player1.exhaustedResourceCount).toBe(2);
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/cards/02_SHD/upgrades/TheDarksaber.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/TheDarksaber.spec.ts
@@ -108,19 +108,13 @@ describe('The Darksaber', function() {
 
                     context.player1.clickCard(context.theDarksaber);
 
-                    expect(context.player1).toBeAbleToSelectExactly([
-                        context.clanWrenRescuer,
-                        // TODO: Non-Mandalorian units should not even be selectable in this scenario
-                        // https://github.com/SWU-Karabast/forceteki/issues/1970
-                        context.pykeSentinel
-                    ]);
+                    // Non-Mandalorian units should not be selectable — the aspect penalty cannot be paid
+                    expect(context.player1).toBeAbleToSelectExactly([context.clanWrenRescuer]);
+                    context.player1.clickCard(context.clanWrenRescuer);
 
-                    context.player1.clickCard(context.pykeSentinel);
-
-                    // Action was cancelled
-                    expect(context.theDarksaber).toBeInZone('hand', context.player1);
-                    expect(context.player1.exhaustedResourceCount).toBe(0);
-                    expect(context.player1).toBeActivePlayer();
+                    expect(context.clanWrenRescuer).toHaveExactUpgradeNames(['the-darksaber']);
+                    expect(context.player1.exhaustedResourceCount).toBe(4);
+                    expect(context.player2).toBeActivePlayer();
                 });
 
                 it('cannot be played with the discount if there are no Mandalorian non-vehicle units in play', async function () {

--- a/test/server/cards/07_LAW/upgrades/Mastery.spec.ts
+++ b/test/server/cards/07_LAW/upgrades/Mastery.spec.ts
@@ -41,6 +41,26 @@ describe('Mastery', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('should not allow targeting a non-unique unit when only enough resources for the discounted cost', function () {
+                const { context } = contextRef;
+
+                // With 3 resources, the player can only afford Mastery on unique units (cost 3),
+                // not on non-unique units (cost 4). The lookahead cost check (seeing Yoda in play)
+                // should not make non-unique units selectable targets.
+                context.player1.setResourceCount(3);
+
+                context.player1.clickCard(context.mastery);
+
+                // Only unique units should be selectable — non-unique units (rebel-pathfinder, cartel-spacer, wampa)
+                // should NOT appear as valid targets when the player can't afford full cost
+                expect(context.player1).toBeAbleToSelectExactly([context.yoda, context.gungi]);
+                context.player1.clickCard(context.yoda);
+
+                expect(context.yoda).toHaveExactUpgradeNames(['mastery']);
+                expect(context.player1.exhaustedResourceCount).toBe(3);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('should work on enemy unique units as well', function () {
                 const { context } = contextRef;
 
@@ -61,6 +81,63 @@ describe('Mastery', function() {
 
                 expect(context.gungi).toHaveExactUpgradeNames(['mastery']);
                 expect(context.player1.exhaustedResourceCount).toBe(7); // 6+1
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
+        describe('Mastery\'s unique discount when played via Reforge with opponent cost increase', function() {
+            it('should correctly stack cost adjustments: Reforge -4, Qira +3, unique discount -1', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'bokatan-kryze#princess-in-exile',
+                        base: 'capital-city',
+                        resources: 4,
+                        hand: ['reforge'],
+                        groundArena: [{ card: 'yoda#old-master', upgrades: ['shield'] }, 'rebel-pathfinder'],
+                        deck: ['mastery']
+                    },
+                    player2: {
+                        resources: 6,
+                        hand: ['qira#playing-her-part']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Player 1 passes so player 2 can play Qira and name Mastery
+                context.player1.passAction();
+
+                // Player 2 plays Qira, looks at player 1's hand (sees Reforge), names Mastery
+                context.player2.clickCard(context.qira);
+                context.player2.clickDone();
+                context.player2.chooseListOption('Mastery');
+
+                // Mastery now costs 3 more for player 1 while Qira is in play
+
+                // Player 1 plays Reforge (cost 2, no aspect penalty — Capital City provides Vigilance)
+                context.player1.clickCard(context.reforge);
+
+                // Defeat the Shield upgrade on Yoda
+                context.player1.clickCard(context.shield);
+                expect(context.shield).toBeInZone('outsideTheGame');
+
+                // Deck search: find Mastery from the top 8 cards
+                expect(context.player1).toHavePrompt('Search the top 8 cards of your deck for an upgrade that can attach to Yoda');
+                context.player1.clickCardInDisplayCardPrompt(context.mastery);
+
+                // Only Yoda is a valid target (Reforge constrains to the unit that lost the upgrade)
+                expect(context.player1).toBeAbleToSelectExactly([context.yoda]);
+                context.player1.clickCard(context.yoda);
+
+                // Cost breakdown:
+                //   Mastery base cost:        4
+                //   Qira cost increase:       +3  → 7
+                //   Reforge discount:         -4  → 3
+                //   Mastery unique discount:  -1  → 2
+                // Reforge cost: 2. Total resources exhausted: 2 + 2 = 4.
+                expect(context.yoda).toHaveExactUpgradeNames(['mastery']);
+                expect(context.player1.exhaustedResourceCount).toBe(4);
                 expect(context.player2).toBeActivePlayer();
             });
         });


### PR DESCRIPTION
Fixes issues where an upgrade has a conditional cost reduction and targeting shows invalid targets

Should fix #1970