### PR TITLE
Rename UnitsDefeatedThisPhaseWatcher to CardsDefeatedThisPhaseWatcher

### DIFF
--- a/server/game/cards/01_SOR/events/TheEmperorsLegion.ts
+++ b/server/game/cards/01_SOR/events/TheEmperorsLegion.ts
@@ -1,12 +1,12 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { ZoneName } from '../../../core/Constants';
 
 export default class TheEmperorsLegion extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId () {
         return {
@@ -16,7 +16,7 @@ export default class TheEmperorsLegion extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -24,7 +24,7 @@ export default class TheEmperorsLegion extends EventCard {
             title: 'Return each unit in your discard pile that was defeated this phase to your hand.',
             immediateEffect: AbilityHelper.immediateEffects.returnToHand((context) => {
                 const friendlyUnitsDefeatedThisPhaseInDiscard =
-                    this.unitsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player)
+                    this.cardsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player)
                         .filter(({ unit, inPlayId: defeatedInPlayId }) =>
                             unit.zoneName === ZoneName.Discard &&
                             unit.mostRecentInPlayId === defeatedInPlayId)

--- a/server/game/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.ts
+++ b/server/game/cards/01_SOR/leaders/IdenVersioInfernoSquadCommander.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers.js';
 
 export default class IdenVersioInfernoSquadCommander extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,7 +16,7 @@ export default class IdenVersioInfernoSquadCommander extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -24,7 +24,7 @@ export default class IdenVersioInfernoSquadCommander extends LeaderUnitCard {
             title: 'Heal 1 from base if an opponent\'s unit was defeated this phase',
             cost: AbilityHelper.costs.exhaustSelf(),
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
                 onTrue: AbilityHelper.immediateEffects.heal((context) => {
                     return { amount: 1, target: context.player.base };
                 }),

--- a/server/game/cards/01_SOR/units/LukeSkywalkerJediKnight.ts
+++ b/server/game/cards/01_SOR/units/LukeSkywalkerJediKnight.ts
@@ -3,10 +3,10 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class LukeSkywalkerJediKnight extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId() {
         return {
             id: '7109944284',
@@ -15,7 +15,7 @@ export default class LukeSkywalkerJediKnight extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -25,7 +25,7 @@ export default class LukeSkywalkerJediKnight extends NonLeaderUnitCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Opponent,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                    condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                     onTrue: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                         effect: AbilityHelper.ongoingEffects.modifyStats({ power: -6, hp: -6 })
                     }),

--- a/server/game/cards/01_SOR/units/ZebOrreliosHeadstrongWarrior.ts
+++ b/server/game/cards/01_SOR/units/ZebOrreliosHeadstrongWarrior.ts
@@ -4,10 +4,10 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName, WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class ZebOrreliosHeadstrongWarrior extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class ZebOrreliosHeadstrongWarrior extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -29,7 +29,7 @@ export default class ZebOrreliosHeadstrongWarrior extends NonLeaderUnitCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 zoneFilter: ZoneName.GroundArena,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                    condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                     onTrue: AbilityHelper.immediateEffects.damage({ amount: 4 }),
                 })
             }

--- a/server/game/cards/02_SHD/events/Bravado.ts
+++ b/server/game/cards/02_SHD/events/Bravado.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Bravado extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,13 +16,13 @@ export default class Bravado extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
             title: `If you've defeated an enemy unit this phase, this event costs ${TextHelper.resource(2)} less to play`,
-            condition: (context) => this.unitsDefeatedThisPhaseWatcher.playerDefeatedEnemyUnit(context.source.controller),
+            condition: (context) => this.cardsDefeatedThisPhaseWatcher.playerDefeatedEnemyUnit(context.source.controller),
             amount: 2
         });
 

--- a/server/game/cards/02_SHD/events/SparkOfHope.ts
+++ b/server/game/cards/02_SHD/events/SparkOfHope.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
 
 export default class SparkOfHope extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,7 +16,7 @@ export default class SparkOfHope extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -27,7 +27,7 @@ export default class SparkOfHope extends EventCard {
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,
                 cardCondition: (card) =>
-                    card.isUnit() && this.unitsDefeatedThisPhaseWatcher.wasDefeatedThisPhase(card),
+                    card.isUnit() && this.cardsDefeatedThisPhaseWatcher.wasDefeatedThisPhase(card),
                 immediateEffect: AbilityHelper.immediateEffects.resourceCard()
             }
         });

--- a/server/game/cards/02_SHD/units/EmboStoicAndResolute.ts
+++ b/server/game/cards/02_SHD/units/EmboStoicAndResolute.ts
@@ -4,10 +4,10 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class EmboStoicAndResolute extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class EmboStoicAndResolute extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -25,7 +25,7 @@ export default class EmboStoicAndResolute extends NonLeaderUnitCard {
             title: 'If the defender was defeated, heal up to 2 damage from a unit',
             attackerMustSurvive: true,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.distributeHealingAmong({
                     amountToDistribute: 2,
                     controller: WildcardRelativePlayer.Any,

--- a/server/game/cards/02_SHD/upgrades/BrutalTraditions.ts
+++ b/server/game/cards/02_SHD/upgrades/BrutalTraditions.ts
@@ -3,10 +3,10 @@ import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatc
 import { WildcardCardType, ZoneName } from '../../../core/Constants';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class BrutalTraditions extends UpgradeCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,13 +16,13 @@ export default class BrutalTraditions extends UpgradeCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
             title: 'If an enemy unit was defeated this phase, play this upgrade from your discard pile',
-            condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
+            condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
             immediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay({ playAsType: WildcardCardType.Upgrade }),
             zoneFilter: ZoneName.Discard
         });

--- a/server/game/cards/03_TWI/events/AFineAddition.ts
+++ b/server/game/cards/03_TWI/events/AFineAddition.ts
@@ -2,14 +2,14 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { WildcardCardType, ZoneName } from '../../../core/Constants';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 import type { Card } from '../../../core/card/Card';
 import type { Player } from '../../../core/Player';
 
 export default class AFineAddition extends EventCard {
-    private unitsDefeatedWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -19,11 +19,11 @@ export default class AFineAddition extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected wasEnemyUnitDefeatedThisPhaseForPlayer(player: Player): boolean {
-        return this.unitsDefeatedWatcher.someDefeatedUnitControlledByPlayer(player);
+        return this.cardsDefeatedWatcher.someDefeatedUnitControlledByPlayer(player);
     }
 
     protected checkZoneAndOwnershipOfCard(card: Card, controllingPlayer: Player): boolean {

--- a/server/game/cards/03_TWI/events/UnnaturalLife.ts
+++ b/server/game/cards/03_TWI/events/UnnaturalLife.ts
@@ -4,11 +4,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { PhaseName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class UnnaturalLife extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -18,7 +18,7 @@ export default class UnnaturalLife extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -28,7 +28,7 @@ export default class UnnaturalLife extends EventCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,
-                cardCondition: (card) => card.isUnit() && this.unitsDefeatedThisPhaseWatcher.wasDefeatedThisPhase(card),
+                cardCondition: (card) => card.isUnit() && this.cardsDefeatedThisPhaseWatcher.wasDefeatedThisPhase(card),
                 immediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay({
                     entersReady: true,
                     adjustCost: { costAdjustType: CostAdjustType.Decrease, amount: 2 },

--- a/server/game/cards/03_TWI/events/WartimeProfiteering.ts
+++ b/server/game/cards/03_TWI/events/WartimeProfiteering.ts
@@ -2,10 +2,10 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class WartimeProfiteering extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -15,14 +15,14 @@ export default class WartimeProfiteering extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
             title: 'Look at cards from the top of your deck equal to the number of units that were defeated this phase. Draw 1 and put the others on the bottom of your deck in a random order',
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
-                searchCount: () => this.unitsDefeatedThisPhaseWatcher.getCurrentValue().length,
+                searchCount: () => this.cardsDefeatedThisPhaseWatcher.getCurrentValue().length,
                 selectedCardsImmediateEffect: AbilityHelper.immediateEffects.drawSpecificCard()
             })
         });

--- a/server/game/cards/03_TWI/leaders/ChancellorPalpatinePlayingBothSides.ts
+++ b/server/game/cards/03_TWI/leaders/ChancellorPalpatinePlayingBothSides.ts
@@ -5,11 +5,11 @@ import { Aspect } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import { TextHelper } from '../../../core/utils/TextHelper';
 import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class ChancellorPalpatinePlayingBothSides extends DoubleSidedLeaderCard {
     private cardsPlayedThisPhaseWatcher: CardsPlayedThisPhaseWatcher;
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId() {
         return {
             id: '0026166404',
@@ -19,7 +19,7 @@ export default class ChancellorPalpatinePlayingBothSides extends DoubleSidedLead
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
         this.cardsPlayedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsPlayedThisPhase();
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: IDoubleSidedLeaderAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -55,9 +55,9 @@ export default class ChancellorPalpatinePlayingBothSides extends DoubleSidedLead
     }
 
     private friendlyHeroismCardDefeatedThisPhase(context): boolean {
-        return this.unitsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((defeatedUnitEntry) =>
-            defeatedUnitEntry.controlledBy === context.player &&
-            defeatedUnitEntry.unit.hasSomeAspect(Aspect.Heroism));
+        return this.cardsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((entry) =>
+            entry.controlledBy === context.player &&
+            entry.card.hasSomeAspect(Aspect.Heroism));
     }
 
     private villainyCardPlayedThisPhase(context): boolean {

--- a/server/game/cards/03_TWI/leaders/NuteGunrayVindictiveViceroy.ts
+++ b/server/game/cards/03_TWI/leaders/NuteGunrayVindictiveViceroy.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class NuteGunrayVindictiveViceroy extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -15,7 +15,7 @@ export default class NuteGunrayVindictiveViceroy extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -23,7 +23,7 @@ export default class NuteGunrayVindictiveViceroy extends LeaderUnitCard {
             title: 'Create a Battle Droid token.',
             cost: AbilityHelper.costs.exhaustSelf(),
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player).length >= 2,
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player).length >= 2,
                 onTrue: AbilityHelper.immediateEffects.createBattleDroid(),
             })
         });

--- a/server/game/cards/03_TWI/leaders/WatTamborTechnoUnionForeman.ts
+++ b/server/game/cards/03_TWI/leaders/WatTamborTechnoUnionForeman.ts
@@ -5,10 +5,10 @@ import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatc
 import type { GameSystem } from '../../../core/gameSystem/GameSystem';
 import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import { WildcardCardType } from '../../../core/Constants';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class WatTamborTechnoUnionForeman extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -18,7 +18,7 @@ export default class WatTamborTechnoUnionForeman extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -46,7 +46,7 @@ export default class WatTamborTechnoUnionForeman extends LeaderUnitCard {
 
     private getWatTamborEffect(AbilityHelper: IAbilityHelper): GameSystem<TriggeredAbilityContext<this>> {
         return AbilityHelper.immediateEffects.conditional({
-            condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+            condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
             onTrue: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                 effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })
             }),

--- a/server/game/cards/03_TWI/units/AdmiralTrenchHoldingTheLine.ts
+++ b/server/game/cards/03_TWI/units/AdmiralTrenchHoldingTheLine.ts
@@ -3,10 +3,10 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, TargetMode, WildcardCardType, ZoneName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class AdmiralTrenchHoldingTheLine extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId () {
         return {
@@ -16,7 +16,7 @@ export default class AdmiralTrenchHoldingTheLine extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -28,7 +28,7 @@ export default class AdmiralTrenchHoldingTheLine extends NonLeaderUnitCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,
-                cardCondition: (card) => card.isUnit() && this.unitsDefeatedThisPhaseWatcher.wasDefeatedThisPhase(card),
+                cardCondition: (card) => card.isUnit() && this.cardsDefeatedThisPhaseWatcher.wasDefeatedThisPhase(card),
                 immediateEffect: AbilityHelper.immediateEffects.returnToHand()
             }
         });

--- a/server/game/cards/03_TWI/units/JynErsoStardust.ts
+++ b/server/game/cards/03_TWI/units/JynErsoStardust.ts
@@ -3,10 +3,10 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class JynErsoStardust extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,13 +16,13 @@ export default class JynErsoStardust extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
             title: 'While an enemy unit has been defeated this phase, this unit gets +1/+0 and gains Saboteur',
-            condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
+            condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 }),
                 AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur)

--- a/server/game/cards/03_TWI/units/RuneHaakoSchemingSecond.ts
+++ b/server/game/cards/03_TWI/units/RuneHaakoSchemingSecond.ts
@@ -3,10 +3,10 @@ import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatc
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType } from '../../../core/Constants';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class RuneHaakoSchemingSecond extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,7 +16,7 @@ export default class RuneHaakoSchemingSecond extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -26,7 +26,7 @@ export default class RuneHaakoSchemingSecond extends NonLeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                    condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                     onTrue: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                         effect: AbilityHelper.ongoingEffects.modifyStats({ power: -1, hp: -1 })
                     }),

--- a/server/game/cards/03_TWI/units/SanHillChairmanOfTheBankingClan.ts
+++ b/server/game/cards/03_TWI/units/SanHillChairmanOfTheBankingClan.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class SanHillChairmanOfTheBankingClan extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId () {
         return {
@@ -15,7 +15,7 @@ export default class SanHillChairmanOfTheBankingClan extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -23,7 +23,7 @@ export default class SanHillChairmanOfTheBankingClan extends NonLeaderUnitCard {
             title: 'For each friendly unit that was defeated this phase, ready a friendly resource.',
             immediateEffect: AbilityHelper.immediateEffects.readyResources((context) => ({
                 target: context.player,
-                amount: this.unitsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player).length
+                amount: this.cardsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player).length
             }))
         });
     }

--- a/server/game/cards/04_JTL/units/AnakinsSkywalkerIllTrySpinning.ts
+++ b/server/game/cards/04_JTL/units/AnakinsSkywalkerIllTrySpinning.ts
@@ -3,11 +3,11 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, TargetMode } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class AnakinsSkywalkerIllTrySpinning extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class AnakinsSkywalkerIllTrySpinning extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -29,7 +29,7 @@ export default class AnakinsSkywalkerIllTrySpinning extends NonLeaderUnitCard {
             },
             targetResolver: {
                 mode: TargetMode.Select,
-                condition: (context) => AttackHelpers.attackerSurvived(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.attackerSurvived(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 choices: (context) => ({
                     [`Return ${context.source.title} to your hand`]: AbilityHelper.immediateEffects.returnToHand({
                         target: context.source,

--- a/server/game/cards/04_JTL/units/TheInvisibleHandCrawlingWithVultures.ts
+++ b/server/game/cards/04_JTL/units/TheInvisibleHandCrawlingWithVultures.ts
@@ -3,12 +3,12 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EventName, Trait, WildcardCardType } from '../../../core/Constants';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class TheInvisibleHandCrawlingWithVultures extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -18,7 +18,7 @@ export default class TheInvisibleHandCrawlingWithVultures extends NonLeaderUnitC
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -32,7 +32,7 @@ export default class TheInvisibleHandCrawlingWithVultures extends NonLeaderUnitC
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) =>
                     context.event.name !== EventName.OnAttackEnd ||
-                    AttackHelpers.attackerSurvived(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                    AttackHelpers.attackerSurvived(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.deckSearch({
                     searchCount: 8,
                     cardCondition: (card, _context) => card.isUnit() && card.hasSomeTrait(Trait.Droid),

--- a/server/game/cards/05_LOF/events/LastWords.ts
+++ b/server/game/cards/05_LOF/events/LastWords.ts
@@ -3,10 +3,10 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class LastWords extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,7 +16,7 @@ export default class LastWords extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -25,7 +25,7 @@ export default class LastWords extends EventCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                    condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                     onTrue: AbilityHelper.immediateEffects.giveExperience({ amount: 2 }),
                 })
             }

--- a/server/game/cards/06_SEC/events/OppressionBreedsRebellion.ts
+++ b/server/game/cards/06_SEC/events/OppressionBreedsRebellion.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class OppressionBreedsRebellion extends EventCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId() {
         return {
             id: '3208071698',
@@ -14,14 +14,14 @@ export default class OppressionBreedsRebellion extends EventCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
             title: 'If a friendly unit was defeated while attacking this phase, draw 3 cards',
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedWhileAttackingUnitControlledByPlayer(context.player),
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedWhileAttackingUnitControlledByPlayer(context.player),
                 onTrue: AbilityHelper.immediateEffects.draw({ amount: 3 })
             })
         });

--- a/server/game/cards/06_SEC/leaders/BailOrganaDoingEverythingHeCan.ts
+++ b/server/game/cards/06_SEC/leaders/BailOrganaDoingEverythingHeCan.ts
@@ -4,10 +4,10 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { GameStateChangeRequired, RelativePlayer, ZoneName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class BailOrganaDoingEverythingHeCan extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class BailOrganaDoingEverythingHeCan extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override deployActionAbilityProps(AbilityHelper: IAbilityHelper) {
@@ -36,7 +36,7 @@ export default class BailOrganaDoingEverythingHeCan extends LeaderUnitCard {
             title: 'If a friendly unit was defeated this phase, return a friendly resource to its owner\'s hand. If you do, put the top card of your deck into play as a resource.',
             cost: [abilityHelper.costs.abilityActivationResourceCost(1), abilityHelper.costs.exhaustSelf()],
             immediateEffect: abilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                 onTrue: abilityHelper.immediateEffects.selectCard({
                     controller: RelativePlayer.Self,
                     zoneFilter: ZoneName.Resource,

--- a/server/game/cards/06_SEC/units/CaptainRexIntoTheFirefight.ts
+++ b/server/game/cards/06_SEC/units/CaptainRexIntoTheFirefight.ts
@@ -3,14 +3,14 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EventName, KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class CaptainRexIntoTheFirefight extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override getImplementationId() {
@@ -30,7 +30,7 @@ export default class CaptainRexIntoTheFirefight extends NonLeaderUnitCard {
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) =>
                     context.event.name !== EventName.OnAttackEnd ||
-                    AttackHelpers.attackerSurvived(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                    AttackHelpers.attackerSurvived(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.simultaneous([
                     AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                         effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/06_SEC/units/DarthSionLordOfPain.ts
+++ b/server/game/cards/06_SEC/units/DarthSionLordOfPain.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class DarthSionLordOfPain extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId() {
         return {
             id: '3182035434',
@@ -14,14 +14,14 @@ export default class DarthSionLordOfPain extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
             title: 'Give an experience token to Darth Sion for each enemy unit defeated this phase',
             immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => ({
-                amount: this.unitsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player.opponent).length,
+                amount: this.cardsDefeatedThisPhaseWatcher.getDefeatedUnitsControlledByPlayer(context.player.opponent).length,
                 target: context.source
             })),
         });

--- a/server/game/cards/06_SEC/units/ISBShuttle.ts
+++ b/server/game/cards/06_SEC/units/ISBShuttle.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class ISBShuttle extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId() {
         return {
             id: '7227136692',
@@ -14,14 +14,14 @@ export default class ISBShuttle extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
             title: 'Create a Spy token',
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                 onTrue: AbilityHelper.immediateEffects.createSpy()
             })
         });

--- a/server/game/cards/07_LAW/leaders/BobaFettKraytsClawCommander.ts
+++ b/server/game/cards/07_LAW/leaders/BobaFettKraytsClawCommander.ts
@@ -3,11 +3,11 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class BobaFettKraytsClawCommander extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class BobaFettKraytsClawCommander extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -30,7 +30,7 @@ export default class BobaFettKraytsClawCommander extends LeaderUnitCard {
             },
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.exhaust(),
             }),
             ifYouDo: {
@@ -49,7 +49,7 @@ export default class BobaFettKraytsClawCommander extends LeaderUnitCard {
                     event.attack.attacker.hasSomeTrait(Trait.BountyHunter)
             },
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.createCreditToken()
             })
         });

--- a/server/game/cards/07_LAW/leaders/JynErsoTimeToFight.ts
+++ b/server/game/cards/07_LAW/leaders/JynErsoTimeToFight.ts
@@ -4,10 +4,10 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class JynErsoTimeToFight extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class JynErsoTimeToFight extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -53,7 +53,7 @@ export default class JynErsoTimeToFight extends LeaderUnitCard {
     }
 
     private friendlyRebelUnitWasDefeatedThisPhase(context: AbilityContext): boolean {
-        return this.unitsDefeatedThisPhaseWatcher
+        return this.cardsDefeatedThisPhaseWatcher
             .someUnitDefeatedThisPhase((entry) =>
                 entry.controlledBy === context.player &&
                 entry.lastKnownInformation.traits.has(Trait.Rebel)

--- a/server/game/cards/07_LAW/units/AnakinSkywalkerPrescientPodracer.ts
+++ b/server/game/cards/07_LAW/units/AnakinSkywalkerPrescientPodracer.ts
@@ -4,10 +4,10 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class AnakinSkywalkerPrescientPodracer extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     private attacksThisPhaseWatcher: AttacksThisPhaseWatcher;
 
     protected override getImplementationId() {
@@ -18,7 +18,7 @@ export default class AnakinSkywalkerPrescientPodracer extends NonLeaderUnitCard 
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
         this.attacksThisPhaseWatcher = AbilityHelper.stateWatchers.attacksThisPhase();
     }
 
@@ -33,7 +33,7 @@ export default class AnakinSkywalkerPrescientPodracer extends NonLeaderUnitCard 
             },
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) =>
-                    AttackHelpers.attackerSurvived(context.event.attack, this.unitsDefeatedThisPhaseWatcher) &&
+                    AttackHelpers.attackerSurvived(context.event.attack, this.cardsDefeatedThisPhaseWatcher) &&
                     this.noOtherUnitsHaveAttackedThisPhase(context.event),
                 onTrue: AbilityHelper.immediateEffects.returnToHand((context) => ({
                     target: context.event.attack.attacker

--- a/server/game/cards/07_LAW/units/CassianAndorEverythingForTheRebellion.ts
+++ b/server/game/cards/07_LAW/units/CassianAndorEverythingForTheRebellion.ts
@@ -3,11 +3,11 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { CardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class CassianAndorEverythingForTheRebellion extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class CassianAndorEverythingForTheRebellion extends NonLeaderUnit
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -28,7 +28,7 @@ export default class CassianAndorEverythingForTheRebellion extends NonLeaderUnit
                     event.attack.attacker.controller === context.player
             },
             immediateEffect: AbilityHelper.immediateEffects.conditional(() => ({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.selectCard({
                     activePromptTitle: 'Select a base to deal 2 damage to',
                     cardTypeFilter: CardType.Base,

--- a/server/game/cards/07_LAW/units/ChewbaccaMightyRescuer.ts
+++ b/server/game/cards/07_LAW/units/ChewbaccaMightyRescuer.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class ChewbaccaMightyRescuer extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,14 +16,14 @@ export default class ChewbaccaMightyRescuer extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
             title: 'If the defending unit was defeated, give an Experience token to Chewbacca and heal 3 damage from him',
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.simultaneous([
                     AbilityHelper.immediateEffects.giveExperience(),
                     AbilityHelper.immediateEffects.heal({ amount: 3 }),

--- a/server/game/cards/07_LAW/units/FettsFiresprayInPursuit.ts
+++ b/server/game/cards/07_LAW/units/FettsFiresprayInPursuit.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class FettsFiresprayInPursuit extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,14 +16,14 @@ export default class FettsFiresprayInPursuit extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
             title: 'If the defending unit was defeated, create a Credit token',
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.createCreditToken(),
             })
         });

--- a/server/game/cards/07_LAW/units/PartisanU-Wing.ts
+++ b/server/game/cards/07_LAW/units/PartisanU-Wing.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class PartisanUWing extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId() {
         return {
             id: '8203697919',
@@ -14,14 +14,14 @@ export default class PartisanUWing extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
             title: 'Create a Credit token',
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                 onTrue: AbilityHelper.immediateEffects.createCreditToken()
             })
         });

--- a/server/game/cards/07_LAW/units/TantiveIVCarryingHope.ts
+++ b/server/game/cards/07_LAW/units/TantiveIVCarryingHope.ts
@@ -2,10 +2,10 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class TantiveIVCarryingHope extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -15,14 +15,14 @@ export default class TantiveIVCarryingHope extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers (registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
             title: 'Heal 4 damage from your base',
             immediateEffect: abilityHelper.immediateEffects.conditional({
-                condition: (context) => this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                 onTrue: abilityHelper.immediateEffects.heal((context) => ({
                     target: context.player.base,
                     amount: 4

--- a/server/game/cards/07_LAW/upgrades/ThermalDetonator.ts
+++ b/server/game/cards/07_LAW/upgrades/ThermalDetonator.ts
@@ -3,10 +3,10 @@ import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistr
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait, ZoneName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class ThermalDetonator extends UpgradeCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
     protected override getImplementationId () {
         return {
             id: '4576623485',
@@ -15,7 +15,7 @@ export default class ThermalDetonator extends UpgradeCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities (registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {

--- a/server/game/cards/08_ASH/leaders/LukeSkywalkerICanSaveHim.ts
+++ b/server/game/cards/08_ASH/leaders/LukeSkywalkerICanSaveHim.ts
@@ -6,10 +6,10 @@ import type {
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class LukeSkywalkerICanSaveHim extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -19,7 +19,7 @@ export default class LukeSkywalkerICanSaveHim extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, abilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper): void {
@@ -33,7 +33,7 @@ export default class LukeSkywalkerICanSaveHim extends LeaderUnitCard {
             optional: true,
             immediateEffect: abilityHelper.immediateEffects.conditional({
                 condition: (context) =>
-                    AttackHelpers.attackerSurvived(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                    AttackHelpers.attackerSurvived(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: abilityHelper.immediateEffects.exhaust(),
             }),
             ifYouDo: (ifYouDoContext) => ({

--- a/server/game/cards/08_ASH/leaders/MoffGideonIndomitableWarlord.ts
+++ b/server/game/cards/08_ASH/leaders/MoffGideonIndomitableWarlord.ts
@@ -7,10 +7,10 @@ import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import { TextHelper } from '../../../core/utils/TextHelper';
 import type { NonParameterKeywordName } from '../../../Interfaces';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class MoffGideonIndomitableWarlord extends LeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -20,7 +20,7 @@ export default class MoffGideonIndomitableWarlord extends LeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, abilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper): void {
@@ -54,7 +54,7 @@ export default class MoffGideonIndomitableWarlord extends LeaderUnitCard {
     }
 
     private friendlyImperialUnitWasDefeatedThisPhase(context): boolean {
-        return this.unitsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((entry) =>
+        return this.cardsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((entry) =>
             entry.controlledBy === context.player &&
             entry.lastKnownInformation.traits.has(Trait.Imperial)
         );

--- a/server/game/cards/08_ASH/units/BaylanSkollFallenJedi.ts
+++ b/server/game/cards/08_ASH/units/BaylanSkollFallenJedi.ts
@@ -4,11 +4,11 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { DamageDealtThisPhaseWatcher } from '../../../stateWatchers/DamageDealtThisPhaseWatcher';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class BaylanSkollFallenJedi extends NonLeaderUnitCard {
     private damageDealtThisPhaseWatcher: DamageDealtThisPhaseWatcher;
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -19,7 +19,7 @@ export default class BaylanSkollFallenJedi extends NonLeaderUnitCard {
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
         this.damageDealtThisPhaseWatcher = AbilityHelper.stateWatchers.damageDealtThisPhase();
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -63,6 +63,6 @@ export default class BaylanSkollFallenJedi extends NonLeaderUnitCard {
     }
 
     private friendlyUpgradeDefeatedThisPhase(context): boolean {
-        return this.unitsDefeatedThisPhaseWatcher.someUpgradeDefeatedThisPhase({ controller: context.player });
+        return this.cardsDefeatedThisPhaseWatcher.someUpgradeDefeatedThisPhase({ controller: context.player });
     }
 }

--- a/server/game/cards/08_ASH/units/CaptainPellaeonPlottingFromTheShadows.ts
+++ b/server/game/cards/08_ASH/units/CaptainPellaeonPlottingFromTheShadows.ts
@@ -3,11 +3,11 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
 
 export default class CaptainPellaeonPlottingFromTheShadows extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,13 +17,13 @@ export default class CaptainPellaeonPlottingFromTheShadows extends NonLeaderUnit
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, abilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
             title: 'While a leader unit has been defeated this phase, this unit gains Raid 3',
-            condition: (context) => this.unitsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((e) => EnumHelpers.isLeaderUnit(e.lastKnownInformation.type)),
+            condition: (context) => this.cardsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((e) => EnumHelpers.isLeaderUnit(e.lastKnownInformation.type)),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 3 })
         });
     }

--- a/server/game/cards/08_ASH/units/GrandAdmiralThrawnOrchestratingHisReturn.ts
+++ b/server/game/cards/08_ASH/units/GrandAdmiralThrawnOrchestratingHisReturn.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class GrandAdmiralThrawnOrchestratingHisReturn extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,14 +16,14 @@ export default class GrandAdmiralThrawnOrchestratingHisReturn extends NonLeaderU
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
             title: 'If the defending unit was defeated, ready this unit',
             immediateEffect: AbilityHelper.immediateEffects.conditional(() => ({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.ready((context) => ({
                     target: context.source
                 }))

--- a/server/game/cards/08_ASH/units/HaloNotAccordingToPlan.ts
+++ b/server/game/cards/08_ASH/units/HaloNotAccordingToPlan.ts
@@ -2,11 +2,11 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
 
 export default class HaloNotAccordingToPlan extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -16,14 +16,14 @@ export default class HaloNotAccordingToPlan extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
             title: 'If the defending unit was defeated, give a Shield token to Halo',
             immediateEffect: AbilityHelper.immediateEffects.conditional({
-                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                 onTrue: AbilityHelper.immediateEffects.giveShield(),
             })
         });

--- a/server/game/cards/08_ASH/units/KoskaReevesWarriorOfMandalore.ts
+++ b/server/game/cards/08_ASH/units/KoskaReevesWarriorOfMandalore.ts
@@ -3,10 +3,10 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export default class KoskaReevesWarriorOfMandalore extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId () {
         return {
@@ -16,7 +16,7 @@ export default class KoskaReevesWarriorOfMandalore extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers (registrar: StateWatcherRegistrar, abilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = abilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
@@ -30,7 +30,7 @@ export default class KoskaReevesWarriorOfMandalore extends NonLeaderUnitCard {
             title: 'Create a Mandalorian token',
             immediateEffect: abilityHelper.immediateEffects.conditional({
                 condition: (context) =>
-                    this.unitsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
+                    this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player),
                 onTrue: abilityHelper.immediateEffects.createMandalorian()
             })
         });

--- a/server/game/cards/08_ASH/units/RukhFromTheShadows.ts
+++ b/server/game/cards/08_ASH/units/RukhFromTheShadows.ts
@@ -3,11 +3,11 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { WildcardCardType } from '../../../core/Constants';
 
 export default class RukhFromTheShadows extends NonLeaderUnitCard {
-    private unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+    private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
     protected override getImplementationId() {
         return {
@@ -17,7 +17,7 @@ export default class RukhFromTheShadows extends NonLeaderUnitCard {
     }
 
     protected override setupStateWatchers(registrar: StateWatcherRegistrar, AbilityHelper: IAbilityHelper): void {
-        this.unitsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.unitsDefeatedThisPhase();
+        this.cardsDefeatedThisPhaseWatcher = AbilityHelper.stateWatchers.cardsDefeatedThisPhase();
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
@@ -27,7 +27,7 @@ export default class RukhFromTheShadows extends NonLeaderUnitCard {
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
-                    condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.unitsDefeatedThisPhaseWatcher),
+                    condition: (context) => AttackHelpers.defenderWasDefeated(context.event.attack, this.cardsDefeatedThisPhaseWatcher),
                     onTrue: AbilityHelper.immediateEffects.giveAdvantage({ amount: 3 }),
                 })
             }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -539,6 +539,7 @@ export enum DamageModificationType {
 export enum StateWatcherName {
     ActionsThisPhase = 'actionsThisPhase',
     AttacksThisPhase = 'attacksThisPhase',
+    CardsDefeatedThisPhase = 'cardsDefeatedThisPhase',
     CardsDiscardedThisPhase = 'cardsDiscardedThisPhase',
     CardsDrawnThisPhase = 'cardsDrawnThisPhase',
     CardsEnteredPlayThisPhase = 'cardsEnteredPlayThisPhase',
@@ -548,7 +549,6 @@ export enum StateWatcherName {
     ForceUsedThisPhase = 'forceUsedThisPhase',
     LeadersDeployedThisPhase = 'leadersDeployedThisPhase',
     TokensCreatedThisPhase = 'tokensCreatedThisPhase',
-    UnitsDefeatedThisPhase = 'unitsDefeatedThisPhase',
     UnitsHealedThisPhase = 'unitsHealedThisPhase',
     BasesHealedThisPhase = 'basesHealedThisPhase',
 

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -107,9 +107,9 @@ export abstract class TriggeredAbilityBase extends CardAbility {
             : GameStateChangeRequired.MustFullyOrPartiallyResolve;
 
         if ('attackerMustSurvive' in properties && properties.attackerMustSurvive) {
-            const unitsDefeatedThisPhaseWatcher = this.game.abilityHelper.stateWatchers.unitsDefeatedThisPhase();
+            const cardsDefeatedThisPhaseWatcher = this.game.abilityHelper.stateWatchers.cardsDefeatedThisPhase();
             this.effectCondition = (context: TriggeredAbilityContext) =>
-                AttackHelpers.attackerSurvived(context.event.attack, unitsDefeatedThisPhaseWatcher);
+                AttackHelpers.attackerSurvived(context.event.attack, cardsDefeatedThisPhaseWatcher);
         }
     }
 

--- a/server/game/core/attack/AttackHelpers.ts
+++ b/server/game/core/attack/AttackHelpers.ts
@@ -1,13 +1,13 @@
 import { InitiateAttackSystem, type IInitiateAttackProperties } from '../../gameSystems/InitiateAttackSystem';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import type { Attack } from './Attack';
 
-export function defenderWasDefeated(attack: Attack, watcher: UnitsDefeatedThisPhaseWatcher): boolean {
+export function defenderWasDefeated(attack: Attack, watcher: CardsDefeatedThisPhaseWatcher): boolean {
     const unitTargets = attack.getAllTargets().filter((target) => target.isUnit() || target.isDeployableLeader());
     return unitTargets.length > 0 && unitTargets.some((target) => watcher.wasDefeatedThisPhase(target, attack.targetInPlayMap.get(target)));
 }
 
-export function attackerSurvived(attack: Attack, watcher: UnitsDefeatedThisPhaseWatcher): boolean {
+export function attackerSurvived(attack: Attack, watcher: CardsDefeatedThisPhaseWatcher): boolean {
     return !watcher.wasDefeatedThisPhase(attack.attacker, attack.attackerInPlayId);
 }
 

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -48,7 +48,7 @@ import type { ITriggeredAbilityRegistrar } from './TriggeredAbilityRegistration'
 import type Clone from '../../../cards/03_TWI/units/Clone';
 import { stateRefArray, stateRef, statePrimitive, registerStateBase } from '../../GameObjectUtils';
 import type { TokensCreatedThisPhaseWatcher } from '../../../stateWatchers/TokensCreatedThisPhaseWatcher';
-import type { UnitsDefeatedThisPhaseWatcher } from '../../../stateWatchers/UnitsDefeatedThisPhaseWatcher';
+import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
 export const UnitPropertiesCard = WithUnitProperties(InPlayCard);
 
@@ -184,7 +184,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
         private _tokensCreatedThisPhaseWatcher: TokensCreatedThisPhaseWatcher;
         private _cardsPlayedThisWatcher: CardsPlayedThisPhaseWatcher;
         private _leadersDeployedThisPhaseWatcher: LeadersDeployedThisPhaseWatcher;
-        private _unitsDefeatedThisPhaseWatcher: UnitsDefeatedThisPhaseWatcher;
+        private _cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
 
         public get capturedUnits() {
             this.assertPropertyEnabledForZone(this._captureZone, 'capturedUnits');
@@ -306,7 +306,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
             this._tokensCreatedThisPhaseWatcher = this.game.abilityHelper.stateWatchers.tokensCreatedThisPhase();
             this._cardsPlayedThisWatcher = this.game.abilityHelper.stateWatchers.cardsPlayedThisPhase();
             this._leadersDeployedThisPhaseWatcher = this.game.abilityHelper.stateWatchers.leadersDeployedThisPhase();
-            this._unitsDefeatedThisPhaseWatcher = this.game.abilityHelper.stateWatchers.unitsDefeatedThisPhase();
+            this._cardsDefeatedThisPhaseWatcher = this.game.abilityHelper.stateWatchers.cardsDefeatedThisPhase();
 
             this.defaultAttackAction = new InitiateAttackAction(this.game, this);
         }

--- a/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
@@ -63,22 +63,18 @@ export class CardsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedCardEntr
         }));
     }
 
-    /**
-     * Returns an array of {@link DefeatedCardEntry} objects representing every unit defeated
-     * this phase so far, as well as the controlling and defeating player.
-     */
-    public override getCurrentValue() {
-        return super.getCurrentValue().filter((entry) => EnumHelpers.isUnit(entry.lastKnownInformation.type));
-    }
-
     /** Get the list of the units that were defeated this phase */
     public someUnitDefeatedThisPhase(filter: (entry: UnwrapRef<DefeatedCardEntry>) => boolean): boolean {
-        return this.getCurrentValue().filter(filter).length > 0;
+        return this.getCurrentValue()
+            .filter((entry) => EnumHelpers.isUnit(entry.lastKnownInformation.type))
+            .filter(filter)
+            .length > 0;
     }
 
     /** Get the list of the specified player's units that were defeated */
     public getDefeatedUnitsControlledByPlayer(controller: Player): InPlayUnit[] {
         return this.getCurrentValue()
+            .filter((entry) => EnumHelpers.isUnit(entry.lastKnownInformation.type))
             .filter((entry) => entry.controlledBy === controller)
             .map((entry) => ({ unit: entry.card as IUnitCard, inPlayId: entry.inPlayId }));
     }
@@ -94,12 +90,21 @@ export class CardsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedCardEntr
 
     /** Check if there is some units controlled by player that was defeated this phase */
     public someDefeatedUnitControlledByPlayer(controller: Player): boolean {
-        return this.getCurrentValue().filter((entry) => entry.controlledBy === controller).length > 0;
+        return this.getCurrentValue()
+            .filter((entry) =>
+                EnumHelpers.isUnit(entry.lastKnownInformation.type) &&
+                entry.controlledBy === controller
+            ).length > 0;
     }
 
     /** Check if there is some units controlled by player that was defeated this phase */
     public someDefeatedWhileAttackingUnitControlledByPlayer(controller: Player): boolean {
-        return this.getCurrentValue().filter((entry) => entry.controlledBy === controller && entry.wasDefeatedWhileAttacking).length > 0;
+        return this.getCurrentValue()
+            .filter((entry) =>
+                EnumHelpers.isUnit(entry.lastKnownInformation.type) &&
+                entry.controlledBy === controller &&
+                entry.wasDefeatedWhileAttacking
+            ).length > 0;
     }
 
     /** Check if the given player defeated an enemy unit */
@@ -112,7 +117,7 @@ export class CardsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedCardEntr
         controller?: Player;
         filter?: (entry: UnwrapRef<DefeatedCardEntry>) => boolean;
     } = {}): boolean {
-        return super.getCurrentValue()
+        return this.getCurrentValue()
             .filter((entry) => EnumHelpers.isUpgrade(entry.lastKnownInformation.type))
             .filter((entry) => controller == null || entry.controlledBy === controller)
             .filter((entry) => filter == null || filter(entry))

--- a/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
@@ -13,21 +13,21 @@ import { registerState, type GameObjectId } from '../core/GameObjectUtils';
 
 
 /**
- * Simplified last known information for defeated units
+ * Simplified last known information for defeated cards
  */
-export interface IDefeatedUnitLKIEntry {
+export interface IDefeatedCardLKIEntry {
     traits: Set<Trait>;
     type: CardType;
     // TODO: Add more fields if needed
 }
 
-export interface DefeatedUnitEntry {
-    unit: GameObjectId<IInPlayCard>;
+export interface DefeatedCardEntry {
+    card: GameObjectId<IInPlayCard>;
     inPlayId: number;
     controlledBy: GameObjectId<Player>;
     defeatedBy?: GameObjectId<Player>;
     wasDefeatedWhileAttacking: IDefeatSource;
-    lastKnownInformation: IDefeatedUnitLKIEntry;
+    lastKnownInformation: IDefeatedCardLKIEntry;
 }
 
 interface InPlayUnit {
@@ -40,23 +40,19 @@ interface InPlayUnit {
  * to unit defeats; helpers ending in `Upgrade*` filter to upgrade defeats; the public
  * {@link getCurrentValue} continues to return only unit defeats so existing callers
  * (which assumed unit-only data) are unaffected.
- *
- * TODO: pure-rename follow-up — rename this watcher (file, class, interface, enum value,
- * library method, fields) from `UnitsDefeated*` to `CardsDefeated*` to reflect its broadened
- * scope. Kept out of this PR to limit blast radius (~47 files).
  */
 @registerState()
-export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntry> {
+export class CardsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedCardEntry> {
     public constructor(
         game: Game,
         registrar: StateWatcherRegistrar) {
-        super(game, StateWatcherName.UnitsDefeatedThisPhase, registrar);
+        super(game, StateWatcherName.CardsDefeatedThisPhase, registrar);
     }
 
-    protected override mapCurrentValue(stateValue: DefeatedUnitEntry[]): UnwrapRefObject<DefeatedUnitEntry>[] {
+    protected override mapCurrentValue(stateValue: DefeatedCardEntry[]): UnwrapRefObject<DefeatedCardEntry>[] {
         return stateValue.map((x) => ({
             inPlayId: x.inPlayId,
-            unit: this.game.getFromId(x.unit),
+            card: this.game.getFromId(x.card),
             controlledBy: this.game.getFromId(x.controlledBy),
             defeatedBy: this.game.getFromId(x.defeatedBy),
             wasDefeatedWhileAttacking: x.wasDefeatedWhileAttacking,
@@ -68,7 +64,7 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
     }
 
     /**
-     * Returns an array of {@link DefeatedUnitEntry} objects representing every unit defeated
+     * Returns an array of {@link DefeatedCardEntry} objects representing every unit defeated
      * this phase so far, as well as the controlling and defeating player.
      */
     public override getCurrentValue() {
@@ -76,7 +72,7 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
     }
 
     /** Get the list of the units that were defeated this phase */
-    public someUnitDefeatedThisPhase(filter: (entry: UnwrapRef<DefeatedUnitEntry>) => boolean): boolean {
+    public someUnitDefeatedThisPhase(filter: (entry: UnwrapRef<DefeatedCardEntry>) => boolean): boolean {
         return this.getCurrentValue().filter(filter).length > 0;
     }
 
@@ -84,7 +80,7 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
     public getDefeatedUnitsControlledByPlayer(controller: Player): InPlayUnit[] {
         return this.getCurrentValue()
             .filter((entry) => entry.controlledBy === controller)
-            .map((entry) => ({ unit: entry.unit as IUnitCard, inPlayId: entry.inPlayId }));
+            .map((entry) => ({ unit: entry.card as IUnitCard, inPlayId: entry.inPlayId }));
     }
 
     /** Check if a specific copy of a unit was defeated this phase */
@@ -92,7 +88,7 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
         const inPlayIdToCheck = inPlayId ?? (card.isInPlay() ? card.inPlayId : card.mostRecentInPlayId);
 
         return this.getCurrentValue().some(
-            (entry) => entry.unit === card && entry.inPlayId === inPlayIdToCheck
+            (entry) => entry.card === card && entry.inPlayId === inPlayIdToCheck
         );
     }
 
@@ -114,7 +110,7 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
     /** Check if some upgrade matching the given criteria was defeated this phase */
     public someUpgradeDefeatedThisPhase({ controller, filter }: {
         controller?: Player;
-        filter?: (entry: UnwrapRef<DefeatedUnitEntry>) => boolean;
+        filter?: (entry: UnwrapRef<DefeatedCardEntry>) => boolean;
     } = {}): boolean {
         return super.getCurrentValue()
             .filter((entry) => EnumHelpers.isUpgrade(entry.lastKnownInformation.type))
@@ -130,9 +126,9 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
                     EnumHelpers.isUnit(event.lastKnownInformation.type) ||
                     EnumHelpers.isUpgrade(event.lastKnownInformation.type)
             },
-            update: (currentState: DefeatedUnitEntry[], event: any) =>
+            update: (currentState: DefeatedCardEntry[], event: any) =>
                 currentState.concat({
-                    unit: event.card.getObjectId(),
+                    card: event.card.getObjectId(),
                     inPlayId: event.card.mostRecentInPlayId,
                     controlledBy: event.lastKnownInformation.controller.getObjectId(),
                     defeatedBy: event.defeatSource.player?.getObjectId(),
@@ -145,7 +141,7 @@ export class UnitsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedUnitEntr
         });
     }
 
-    protected override getResetValue(): DefeatedUnitEntry[] {
+    protected override getResetValue(): DefeatedCardEntry[] {
         return [];
     }
 }

--- a/server/game/stateWatchers/StateWatcherLibrary.ts
+++ b/server/game/stateWatchers/StateWatcherLibrary.ts
@@ -1,7 +1,7 @@
 import { AttacksThisPhaseWatcher } from './AttacksThisPhaseWatcher';
 import { CardsLeftPlayThisPhaseWatcher } from './CardsLeftPlayThisPhaseWatcher';
 import { CardsPlayedThisPhaseWatcher } from './CardsPlayedThisPhaseWatcher';
-import { UnitsDefeatedThisPhaseWatcher } from './UnitsDefeatedThisPhaseWatcher';
+import { CardsDefeatedThisPhaseWatcher } from './CardsDefeatedThisPhaseWatcher';
 import { CardsEnteredPlayThisPhaseWatcher } from './CardsEnteredPlayThisPhaseWatcher';
 import { DamageDealtThisPhaseWatcher } from './DamageDealtThisPhaseWatcher';
 import { CardsDrawnThisPhaseWatcher } from './CardsDrawnThisPhaseWatcher';
@@ -41,6 +41,13 @@ export class StateWatcherLibrary {
         return this.game.stateWatcherRegistrar.registerWatcher(
             StateWatcherName.ActionsThisPhase,
             (registrar: StateWatcherRegistrar) => new ActionsThisPhaseWatcher(this.game, registrar)
+        );
+    }
+
+    public cardsDefeatedThisPhase() {
+        return this.game.stateWatcherRegistrar.registerWatcher(
+            StateWatcherName.CardsDefeatedThisPhase,
+            (registrar: StateWatcherRegistrar) => new CardsDefeatedThisPhaseWatcher(this.game, registrar)
         );
     }
 
@@ -104,13 +111,6 @@ export class StateWatcherLibrary {
         return this.game.stateWatcherRegistrar.registerWatcher(
             StateWatcherName.TokensCreatedThisPhase,
             (registrar: StateWatcherRegistrar) => new TokensCreatedThisPhaseWatcher(this.game, registrar)
-        );
-    }
-
-    public unitsDefeatedThisPhase() {
-        return this.game.stateWatcherRegistrar.registerWatcher(
-            StateWatcherName.UnitsDefeatedThisPhase,
-            (registrar: StateWatcherRegistrar) => new UnitsDefeatedThisPhaseWatcher(this.game, registrar)
         );
     }
 

--- a/test/scenarios/undo/Undo.spec.ts
+++ b/test/scenarios/undo/Undo.spec.ts
@@ -1478,7 +1478,7 @@ describe('Undo', function() {
             // TODO: LeadersDeployedThisPhaseWatcher is not used directly, need to find an example.
             // describe('LeadersDeployedThisPhaseWatcher', function () { });
 
-            describe('UnitsDefeatedThisPhaseWatcher', function() {
+            describe('CardsDefeatedThisPhaseWatcher', function() {
                 undoIt('Bravado readies unit with cost reduction when smuggled', async function () {
                     await contextRef.setupTestAsync({
                         phase: 'action',


### PR DESCRIPTION
Follow-up rename from the prior PR that expanded this watcher to track upgrades as well as units. Pure rename — no behavior changes.

- File, class, entry interfaces, `unit` field → `card`, enum value, library method
- Helper method names (e.g. `someUnitDefeatedThisPhase`, `someUpgradeDefeatedThisPhase`) intentionally left alone since they describe their filter

## Test plan
- [x] `npm run lint`
- [x] `npm run test-parallel` (7243 specs, 0 failures)