### PR TITLE
Ezra Bridger improvements

### DIFF
--- a/server/game/cards/08_ASH/leaders/EzraBridgerItsNowOrNever.ts
+++ b/server/game/cards/08_ASH/leaders/EzraBridgerItsNowOrNever.ts
@@ -25,28 +25,23 @@ export default class EzraBridgerItsNowOrNever extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit',
+            title: 'Give an Advantage token to a different unit',
+            contextTitle: (context) => this.getContextTitle(context),
             when: {
                 onAttackEnd: (event, context) =>
-                    event.attack.attackingPlayer === context.player
+                    event.attack.attackingPlayer === context.player &&
+                    this.damageDealtThisPhaseWatcher.getDamageDealtToBaseByUnitThisAttack(context.event.attack.attacker, context) >= 3,
             },
             optional: true,
             immediateEffect: abilityHelper.immediateEffects.exhaust(),
             ifYouDo: {
                 title: 'Give an Advantage token to a different unit',
                 contextTitle: (context) => this.getContextTitle(context),
-                immediateEffect: abilityHelper.immediateEffects.conditional({
-                    condition: (context) => {
-                        const damage = this.damageDealtThisPhaseWatcher.getDamageDealtToBaseByUnitThisAttack(context.event.attack.attacker, context);
-                        return damage >= 3;
-                    },
-                    onTrue: abilityHelper.immediateEffects.selectCard({
-                        activePromptTitle: 'Give an Advantage token to a different unit',
-                        cardTypeFilter: WildcardCardType.Unit,
-                        cardCondition: (card, context) => card !== context.event.attack.attacker,
-                        immediateEffect: abilityHelper.immediateEffects.giveAdvantage(),
-                    })
-                }),
+                targetResolver: {
+                    cardTypeFilter: WildcardCardType.Unit,
+                    cardCondition: (card, context) => card !== context.event.attack.attacker,
+                    immediateEffect: abilityHelper.immediateEffects.giveAdvantage(),
+                }
             }
         });
     }
@@ -57,25 +52,19 @@ export default class EzraBridgerItsNowOrNever extends LeaderUnitCard {
             contextTitle: (context) => this.getContextTitle(context),
             when: {
                 onAttackEnd: (event, context) =>
-                    event.attack.attackingPlayer === context.player
+                    event.attack.attackingPlayer === context.player &&
+                    this.damageDealtThisPhaseWatcher.getDamageDealtToBaseByUnitThisAttack(context.event.attack.attacker, context) >= 3
             },
             optional: true,
-            immediateEffect: abilityHelper.immediateEffects.conditional({
-                condition: (context) => {
-                    const damage = this.damageDealtThisPhaseWatcher.getDamageDealtToBaseByUnitThisAttack(context.event.attack.attacker, context);
-                    return damage >= 3;
-                },
-                onTrue: abilityHelper.immediateEffects.selectCard({
-                    activePromptTitle: 'Give an Advantage token to a different unit',
-                    cardTypeFilter: WildcardCardType.Unit,
-                    cardCondition: (card, context) => card !== context.event.attack.attacker,
-                    immediateEffect: abilityHelper.immediateEffects.giveAdvantage(),
-                })
-            }),
+            targetResolver: {
+                cardTypeFilter: WildcardCardType.Unit,
+                cardCondition: (card, context) => card !== context.event.attack.attacker,
+                immediateEffect: abilityHelper.immediateEffects.giveAdvantage(),
+            }
         });
     }
 
     private getContextTitle(context: TriggeredAbilityContext): string {
-        return `If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit than ${context.event.attack.attacker.title}`;
+        return `Give an Advantage token to a different unit than ${context.event.attack.attacker.title}`;
     }
 }

--- a/test/server/cards/08_ASH/leaders/EzraBridgerItsNowOrNever.spec.ts
+++ b/test/server/cards/08_ASH/leaders/EzraBridgerItsNowOrNever.spec.ts
@@ -5,7 +5,7 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        groundArena: ['sabine-wren#explosives-artist', 'atst'],
+                        groundArena: ['sabine-wren#explosives-artist', 'atst', 'imperial-dark-trooper'],
                         spaceArena: ['awing'],
                         leader: 'ezra-bridger#its-now-or-never'
                     },
@@ -22,10 +22,11 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.atst);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit');
-
+                expect(context.player1).toHavePassAbilityPrompt('Give an Advantage token to a different unit than AT-ST');
                 context.player1.clickPrompt('Trigger');
-                expect(context.player1).toBeAbleToSelectExactly([context.porg, context.awing, context.battlefieldMarine, context.yoda, context.sabineWren]);
+
+                expect(context.player1).toHavePrompt('Give an Advantage token to a different unit than AT-ST');
+                expect(context.player1).toBeAbleToSelectExactly([context.porg, context.awing, context.battlefieldMarine, context.yoda, context.sabineWren, context.imperialDarkTrooper]);
                 expect(context.player1).not.toHaveChooseNothingButton();
                 expect(context.player1).not.toHavePassAbilityButton();
                 context.player1.clickCard(context.porg);
@@ -36,17 +37,32 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 expect(context.ezraBridger.exhausted).toBeTrue();
             });
 
+            it('should allow to give an Advantage token to a different unit (due to Overwhelm)', function() {
+                const { context } = contextRef;
+
+                // 3 Damage dealt to base from AT-ST
+                context.player1.clickCard(context.atst);
+                context.player1.clickCard(context.porg);
+
+                expect(context.player1).toHavePassAbilityPrompt('Give an Advantage token to a different unit than AT-ST');
+                context.player1.clickPrompt('Trigger');
+                context.player1.clickCard(context.awing);
+
+                expect(context.player2).toBeActivePlayer();
+                expect(context.awing).toHaveExactUpgradeNames(['advantage']);
+                expect(context.ezraBridger.exhausted).toBeTrue();
+            });
+
             it('should not trigger if damage is less than 3', function() {
                 const { context } = contextRef;
 
                 // 2 Damage dealt to base from AWing
                 context.player1.clickCard(context.awing);
                 context.player1.clickCard(context.p2Base);
-                context.player1.clickPrompt('Trigger');
 
                 expect(context.player2).toBeActivePlayer();
                 expect(context.p2Base.damage).toBe(2);
-                expect(context.ezraBridger.exhausted).toBeTrue();
+                expect(context.ezraBridger.exhausted).toBeFalse();
             });
 
             it('should not trigger if damage is by combat is less than 3', function() {
@@ -55,12 +71,20 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.sabineWren);
                 context.player1.clickCard(context.p2Base);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit');
-                context.player1.clickPrompt('Trigger');
 
                 expect(context.player2).toBeActivePlayer();
                 expect(context.p2Base.damage).toBe(3);
-                expect(context.ezraBridger.exhausted).toBeTrue();
+                expect(context.ezraBridger.exhausted).toBeFalse();
+            });
+
+            it('should not trigger if there is no damage dealt to base', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.imperialDarkTrooper);
+                context.player1.clickCard(context.yoda);
+
+                expect(context.player2).toBeActivePlayer();
+                expect(context.ezraBridger.exhausted).toBeFalse();
             });
 
             it('should be able to choose nothing', function() {
@@ -69,8 +93,9 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.atst);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit');
+                expect(context.player1).toHavePassAbilityPrompt('Give an Advantage token to a different unit than AT-ST');
                 context.player1.clickPrompt('Pass');
+
                 expect(context.player2).toBeActivePlayer();
                 expect(context.p2Base.damage).toBe(6);
                 expect(context.ezraBridger.exhausted).toBeFalse();
@@ -96,9 +121,9 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.ezraBridger);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit than Ezra Bridger');
-                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePrompt('Give an Advantage token to a different unit than Ezra Bridger');
                 expect(context.player1).toBeAbleToSelectExactly([context.porg, context.awing, context.sabineWren, context.yoda, context.battlefieldMarine]);
+                expect(context.player1).toHavePassAbilityButton();
 
                 context.player1.clickCard(context.yoda);
 
@@ -125,9 +150,9 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.atst);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit than AT-ST');
-                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePrompt('Give an Advantage token to a different unit than AT-ST');
                 expect(context.player1).toBeAbleToSelectExactly([context.porg, context.awing, context.sabineWren, context.yoda, context.battlefieldMarine, context.ezraBridger]);
+                expect(context.player1).toHavePassAbilityButton();
 
                 context.player1.clickCard(context.yoda);
 
@@ -154,9 +179,9 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.atst);
                 context.player1.clickCard(context.porg);
 
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit than AT-ST');
-                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePrompt('Give an Advantage token to a different unit than AT-ST');
                 expect(context.player1).toBeAbleToSelectExactly([context.awing, context.sabineWren, context.yoda, context.battlefieldMarine, context.ezraBridger]);
+                expect(context.player1).toHavePassAbilityButton();
 
                 context.player1.clickCard(context.yoda);
 
@@ -229,9 +254,9 @@ describe('Ezra Bridger, Its Now or Never', function() {
                 context.player1.clickCard(context.atst);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHavePassAbilityPrompt('If you dealt 3 or more combat damage to a base, give an Advantage token to a different unit than AT-ST');
-                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePrompt('Give an Advantage token to a different unit than AT-ST');
                 expect(context.player1).toBeAbleToSelectExactly([context.porg, context.awing, context.sabineWren, context.yoda, context.battlefieldMarine, context.ezraBridger]);
+                expect(context.player1).toHavePassAbilityButton();
 
                 context.player1.clickCard(context.yoda);
 
@@ -243,12 +268,51 @@ describe('Ezra Bridger, Its Now or Never', function() {
 
                 context.player1.clickCard(context.ezraBridger);
                 context.player1.clickCard(context.p2Base);
-                context.player1.clickPrompt('Trigger');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.porg, context.awing, context.sabineWren, context.yoda, context.battlefieldMarine, context.atst]);
                 context.player1.clickCard(context.porg);
                 expect(context.p2Base.damage).toBe(9);
                 expect(context.porg).toHaveExactUpgradeNames(['advantage']);
+            });
+
+            it('should have its prompt be clear (when multiple triggers)', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['cassian-andor#everything-for-the-rebellion', 'atst'],
+                        spaceArena: ['awing'],
+                        leader: { card: 'ezra-bridger#its-now-or-never', deployed: true }
+                    },
+                    player2: {
+                        groundArena: ['porg', 'battlefield-marine', 'yoda#old-master'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.atst);
+                context.player1.clickCard(context.porg);
+
+                expect(context.player1).toHaveEnabledPromptButtons(['Give an Advantage token to a different unit than AT-ST', 'If the defending unit was defeated, deal 2 damage to a base']);
+                context.player1.clickPrompt('If the defending unit was defeated, deal 2 damage to a base');
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toHavePrompt('Give an Advantage token to a different unit than AT-ST');
+                context.player1.clickCard(context.yoda);
+
+                expect(context.player2).toBeActivePlayer();
+                expect(context.yoda).toHaveExactUpgradeNames(['advantage']);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.ezraBridger);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toHaveEnabledPromptButtons(['Give an Advantage token to a different unit than Ezra Bridger', '(No effect) If the defending unit was defeated, deal 2 damage to a base']);
+                context.player1.clickPrompt('Give an Advantage token to a different unit than Ezra Bridger');
+
+                context.player1.clickCard(context.yoda);
+                expect(context.yoda).toHaveExactUpgradeNames(['advantage', 'advantage']);
             });
         });
     });

--- a/test/server/cards/08_ASH/leaders/EzraBridgerItsNowOrNever.spec.ts
+++ b/test/server/cards/08_ASH/leaders/EzraBridgerItsNowOrNever.spec.ts
@@ -102,6 +102,27 @@ describe('Ezra Bridger, Its Now or Never', function() {
             });
         });
 
+        it('Ezra Bridger leader side ability should still prompt even if no other units on board in case there is an ability which create or play another unit', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['wampa'],
+                    leader: 'ezra-bridger#its-now-or-never'
+                },
+            });
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.wampa);
+            context.player1.clickCard(context.p2Base);
+
+            expect(context.player1).toHavePassAbilityPrompt('Give an Advantage token to a different unit than Wampa');
+            context.player1.clickPrompt('Pass');
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.p2Base.damage).toBe(4);
+            expect(context.ezraBridger.exhausted).toBeFalse();
+        });
+
         describe('Leader unit side triggered ability', function() {
             it('should allow to give an Advantage token to a different unit if he attacks', async function() {
                 await contextRef.setupTestAsync({
@@ -313,6 +334,23 @@ describe('Ezra Bridger, Its Now or Never', function() {
 
                 context.player1.clickCard(context.yoda);
                 expect(context.yoda).toHaveExactUpgradeNames(['advantage', 'advantage']);
+            });
+
+            it('should not prompt if no other units', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'ezra-bridger#its-now-or-never', deployed: true }
+                    },
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.ezraBridger);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player2).toBeActivePlayer();
+                expect(context.p2Base.damage).toBe(3);
             });
         });
     });


### PR DESCRIPTION
I include condition of Ezra in trigger condition. It's not how Ezra is written but the main goal is to reduce the number of times of Ezra's ability prompt. Now it prompts every attack even when the ability will fail on second condition (without (No effect) warning)