### PR TITLE
Use numeric prompt on credit usage

### DIFF
--- a/server/game/core/cost/DefeatCreditTokensCostAdjuster.ts
+++ b/server/game/core/cost/DefeatCreditTokensCostAdjuster.ts
@@ -13,7 +13,7 @@ import { CostAdjustStage, ResourceCostType } from './CostInterfaces';
 import type { ICostResult } from './ICost';
 import { Contract } from '../utils/Contract';
 import { ChatHelpers } from '../chat/ChatHelpers';
-import type { IDropdownListPromptProperties } from '../gameSteps/prompts/DropdownListPrompt';
+import type { INumberPromptProperties } from '../gameSteps/prompts/NumberPrompt';
 import type { FormatMessage } from '../chat/GameChat';
 
 import { registerState } from '../GameObjectUtils';
@@ -105,7 +105,7 @@ export class DefeatCreditTokensCostAdjuster extends CostAdjusterWithGameSteps {
         } else {
             choices.push('Select amount');
             handlers.push(() => {
-                this.promptDropdownList(
+                this.promptWithNumberMenu(
                     Math.max(1, minimumCreditsRequiredToPay),
                     maximumCreditsThatCanBeUsed,
                     context,
@@ -187,20 +187,21 @@ export class DefeatCreditTokensCostAdjuster extends CostAdjusterWithGameSteps {
         return overallPaymentEvent;
     }
 
-    private promptDropdownList(
+    private promptWithNumberMenu(
         min: number,
         max: number,
         context: AbilityContext<Card>,
         onSelect: (chosenAmount: number) => void
     ): void {
-        const props: IDropdownListPromptProperties = {
+        const props: INumberPromptProperties = {
             promptTitle: 'Select amount of Credit tokens',
-            options: Array.from({ length: max - min + 1 }, (_, i) => (i + min).toString()),
+            min,
+            max,
             source: context.source,
             choiceHandler: (choice: string) => onSelect(parseInt(choice, 10))
         };
 
-        context.game.promptWithDropdownListMenu(this.sourcePlayer, props);
+        context.game.promptWithNumberMenu(this.sourcePlayer, props);
     }
 
     private creditString(count: number): string {

--- a/test/helpers/CustomMatchers.js
+++ b/test/helpers/CustomMatchers.js
@@ -927,6 +927,28 @@ var customMatchers = {
             }
         };
     },
+    toHaveNumericPromptRange: function () {
+        return {
+            compare: function (player, min, max) {
+                let result = {};
+
+                const actualRange = player.currentPrompt().selectNumber;
+
+                result.pass = actualRange?.min === min && actualRange?.max === max;
+
+                if (result.pass) {
+                    result.message = `Expected ${player.name} not to have numeric prompt range ${min}-${max} but it does`;
+                } else {
+                    const actualRangeText = actualRange ? `${actualRange.min}-${actualRange.max}` : 'no numeric prompt range';
+                    result.message = `Expected ${player.name} to have numeric prompt range ${min}-${max} but it has ${actualRangeText}`;
+                }
+
+                result.message += `\n\n${generatePromptHelpMessage(player.testContext)}`;
+
+                return result;
+            }
+        };
+    },
     toHaveExactSelectableDisplayPromptCards: function() {
         return {
             compare: function (player, expectedCardsInPromptRaw) {

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -151,6 +151,7 @@ declare namespace jasmine {
         toHaveExactUpgradeNames(upgradeNames: any[]): boolean;
         toHaveExactPromptButtons<T extends PlayerInteractionWrapper>(this: Matchers<T>, buttons: any[]): boolean;
         toHaveExactDropdownListOptions<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedOptions: any[]): boolean;
+        toHaveNumericPromptRange<T extends PlayerInteractionWrapper>(this: Matchers<T>, min: number, max: number): boolean;
         toHaveExactDisplayPromptCards<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedPromptState: ICardDisplaySelectionState): boolean;
         toHaveExactSelectableDisplayPromptCards<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedCardsInPrompt: (Card | { card: Card; displayText: string })[]): boolean;
         toHaveExactViewableDisplayPromptCards<T extends PlayerInteractionWrapper>(this: Matchers<T>, expectedCardsInPrompt: (Card | { card: Card; displayText: string })[]): boolean;

--- a/test/server/cards/01_SOR/events/ForceLightning.spec.ts
+++ b/test/server/cards/01_SOR/events/ForceLightning.spec.ts
@@ -36,7 +36,7 @@ describe('Force Lightning', function() {
                 expect(context.tieBomber.getHp()).toBe(4);
 
                 // can choose from 0 - 9 resources since 1 was paid for Force Lightning already
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('1');
 
                 expect(context.victorLeader.damage).toBe(2);
@@ -61,7 +61,7 @@ describe('Force Lightning', function() {
                 ]);
 
                 context.player1.clickCard(context.atst);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('3');
                 expect(context.atst.damage).toBe(6);
                 expect(context.player1.exhaustedResourceCount).toBe(4);
@@ -84,7 +84,7 @@ describe('Force Lightning', function() {
                 expect(context.tieBomber.getPower()).toBe(0);
                 expect(context.tieBomber.getHp()).toBe(4);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('0');
 
                 expect(context.victorLeader.damage).toBe(0);
@@ -104,7 +104,7 @@ describe('Force Lightning', function() {
                 ]);
 
                 context.player1.clickCard(context.atst);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('9');
                 expect(context.atst).toBeInZone('discard');
                 expect(context.player1.exhaustedResourceCount).toBe(10);
@@ -123,7 +123,7 @@ describe('Force Lightning', function() {
                 ]);
 
                 context.player1.clickCard(context.fireball);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('0');
                 expect(context.fireball.damage).toBe(0);
                 expect(context.player1.exhaustedResourceCount).toBe(1);

--- a/test/server/cards/01_SOR/units/C-3POProtocolDroid.spec.ts
+++ b/test/server/cards/01_SOR/units/C-3POProtocolDroid.spec.ts
@@ -21,7 +21,7 @@ describe('C-3PO, Protocol Droid', function() {
                 context.player1.clickCard(context.c3po);
 
                 // should have prompt options from 0 to 20
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('4');
                 expect(context.getChatLogs(3)).toContain('player1 names 4 using C-3PO');
 
@@ -45,7 +45,7 @@ describe('C-3PO, Protocol Droid', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.c3po);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('0');
 
                 // P1 sees the top card of their deck
@@ -63,7 +63,7 @@ describe('C-3PO, Protocol Droid', function() {
                 context.player2.passAction();
                 context.player1.clickCard(context.c3po);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
 
                 // P1 sees the top card of their deck

--- a/test/server/cards/03_TWI/events/TheCloneWars.spec.ts
+++ b/test/server/cards/03_TWI/events/TheCloneWars.spec.ts
@@ -13,7 +13,7 @@ describe('The Clone Wars ability\'s', function() {
 
             context.player1.clickCard(context.theCloneWars);
             expect(context.player1.readyResourceCount).toBe(4);
-            expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 4 + 1 }, (x, i) => `${i}`));
+            expect(context.player1).toHaveNumericPromptRange(0, 4);
             context.player1.chooseListOption('2');
             expect(context.getChatLogs(3)).toContain('player1 names 2 using The Clone Wars');
             expect(context.player1.readyResourceCount).toBe(2);
@@ -38,7 +38,7 @@ describe('The Clone Wars ability\'s', function() {
 
             context.player1.clickCard(context.theCloneWars);
             expect(context.player1.readyResourceCount).toBe(6);
-            expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 6 + 1 }, (x, i) => `${i}`));
+            expect(context.player1).toHaveNumericPromptRange(0, 6);
             context.player1.chooseListOption('0');
             expect(context.player1.readyResourceCount).toBe(6);
             const cloneTroopers = context.player1.findCardsByName('clone-trooper');

--- a/test/server/cards/05_LOF/units/CuriousFlock.spec.ts
+++ b/test/server/cards/05_LOF/units/CuriousFlock.spec.ts
@@ -12,7 +12,7 @@ describe('Curious Flock', function () {
             const { context } = contextRef;
 
             context.player1.clickCard(context.curiousFlock);
-            expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 7 }, (_x, i) => `${i}`));
+            expect(context.player1).toHaveNumericPromptRange(0, 6);
             context.player1.chooseListOption('3');
 
             expect(context.player2).toBeActivePlayer();
@@ -37,7 +37,7 @@ describe('Curious Flock', function () {
             const { context } = contextRef;
 
             context.player1.clickCard(context.curiousFlock);
-            expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 7 }, (_x, i) => `${i}`));
+            expect(context.player1).toHaveNumericPromptRange(0, 6);
             context.player1.chooseListOption('0');
 
             expect(context.player2).toBeActivePlayer();
@@ -57,7 +57,7 @@ describe('Curious Flock', function () {
             const { context } = contextRef;
 
             context.player1.clickCard(context.curiousFlock);
-            expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 3 }, (_x, i) => `${i}`));
+            expect(context.player1).toHaveNumericPromptRange(0, 2);
             context.player1.chooseListOption('1');
 
             expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/06_SEC/events/EmergencyPowers.spec.ts
+++ b/test/server/cards/06_SEC/events/EmergencyPowers.spec.ts
@@ -35,7 +35,7 @@ describe('Emergency Powers', function() {
                 context.player1.clickCard(context.darthMaul);
 
                 // can choose from 0 - 9 resources since 1 was paid for Emergency Powers already
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('1');
 
                 expect(context.darthMaul).toHaveExactUpgradeNames(['experience']);
@@ -55,7 +55,7 @@ describe('Emergency Powers', function() {
                 ]);
 
                 context.player1.clickCard(context.atst);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('3');
                 expect(context.atst).toHaveExactUpgradeNames(['experience', 'experience', 'experience']);
                 expect(context.player1.exhaustedResourceCount).toBe(4);
@@ -75,7 +75,7 @@ describe('Emergency Powers', function() {
 
                 context.player1.clickCard(context.victorLeader);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('0');
 
                 expect(context.victorLeader).toHaveExactUpgradeNames([]);
@@ -95,7 +95,7 @@ describe('Emergency Powers', function() {
                 ]);
 
                 context.player1.clickCard(context.atst);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 9);
                 context.player1.chooseListOption('9');
                 expect(context.atst).toHaveExactUpgradeNames([
                     'experience',
@@ -153,7 +153,7 @@ describe('Emergency Powers', function() {
             ]);
 
             context.player1.clickCard(context.atst);
-            expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 10 }, (_x, i) => `${i}`));
+            expect(context.player1).toHaveNumericPromptRange(0, 9);
             context.player1.chooseListOption('9');
             expect(context.atst).toHaveExactUpgradeNames([
                 'experience',

--- a/test/server/cards/06_SEC/units/GalenErsoYoullNeverWin.spec.ts
+++ b/test/server/cards/06_SEC/units/GalenErsoYoullNeverWin.spec.ts
@@ -433,7 +433,7 @@ describe('Galen Erso - You\'ll Never Win', function() {
 
                 context.player1.clickCard(context.c3po);
                 context.player1.clickCard(context.p2Base);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('5');
                 context.player1.clickDone();
             });

--- a/test/server/cards/07_LAW/units/CadBaneNowItsMyTurn.spec.ts
+++ b/test/server/cards/07_LAW/units/CadBaneNowItsMyTurn.spec.ts
@@ -21,7 +21,7 @@ describe('Cad Bane, Now it\'s My Turn', function() {
                 context.player1.clickCard(context.cadBane);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 5 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 4);
                 context.player1.chooseListOption('4');
 
                 expect(context.p2Base.damage).toBe(10);
@@ -37,7 +37,7 @@ describe('Cad Bane, Now it\'s My Turn', function() {
                 context.player1.clickCard(context.cadBane);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 5 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 4);
                 context.player1.chooseListOption('2');
 
                 expect(context.p2Base.damage).toBe(8);
@@ -53,7 +53,7 @@ describe('Cad Bane, Now it\'s My Turn', function() {
                 context.player1.clickCard(context.cadBane);
                 context.player1.clickCard(context.p2Base);
 
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 5 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 4);
                 context.player1.chooseListOption('0');
 
                 expect(context.p2Base.damage).toBe(6);

--- a/test/server/cards/08_ASH/events/SenseThroughTheForce.spec.ts
+++ b/test/server/cards/08_ASH/events/SenseThroughTheForce.spec.ts
@@ -21,7 +21,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
                 expect(context.getChatLogs(3)).toContain('player1 names 2 using Sense Through the Force');
 
@@ -57,7 +57,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
                 expect(context.getChatLogs(3)).toContain('player1 names 2 using Sense Through the Force');
 
@@ -91,7 +91,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
                 expect(context.getChatLogs(3)).toContain('player1 names 2 using Sense Through the Force');
 
@@ -126,7 +126,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
                 expect(context.getChatLogs(3)).toContain('player1 names 2 using Sense Through the Force');
 
@@ -161,7 +161,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
                 expect(context.getChatLogs(3)).toContain('player1 names 2 using Sense Through the Force');
 
@@ -196,7 +196,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('4');
                 expect(context.getChatLogs(3)).toContain('player1 names 4 using Sense Through the Force');
 
@@ -227,7 +227,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('4');
                 expect(context.getChatLogs(3)).toContain('player1 names 4 using Sense Through the Force');
                 context.player1.clickPrompt('Take nothing');
@@ -242,7 +242,7 @@ describe('Sense Through The Force', function() {
 
                 context.player1.setDeck([context.battlefieldMarine, context.cellBlockGuard, context.cartelSpacer]);
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('2');
                 expect(context.getChatLogs(3)).toContain('player1 names 2 using Sense Through the Force');
 
@@ -299,7 +299,7 @@ describe('Sense Through The Force', function() {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.senseThroughTheForce);
-                expect(context.player1).toHaveExactDropdownListOptions(Array.from({ length: 21 }, (x, i) => `${i}`));
+                expect(context.player1).toHaveNumericPromptRange(0, 20);
                 context.player1.chooseListOption('4');
                 expect(context.getChatLogs(3)).toContain('player1 names 4 using Sense Through the Force');
 

--- a/test/server/gameSystems/CreditToken.spec.ts
+++ b/test/server/gameSystems/CreditToken.spec.ts
@@ -338,7 +338,7 @@ describe('Credit token', function () {
                 context.player1.clickPrompt('Select amount');
 
                 // Should be able to choose from 2 to 4 credits, despite having 6 available
-                expect(context.player1.currentPrompt().selectNumber).toEqual({ min: 2, max: 4 });
+                expect(context.player1).toHaveNumericPromptRange(2, 4);
                 context.player1.chooseListOption('3');
 
                 // 3 credit tokens were defeated, 1 resource was spent

--- a/test/server/gameSystems/CreditToken.spec.ts
+++ b/test/server/gameSystems/CreditToken.spec.ts
@@ -338,7 +338,7 @@ describe('Credit token', function () {
                 context.player1.clickPrompt('Select amount');
 
                 // Should be able to choose from 2 to 4 credits, despite having 6 available
-                expect(context.player1).toHaveExactDropdownListOptions(['2', '3', '4']);
+                expect(context.player1.currentPrompt().selectNumber).toEqual({ min: 2, max: 4 });
                 context.player1.chooseListOption('3');
 
                 // 3 credit tokens were defeated, 1 resource was spent


### PR DESCRIPTION
Use the new numeric prompt when using credit tokens and multiple amounts are legal.

# Old behavior

It prompts a text autocomplete which on mobile opens up the keyboard

<img width="1249" height="424" alt="Screenshot 2026-06-19 at 4 51 54 PM" src="https://github.com/user-attachments/assets/3e6a113b-4d57-4674-8291-145f62224bb3" />

# New behavior

https://github.com/user-attachments/assets/ed02b8b1-fc13-4d7d-946b-de280e4ba668



Game Setup File for testing
```json
{
    "phase": "action",
    "player1": {
        "hasInitiative": true,
        "resources": 6,
        "credits": 2,
        "base": "administrators-tower",
        "leader": "lando-calrissian#full-sabacc",
        "hand": [
            "consular-security-force",
            "han-solo#has-his-moments",
            "millennium-falcon#landos-pride",
            "maul#shadow-collective-visionary",
            "superlaser-blast"
        ]
    },
    "player2": {
        "resources": 6,
        "base": "echo-base",
        "leader": "luke-skywalker#faithful-friend",
        "groundArena": [
            "wampa"
        ],
        "hand": [
            "takedown"
        ]
    }
}

```
