### PR TITLE
Fix Bothan 5 to work correctly with stolen units

### DIFF
--- a/server/game/cards/08_ASH/units/Bothan5NewRepublicPrisonShip.ts
+++ b/server/game/cards/08_ASH/units/Bothan5NewRepublicPrisonShip.ts
@@ -26,7 +26,7 @@ export default class Bothan5NewRepublicPrisonShip extends NonLeaderUnitCard {
             optional: true,
             limit: abilityHelper.limit.perRound(1),
             immediateEffect: abilityHelper.immediateEffects.conditional({
-                condition: (context) => context.event.card.zoneName === ZoneName.Discard,
+                condition: (context) => context.event.card.zone === context.player.discardZone,
                 onTrue: abilityHelper.immediateEffects.capture((context) => ({
                     captor: context.source,
                     target: context.event.card,

--- a/server/game/cards/08_ASH/units/Bothan5NewRepublicPrisonShip.ts
+++ b/server/game/cards/08_ASH/units/Bothan5NewRepublicPrisonShip.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
-import { Trait, ZoneName } from '../../../core/Constants';
+import { Trait } from '../../../core/Constants';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
 
 export default class Bothan5NewRepublicPrisonShip extends NonLeaderUnitCard {

--- a/test/server/cards/08_ASH/units/Bothan5NewRepublicPrisonShip.spec.ts
+++ b/test/server/cards/08_ASH/units/Bothan5NewRepublicPrisonShip.spec.ts
@@ -198,5 +198,26 @@ describe('Bothan-5, New Republic Prison Ship', function() {
             expect(context.player1.resources.length).toBe(resourceCount);
             expect(context.superlaserTechnician).toBeCapturedBy(context.bothan5);
         });
+
+        it('Bothan-5\'s ability should not capture a defeated friendly unit that is not in your discard pile', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['no-glory-only-results'],
+                    spaceArena: ['bothan5#new-republic-prison-ship']
+                },
+                player2: {
+                    groundArena: ['wampa'],
+                },
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.noGloryOnlyResults);
+            context.player1.clickCard(context.wampa);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.wampa).toBeInZone('discard', context.player2);
+        });
     });
 });


### PR DESCRIPTION
<img width="286" height="400" alt="image" src="https://github.com/user-attachments/assets/fddce250-9d4a-438b-b749-f3388d87afd8" />

It can only capture units that go into your discard pile.