### PR TITLE
prevent grogu from treating piloting upgrades as units for flip

### DIFF
--- a/server/game/cards/08_ASH/leaders/GroguCharmingCompanion.ts
+++ b/server/game/cards/08_ASH/leaders/GroguCharmingCompanion.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { RelativePlayer } from '../../../core/Constants';
+import { EnumHelpers } from '../../../core/utils/EnumHelpers';
 
 export default class GroguCharmingCompanion extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -26,7 +27,7 @@ export default class GroguCharmingCompanion extends LeaderUnitCard {
             when: {
                 onCardPlayed: (event, context) =>
                     event.player === context.player &&
-                    event.card.isUnit() &&
+                    EnumHelpers.isUnit(event.cardTypeWhenInPlay) &&
                     event.card.unique &&
                     event.card.cost >= 4
             },

--- a/test/server/cards/08_ASH/leaders/GroguCharmingCompanion.spec.ts
+++ b/test/server/cards/08_ASH/leaders/GroguCharmingCompanion.spec.ts
@@ -194,6 +194,31 @@ describe('Grogu: Charming Companion', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('should NOT trigger when a unique pilot costing 4 or more is played as an upgrade via Piloting', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'grogu#charming-companion',
+                        hand: ['chewbacca#faithful-first-mate'], // unique, cost 5, has Piloting
+                        spaceArena: ['awing'], // Vehicle to attach the pilot to
+                        resources: 10
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Chewbacca is unique and costs 5, but is played as a pilot upgrade, not as a unit
+                context.player1.clickCard(context.chewbacca);
+                context.player1.clickPrompt('Play Chewbacca with Piloting');
+                context.player1.clickCard(context.awing);
+
+                // Grogu must not offer to deploy — the pilot entered play as an upgrade
+                expect(context.chewbacca).toBeAttachedTo(context.awing);
+                expect(context.grogu).not.toBeInZone('groundArena');
+                expect(context.grogu.exhausted).toBeFalse();
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('should allow Grogu to deploy again after being defeated and readied in a new round', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
Check `event.cardTypeWhenInPlay` intead of `event.card.isUnit()` for Grogu flip check to prevent firing for piloting upgrades

Fixes #2583 