### PR TITLE
fix when defeated using old information if unit still in play

### DIFF
--- a/server/game/gameSystems/UseWhenDefeatedSystem.ts
+++ b/server/game/gameSystems/UseWhenDefeatedSystem.ts
@@ -63,8 +63,16 @@ export class UseWhenDefeatedSystem<TContext extends AbilityContext = AbilityCont
         const whenDefeatedProps = { ...(whenDefeatedAbility.properties as ITriggeredAbilityProps), optional: false, target: whenDefeatedSource };
         const ability = event.context.game.gameObjectManager.createWithoutRefsUnsafe(() => new TriggeredAbility(event.context.game, whenDefeatedSource, whenDefeatedProps));
 
-        // This is needed for cards that use Last Known Information i.e. Raddus
-        const whenDefeatedEvent = onDefeatEvent || new DefeatCardSystem(whenDefeatedProps).generateEvent(event.context, whenDefeatedSource, true);
+        // Reusing the original onDefeatEvent is needed for cards that use Last Known Information i.e. Raddus,
+        // where the source has actually been defeated and its stats can no longer be read from the live card.
+        // However, if the source is still in play (e.g. its When Defeated was used via Chimaera rather than an
+        // actual defeat) we must regenerate the event so its Last Known Information reflects the source's current
+        // stats. Otherwise a re-use (e.g. Thrawn copying the ability) would read a stale snapshot captured before
+        // the first resolution changed the source's power (e.g. Helgait gaining Advantage tokens).
+        const sourceStillInPlay = whenDefeatedSource.canBeInPlay() && whenDefeatedSource.isInPlay();
+        const whenDefeatedEvent = (onDefeatEvent && !sourceStillInPlay)
+            ? onDefeatEvent
+            : new DefeatCardSystem(whenDefeatedProps).generateEvent(event.context, whenDefeatedSource, true);
 
         // Mark this as a manually activated ability (not naturally triggered by game events)
         const context = ability.createContext(event.context.player, whenDefeatedEvent);

--- a/test/server/cards/04_JTL/leaders/GrandAdmiralThrawnHowUnfortunate.spec.ts
+++ b/test/server/cards/04_JTL/leaders/GrandAdmiralThrawnHowUnfortunate.spec.ts
@@ -628,6 +628,44 @@ describe('Grand Admiral Thrawn, How Unfortunate', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('should re-evaluate the source unit\'s power when re-using a When Defeated triggered by Chimaera (Helgait)', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'grand-admiral-thrawn#how-unfortunate',
+                        hand: ['chimaera#reinforcing-the-center'],
+                        groundArena: ['helgait#dooku-was-a-visionary']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Play Chimaera and use its When Played to trigger Helgait's When Defeated (Helgait stays in play)
+                context.player1.clickCard(context.chimaera);
+                context.player1.clickCard(context.helgait);
+
+                // First trigger: Helgait's power is 6, distribute 6 Advantage tokens all onto Helgait (now power 12)
+                expect(context.player1).toHavePrompt('Distribute 6 Advantage tokens among targets');
+                context.player1.setDistributeAmongTargetsPromptState(new Map([
+                    [context.helgait, 6]
+                ]), 'distributeAdvantage');
+                expect(context.helgait.getPower()).toBe(12);
+
+                // Thrawn re-uses Helgait's When Defeated ability
+                expect(context.player1).toHavePassAbilityPrompt(whenDefeatedPrompt(context.helgait.title));
+                context.player1.clickPrompt('Trigger');
+                expect(context.grandAdmiralThrawn.exhausted).toBe(true);
+
+                // Second trigger should see Helgait's updated power of 12, not the stale value of 6
+                expect(context.player1).toHavePrompt('Distribute 12 Advantage tokens among targets');
+                context.player1.setDistributeAmongTargetsPromptState(new Map([
+                    [context.helgait, 12]
+                ]), 'distributeAdvantage');
+                expect(context.helgait.getPower()).toBe(24);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('should not trigger when playing a unit with played/defeated trigger that was defeated this phase', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
Fixes #2581 

UseWhenDefeatedSystem was using stale LKI for units that are still in play. This change makes it so if the unit is in play, we use the live stats instead.

This fixes the bug where using JTL Chimera on Helgait and doubling it with Thrawn gives 2 instances of +6 advantage, instead of +6 and +12.