### PR TITLE
Add related card id when asking for multiple triggers selection

### DIFF
--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -29,7 +29,10 @@ export interface IButton {
     arg: string;
     command?: string;
     disabled?: boolean;
-    relatedCardId?: string;
+}
+
+export interface ITriggerWindowButton extends IButton {
+    sourceCardSetId?: ISetId;
 }
 
 export interface INumberPromptData {

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -29,6 +29,7 @@ export interface IButton {
     arg: string;
     command?: string;
     disabled?: boolean;
+    relatedCardId?: string;
 }
 
 export interface INumberPromptData {

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -42,6 +42,7 @@ export interface ITriggerWindowSourceCard {
 
 export interface ITriggerWindowButton extends IButton {
     sourceCard?: ITriggerWindowSourceCard;
+    hasLegalEffects: boolean;
 }
 
 export interface INumberPromptData {

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -31,8 +31,17 @@ export interface IButton {
     disabled?: boolean;
 }
 
+export interface ITriggerWindowSourceCard {
+    id: string;
+    uuid: string;
+    name: string;
+    setId?: Partial<ISetId>;
+    type: string;
+    printedType?: string;
+}
+
 export interface ITriggerWindowButton extends IButton {
-    sourceCardSetId?: ISetId;
+    sourceCard?: ITriggerWindowSourceCard;
 }
 
 export interface INumberPromptData {

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -9,7 +9,7 @@ import type { Card } from '../../card/Card';
 import { TriggeredAbilityWindowTitle } from './TriggeredAbilityWindowTitle';
 import { BaseStep } from '../BaseStep';
 import type { Game } from '../../Game';
-import { PromptType } from '../PromptInterfaces';
+import { TriggeredAbilityResolutionPrompt } from '../prompts/TriggeredAbilityResolutionPrompt';
 
 export abstract class TriggerWindowBase extends BaseStep {
     /** Triggered effects / abilities that have not yet been resolved, organized by owning player */
@@ -263,23 +263,13 @@ export abstract class TriggerWindowBase extends BaseStep {
     private promptForNextAbilityToResolve() {
         const abilitiesToResolve = this.getCurrentlyResolvingAbilities();
 
-        let choices: { text: string; relatedCardId: string }[] = [];
-        let handlers: (() => void)[] = [];
-
-        // If its a multi-select, append the card name at the end of the ability name to differentiate them
-        choices = abilitiesToResolve.map((context) => ({
-            text: this.getChoiceTitle(context),
-            relatedCardId: context.source.uuid
-        }));
-        handlers = abilitiesToResolve.map((context) => () => this.resolveAbility(context));
-
-        this.game.promptWithHandlerMenu(this.currentlyResolvingPlayer, {
-            activePromptTitle: 'You have multiple triggers to resolve. Choose which to resolve first:',
-            source: 'Choose Triggered Ability Resolution Order',
-            choices,
-            handlers,
-            promptType: PromptType.TriggerWindow
-        });
+        this.game.queueStep(new TriggeredAbilityResolutionPrompt(
+            this.game,
+            this.currentlyResolvingPlayer,
+            abilitiesToResolve,
+            (context) => this.getChoiceTitle(context),
+            (context) => this.resolveAbility(context)
+        ));
 
         // TODO: a variation of this was being used in the L5R code to choose which card to activate triggered abilities on.
         // not used now b/c we're doing a shortcut where we just present each ability text name, which doesn't work well in all cases sadly.

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -263,11 +263,14 @@ export abstract class TriggerWindowBase extends BaseStep {
     private promptForNextAbilityToResolve() {
         const abilitiesToResolve = this.getCurrentlyResolvingAbilities();
 
-        let choices: string[] = [];
+        let choices: { text: string; relatedCardId: string }[] = [];
         let handlers: (() => void)[] = [];
 
         // If its a multi-select, append the card name at the end of the ability name to differentiate them
-        choices = abilitiesToResolve.map((context) => this.getChoiceTitle(context));
+        choices = abilitiesToResolve.map((context) => ({
+            text: this.getChoiceTitle(context),
+            relatedCardId: context.source.uuid
+        }));
         handlers = abilitiesToResolve.map((context) => () => this.resolveAbility(context));
 
         this.game.promptWithHandlerMenu(this.currentlyResolvingPlayer, {

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -215,15 +215,6 @@ export abstract class TriggerWindowBase extends BaseStep {
         return this.unresolved.get(this.currentlyResolvingPlayer);
     }
 
-    private getChoiceTitle(context: TriggeredAbilityContext) {
-        let title = context.ability.getTitle(context);
-        if (!context.ability.hasAnyLegalEffects(context, SubStepCheck.All)) {
-            title = `(No effect) ${title}`;
-        }
-
-        return title;
-    }
-
     private getOverrideTitle(context: TriggeredAbilityContext) {
         return `${context.ability.getTitle(context)}: ${context.event.card.title}`;
     }
@@ -267,19 +258,8 @@ export abstract class TriggerWindowBase extends BaseStep {
             this.game,
             this.currentlyResolvingPlayer,
             abilitiesToResolve,
-            (context) => this.getChoiceTitle(context),
             (context) => this.resolveAbility(context)
         ));
-
-        // TODO: a variation of this was being used in the L5R code to choose which card to activate triggered abilities on.
-        // not used now b/c we're doing a shortcut where we just present each ability text name, which doesn't work well in all cases sadly.
-
-        // this.game.promptForSelect(this.currentlyResolvingPlayer, Object.assign(this.getPromptForSelectProperties(), {
-        //     onSelect: (player, card) => {
-        //         this.resolveAbility(abilitiesToResolve.find((context) => context.source === card));
-        //         return true;
-        //     }
-        // }));
     }
 
     // this is here to allow for overriding in subclasses

--- a/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
+++ b/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
@@ -7,7 +7,7 @@ const { UiPrompt } = require('./UiPrompt.js');
  * a handler for each. Handlers should return nothing or true in order to complete the prompt.
  *
  * The properties option object may contain the following:
- * choices            - an array of titles for menu buttons
+ * choices            - an array of titles for menu buttons, or objects with text and relatedCardId
  * handlers           - an array of handlers corresponding to the menu buttons
  * activePromptTitle  - the title that should be used in the prompt for the
  *                      choosing player.
@@ -65,9 +65,13 @@ class HandlerMenuPrompt extends UiPrompt {
             });
         }
         buttons = buttons.concat(this.properties.choices.map((choice, index) => {
-            return { text: choice, arg: index };
+            return {
+                text: typeof choice === 'string' ? choice : choice.text,
+                arg: index,
+                relatedCardId: choice.relatedCardId
+            };
         }));
-        if (this.game.manualMode && (!this.properties.choices || this.properties.choices.every((choice) => choice !== 'Cancel'))) {
+        if (this.game.manualMode && (!this.properties.choices || this.properties.choices.every((choice) => (typeof choice === 'string' ? choice : choice.text) !== 'Cancel'))) {
             buttons = buttons.concat({ text: 'Cancel Prompt', arg: 'cancel' });
         }
         return {

--- a/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
+++ b/server/game/core/gameSteps/prompts/HandlerMenuPrompt.js
@@ -7,7 +7,7 @@ const { UiPrompt } = require('./UiPrompt.js');
  * a handler for each. Handlers should return nothing or true in order to complete the prompt.
  *
  * The properties option object may contain the following:
- * choices            - an array of titles for menu buttons, or objects with text and relatedCardId
+ * choices            - an array of titles for menu buttons, or objects with text
  * handlers           - an array of handlers corresponding to the menu buttons
  * activePromptTitle  - the title that should be used in the prompt for the
  *                      choosing player.
@@ -67,8 +67,7 @@ class HandlerMenuPrompt extends UiPrompt {
         buttons = buttons.concat(this.properties.choices.map((choice, index) => {
             return {
                 text: typeof choice === 'string' ? choice : choice.text,
-                arg: index,
-                relatedCardId: choice.relatedCardId
+                arg: index
             };
         }));
         if (this.game.manualMode && (!this.properties.choices || this.properties.choices.every((choice) => (typeof choice === 'string' ? choice : choice.text) !== 'Cancel'))) {

--- a/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
@@ -1,0 +1,73 @@
+import type { Player } from '../../Player';
+import type { Game } from '../../Game';
+import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
+import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
+import { PromptType, type ITriggerWindowButton } from '../PromptInterfaces';
+import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
+import { UiPrompt } from './UiPrompt';
+
+export class TriggeredAbilityResolutionPrompt extends UiPrompt {
+    private readonly source = new OngoingEffectSource(this.game, 'Choose Triggered Ability Resolution Order');
+
+    public constructor(
+        game: Game,
+        private readonly player: Player,
+        private readonly triggeredAbilities: TriggeredAbilityContext[],
+        private readonly getChoiceTitle: (context: TriggeredAbilityContext) => string,
+        private readonly resolveAbility: (context: TriggeredAbilityContext) => void
+    ) {
+        super(game);
+    }
+
+    public override activeCondition(player: Player): boolean {
+        return player === this.player;
+    }
+
+    public override activePromptInternal(): IPlayerPromptStateProperties {
+        const buttons: ITriggerWindowButton[] = this.triggeredAbilities.map((context, index) => ({
+            text: this.getChoiceTitle(context),
+            arg: index.toString(),
+            sourceCardSetId: context.source.setId
+        }));
+
+        if (this.game.manualMode) {
+            buttons.push({
+                text: 'Cancel Prompt',
+                arg: 'cancel'
+            });
+        }
+
+        return {
+            menuTitle: 'You have multiple triggers to resolve. Choose which to resolve first:',
+            buttons,
+            promptTitle: this.source.name,
+            promptUuid: this.uuid,
+            promptType: PromptType.TriggerWindow
+        };
+    }
+
+    public override waitingPrompt(): IPlayerPromptStateProperties {
+        return {
+            menuTitle: 'Waiting for opponent',
+            promptUuid: this.uuid
+        };
+    }
+
+    public override menuCommand(_player: Player, arg: string): boolean {
+        if (arg === 'cancel') {
+            this.complete();
+            return true;
+        }
+
+        const selectedIndex = Number(arg);
+        const triggeredAbility = this.triggeredAbilities[selectedIndex];
+
+        if (!triggeredAbility) {
+            return false;
+        }
+
+        this.resolveAbility(triggeredAbility);
+        this.complete();
+        return true;
+    }
+}

--- a/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
@@ -22,8 +22,23 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
         super(game);
 
         this.player = player;
-        this.triggeredAbilities = triggeredAbilities;
         this.resolveAbility = resolveAbility;
+
+        const sortedAbilities = triggeredAbilities
+            .map((context) => {
+                const hasLegalEffects = context.ability.hasAnyLegalEffects(context, SubStepCheck.All);
+                return { context, hasLegalEffects };
+            })
+            .sort((a, b) => {
+                if (a.hasLegalEffects && !b.hasLegalEffects) {
+                    return -1;
+                } else if (!a.hasLegalEffects && b.hasLegalEffects) {
+                    return 1;
+                }
+                return 0;
+            });
+
+        this.triggeredAbilities = sortedAbilities.map((item) => item.context);
     }
 
     public override activeCondition(player: Player): boolean {
@@ -33,16 +48,6 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     public override activePromptInternal(): IPlayerPromptStateProperties {
         const buttons = this.triggeredAbilities
             .map((context, index) => this.makeChoiceButton(context, index));
-
-        // Sort buttons so that those with legal effects are first
-        buttons.sort((a, b) => {
-            if (a.hasLegalEffects && !b.hasLegalEffects) {
-                return -1;
-            } else if (!a.hasLegalEffects && b.hasLegalEffects) {
-                return 1;
-            }
-            return 0;
-        });
 
         return {
             menuTitle: 'You have multiple triggers to resolve. Choose which to resolve first:',

--- a/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
@@ -65,8 +65,11 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     }
 
     private makeChoiceButton(context: TriggeredAbilityContext, num: number): ITriggerWindowButton {
-        const title = context.ability.getTitle(context);
         const hasLegalEffects = context.ability.hasAnyLegalEffects(context, SubStepCheck.All);
+
+        // Keep the "(No effect)" prefix for tests so it's easy to tell which abilities have no effect
+        const noEffectPrefix = process.env.NODE_ENV === 'test' && !hasLegalEffects ? '(No effect) ' : '';
+        const title = `${noEffectPrefix}${context.ability.getTitle(context)}`;
 
         return {
             text: title,

--- a/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
@@ -5,18 +5,25 @@ import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
 import { PromptType, type ITriggerWindowButton, type ITriggerWindowSourceCard } from '../PromptInterfaces';
 import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
 import { UiPrompt } from './UiPrompt';
+import { SubStepCheck } from '../../Constants';
 
 export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     private readonly source = new OngoingEffectSource(this.game, 'Choose Triggered Ability Resolution Order');
+    private readonly player: Player;
+    private readonly triggeredAbilities: TriggeredAbilityContext[];
+    private readonly resolveAbility: (context: TriggeredAbilityContext) => void;
 
     public constructor(
         game: Game,
-        private readonly player: Player,
-        private readonly triggeredAbilities: TriggeredAbilityContext[],
-        private readonly getChoiceTitle: (context: TriggeredAbilityContext) => string,
-        private readonly resolveAbility: (context: TriggeredAbilityContext) => void
+        player: Player,
+        triggeredAbilities: TriggeredAbilityContext[],
+        resolveAbility: (context: TriggeredAbilityContext) => void
     ) {
         super(game);
+
+        this.player = player;
+        this.triggeredAbilities = triggeredAbilities;
+        this.resolveAbility = resolveAbility;
     }
 
     public override activeCondition(player: Player): boolean {
@@ -24,26 +31,18 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     }
 
     public override activePromptInternal(): IPlayerPromptStateProperties {
-        const buttons: ITriggerWindowButton[] = this.triggeredAbilities.map((context, index) => {
-            const button: ITriggerWindowButton = {
-                text: this.getChoiceTitle(context),
-                arg: index.toString()
-            };
+        const buttons = this.triggeredAbilities
+            .map((context, index) => this.makeChoiceButton(context, index));
 
-            const sourceCard = this.getSourceCard(context);
-            if (sourceCard) {
-                button.sourceCard = sourceCard;
+        // Sort buttons so that those with legal effects are first
+        buttons.sort((a, b) => {
+            if (a.hasLegalEffects && !b.hasLegalEffects) {
+                return -1;
+            } else if (!a.hasLegalEffects && b.hasLegalEffects) {
+                return 1;
             }
-
-            return button;
+            return 0;
         });
-
-        if (this.game.manualMode) {
-            buttons.push({
-                text: 'Cancel Prompt',
-                arg: 'cancel'
-            });
-        }
 
         return {
             menuTitle: 'You have multiple triggers to resolve. Choose which to resolve first:',
@@ -59,12 +58,21 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
             return undefined;
         }
 
-        const sourceCardSummary = context.source.getShortSummary();
+        return {
+            ...context.source.getShortSummary(),
+            type: context.source.type
+        };
+    }
+
+    private makeChoiceButton(context: TriggeredAbilityContext, num: number): ITriggerWindowButton {
+        const title = context.ability.getTitle(context);
+        const hasLegalEffects = context.ability.hasAnyLegalEffects(context, SubStepCheck.All);
 
         return {
-            ...sourceCardSummary,
-            setId: context.source.setId,
-            type: context.source.type
+            text: title,
+            arg: num.toString(),
+            sourceCard: this.getSourceCard(context),
+            hasLegalEffects
         };
     }
 

--- a/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
@@ -2,7 +2,7 @@ import type { Player } from '../../Player';
 import type { Game } from '../../Game';
 import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
-import { PromptType, type ITriggerWindowButton } from '../PromptInterfaces';
+import { PromptType, type ITriggerWindowButton, type ITriggerWindowSourceCard } from '../PromptInterfaces';
 import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
 import { UiPrompt } from './UiPrompt';
 
@@ -24,11 +24,19 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     }
 
     public override activePromptInternal(): IPlayerPromptStateProperties {
-        const buttons: ITriggerWindowButton[] = this.triggeredAbilities.map((context, index) => ({
-            text: this.getChoiceTitle(context),
-            arg: index.toString(),
-            sourceCardSetId: context.source.setId
-        }));
+        const buttons: ITriggerWindowButton[] = this.triggeredAbilities.map((context, index) => {
+            const button: ITriggerWindowButton = {
+                text: this.getChoiceTitle(context),
+                arg: index.toString()
+            };
+
+            const sourceCard = this.getSourceCard(context);
+            if (sourceCard) {
+                button.sourceCard = sourceCard;
+            }
+
+            return button;
+        });
 
         if (this.game.manualMode) {
             buttons.push({
@@ -43,6 +51,20 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
             promptTitle: this.source.name,
             promptUuid: this.uuid,
             promptType: PromptType.TriggerWindow
+        };
+    }
+
+    private getSourceCard(context: TriggeredAbilityContext): ITriggerWindowSourceCard | undefined {
+        if (!context.source?.isCard?.()) {
+            return undefined;
+        }
+
+        const sourceCardSummary = context.source.getShortSummary();
+
+        return {
+            ...sourceCardSummary,
+            setId: context.source.setId,
+            type: context.source.type
         };
     }
 


### PR DESCRIPTION
**WARNING:** It must go out with its [FE counterpart](https://github.com/SWU-Karabast/forceteki-client/pull/748). 

The goal is to support card display when selecting multiple action triggers:

<img width="1046" height="950" alt="Screenshot 2026-06-13 at 12 04 22 PM" src="https://github.com/user-attachments/assets/911b6f97-c12e-40a7-98e3-b7796ca87088" />

