### PR TITLE
Remaining Jerjerrod card fixes and a lint rule

### DIFF
--- a/eslint-rules/no-event-generated-tokens.mjs
+++ b/eslint-rules/no-event-generated-tokens.mjs
@@ -1,0 +1,58 @@
+/**
+ * Disallow reading `.generatedTokens` from an `events[...]` index access.
+ *
+ * When a token-creation event is replaced (e.g. by Moff Jerjerrod's replacement
+ * effect), the original event never resolves and its `generatedTokens` is empty or
+ * undefined. Any follow-up effect that needs the created tokens must read them from
+ * the resolved (possibly replacement) events via `resolvedEvents[...]?.generatedTokens`
+ * instead of `events[...].generatedTokens`.
+ * 
+ * We will eventually do a code change to add a clearer and safer pattern around this,
+ * this rule is just a stopgap for now to keep any new cases from slipping through.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow reading generatedTokens from events[...]; use resolvedEvents[...]?.generatedTokens so replaced token-creation events (e.g. Moff Jerjerrod) are handled correctly.',
+        },
+        messages: {
+            useResolvedEvents: 'Do not read `.generatedTokens` from `events[...]`. Use `resolvedEvents[...]?.generatedTokens` instead so replaced token-creation events (e.g. Moff Jerjerrod) are handled correctly.',
+        },
+        schema: [],
+    },
+    create(context) {
+        // Matches `<obj>.events[<idx>]` or `events[<idx>]`
+        function isEventsIndexAccess(node) {
+            if (node.type !== 'MemberExpression' || !node.computed) {
+                return false;
+            }
+
+            const object = node.object;
+            if (
+                object.type === 'MemberExpression' &&
+                !object.computed &&
+                object.property.type === 'Identifier' &&
+                object.property.name === 'events'
+            ) {
+                return true;
+            }
+
+            return object.type === 'Identifier' && object.name === 'events';
+        }
+
+        return {
+            MemberExpression(node) {
+                if (
+                    node.property.type === 'Identifier' &&
+                    node.property.name === 'generatedTokens' &&
+                    isEventsIndexAccess(node.object)
+                ) {
+                    context.report({ node, messageId: 'useResolvedEvents' });
+                }
+            },
+        };
+    },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import tsParser from '@typescript-eslint/parser';
 import unusedImports from "eslint-plugin-unused-imports";
 import noRawTokenText from './eslint-rules/no-raw-token-text.mjs';
 import stateRefArrayRequiresIStateArray from './eslint-rules/state-ref-array-requires-istatearray.mjs';
+import noEventGeneratedTokens from './eslint-rules/no-event-generated-tokens.mjs';
 
 export default tseslint.config(
     {
@@ -254,12 +255,14 @@ export default tseslint.config(
                 rules: {
                     'no-raw-token-text': noRawTokenText,
                     'state-ref-array-requires-istatearray': stateRefArrayRequiresIStateArray,
+                    'no-event-generated-tokens': noEventGeneratedTokens,
                 }
             }
         },
         rules: {
             'forceteki/no-raw-token-text': 'error',
             'forceteki/state-ref-array-requires-istatearray': 'error',
+            'forceteki/no-event-generated-tokens': 'error',
         }
     }
 );

--- a/server/game/cards/04_JTL/events/TimelyReinforcements.ts
+++ b/server/game/cards/04_JTL/events/TimelyReinforcements.ts
@@ -22,7 +22,7 @@ export default class TimelyReinforcements extends EventCard {
                 title: 'Give them Sentinel for this phase',
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel }),
-                    target: thenContext.events[0].generatedTokens
+                    target: thenContext.resolvedEvents[0]?.generatedTokens
                 })
             })
         });

--- a/server/game/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.ts
+++ b/server/game/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.ts
@@ -21,7 +21,7 @@ export default class ChancellorPalpatineIAmTheSenate extends NonLeaderUnitCard {
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Give those tokens Sentinel for this phase',
                 immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect({
-                    target: ifYouDoContext.events[0].generatedTokens,
+                    target: ifYouDoContext.resolvedEvents[0]?.generatedTokens,
                     effect: abilityHelper.ongoingEffects.gainKeyword({
                         keyword: KeywordName.Sentinel,
                     })

--- a/server/game/cards/07_TS26/units/JediGeneral.ts
+++ b/server/game/cards/07_TS26/units/JediGeneral.ts
@@ -22,7 +22,7 @@ export default class JediGeneral extends NonLeaderUnitCard {
             ifYouDo: (ifYouDoContext) => ({
                 title: 'Give this token an Experience token',
                 immediateEffect: abilityHelper.immediateEffects.giveExperience({
-                    target: ifYouDoContext.events[0].generatedTokens,
+                    target: ifYouDoContext.resolvedEvents[0]?.generatedTokens,
                 })
             }),
         });

--- a/server/game/cards/07_TS26/units/YodaBegunTheCloneWarHas.ts
+++ b/server/game/cards/07_TS26/units/YodaBegunTheCloneWarHas.ts
@@ -30,7 +30,7 @@ export default class YodaBegunTheCloneWarHas extends NonLeaderUnitCard {
                 title: 'Give it Sentinel for this phase',
                 immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel }),
-                    target: thenContext.events[0].generatedTokens
+                    target: thenContext.resolvedEvents[0]?.generatedTokens
                 })
             })
         });

--- a/server/game/cards/08_ASH/events/BuyTime.ts
+++ b/server/game/cards/08_ASH/events/BuyTime.ts
@@ -19,7 +19,7 @@ export default class BuyTime extends EventCard {
                 title: 'Give it Sentinel for this phase',
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel }),
-                    target: thenContext.events[0].generatedTokens
+                    target: thenContext.resolvedEvents[0]?.generatedTokens
                 })
             })
         });

--- a/server/game/cards/08_ASH/events/ChooseYourPath.ts
+++ b/server/game/cards/08_ASH/events/ChooseYourPath.ts
@@ -29,7 +29,7 @@ export default class ChooseYourPath extends EventCard {
                             condition: (c) => c.player.hasSomeArenaUnit({ trait: Trait.Mandalorian }),
                             onTrue: abilityHelper.immediateEffects.sequential([
                                 abilityHelper.immediateEffects.createMandalorian(),
-                                abilityHelper.immediateEffects.giveAdvantage((context) => ({ target: context.events[0]?.generatedTokens[0] }))
+                                abilityHelper.immediateEffects.giveAdvantage((context) => ({ target: context.resolvedEvents[0]?.generatedTokens }))
                             ])
                         })
                 }

--- a/test/server/cards/04_JTL/events/TimelyReinforcements.spec.ts
+++ b/test/server/cards/04_JTL/events/TimelyReinforcements.spec.ts
@@ -143,5 +143,37 @@ describe('Timely Reinforcements', function () {
                 expect(secondXwingBatch[1]).toBeInZone('outsideTheGame');
             });
         });
+
+        describe('Timely Reinforcements with Moff Jerjerrod', function () {
+            it('should give Sentinel to all of the doubled X-Wing tokens', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['timely-reinforcements'],
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
+                    },
+                    player2: {
+                        spaceArena: ['cartel-spacer'],
+                        resources: 6
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.timelyReinforcements);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 6 X-Wing tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                const xwingTokens = context.player1.findCardsByName('xwing', 'spaceArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(xwingTokens.length).toBe(6);
+                expect(xwingTokens.every((xwing) => xwing.keywords.some((keyword) => keyword.name === 'sentinel'))).toBe(true);
+
+                // Opponent must attack a Sentinel this phase
+                context.player2.clickCard(context.cartelSpacer);
+                expect(context.player2).toBeAbleToSelectExactly(xwingTokens);
+                context.player2.clickCard(xwingTokens[0]);
+            });
+        });
     });
 });

--- a/test/server/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.spec.ts
+++ b/test/server/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.spec.ts
@@ -155,5 +155,37 @@ describe('Chancellor Palpatine, I Am The Senate', function() {
             // Resolve the attack selection to avoid unresolved prompt
             context.player2.clickCard(spies[0]);
         });
+
+        describe('When Played with Moff Jerjerrod', function () {
+            it('doubles the Spy tokens and gives all of them Sentinel for this phase', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: { card: 'iden-versio#inferno-squad-commander', deployed: true },
+                        hand: ['chancellor-palpatine#i-am-the-senate'],
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
+                    },
+                    player2: {
+                        groundArena: ['wampa']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chancellorPalpatineIAmTheSenate);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 4 Spy tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                const spies = context.player1.findCardsByName('spy', 'groundArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(spies.length).toBe(4);
+                expect(spies.every((spy) => spy.keywords.some((keyword) => keyword.name === 'sentinel'))).toBeTrue();
+
+                // Opponent must attack a Sentinel this phase
+                context.player2.clickCard(context.wampa);
+                expect(context.player2).toBeAbleToSelectExactly(spies);
+                context.player2.clickCard(spies[0]);
+            });
+        });
     });
 });

--- a/test/server/cards/07_TS26/units/JediGeneral.spec.ts
+++ b/test/server/cards/07_TS26/units/JediGeneral.spec.ts
@@ -120,5 +120,32 @@ describe('Jedi General', function() {
             expect(troopers[0]).toHaveExactUpgradeNames(['experience']);
             expect(context.player2).toBeActivePlayer();
         });
+
+        it('should give an Experience token to both Clone Troopers when doubled by Moff Jerjerrod', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['jedi-general'],
+                    groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
+                    leader: { card: 'captain-rex#fighting-for-his-brothers', deployed: true }
+                },
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.jediGeneral);
+            context.player1.clickPrompt('(No effect) Ambush');
+            expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Clone Trooper tokens instead');
+            context.player1.clickPrompt('Trigger');
+
+            const troopers = context.player1.findCardsByName('clone-trooper', 'groundArena');
+            expect(context.moffJerjerrod).toBeInZone('discard');
+            expect(troopers.length).toBe(2);
+            expect(troopers.every((trooper) => trooper.exhausted)).toBeTrue();
+            troopers.forEach((trooper) => {
+                expect(trooper).toHaveExactUpgradeNames(['experience']);
+            });
+            expect(context.player2).toBeActivePlayer();
+        });
     });
 });

--- a/test/server/cards/07_TS26/units/YodaBegunTheCloneWarHas.spec.ts
+++ b/test/server/cards/07_TS26/units/YodaBegunTheCloneWarHas.spec.ts
@@ -194,5 +194,37 @@ describe('Yoda, Begun, The Clone War Has', function () {
                 expect(context.player2).toBeActivePlayer();
             });
         });
+
+        describe('Yoda, Begun The Clone War Has with Moff Jerjerrod', function () {
+            it('should give Sentinel to both of the doubled Clone Trooper tokens', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['yoda#begun-the-clone-war-has'],
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
+                        leader: 'chewbacca#walking-carpet',
+                        base: 'echo-base'
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.yoda);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Clone Trooper tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                const clones = context.player1.findCardsByName('clone-trooper', 'groundArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(clones.length).toBe(2);
+                expect(clones.every((clone) => clone.keywords.some((keyword) => keyword.name === 'sentinel'))).toBe(true);
+
+                // Opponent must attack a Sentinel this phase
+                context.player2.clickCard(context.wampa);
+                expect(context.player2).toBeAbleToSelectExactly(clones);
+                context.player2.clickCard(clones[0]);
+            });
+        });
     });
 });

--- a/test/server/cards/08_ASH/events/BuyTime.spec.ts
+++ b/test/server/cards/08_ASH/events/BuyTime.spec.ts
@@ -62,5 +62,40 @@ describe('Buy Time', function () {
                 expect(context.p1Base.damage).toBe(4);
             });
         });
+
+        describe('Buy Time with Moff Jerjerrod', function () {
+            it('should give Sentinel to both of the doubled Mandalorian tokens', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['buy-time'],
+                        groundArena: ['moff-jerjerrod#we-shall-redouble-our-efforts'],
+                        base: 'echo-base'
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.buyTime);
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Mandalorian tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                // Both doubled Mandalorian tokens have Shielded, so their triggers must be ordered
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                context.player1.clickPrompt('Shielded');
+
+                const mandalorians = context.player1.findCardsByName('mandalorian', 'groundArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(mandalorians.length).toBe(2);
+                expect(mandalorians.every((mandalorian) => mandalorian.keywords.some((keyword) => keyword.name === 'sentinel'))).toBe(true);
+
+                // Opponent must attack a Sentinel this phase
+                context.player2.clickCard(context.wampa);
+                expect(context.player2).toBeAbleToSelectExactly(mandalorians);
+                context.player2.clickCard(mandalorians[0]);
+            });
+        });
     });
 });

--- a/test/server/cards/08_ASH/events/ChooseYourPath.spec.ts
+++ b/test/server/cards/08_ASH/events/ChooseYourPath.spec.ts
@@ -138,5 +138,39 @@ describe('Choose Your Path', function() {
             const mandalorians = context.player1.findCardsByName('mandalorian');
             expect(mandalorians.length).toBe(0);
         });
+
+        describe('Choose Your Path with Moff Jerjerrod', function() {
+            it('should give an Advantage token to both Mandalorian tokens when doubled by Moff Jerjerrod', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['choose-your-path'],
+                        groundArena: ['mandalorian-warrior', 'moff-jerjerrod#we-shall-redouble-our-efforts'],
+                        base: { card: 'echo-base', damage: 10 }
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.chooseYourPath);
+                context.player1.clickPrompt('If you control a Mandalorian unit, create a Mandalorian token and give an Advantage token to it');
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Mandalorian tokens instead');
+                context.player1.clickPrompt('Trigger');
+
+                // Both doubled Mandalorian tokens have Shielded, so their triggers must be ordered
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                context.player1.clickPrompt('Shielded');
+
+                const mandalorians = context.player1.findCardsByName('mandalorian', 'groundArena');
+                expect(context.moffJerjerrod).toBeInZone('discard');
+                expect(mandalorians.length).toBe(2);
+                mandalorians.forEach((mandalorian) => {
+                    expect(mandalorian).toHaveExactUpgradeNames(['shield', 'advantage']);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
A previous PR (https://github.com/SWU-Karabast/forceteki/pull/2423) did a fix for Moff Jerjerrod so that any effects applied to doubled created token units would work correctly. However, each relevant card also had to be updated, and we missed several.

This PR catches the ones that got overlooked and adds an ESLint rule to flag the original problematic access pattern so it doesn't happen again. This is a stopgap and we definitely need to rethink the patterns we use so that this is easier to do the right way, but for now it's fine.