### PR TITLE
Apply text replacement tokens for Keywords

### DIFF
--- a/eslint-rules/no-raw-token-text.mjs
+++ b/eslint-rules/no-raw-token-text.mjs
@@ -16,6 +16,12 @@ const TOKEN_CATEGORIES = [
         message: 'Raw aspect name "{{match}}" in string literal. Use the corresponding TextHelper constant (e.g. `TextHelper.Aggression`) or `TextHelper.aspect(Aspect.X)` in a template literal instead, so it can be replaced with an icon on the client side.',
     },
     {
+        pattern: 'Keywords?|Ambush|Grit|Overwhelm|Raid\\s+\\d+|Restore\\s+\\d+|Saboteur|Sentinel|Shielded|Bounty|Smuggle|Coordinate|Exploit\\s+\\d+|Piloting|Hidden|Plot',
+        flags: 'g',
+        messageId: 'rawKeyword',
+        message: 'Raw keyword "{{match}}" in string literal. Use the corresponding TextHelper constant (e.g. `TextHelper.Ambush`) in a template literal instead, so it can be styled correctly on the client side.',
+    },
+    {
         // Matches "pay(s) N resource(s)", "cost(s) N (resources) more/less", and "play(s) (it/them) for N more/less"
         // but NOT "costs N or more/less" (references to printed cost)
         // and NOT "ready/exhaust N resources" (effects that manipulate resources)

--- a/eslint-rules/no-raw-token-text.mjs
+++ b/eslint-rules/no-raw-token-text.mjs
@@ -41,8 +41,11 @@ const compiledCategories = TOKEN_CATEGORIES.map((cat) => {
             messageId: cat.messageId,
         };
     }
+    // Wrap in word boundaries so a token is only matched as a whole word — e.g. "Smuggle"
+    // should not match inside "Smuggled", nor "Plot" inside "Plotting". Every alternative in
+    // these patterns starts and ends with a word character, so the boundaries are well-defined.
     return {
-        regex: new RegExp(`(${cat.pattern})`, cat.flags || 'gi'),
+        regex: new RegExp(`\\b(${cat.pattern})\\b`, cat.flags || 'gi'),
         messageId: cat.messageId,
     };
 });
@@ -51,6 +54,53 @@ const compiledCategories = TOKEN_CATEGORIES.map((cat) => {
 const messages = Object.fromEntries(
     TOKEN_CATEGORIES.map((cat) => [cat.messageId, cat.message])
 );
+
+/**
+ * Some string literals never reach the client as display text, so matching token words inside
+ * them is always a false positive. Skip:
+ *   - module-source strings (`import ... from './GainKeyword'`, `export ... from`, dynamic import)
+ *   - enum member values (`Smuggle = 'whenPlayedUsingSmuggle'`)
+ *   - developer-facing error text (`throw new Error(...)`, `Contract.fail(...)`/`Contract.assert*(...)`)
+ */
+function isExemptContext(node) {
+    const parent = node.parent;
+
+    // Module source: the string is the `source` of an import/export/dynamic-import node.
+    if (
+        parent &&
+        (parent.type === 'ImportDeclaration' ||
+            parent.type === 'ExportNamedDeclaration' ||
+            parent.type === 'ExportAllDeclaration' ||
+            parent.type === 'ImportExpression') &&
+        parent.source === node
+    ) {
+        return true;
+    }
+
+    // Enum member value: `SomeName = 'someValue'`
+    if (parent && parent.type === 'TSEnumMember' && parent.initializer === node) {
+        return true;
+    }
+
+    // Developer-facing errors: anywhere inside a `throw` statement or a `Contract.*(...)` call.
+    for (let cur = parent; cur; cur = cur.parent) {
+        if (cur.type === 'ThrowStatement') {
+            return true;
+        }
+        if (
+            cur.type === 'CallExpression' &&
+            cur.callee &&
+            cur.callee.type === 'MemberExpression' &&
+            cur.callee.object &&
+            cur.callee.object.type === 'Identifier' &&
+            cur.callee.object.name === 'Contract'
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 /** @type {import('eslint').Rule.RuleModule} */
 export default {
@@ -79,12 +129,14 @@ export default {
 
         return {
             Literal(node) {
-                if (typeof node.value === 'string') {
+                if (typeof node.value === 'string' && !isExemptContext(node)) {
                     checkForTokenText(node, node.value);
                 }
             },
             TemplateElement(node) {
-                checkForTokenText(node, node.value.raw);
+                if (!isExemptContext(node)) {
+                    checkForTokenText(node, node.value.raw);
+                }
             },
         };
     },

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -619,7 +619,8 @@ export type NonNumericKeywordName =
   | KeywordName.Saboteur
   | KeywordName.Sentinel
   | KeywordName.Shielded
-  | KeywordName.Smuggle;
+  | KeywordName.Smuggle
+  | KeywordName.Support;
 
 export type NumericKeywordName =
   | KeywordName.Raid

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -516,7 +516,7 @@ interface IKeywordPropertiesBase {
     keyword: KeywordName;
 }
 
-interface INumericKeywordProperties extends IKeywordPropertiesBase {
+export interface INumericKeywordProperties extends IKeywordPropertiesBase {
     amount: number;
 }
 
@@ -606,6 +606,20 @@ export type NonParameterKeywordName =
   | KeywordName.Sentinel
   | KeywordName.Shielded
   | KeywordName.Support;
+
+export type NonNumericKeywordName =
+  | KeywordName.Ambush
+  | KeywordName.Bounty
+  | KeywordName.Coordinate
+  | KeywordName.Grit
+  | KeywordName.Hidden
+  | KeywordName.Overwhelm
+  | KeywordName.Piloting
+  | KeywordName.Plot
+  | KeywordName.Saboteur
+  | KeywordName.Sentinel
+  | KeywordName.Shielded
+  | KeywordName.Smuggle;
 
 export type NumericKeywordName =
   | KeywordName.Raid

--- a/server/game/abilities/keyword/AmbushAbility.ts
+++ b/server/game/abilities/keyword/AmbushAbility.ts
@@ -4,6 +4,7 @@ import type { Card } from '../../core/card/Card';
 import { KeywordName, WildcardZoneName } from '../../core/Constants';
 import type { Game } from '../../core/Game';
 import { Contract } from '../../core/utils/Contract';
+import { TextHelper } from '../../core/utils/TextHelper';
 import { ConditionalSystem } from '../../gameSystems/ConditionalSystem';
 import { InitiateAttackSystem } from '../../gameSystems/InitiateAttackSystem';
 import { NoActionSystem } from '../../gameSystems/NoActionSystem';
@@ -17,7 +18,7 @@ export class AmbushAbility extends TriggeredAbilityBase {
 
     public static buildAmbushAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {
-            title: 'Ambush',
+            title: `${TextHelper.Ambush}`,
             optional: true,
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,

--- a/server/game/abilities/keyword/BountyAbility.ts
+++ b/server/game/abilities/keyword/BountyAbility.ts
@@ -6,6 +6,7 @@ import { EventName, KeywordName, RelativePlayer, SubStepCheck, WildcardZoneName 
 import { GameEvent } from '../../core/event/GameEvent';
 import type { Game } from '../../core/Game';
 import { Contract } from '../../core/utils/Contract';
+import { TextHelper } from '../../core/utils/TextHelper';
 import type { ITriggeredAbilityBaseProps } from '../../Interfaces';
 
 import { registerState } from '../../core/GameObjectUtils';
@@ -36,7 +37,7 @@ export class BountyAbility extends TriggeredAbilityBase {
 
         const fullProps = {
             ...properties,
-            title: 'Collect Bounty: ' + title,
+            title: `Collect ${TextHelper.Bounty}: ${title}`,
             // 7.5.13.E : Resolving a Bounty ability is optional. If a player chooses not to resolve a Bounty ability, they are not considered to have collected that Bounty.
             // however, we do allow overriding the optional behavior in some special cases (e.g. for readying resources or Bossk ability)
             optional: optional ?? true,

--- a/server/game/abilities/keyword/PlotAbility.ts
+++ b/server/game/abilities/keyword/PlotAbility.ts
@@ -3,6 +3,7 @@ import type { Card } from '../../core/card/Card';
 import { KeywordName, PlayType, WildcardCardType, ZoneName } from '../../core/Constants';
 import type { Game } from '../../core/Game';
 import { Contract } from '../../core/utils/Contract';
+import { TextHelper } from '../../core/utils/TextHelper';
 import { PlayCardSystem } from '../../gameSystems/PlayCardSystem';
 import { ResourceCardSystem } from '../../gameSystems/ResourceCardSystem';
 import type { ITriggeredAbilityProps } from '../../Interfaces';
@@ -15,7 +16,7 @@ export class PlotAbility extends TriggeredAbilityBase {
 
     public static buildPlotAbilityProperties<TSource extends Card = Card>(cardTitle: string): ITriggeredAbilityProps<TSource> {
         return {
-            title: `Play ${cardTitle} using Plot`,
+            title: `Play ${cardTitle} using ${TextHelper.Plot}`,
             optional: true,
             when: {
                 onLeaderDeployed: (event, context) => event.card.owner === context.source.controller && context.source.zoneName === ZoneName.Resource // TODO See if we can remove this zone check once we update Plot registration

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -5,6 +5,7 @@ import type { Card } from '../../core/card/Card';
 import { KeywordName, WildcardZoneName } from '../../core/Constants';
 import type { Game } from '../../core/Game';
 import { Contract } from '../../core/utils/Contract';
+import { TextHelper } from '../../core/utils/TextHelper';
 import { DefeatCardSystem } from '../../gameSystems/DefeatCardSystem';
 import type { ITriggeredAbilityProps } from '../../Interfaces';
 
@@ -16,7 +17,7 @@ export class SaboteurDefeatShieldsAbility extends TriggeredAbilityBase {
 
     public static buildSaboteurAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {
-            title: 'Saboteur: defeat all shields',
+            title: `${TextHelper.Saboteur}: defeat all shields`,
             when: {
                 onAttackDeclared: (event, context) => event.attack.attacker === context.source &&
                   event.attack.attacker.isUnit() &&

--- a/server/game/abilities/keyword/ShieldedAbility.ts
+++ b/server/game/abilities/keyword/ShieldedAbility.ts
@@ -3,6 +3,7 @@ import type { Card } from '../../core/card/Card';
 import { KeywordName, WildcardZoneName } from '../../core/Constants';
 import type { Game } from '../../core/Game';
 import { Contract } from '../../core/utils/Contract';
+import { TextHelper } from '../../core/utils/TextHelper';
 import { GiveShieldSystem } from '../../gameSystems/GiveShieldSystem';
 import type { ITriggeredAbilityProps } from '../../Interfaces';
 
@@ -14,7 +15,7 @@ export class ShieldedAbility extends TriggeredAbilityBase {
 
     public static buildShieldedAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {
-            title: 'Shielded',
+            title: `${TextHelper.Shielded}`,
             when: {
                 onCardPlayed: (event, context) => event.card === context.source,
                 onLeaderDeployed: (event, context) => event.card === context.source,

--- a/server/game/actions/PlayUnitAction.ts
+++ b/server/game/actions/PlayUnitAction.ts
@@ -4,6 +4,7 @@ import { PutIntoPlaySystem } from '../gameSystems/PutIntoPlaySystem.js';
 import type { PlayCardContext, IPlayCardActionProperties } from '../core/ability/PlayCardAction.js';
 import { PlayCardAction } from '../core/ability/PlayCardAction.js';
 import { Contract } from '../core/utils/Contract.js';
+import { TextHelper } from '../core/utils/TextHelper.js';
 import type { Card } from '../core/card/Card.js';
 import type { Game } from '../core/Game';
 import type { FormatMessage } from '../core/chat/GameChat.js';
@@ -52,7 +53,7 @@ export abstract class PlayUnitActionBase extends PlayCardAction {
     public override displayMessage(context: AbilityContext): void {
         let playTypeDescription = '';
         if (context.playType === PlayType.Smuggle) {
-            playTypeDescription = ' using Smuggle';
+            playTypeDescription = ` using ${TextHelper.Smuggle}`;
         }
         let costDescription: FormatMessage | string = '';
         const costMessages = this.getCostsMessages(context);

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -8,6 +8,7 @@ import type { Restriction } from '../core/ongoingEffect/effectImpl/Restriction';
 import type { Player } from '../core/Player';
 import type { Game } from '../core/Game';
 import { Contract } from '../core/utils/Contract';
+import { TextHelper } from '../core/utils/TextHelper';
 import { ChatHelpers } from '../core/chat/ChatHelpers.js';
 import { AttachUpgradeSystem } from '../gameSystems/AttachUpgradeSystem';
 import { attachUpgrade } from '../gameSystems/GameSystemLibrary';
@@ -96,9 +97,9 @@ export class PlayUpgradeAction extends PlayCardAction {
     public override displayMessage(context: AbilityContext) {
         let playTypeDescription = '';
         if (context.playType === PlayType.Smuggle) {
-            playTypeDescription = ' using Smuggle';
+            playTypeDescription = ` using ${TextHelper.Smuggle}`;
         } else if (context.playType === PlayType.Piloting) {
-            playTypeDescription = ' with Piloting';
+            playTypeDescription = ` with ${TextHelper.Piloting}`;
         }
         const locationDescription = ChatHelpers.getTargetLocationMessage(context.source, context, new Set([ZoneName.Hand]));
         context.game.addMessage('{0} plays {1}{2}{3}, attaching it to {4}', context.player, context.source, locationDescription, playTypeDescription, context.target);

--- a/server/game/cards/01_SOR/events/PrecisionFire.ts
+++ b/server/game/cards/01_SOR/events/PrecisionFire.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PrecisionFire extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PrecisionFire extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a unit. It gains Saboteur for this attack. If it’s a Trooper, it also gets +2/+0 for this attack.',
+            title: `Attack with a unit. It gains ${TextHelper.Saboteur} for this attack. If it’s a Trooper, it also gets +2/+0 for this attack.`,
             initiateAttack: {
                 attackerLastingEffects: [
                     { effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur) },

--- a/server/game/cards/01_SOR/events/RallyingCry.ts
+++ b/server/game/cards/01_SOR/events/RallyingCry.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RallyingCry extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RallyingCry extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Each friendly unit gains Raid 2 this phase',
+            title: `Each friendly unit gains ${TextHelper.Raid(2)} this phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 }),
                 target: context.player.getArenaUnits()

--- a/server/game/cards/01_SOR/leaders/IG88RuthlessBountyHunter.ts
+++ b/server/game/cards/01_SOR/leaders/IG88RuthlessBountyHunter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class IG88RuthlessBountyHunter extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -30,7 +31,7 @@ export default class IG88RuthlessBountyHunter extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Raid 1',
+            title: `Each other friendly unit gains ${TextHelper.Raid(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit(),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
                 keyword: KeywordName.Raid,

--- a/server/game/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.ts
+++ b/server/game/cards/01_SOR/units/AdmiralPiettCaptainOfTheExecutor.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AdmiralPiettCaptainOfTheExecutor extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class AdmiralPiettCaptainOfTheExecutor extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly non-leader unit that costs 6 or more gains Ambush',
+            title: `Each friendly non-leader unit that costs 6 or more gains ${TextHelper.Ambush}`,
             targetController: RelativePlayer.Self,
             matchTarget: (card) => card.isNonLeaderUnit() && card.cost >= 6,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)

--- a/server/game/cards/01_SOR/units/BazeMalbusTempleGuardian.ts
+++ b/server/game/cards/01_SOR/units/BazeMalbusTempleGuardian.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BazeMalbusTempleGuardian extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class BazeMalbusTempleGuardian extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you have the initiative, this unit gains Sentinel',
+            title: `While you have the initiative, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasInitiative(),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/01_SOR/units/BenthicTwoTubes.ts
+++ b/server/game/cards/01_SOR/units/BenthicTwoTubes.ts
@@ -14,7 +14,7 @@ export default class BenthicTwoTubes extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `Give Raid 2 to a friendly ${TextHelper.Aggression} unit`,
+            title: `Give ${TextHelper.Raid(2)} to a friendly ${TextHelper.Aggression} unit`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardCondition: (card, context) => card !== context.source && card.isUnit() && card.hasSomeAspect(Aspect.Aggression),

--- a/server/game/cards/01_SOR/units/ChopperMetalMenace.ts
+++ b/server/game/cards/01_SOR/units/ChopperMetalMenace.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ChopperMetalMenace extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -28,7 +29,7 @@ export default class ChopperMetalMenace extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'While you control another Spectre unit, Chopper gains Raid 1',
+            title: `While you control another Spectre unit, Chopper gains ${TextHelper.Raid(1)}`,
             condition: (context) => context.player.hasSomeArenaUnit({ otherThan: context.source, trait: Trait.Spectre }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/01_SOR/units/ConsortiumStarViper.ts
+++ b/server/game/cards/01_SOR/units/ConsortiumStarViper.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ConsortiumStarViper extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class ConsortiumStarViper extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you have the initiative, this unit gains Restore 2.',
+            title: `While you have the initiative, this unit gains ${TextHelper.Restore(2)}.`,
             condition: (context) => context.player.hasInitiative(),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 }),
         });

--- a/server/game/cards/01_SOR/units/EmperorsRoyalGuard.ts
+++ b/server/game/cards/01_SOR/units/EmperorsRoyalGuard.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class EmperorsRoyalGuard extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class EmperorsRoyalGuard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control an Official unit, this gains Sentinel',
+            title: `While you control an Official unit, this gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasSomeArenaUnit({ trait: Trait.Official }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel })
         });

--- a/server/game/cards/01_SOR/units/EscortSkiff.ts
+++ b/server/game/cards/01_SOR/units/EscortSkiff.ts
@@ -14,7 +14,7 @@ export default class EscortSkiff extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Gain Ambush while you control another ${TextHelper.Command} unit`,
+            title: `Gain ${TextHelper.Ambush} while you control another ${TextHelper.Command} unit`,
             condition: (context) => context.player.isAspectInPlay(Aspect.Command, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/01_SOR/units/FifthBrotherFearHunter.ts
+++ b/server/game/cards/01_SOR/units/FifthBrotherFearHunter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FifthBrotherFearHunter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -30,7 +31,7 @@ export default class FifthBrotherFearHunter extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'This unit gains Raid 1 for each damage on him',
+            title: `This unit gains ${TextHelper.Raid(1)} for each damage on him`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(
                 (target) => ({ keyword: KeywordName.Raid, amount: target.damage })
             )

--- a/server/game/cards/01_SOR/units/FirstLegionSnowtrooper.ts
+++ b/server/game/cards/01_SOR/units/FirstLegionSnowtrooper.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FirstLegionSnowtrooper extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class FirstLegionSnowtrooper extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While attacking a damaged unit, this unit gets +2/+0 and gains Overwhelm.',
+            title: `While attacking a damaged unit, this unit gets +2/+0 and gains ${TextHelper.Overwhelm}.`,
             condition: (context) => context.source.isAttacking() && context.source.activeAttack?.targetIsUnit((card) => card.damage > 0),
             ongoingEffect: [AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm), AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })],
         });

--- a/server/game/cards/01_SOR/units/FrontierATRT.ts
+++ b/server/game/cards/01_SOR/units/FrontierATRT.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FrontierATRT extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class FrontierATRT extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Gain Ambush while you control another Vehicle unit',
+            title: `Gain ${TextHelper.Ambush} while you control another Vehicle unit`,
             condition: (context) => context.player.isTraitInPlay(Trait.Vehicle, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/01_SOR/units/GamorreanGuards.ts
+++ b/server/game/cards/01_SOR/units/GamorreanGuards.ts
@@ -14,7 +14,7 @@ export default class GamorreanGuards extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another ${TextHelper.Cunning} unit, this unit gains Sentinel`,
+            title: `While you control another ${TextHelper.Cunning} unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.isAspectInPlay(Aspect.Cunning, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/01_SOR/units/HomeOneAllianceFlagship.ts
+++ b/server/game/cards/01_SOR/units/HomeOneAllianceFlagship.ts
@@ -28,7 +28,7 @@ export default class HomeOneAllianceFlagship extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Restore 1.',
+            title: `Each other friendly unit gains ${TextHelper.Restore(1)}.`,
             matchTarget: (card, context) => card.isUnit() && card.controller === context.player && card !== context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 })
         });

--- a/server/game/cards/01_SOR/units/HomesteadMilitia.ts
+++ b/server/game/cards/01_SOR/units/HomesteadMilitia.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HomesteadMilitia extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class HomesteadMilitia extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control 6 or more resources, this unit gains Sentinel',
+            title: `While you control 6 or more resources, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.resources.length >= 6,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/01_SOR/units/PartisanInsurgent.ts
+++ b/server/game/cards/01_SOR/units/PartisanInsurgent.ts
@@ -14,7 +14,7 @@ export default class PartisanInsurgent extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another ${TextHelper.Aggression} unit, this unit gains Raid 2`,
+            title: `While you control another ${TextHelper.Aggression} unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isAspectInPlay(Aspect.Aggression, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/01_SOR/units/RedThreeUnstoppable.ts
+++ b/server/game/cards/01_SOR/units/RedThreeUnstoppable.ts
@@ -14,7 +14,7 @@ export default class RedThreeUnstoppable extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each other friendly ${TextHelper.Heroism} unit gains Raid 1`,
+            title: `Each other friendly ${TextHelper.Heroism} unit gains ${TextHelper.Raid(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeAspect(Aspect.Heroism),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/01_SOR/units/SpecForceSoldier.ts
+++ b/server/game/cards/01_SOR/units/SpecForceSoldier.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SpecForceSoldier extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -18,7 +19,7 @@ export default class SpecForceSoldier extends NonLeaderUnitCard {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.loseKeyword(KeywordName.Sentinel),
-                    ongoingEffectDescription: 'remove Sentinel from'
+                    ongoingEffectDescription: `remove ${TextHelper.Sentinel} from`
                 })
             }
         });

--- a/server/game/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.ts
+++ b/server/game/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WedgeAntillesStarOfTheRebellion extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class WedgeAntillesStarOfTheRebellion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly Vehicle unit gets +1/+1 and gains Ambush.',
+            title: `Each friendly Vehicle unit gets +1/+1 and gains ${TextHelper.Ambush}.`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/02_SHD/events/BountyPosting.ts
+++ b/server/game/cards/02_SHD/events/BountyPosting.ts
@@ -14,6 +14,7 @@ export default class BountyPosting extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty" here is the Bounty trait, not the Bounty keyword
             title: 'Search your deck for a Bounty upgrade, reveal it, and draw it (shuffle your deck)',
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchWholeDeck: true,

--- a/server/game/cards/02_SHD/events/Commission.ts
+++ b/server/game/cards/02_SHD/events/Commission.ts
@@ -13,6 +13,7 @@ export default class Commission extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty" here is part of the Bounty Hunter trait, not the Bounty keyword
             title: 'Search the top 10 cards for a Bounty Hunter, Item, or Transport card, reveal it, and draw it',
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 10,

--- a/server/game/cards/02_SHD/events/RelentlessPursuit.ts
+++ b/server/game/cards/02_SHD/events/RelentlessPursuit.ts
@@ -13,6 +13,7 @@ export default class RelentlessPursuit extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait reference, not the Bounty keyword
             title: 'Choose a friendly unit. It captures an enemy non-leader unit that costs the same as or less than it. If the friendly unit is a Bounty Hunter, give a Shield token to it.',
             targetResolvers: {
                 friendlyUnit: {

--- a/server/game/cards/02_SHD/events/SwoopDown.ts
+++ b/server/game/cards/02_SHD/events/SwoopDown.ts
@@ -3,6 +3,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EffectName, KeywordName, ZoneName } from '../../../core/Constants';
 import { OngoingEffectBuilder } from '../../../core/ongoingEffect/OngoingEffectBuilder';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SwoopDown extends EventCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class SwoopDown extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a space unit. It gains Saboteur and can attack ground units for this attack. If it attacks a ground unit, it gets +2/+0 and the defender gets –2/–0 for this attack.',
+            title: `Attack with a space unit. It gains ${TextHelper.Saboteur} and can attack ground units for this attack. If it attacks a ground unit, it gets +2/+0 and the defender gets –2/–0 for this attack.`,
             initiateAttack: {
                 attackerCondition: (card) => card.zoneName === ZoneName.SpaceArena,
                 attackerLastingEffects: [

--- a/server/game/cards/02_SHD/leaders/BosskHuntingHisPrey.ts
+++ b/server/game/cards/02_SHD/leaders/BosskHuntingHisPrey.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BosskHuntingHisPrey extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BosskHuntingHisPrey extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Deal 1 damage to a unit with a Bounty. You may give it +1/+0 for this phase.',
+            title: `Deal 1 damage to a unit with a ${TextHelper.Bounty}. You may give it +1/+0 for this phase.`,
             cost: [AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -34,7 +35,7 @@ export default class BosskHuntingHisPrey extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Collect the Bounty again',
+            title: `Collect the ${TextHelper.Bounty} again`,
             optional: true,
             when: {
                 onBountyCollected: (event, context) => event.context.player === context.player

--- a/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
+++ b/server/game/cards/02_SHD/leaders/JabbaTheHuttHisHighExaltedness.ts
@@ -14,7 +14,7 @@ export default class JabbaTheHuttHisHighExaltedness extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Choose a unit. For this phase, it gains: "Bounty — The next unit you play this phase costs ${TextHelper.resource(1)} less."`,
+            title: `Choose a unit. For this phase, it gains: "${TextHelper.Bounty} — The next unit you play this phase costs ${TextHelper.resource(1)} less."`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -59,7 +59,7 @@ export default class JabbaTheHuttHisHighExaltedness extends LeaderUnitCard {
         });
 
         registrar.addActionAbility({
-            title: `Choose a unit. For this phase, it gains: "Bounty — The next unit you play this phase costs ${TextHelper.resource(2)} less."`,
+            title: `Choose a unit. For this phase, it gains: "${TextHelper.Bounty} — The next unit you play this phase costs ${TextHelper.resource(2)} less."`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/leaders/LandoCalrissianWithImpeccableTaste.ts
+++ b/server/game/cards/02_SHD/leaders/LandoCalrissianWithImpeccableTaste.ts
@@ -46,7 +46,7 @@ export default class LandoCalrissianWithImpeccableTaste extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Play a card using Smuggle. It costs ${TextHelper.resource(2)} less. Defeat a resource you own and control.`,
+            title: `Play a card using ${TextHelper.Smuggle}. It costs ${TextHelper.resource(2)} less. Defeat a resource you own and control.`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: this.buildSmuggleCardAbility(AbilityHelper),
             then: this.buildDefeatResourceAbility(AbilityHelper)
@@ -55,7 +55,7 @@ export default class LandoCalrissianWithImpeccableTaste extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Play a card using Smuggle. It costs ${TextHelper.resource(2)} less. Defeat a resource you own and control. Use this ability only once each round`,
+            title: `Play a card using ${TextHelper.Smuggle}. It costs ${TextHelper.resource(2)} less. Defeat a resource you own and control. Use this ability only once each round`,
             limit: AbilityHelper.limit.perRound(1),
             targetResolver: this.buildSmuggleCardAbility(AbilityHelper),
             then: this.buildDefeatResourceAbility(AbilityHelper)

--- a/server/game/cards/02_SHD/leaders/MoffGideonFormidableCommander.ts
+++ b/server/game/cards/02_SHD/leaders/MoffGideonFormidableCommander.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MoffGideonFormidableCommander extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -29,7 +30,7 @@ export default class MoffGideonFormidableCommander extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly unit that costs 3 or less gets +1/+0 and gains Overwhelm while attacking an enemy unit',
+            title: `Each friendly unit that costs 3 or less gets +1/+0 and gains ${TextHelper.Overwhelm} while attacking an enemy unit`,
             targetZoneFilter: WildcardZoneName.AnyArena,
             matchTarget: (card, context) => card.isUnit() && card.isAttacking() && card.controller === context.player && card.cost <= 3 && card.activeAttack?.getSingleTarget().isUnit(),
             ongoingEffect: [AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm), AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 })],

--- a/server/game/cards/02_SHD/units/4-LOMBountyHunterForHire.ts
+++ b/server/game/cards/02_SHD/units/4-LOMBountyHunterForHire.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class _4LOMBountyHunterForHire extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class _4LOMBountyHunterForHire extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly unit named Zuckuss gets +1/+1 and gains Ambush',
+            title: `Each friendly unit named Zuckuss gets +1/+1 and gains ${TextHelper.Ambush}`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card, context) => card.controller === context.player && card.title === 'Zuckuss',

--- a/server/game/cards/02_SHD/units/BountyGuildInitiate.ts
+++ b/server/game/cards/02_SHD/units/BountyGuildInitiate.ts
@@ -13,6 +13,7 @@ export default class BountyGuildInitiate extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait reference, not the Bounty keyword
             title: 'Deal 2 damage to a ground unit if you control another Bounty Hunter unit',
             optional: true,
             targetResolver: {

--- a/server/game/cards/02_SHD/units/ChainCodeCollector.ts
+++ b/server/game/cards/02_SHD/units/ChainCodeCollector.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ChainCodeCollector extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ChainCodeCollector extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'If the defender has a Bounty, it gets –4/–0 for this attack',
+            title: `If the defender has a ${TextHelper.Bounty}, it gets –4/–0 for this attack`,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => context.event.attack.targetIsUnit((card) => card.hasSomeKeyword(KeywordName.Bounty)),
                 onTrue: AbilityHelper.immediateEffects.forThisAttackCardEffect((context) => ({

--- a/server/game/cards/02_SHD/units/ClanChallengers.ts
+++ b/server/game/cards/02_SHD/units/ClanChallengers.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ClanChallengers extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ClanChallengers extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit is upgraded, it gains Overwhelm',
+            title: `While this unit is upgraded, it gains ${TextHelper.Overwhelm}`,
             condition: (context) => context.source.isUpgraded(),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm)
         });

--- a/server/game/cards/02_SHD/units/CovetousRivals.ts
+++ b/server/game/cards/02_SHD/units/CovetousRivals.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CovetousRivals extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CovetousRivals extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Deal 2 damage to a unit with a Bounty',
+            title: `Deal 2 damage to a unit with a ${TextHelper.Bounty}`,
             when: {
                 onAttack: true,
                 whenPlayed: true,

--- a/server/game/cards/02_SHD/units/EnfysNestMarauder.ts
+++ b/server/game/cards/02_SHD/units/EnfysNestMarauder.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class EnfysNestMarauder extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class EnfysNestMarauder extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'When a friendly unit is attacking using Ambush, the defender gets -3/-0',
+            title: `When a friendly unit is attacking using ${TextHelper.Ambush}, the defender gets -3/-0`,
             targetController: RelativePlayer.Opponent,
             matchTarget: (card, context) =>
                 card.isUnit() &&

--- a/server/game/cards/02_SHD/units/FirstLightHeadquartersOfTheCrimsonDawn.ts
+++ b/server/game/cards/02_SHD/units/FirstLightHeadquartersOfTheCrimsonDawn.ts
@@ -5,6 +5,7 @@ import type { IPlayCardActionOverrides } from '../../../core/card/baseClasses/Pl
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Aspect, KeywordName, PlayType, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 import { registerState } from '../../../core/GameObjectUtils';
 
@@ -26,7 +27,7 @@ export default class FirstLightHeadquartersOfTheCrimsonDawn extends NonLeaderUni
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly non-leader unit gains Grit',
+            title: `Each other friendly non-leader unit gains ${TextHelper.Grit}`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.NonLeaderUnit,
             matchTarget: (card, context) => card !== context.source,
@@ -46,7 +47,7 @@ class FirstLightSmuggleAction extends PlayUnitActionBase {
         });
 
         return {
-            title: 'Play First Light with Smuggle by dealing 4 damage to a friendly unit',
+            title: `Play First Light with ${TextHelper.Smuggle} by dealing 4 damage to a friendly unit`,
             ...properties,
             playType: PlayType.Smuggle,
             alternatePlayActionAspects: [Aspect.Vigilance, Aspect.Villainy],

--- a/server/game/cards/02_SHD/units/GamorreanRetainer.ts
+++ b/server/game/cards/02_SHD/units/GamorreanRetainer.ts
@@ -14,7 +14,7 @@ export default class GamorreanRetainer extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another ${TextHelper.Command} unit, this unit gains Sentinel`,
+            title: `While you control another ${TextHelper.Command} unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.isAspectInPlay(Aspect.Command, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.ts
+++ b/server/game/cards/02_SHD/units/GeneralRieekanDefensiveStrategist.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralRieekanDefensiveStrategist extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GeneralRieekanDefensiveStrategist extends NonLeaderUnitCard
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Choose a friendly unit. If it has Sentinel, give an Experience token to it. Otherwise, it gains Sentinel for this phase',
+            title: `Choose a friendly unit. If it has ${TextHelper.Sentinel}, give an Experience token to it. Otherwise, it gains ${TextHelper.Sentinel} for this phase`,
             when: {
                 onAttack: true,
                 whenPlayed: true,

--- a/server/game/cards/02_SHD/units/HunterOfTheHaxionBrood.ts
+++ b/server/game/cards/02_SHD/units/HunterOfTheHaxionBrood.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HunterOfTheHaxionBrood extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HunterOfTheHaxionBrood extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an enemy unit has a Bounty, this unit gains Shielded',
+            title: `While an enemy unit has a ${TextHelper.Bounty}, this unit gains ${TextHelper.Shielded}`,
             condition: (context) => context.player.opponent.isKeywordInPlay(KeywordName.Bounty),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Shielded),
         });

--- a/server/game/cards/02_SHD/units/HuntingNexu.ts
+++ b/server/game/cards/02_SHD/units/HuntingNexu.ts
@@ -14,7 +14,7 @@ export default class HuntingNexu extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another ${TextHelper.Aggression} unit, this unit gains Raid 2`,
+            title: `While you control another ${TextHelper.Aggression} unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isAspectInPlay(Aspect.Aggression, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/02_SHD/units/JangoFettRenownedBountyHunter.ts
+++ b/server/game/cards/02_SHD/units/JangoFettRenownedBountyHunter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { DefeatCardSystem } from '../../../gameSystems/DefeatCardSystem';
 
 export default class JangoFettRenownedBountyHunter extends NonLeaderUnitCard {
@@ -14,7 +15,7 @@ export default class JangoFettRenownedBountyHunter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While attacking a unit with Bounty, this unit gets +3/+0 and gains Overwhelm.',
+            title: `While attacking a unit with ${TextHelper.Bounty}, this unit gets +3/+0 and gains ${TextHelper.Overwhelm}.`,
             condition: (context) => context.source.isAttacking() && context.source.activeAttack?.targetIsUnit((card) => card.hasSomeKeyword(KeywordName.Bounty)),
             ongoingEffect: [AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm), AbilityHelper.ongoingEffects.modifyStats({ power: 3, hp: 0 })],
         });

--- a/server/game/cards/02_SHD/units/MillenniumFalconLandosPride.ts
+++ b/server/game/cards/02_SHD/units/MillenniumFalconLandosPride.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class MillenniumFalconLandosPride extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'This unit gains Ambush if it was played from hand',
+            title: `This unit gains ${TextHelper.Ambush} if it was played from hand`,
             condition: (context) => context.source.isInPlay() && this.cardsPlayedThisPhaseWatcher.someCardPlayed((entry) => entry.card === context.source && entry.inPlayId === context.source.inPlayId && entry.originalZone === ZoneName.Hand),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/02_SHD/units/PrivateerScyk.ts
+++ b/server/game/cards/02_SHD/units/PrivateerScyk.ts
@@ -14,7 +14,7 @@ export default class PrivateerScyk extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another ${TextHelper.Cunning} unit, this unit gains Shielded`,
+            title: `While you control another ${TextHelper.Cunning} unit, this unit gains ${TextHelper.Shielded}`,
             condition: (context) => context.player.isAspectInPlay(Aspect.Cunning, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Shielded)

--- a/server/game/cards/02_SHD/units/ReputableHunter.ts
+++ b/server/game/cards/02_SHD/units/ReputableHunter.ts
@@ -14,7 +14,7 @@ export default class ReputableHunter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `While an enemy unit has a Bounty, this unit costs ${TextHelper.resource(1)} less to play`,
+            title: `While an enemy unit has a ${TextHelper.Bounty}, this unit costs ${TextHelper.resource(1)} less to play`,
             condition: (context) => context.player.opponent.isKeywordInPlay(KeywordName.Bounty),
             amount: 1
         });

--- a/server/game/cards/02_SHD/units/ScanningOfficer.ts
+++ b/server/game/cards/02_SHD/units/ScanningOfficer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ScanningOfficer extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ScanningOfficer extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Reveal 3 enemy resources. Defeat each resource with Smuggle that was revealed and replace it with the top card of its controllers deck.',
+            title: `Reveal 3 enemy resources. Defeat each resource with ${TextHelper.Smuggle} that was revealed and replace it with the top card of its controllers deck.`,
             immediateEffect: AbilityHelper.immediateEffects.randomSelection((context) => ({
                 // TODO: Improve RandomSelectionSystem so that it can shuffle the resources like getRandomResources does
                 // Even if the random selection effectivaly happens in getRandomResources, we use RandomSelectionSystem
@@ -26,7 +27,7 @@ export default class ScanningOfficer extends NonLeaderUnitCard {
                 })
             })),
             then: (thenContext) => ({
-                title: 'Defeat each resource with Smuggle',
+                title: `Defeat each resource with ${TextHelper.Smuggle}`,
                 thenCondition: () => thenContext.events[0].cards.some((card) => card.hasSomeKeyword(KeywordName.Smuggle)),
                 immediateEffect: AbilityHelper.immediateEffects.simultaneous(() => {
                     const smuggleCards = thenContext.events[0].cards.filter((card) => card.hasSomeKeyword(KeywordName.Smuggle));

--- a/server/game/cards/02_SHD/units/SugiHiredGuardian.ts
+++ b/server/game/cards/02_SHD/units/SugiHiredGuardian.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SugiHiredGuardian extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SugiHiredGuardian extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Gain Sentinel while an enemy unit is upgraded',
+            title: `Gain ${TextHelper.Sentinel} while an enemy unit is upgraded`,
             condition: (context) => context.player.opponent.hasSomeArenaUnit({ condition: (card) => card.isUnit() && card.isUpgraded() }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/02_SHD/units/SynaraSanLoyalToKragan.ts
+++ b/server/game/cards/02_SHD/units/SynaraSanLoyalToKragan.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { CardType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SynaraSanLoyalToKragan extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SynaraSanLoyalToKragan extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'When this unit is exhausted, it gains \'Bounty - Deal 5 damage to a base\'',
+            title: `When this unit is exhausted, it gains '${TextHelper.Bounty} - Deal 5 damage to a base'`,
             condition: (context) => context.source.exhausted,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
                 keyword: KeywordName.Bounty,

--- a/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
+++ b/server/game/cards/02_SHD/units/TechSourceOfInsight.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TechSourceOfInsight extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TechSourceOfInsight extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly resource gains Smuggle',
+            title: `Each friendly resource gains ${TextHelper.Smuggle}`,
             targetZoneFilter: ZoneName.Resource,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Any,

--- a/server/game/cards/02_SHD/units/TheClientDictatedByDiscretion.ts
+++ b/server/game/cards/02_SHD/units/TheClientDictatedByDiscretion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { CardType, KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheClientDictatedByDiscretion extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheClientDictatedByDiscretion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'For this phase, targeted unit gains: "Bounty — Heal 5 damage from a base."',
+            title: `For this phase, targeted unit gains: "${TextHelper.Bounty} — Heal 5 damage from a base."`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/units/ToroCalicanAmbitiousUpstart.ts
+++ b/server/game/cards/02_SHD/units/ToroCalicanAmbitiousUpstart.ts
@@ -13,6 +13,7 @@ export default class ToroCalicanAmbitiousUpstart extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait, not the Bounty keyword
             title: 'Deal 1 damage to the played Bounty Hunter unit to ready this unit',
             when: {
                 onCardPlayed: (event, context) =>

--- a/server/game/cards/02_SHD/units/TrandoshanHunters.ts
+++ b/server/game/cards/02_SHD/units/TrandoshanHunters.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TrandoshanHunters extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TrandoshanHunters extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'If an enemy unit has a Bounty, give an Experience token to this unit',
+            title: `If an enemy unit has a ${TextHelper.Bounty}, give an Experience token to this unit`,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.opponent.isKeywordInPlay(KeywordName.Bounty),
                 onTrue: AbilityHelper.immediateEffects.giveExperience(),

--- a/server/game/cards/02_SHD/units/UnlicensedHeadhunter.ts
+++ b/server/game/cards/02_SHD/units/UnlicensedHeadhunter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class UnlicensedHeadhunter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class UnlicensedHeadhunter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'When this unit is exhausted, it gains \'Bounty - Heal 5 damage from your base\'',
+            title: `When this unit is exhausted, it gains '${TextHelper.Bounty} - Heal 5 damage from your base'`,
             condition: (context) => context.source.exhausted,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
                 keyword: KeywordName.Bounty,

--- a/server/game/cards/02_SHD/units/ZuckussBountyHunterForHire.ts
+++ b/server/game/cards/02_SHD/units/ZuckussBountyHunterForHire.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ZuckussBountyHunterForHire extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ZuckussBountyHunterForHire extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly unit named 4-LOM gets +1/+1 and gains Saboteur',
+            title: `Each friendly unit named 4-LOM gets +1/+1 and gains ${TextHelper.Saboteur}`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card, context) => card.controller === context.player && card.title === '4-LOM',

--- a/server/game/cards/02_SHD/upgrades/GuildTarget.ts
+++ b/server/game/cards/02_SHD/upgrades/GuildTarget.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { CardType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GuildTarget extends UpgradeCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class GuildTarget extends UpgradeCard {
         registrar.addGainKeywordTargetingAttached({
             keyword: KeywordName.Bounty,
             ability: {
-                title: 'Deal 2 damage to a base. If the Bounty unit is unique, deal 3 damage instead',
+                title: `Deal 2 damage to a base. If the ${TextHelper.Bounty} unit is unique, deal 3 damage instead`,
                 targetResolver: {
                     cardTypeFilter: CardType.Base,
                     immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({ amount: context.source.unique ? 3 : 2 })),

--- a/server/game/cards/02_SHD/upgrades/HeroicResolve.ts
+++ b/server/game/cards/02_SHD/upgrades/HeroicResolve.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HeroicResolve extends UpgradeCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HeroicResolve extends UpgradeCard {
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addGainActionAbilityTargetingAttached({
-            title: 'Attack with this unit. It gains +4/+0 and Overwhelm for this attack.',
+            title: `Attack with this unit. It gains +4/+0 and ${TextHelper.Overwhelm} for this attack.`,
             cost: [
                 AbilityHelper.costs.abilityActivationResourceCost(2),
                 AbilityHelper.costs.defeat({

--- a/server/game/cards/02_SHD/upgrades/HotshotDL44Blaster.ts
+++ b/server/game/cards/02_SHD/upgrades/HotshotDL44Blaster.ts
@@ -15,7 +15,7 @@ export default class HotshotDL44Blaster extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addTriggeredAbility({
-            title: 'When Smuggled, attack with attached unit',
+            title: 'Attack with attached unit',
             when: {
                 whenPlayedUsingSmuggle: true,
             },

--- a/server/game/cards/02_SHD/upgrades/TopTarget.ts
+++ b/server/game/cards/02_SHD/upgrades/TopTarget.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { CardType, KeywordName, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TopTarget extends UpgradeCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class TopTarget extends UpgradeCard {
         registrar.addGainKeywordTargetingAttached({
             keyword: KeywordName.Bounty,
             ability: {
-                title: 'Heal 4 damage from a unit or base. If the Bounty unit is unique, heal 6 damage instead.',
+                title: `Heal 4 damage from a unit or base. If the ${TextHelper.Bounty} unit is unique, heal 6 damage instead.`,
                 targetResolver: {
                     controller: WildcardRelativePlayer.Any,
                     cardTypeFilter: [CardType.Base, WildcardCardType.Unit],

--- a/server/game/cards/03_TWI/events/BreakingIn.ts
+++ b/server/game/cards/03_TWI/events/BreakingIn.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BreakingIn extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BreakingIn extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a unit. It gets +2/+0 and gains Saboteur for this attack.',
+            title: `Attack with a unit. It gets +2/+0 and gains ${TextHelper.Saboteur} for this attack.`,
             initiateAttack: {
                 attackerLastingEffects: [
                     { effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur) },

--- a/server/game/cards/03_TWI/events/GrimResolve.ts
+++ b/server/game/cards/03_TWI/events/GrimResolve.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrimResolve extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GrimResolve extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a non-leader unit. It gains Grit for this attack',
+            title: `Attack with a non-leader unit. It gains ${TextHelper.Grit} for this attack`,
             initiateAttack: {
                 attackerCondition: (card) => card.isNonLeaderUnit(),
                 attackerLastingEffects: {

--- a/server/game/cards/03_TWI/events/GuardingTheWay.ts
+++ b/server/game/cards/03_TWI/events/GuardingTheWay.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GuardingTheWay extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GuardingTheWay extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give Sentinel for the phase. If you have the initiative, also give that unit +2/+2 for this phase.',
+            title: `Give ${TextHelper.Sentinel} for the phase. If you have the initiative, also give that unit +2/+2 for this phase.`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.simultaneous([

--- a/server/game/cards/03_TWI/events/HeroesOnBothSides.ts
+++ b/server/game/cards/03_TWI/events/HeroesOnBothSides.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName, TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HeroesOnBothSides extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HeroesOnBothSides extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give each chosen unit +2/+2 and Saboteur for this phase',
+            title: `Give each chosen unit +2/+2 and ${TextHelper.Saboteur} for this phase`,
             targetResolvers: {
                 republicUnit: {
                     activePromptTitle: 'Choose a Republic unit',

--- a/server/game/cards/03_TWI/events/InDefenseOfKamino.ts
+++ b/server/game/cards/03_TWI/events/InDefenseOfKamino.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { AbilityType, KeywordName, Trait } from '../../../core/Constants';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class InDefenseOfKamino extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class InDefenseOfKamino extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'For this phase, each friendly Republic unit gains Restore 2 and: "When Defeated: Create a Clone Trooper token"',
+            title: `For this phase, each friendly Republic unit gains ${TextHelper.Restore(2)} and: "When Defeated: Create a Clone Trooper token"`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 effect: [
                     AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 }),

--- a/server/game/cards/03_TWI/events/PlanetaryInvasion.ts
+++ b/server/game/cards/03_TWI/events/PlanetaryInvasion.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName, TargetMode, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PlanetaryInvasion extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PlanetaryInvasion extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Ready up to 3 units. Each of those units gets +1/+0 and gains Overwhelm for this phase.',
+            title: `Ready up to 3 units. Each of those units gets +1/+0 and gains ${TextHelper.Overwhelm} for this phase.`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/03_TWI/events/SwordAndShieldManeuver.ts
+++ b/server/game/cards/03_TWI/events/SwordAndShieldManeuver.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SwordAndShieldManeuver extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SwordAndShieldManeuver extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give each friendly Trooper unit Raid 1 for this phase. Give each friendly Jedi unit Sentinel for this phase.',
+            title: `Give each friendly Trooper unit ${TextHelper.Raid(1)} for this phase. Give each friendly Jedi unit ${TextHelper.Sentinel} for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 }),

--- a/server/game/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.ts
+++ b/server/game/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CountDookuFaceOfTheConfederacy extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CountDookuFaceOfTheConfederacy extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Play a Separatist card from your hand. It gains Exploit 1.',
+            title: `Play a Separatist card from your hand. It gains ${TextHelper.Exploit(1)}.`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 controller: RelativePlayer.Self,
@@ -29,7 +30,7 @@ export default class CountDookuFaceOfTheConfederacy extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'The next Separatist card you play this phase gains Exploit 3',
+            title: `The next Separatist card you play this phase gains ${TextHelper.Exploit(3)}`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.addExploit({
                     match: (card) => card.hasSomeTrait(Trait.Separatist),

--- a/server/game/cards/03_TWI/leaders/GeneralGrievousGeneralOfTheDroidArmies.ts
+++ b/server/game/cards/03_TWI/leaders/GeneralGrievousGeneralOfTheDroidArmies.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralGrievousGeneralOfTheDroidArmies extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GeneralGrievousGeneralOfTheDroidArmies extends LeaderUnitCa
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Give a Droid unit Sentinel for this phase',
+            title: `Give a Droid unit ${TextHelper.Sentinel} for this phase`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -27,7 +28,7 @@ export default class GeneralGrievousGeneralOfTheDroidArmies extends LeaderUnitCa
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give a Droid unit +1/+0 and Sentinel for this phase',
+            title: `Give a Droid unit +1/+0 and ${TextHelper.Sentinel} for this phase`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/03_TWI/leaders/MaulARivalInDarkness.ts
+++ b/server/game/cards/03_TWI/leaders/MaulARivalInDarkness.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MaulARivalInDarkness extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MaulARivalInDarkness extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a unit. It gains Overwhelm for this attack',
+            title: `Attack with a unit. It gains ${TextHelper.Overwhelm} for this attack`,
             cost: [AbilityHelper.costs.exhaustSelf()],
             initiateAttack: {
                 attackerLastingEffects: [
@@ -25,7 +26,7 @@ export default class MaulARivalInDarkness extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Overwhelm',
+            title: `Each other friendly unit gains ${TextHelper.Overwhelm}`,
             matchTarget: (card, context) => card.isUnit() && card.controller === context.player && card !== context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Overwhelm })
         });

--- a/server/game/cards/03_TWI/leaders/PreVizslaPursuingTheThrone.ts
+++ b/server/game/cards/03_TWI/leaders/PreVizslaPursuingTheThrone.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsDrawnThisPhaseWatcher } from '../../../stateWatchers/CardsDrawnThisPhaseWatcher';
 
@@ -35,7 +36,7 @@ export default class PreVizslaPursuingTheThrone extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you have 3 or more cards in your hand, this unit gains Saboteur',
+            title: `While you have 3 or more cards in your hand, this unit gains ${TextHelper.Saboteur}`,
             condition: (context) => context.player.hand.length >= 3,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur)
         });

--- a/server/game/cards/03_TWI/units/AhsokaTanoAlwaysReadyForTrouble.ts
+++ b/server/game/cards/03_TWI/units/AhsokaTanoAlwaysReadyForTrouble.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AhsokaTanoAlwaysReadyForTrouble extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -24,7 +25,7 @@ export default class AhsokaTanoAlwaysReadyForTrouble extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'Gain Ambush',
+            title: `Gain ${TextHelper.Ambush}`,
             condition: (context) => {
                 const player = context.player;
                 const opponent = player.opponent;

--- a/server/game/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.ts
+++ b/server/game/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BoKatanKryzeDeathWatchLieutenant extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BoKatanKryzeDeathWatchLieutenant extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Mandalorian unit, this unit gains Overwhelm and Saboteur',
+            title: `While you control another Mandalorian unit, this unit gains ${TextHelper.Overwhelm} and ${TextHelper.Saboteur}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Mandalorian, context.source),
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm),

--- a/server/game/cards/03_TWI/units/CalculatingMagnaGuard.ts
+++ b/server/game/cards/03_TWI/units/CalculatingMagnaGuard.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CalculatingMagnaGuard extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class CalculatingMagnaGuard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'This unit gains Sentinel for this phase',
+            title: `This unit gains ${TextHelper.Sentinel} for this phase`,
             when: {
                 whenPlayed: true,
                 onCardDefeated: (event, context) =>

--- a/server/game/cards/03_TWI/units/CaptainTyphoProtectingTheSenator.ts
+++ b/server/game/cards/03_TWI/units/CaptainTyphoProtectingTheSenator.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CaptainTyphoProtectingTheSenator extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CaptainTyphoProtectingTheSenator extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give a unit Sentinel for this phase',
+            title: `Give a unit ${TextHelper.Sentinel} for this phase`,
             optional: false,
             when: {
                 onAttack: true,

--- a/server/game/cards/03_TWI/units/CloneCommanderCodyCommandingThe212th.ts
+++ b/server/game/cards/03_TWI/units/CloneCommanderCodyCommandingThe212th.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CloneCommanderCodyCommandingThe212th extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CloneCommanderCodyCommandingThe212th extends NonLeaderUnitC
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
-            title: 'Each other friendly unit gets +1/+1 and gains Overwhelm',
+            title: `Each other friendly unit gets +1/+1 and gains ${TextHelper.Overwhelm}`,
             type: AbilityType.Constant,
             matchTarget: (card, context) => card !== context.source,
             ongoingEffect: [

--- a/server/game/cards/03_TWI/units/CoruscantGuard.ts
+++ b/server/game/cards/03_TWI/units/CoruscantGuard.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CoruscantGuard extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,7 +15,7 @@ export default class CoruscantGuard extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Gain Ambush',
+            title: `Gain ${TextHelper.Ambush}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });
     }

--- a/server/game/cards/03_TWI/units/DaughterOfDathomir.ts
+++ b/server/game/cards/03_TWI/units/DaughterOfDathomir.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DaughterOfDathomir extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DaughterOfDathomir extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit is undamaged, it gains Restore 2',
+            title: `While this unit is undamaged, it gains ${TextHelper.Restore(2)}`,
             condition: (context) => context.source.damage === 0,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 })
         });

--- a/server/game/cards/03_TWI/units/DroidCommando.ts
+++ b/server/game/cards/03_TWI/units/DroidCommando.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DroidCommando extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DroidCommando extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Separatist unit, this unit gains Ambush',
+            title: `While you control another Separatist unit, this unit gains ${TextHelper.Ambush}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Separatist, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/03_TWI/units/DuchesssChampion.ts
+++ b/server/game/cards/03_TWI/units/DuchesssChampion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DuchesssChampion extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DuchesssChampion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Gain Sentinel while an opponent controls 3 or more units',
+            title: `Gain ${TextHelper.Sentinel} while an opponent controls 3 or more units`,
             condition: (context) => context.player.opponent.getArenaUnits().length >= 3,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/03_TWI/units/HevyStaunchMartyr.ts
+++ b/server/game/cards/03_TWI/units/HevyStaunchMartyr.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HevyStaunchMartyr extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class HevyStaunchMartyr extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Gain Raid 2',
+            title: `Gain ${TextHelper.Raid(2)}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 }),
         });
 

--- a/server/game/cards/03_TWI/units/InfantryOfThe212th.ts
+++ b/server/game/cards/03_TWI/units/InfantryOfThe212th.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class InfantryOfThe212th extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,7 +15,7 @@ export default class InfantryOfThe212th extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Sentinel',
+            title: `${TextHelper.Sentinel}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });
     }

--- a/server/game/cards/03_TWI/units/JynErsoStardust.ts
+++ b/server/game/cards/03_TWI/units/JynErsoStardust.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class JynErsoStardust extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an enemy unit has been defeated this phase, this unit gets +1/+0 and gains Saboteur',
+            title: `While an enemy unit has been defeated this phase, this unit gets +1/+0 and gains ${TextHelper.Saboteur}`,
             condition: (context) => this.cardsDefeatedThisPhaseWatcher.someDefeatedUnitControlledByPlayer(context.player.opponent),
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 }),

--- a/server/game/cards/03_TWI/units/LuminaraUnduliSoftSpokenMaster.ts
+++ b/server/game/cards/03_TWI/units/LuminaraUnduliSoftSpokenMaster.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, CardType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LuminaraUnduliSoftSpokenMaster extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class LuminaraUnduliSoftSpokenMaster extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Gain Grit',
+            title: `Gain ${TextHelper.Grit}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Grit),
         });
 

--- a/server/game/cards/03_TWI/units/OutspokenRepresentative.ts
+++ b/server/game/cards/03_TWI/units/OutspokenRepresentative.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class OutspokenRepresentative extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class OutspokenRepresentative extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Republic unit, this unit gains Sentinel.',
+            title: `While you control another Republic unit, this unit gains ${TextHelper.Sentinel}.`,
             condition: (context) => context.player.isTraitInPlay(Trait.Republic, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel })
         });

--- a/server/game/cards/03_TWI/units/PloKoonKohtoyah.ts
+++ b/server/game/cards/03_TWI/units/PloKoonKohtoyah.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PloKoonKohtoyah extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class PloKoonKohtoyah extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Gain Raid 3',
+            title: `Gain ${TextHelper.Raid(3)}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 3 }),
         });
     }

--- a/server/game/cards/03_TWI/units/RepublicCommando.ts
+++ b/server/game/cards/03_TWI/units/RepublicCommando.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RepublicCommando extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,7 +15,7 @@ export default class RepublicCommando extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Constant,
-            title: 'Gain Saboteur',
+            title: `Gain ${TextHelper.Saboteur}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur)
         });
     }

--- a/server/game/cards/03_TWI/units/SeparatistCommando.ts
+++ b/server/game/cards/03_TWI/units/SeparatistCommando.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SeparatistCommando extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SeparatistCommando extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Separatist unit, this unit gains Raid 2',
+            title: `While you control another Separatist unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Separatist, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/03_TWI/upgrades/ForTheRepublic.ts
+++ b/server/game/cards/03_TWI/upgrades/ForTheRepublic.ts
@@ -22,7 +22,7 @@ export default class ForTheRepublic extends UpgradeCard {
         registrar.addGainKeywordTargetingAttached({
             keyword: KeywordName.Coordinate,
             ability: {
-                title: 'Gain Restore 2',
+                title: `Gain ${TextHelper.Restore(2)}`,
                 type: AbilityType.Constant,
                 ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({
                     keyword: KeywordName.Restore,

--- a/server/game/cards/04_JTL/events/Diversion.ts
+++ b/server/game/cards/04_JTL/events/Diversion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Diversion extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Diversion extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give a unit Sentinel for this phase',
+            title: `Give a unit ${TextHelper.Sentinel} for this phase`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({

--- a/server/game/cards/04_JTL/events/InTheHeatOfBattle.ts
+++ b/server/game/cards/04_JTL/events/InTheHeatOfBattle.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class InTheHeatOfBattle extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class InTheHeatOfBattle extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Each unit gains Sentinel and loses Saboteur for this phase.',
+            title: `Each unit gains ${TextHelper.Sentinel} and loses ${TextHelper.Saboteur} for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.game.getArenaUnits(),
                 effect: [

--- a/server/game/cards/04_JTL/events/TimelyReinforcements.ts
+++ b/server/game/cards/04_JTL/events/TimelyReinforcements.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TimelyReinforcements extends EventCard {
     protected override getImplementationId() {
@@ -19,7 +20,7 @@ export default class TimelyReinforcements extends EventCard {
                 target: context.player,
             })),
             then: (thenContext) => ({
-                title: 'Give them Sentinel for this phase',
+                title: `Give them ${TextHelper.Sentinel} for this phase`,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel }),
                     target: thenContext.resolvedEvents[0]?.generatedTokens

--- a/server/game/cards/04_JTL/leaders/RioDurantWisecrackingWheelman.ts
+++ b/server/game/cards/04_JTL/leaders/RioDurantWisecrackingWheelman.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RioDurantWisecrackingWheelman extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class RioDurantWisecrackingWheelman extends LeaderUnitCard {
         registrar.addPilotDeploy();
 
         registrar.addActionAbility({
-            title: 'Attack with a space unit. It gets +1/+0 and gains Saboteur for this attack',
+            title: `Attack with a space unit. It gets +1/+0 and gains ${TextHelper.Saboteur} for this attack`,
             cost: [AbilityHelper.costs.exhaustSelf(), AbilityHelper.costs.abilityActivationResourceCost(1)],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/04_JTL/leaders/WedgeAntillesLeaderOfRedSquadron.ts
+++ b/server/game/cards/04_JTL/leaders/WedgeAntillesLeaderOfRedSquadron.ts
@@ -25,7 +25,7 @@ export default class WedgeAntillesLeaderOfRedSquadron extends LeaderUnitCard {
         registrar.addPilotDeploy();
 
         registrar.addActionAbility({
-            title: `Play a card from your hand using Piloting. It costs ${TextHelper.resource(1)} less.`,
+            title: `Play a card from your hand using ${TextHelper.Piloting}. It costs ${TextHelper.resource(1)} less.`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/04_JTL/units/AdmiralYularenFleetCoordinator.ts
+++ b/server/game/cards/04_JTL/units/AdmiralYularenFleetCoordinator.ts
@@ -1,8 +1,8 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
-import * as KeywordHelpers from '../../../core/ability/KeywordHelpers';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName, TargetMode, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { KeywordNameOrProperties } from '../../../Interfaces';
 import type { Player } from '../../../core/Player';
 
@@ -15,18 +15,24 @@ export default class AdmiralYularenFleetCoordinator extends NonLeaderUnitCard {
     }
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        const grit = TextHelper.Grit;
+        const restore1 = TextHelper.Restore(1);
+        const sentinel = TextHelper.Sentinel;
+        const shielded = TextHelper.Shielded;
+
         registrar.addWhenPlayedAbility({
-            title: `Choose Grit, Restore 1, Sentinel, or Shielded. While ${this.title} is in play, each friendly Vehicle unit gains the chosen keyword.`,
+            title: `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}. While ${this.title} is in play, each friendly Vehicle unit gains the chosen keyword.`,
+            contextTitle: (context) => `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}. While ${context.source.title} is in play, each friendly Vehicle unit gains the chosen keyword.`,
             targetResolver: {
                 mode: TargetMode.Select,
-                activePromptTitle: 'Choose Grit, Restore 1, Sentinel, or Shielded',
+                activePromptTitle: `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}`,
                 choices: (context) => {
                     const playedByPlayer = context.player;
                     return {
-                        ['Grit']: this.buildYularenEffect(KeywordName.Grit, AbilityHelper, playedByPlayer),
-                        ['Restore 1']: this.buildYularenEffect({ keyword: KeywordName.Restore, amount: 1 }, AbilityHelper, playedByPlayer),
-                        ['Sentinel']: this.buildYularenEffect(KeywordName.Sentinel, AbilityHelper, playedByPlayer),
-                        ['Shielded']: this.buildYularenEffect(KeywordName.Shielded, AbilityHelper, playedByPlayer)
+                        [grit]: this.buildYularenEffect(KeywordName.Grit, AbilityHelper, playedByPlayer),
+                        [restore1]: this.buildYularenEffect({ keyword: KeywordName.Restore, amount: 1 }, AbilityHelper, playedByPlayer),
+                        [sentinel]: this.buildYularenEffect(KeywordName.Sentinel, AbilityHelper, playedByPlayer),
+                        [shielded]: this.buildYularenEffect(KeywordName.Shielded, AbilityHelper, playedByPlayer)
                     };
                 }
             }
@@ -35,11 +41,11 @@ export default class AdmiralYularenFleetCoordinator extends NonLeaderUnitCard {
 
     private buildYularenEffect(choice: KeywordNameOrProperties, AbilityHelper: IAbilityHelper, playedByPlayer: Player) {
         return AbilityHelper.immediateEffects.whileSourceInPlayCardEffect({
-            ongoingEffectDescription: `give ${KeywordHelpers.keywordDescription(choice)} to`,
+            ongoingEffectDescription: `give ${TextHelper.keyword(choice)} to`,
             ongoingEffectTargetDescription: 'each friendly Vehicle unit',
             effect: AbilityHelper.ongoingEffects.gainAbility({
                 type: AbilityType.Constant,
-                title: `Friendly Vehicle units gains ${choice}`,
+                title: `Friendly Vehicle units gains ${TextHelper.keyword(choice)}`,
                 targetController: WildcardRelativePlayer.Any,
                 targetCardTypeFilter: WildcardCardType.Unit,
                 matchTarget: (card) => card.hasSomeTrait(Trait.Vehicle) && card.controller === playedByPlayer,

--- a/server/game/cards/04_JTL/units/BunkerDefender.ts
+++ b/server/game/cards/04_JTL/units/BunkerDefender.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BunkerDefender extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class BunkerDefender extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a Vehicle unit, this unit gains Sentinel',
+            title: `While you control a Vehicle unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Vehicle),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/04_JTL/units/CaptainTarkinFullForwardAssault.ts
+++ b/server/game/cards/04_JTL/units/CaptainTarkinFullForwardAssault.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CaptainTarkinFullForwardAssault extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CaptainTarkinFullForwardAssault extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly Vehicle unit gets +1/+0 and gains Overwhelm',
+            title: `Each friendly Vehicle unit gets +1/+0 and gains ${TextHelper.Overwhelm}`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/04_JTL/units/FirstOrderTIEFighter.ts
+++ b/server/game/cards/04_JTL/units/FirstOrderTIEFighter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FirstOrderTIEFighter extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class FirstOrderTIEFighter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a token unit, this unit gain Raid 1',
+            title: `While you control a token unit, this unit gain ${TextHelper.Raid(1)}`,
             condition: (context) => context.player.hasSomeArenaUnit({ condition: (card) => card.isTokenUnit() }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/04_JTL/units/FlankingFangFighter.ts
+++ b/server/game/cards/04_JTL/units/FlankingFangFighter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FlankingFangFighter extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class FlankingFangFighter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Fighter unit, this unit gains Raid 2',
+            title: `While you control another Fighter unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Fighter, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/04_JTL/units/GeneralHuxNoTermsNoSurrender.ts
+++ b/server/game/cards/04_JTL/units/GeneralHuxNoTermsNoSurrender.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class GeneralHuxNoTermsNoSurrender extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly First Order unit gains Raid 1',
+            title: `Each other friendly First Order unit gains ${TextHelper.Raid(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.FirstOrder),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/04_JTL/units/IndependentSmuggler.ts
+++ b/server/game/cards/04_JTL/units/IndependentSmuggler.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class IndependentSmuggler extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class IndependentSmuggler extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addPilotingConstantAbilityTargetingAttached({
-            title: 'Attached unit gains Raid 1',
+            title: `Attached unit gains ${TextHelper.Raid(1)}`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });
     }

--- a/server/game/cards/04_JTL/units/LeiaOrganaPilotsToYourStations.ts
+++ b/server/game/cards/04_JTL/units/LeiaOrganaPilotsToYourStations.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LeiaOrganaPilotsToYourStations extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class LeiaOrganaPilotsToYourStations extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Attack with a Pilot unit or a unit with a Pilot on it. It gets +1/+0 and gainsRestore 1 for this attack.',
+            title: `Attack with a Pilot unit or a unit with a Pilot on it. It gets +1/+0 and gains ${TextHelper.Restore(1)} for this attack.`,
             optional: true,
             initiateAttack: {
                 attackerCondition: (card) => card.isUnit() && (card.hasSomeTrait(Trait.Pilot) || card.upgrades.some((upgrade) => upgrade.hasSomeTrait(Trait.Pilot))),

--- a/server/game/cards/04_JTL/units/PhantomIiModifiedToDock.ts
+++ b/server/game/cards/04_JTL/units/PhantomIiModifiedToDock.ts
@@ -5,6 +5,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, KeywordName, WildcardRelativePlayer } from '../../../core/Constants';
 import type { Player } from '../../../core/Player';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PhantomIiModifiedToDock extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -45,7 +46,7 @@ export default class PhantomIiModifiedToDock extends NonLeaderUnitCard {
 
         // TODO: rework things a bit so we don't have to declare this as a piloting ability when it technically isn't
         registrar.addPilotingAbility({
-            title: 'Attached unit gets +3/+3 and gains Grit',
+            title: `Attached unit gets +3/+3 and gains ${TextHelper.Grit}`,
             type: AbilityType.Constant,
             condition: (context) => context.source.isAttached(),
             matchTarget: (card, context) => card === context.source.parentCard,

--- a/server/game/cards/04_JTL/units/RaddusHoldosFinalCommand.ts
+++ b/server/game/cards/04_JTL/units/RaddusHoldosFinalCommand.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RaddusHoldosFinalCommand extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RaddusHoldosFinalCommand extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another resistance card, this unit gains Sentinel',
+            title: `While you control another resistance card, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.controlsCardWithTrait(Trait.Resistance, false, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/04_JTL/units/VonregsTieInterceptorAceOfTheFirstOrder.ts
+++ b/server/game/cards/04_JTL/units/VonregsTieInterceptorAceOfTheFirstOrder.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class VonregsTieInterceptorAceOfTheFirstOrder extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,13 +14,13 @@ export default class VonregsTieInterceptorAceOfTheFirstOrder extends NonLeaderUn
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit has 4 or more power, it gains Overwhelm.',
+            title: `While this unit has 4 or more power, it gains ${TextHelper.Overwhelm}.`,
             condition: (context) => context.source.getPower() >= 4,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm)
         });
 
         registrar.addConstantAbility({
-            title: 'While this unit has 6 or more power, it gains Raid 1.',
+            title: `While this unit has 6 or more power, it gains ${TextHelper.Raid(1)}.`,
             condition: (context) => context.source.getPower() >= 6,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/05_LOF/events/FocusDeterminesReality.ts
+++ b/server/game/cards/05_LOF/events/FocusDeterminesReality.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FocusDeterminesReality extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class FocusDeterminesReality extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Each friendly Force unit gains Raid 1 and Saboteur for this phase.',
+            title: `Each friendly Force unit gains ${TextHelper.Raid(1)} and ${TextHelper.Saboteur} for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 }),

--- a/server/game/cards/05_LOF/events/ForceIllusion.ts
+++ b/server/game/cards/05_LOF/events/ForceIllusion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ForceIllusion extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ForceIllusion extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Exhaust an enemy unit. A friendly unit gains Sentinel for this phase',
+            title: `Exhaust an enemy unit. A friendly unit gains ${TextHelper.Sentinel} for this phase`,
             immediateEffect: AbilityHelper.immediateEffects.sequential([
                 AbilityHelper.immediateEffects.selectCard({
                     activePromptTitle: 'Exhaust an enemy unit',
@@ -22,7 +23,7 @@ export default class ForceIllusion extends EventCard {
                     immediateEffect: AbilityHelper.immediateEffects.exhaust()
                 }),
                 AbilityHelper.immediateEffects.selectCard({
-                    activePromptTitle: 'A friendly unit gains Sentinel for this phase',
+                    activePromptTitle: `A friendly unit gains ${TextHelper.Sentinel} for this phase`,
                     controller: RelativePlayer.Self,
                     cardTypeFilter: WildcardCardType.Unit,
                     immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({

--- a/server/game/cards/05_LOF/events/InTheShadows.ts
+++ b/server/game/cards/05_LOF/events/InTheShadows.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, TargetMode, RelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class InTheShadows extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class InTheShadows extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give an Experience token to up to 3 friendly units with Hidden',
+            title: `Give an Experience token to up to 3 friendly units with ${TextHelper.Hidden}`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/05_LOF/events/ShienFlurry.ts
+++ b/server/game/cards/05_LOF/events/ShienFlurry.ts
@@ -10,6 +10,7 @@ import {
     ZoneName
 } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class ShienFlurry extends EventCard {
@@ -22,7 +23,7 @@ export default class ShienFlurry extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Play a Force unit from your hand. It gains Ambush for this phase. The next time it would be dealt damage this phase prevent 2 of that damage',
+            title: `Play a Force unit from your hand. It gains ${TextHelper.Ambush} for this phase. The next time it would be dealt damage this phase prevent 2 of that damage`,
             cannotTargetFirst: true,
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/events/ThreeLessons.ts
+++ b/server/game/cards/05_LOF/events/ThreeLessons.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ThreeLessons extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ThreeLessons extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Play a unit from your hand. It gains Hidden for this phase. Give an Experience token and a Shield token to it.',
+            title: `Play a unit from your hand. It gains ${TextHelper.Hidden} for this phase. Give an Experience token and a Shield token to it.`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/leaders/AhsokaTanoFightingForPeace.ts
+++ b/server/game/cards/05_LOF/leaders/AhsokaTanoFightingForPeace.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AhsokaTanoFightingForPeace extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class AhsokaTanoFightingForPeace extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Give a friendly unit Sentinel for this phase',
+            title: `Give a friendly unit ${TextHelper.Sentinel} for this phase`,
             cost: [AbilityHelper.costs.exhaustSelf(), AbilityHelper.costs.useTheForce()],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -27,7 +28,7 @@ export default class AhsokaTanoFightingForPeace extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give a friendly unit Sentinel for this phase',
+            title: `Give a friendly unit ${TextHelper.Sentinel} for this phase`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/leaders/AvarKrissMarshalOfStarlight.ts
+++ b/server/game/cards/05_LOF/leaders/AvarKrissMarshalOfStarlight.ts
@@ -3,6 +3,7 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { ForceUsedThisPhaseWatcher } from '../../../stateWatchers/ForceUsedThisPhaseWatcher';
 
 export default class AvarKrissMarshalOfStarlight extends LeaderUnitCard {
@@ -36,7 +37,7 @@ export default class AvarKrissMarshalOfStarlight extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While the Force is with you, this units gets +4/+0 and gains Overwhelm',
+            title: `While the Force is with you, this units gets +4/+0 and gains ${TextHelper.Overwhelm}`,
             condition: (context) => context.player.hasTheForce,
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.modifyStats({ power: 4, hp: 0 }),

--- a/server/game/cards/05_LOF/leaders/MorganElsbethFollowingTheCall.ts
+++ b/server/game/cards/05_LOF/leaders/MorganElsbethFollowingTheCall.ts
@@ -34,7 +34,7 @@ export default class MorganElsbethFollowingTheCall extends LeaderUnitCard {
                     cardCondition: (card) => this.attacksThisPhaseWatcher.cardDidAttack(card)
                 },
                 playFromHand: {
-                    activePromptTitle: 'Play a unit from you hand that shares a Keyword with the chosen unit',
+                    activePromptTitle: `Play a unit from you hand that shares a ${TextHelper.Keyword} with the chosen unit`,
                     dependsOn: 'friendlyUnit',
                     // TODO remove cardTypeFilter but fix Choose nothing button before
                     cardTypeFilter: CardType.BasicUnit,
@@ -57,7 +57,7 @@ export default class MorganElsbethFollowingTheCall extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `The next unit you play this phase costs ${TextHelper.resource(1)} less if it shares a Keyword with a friendly unit.`,
+            title: `The next unit you play this phase costs ${TextHelper.resource(1)} less if it shares a ${TextHelper.Keyword} with a friendly unit.`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/leaders/ThirdSisterSeethingWithAmbition.ts
+++ b/server/game/cards/05_LOF/leaders/ThirdSisterSeethingWithAmbition.ts
@@ -11,6 +11,7 @@ import {
     WildcardCardType,
     ZoneName
 } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class ThirdSisterSeethingWithAmbition extends LeaderUnitCard {
@@ -23,7 +24,7 @@ export default class ThirdSisterSeethingWithAmbition extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Play a unit from your hand. It gains Hidden for this phase',
+            title: `Play a unit from your hand. It gains ${TextHelper.Hidden} for this phase`,
             cost: [AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 // TODO remove cardTypeFilter but fix Choose nothing button before
@@ -47,14 +48,14 @@ export default class ThirdSisterSeethingWithAmbition extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'The next unit you play this phase gains Hidden',
+            title: `The next unit you play this phase gains ${TextHelper.Hidden}`,
             immediateEffect: AbilityHelper.immediateEffects.delayedPlayerEffect({
-                title: 'The next unit you play this phase gains Hidden',
+                title: `The next unit you play this phase gains ${TextHelper.Hidden}`,
                 when: {
                     onCardPlayed: (event, context) => this.isUnitPlayedEvent(event, context),
                 },
                 duration: Duration.UntilEndOfPhase,
-                effectDescription: 'give Hidden to the next unit they play this phase',
+                effectDescription: `give ${TextHelper.Hidden} to the next unit they play this phase`,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     target: context.events.find((event) => this.isUnitPlayedEvent(event, context)).card,
                     effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Hidden),

--- a/server/game/cards/05_LOF/units/BD1BeepBooBooBweep.ts
+++ b/server/game/cards/05_LOF/units/BD1BeepBooBooBweep.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BD1BeepBooBooBweep extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BD1BeepBooBooBweep extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Choose another friendly unit. While this unit is in play, the chosen unit gets +1/+0 and gains Saboteur.',
+            title: `Choose another friendly unit. While this unit is in play, the chosen unit gets +1/+0 and gains ${TextHelper.Saboteur}.`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/DarthTyranusServantOfSidious.ts
+++ b/server/game/cards/05_LOF/units/DarthTyranusServantOfSidious.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DarthTyranusServantOfSidious extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DarthTyranusServantOfSidious extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While the Force is with you, this unit gains Ambush',
+            title: `While the Force is with you, this unit gains ${TextHelper.Ambush}`,
             condition: (context) => context.player.hasTheForce,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/05_LOF/units/DeceptiveShade.ts
+++ b/server/game/cards/05_LOF/units/DeceptiveShade.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { CardType, Duration, EventName, KeywordName } from '../../../core/Constants';
 import type { Player } from '../../../core/Player';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DeceptiveShade extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,14 +15,14 @@ export default class DeceptiveShade extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'The next unit you play this phase gains Ambush for this phase',
+            title: `The next unit you play this phase gains ${TextHelper.Ambush} for this phase`,
             immediateEffect: AbilityHelper.immediateEffects.delayedPlayerEffect((context) => ({
-                title: 'The next unit you play this phase gains Ambush',
+                title: `The next unit you play this phase gains ${TextHelper.Ambush}`,
                 when: {
                     onCardPlayed: (event, _) => this.isUnitPlayedEvent(event, context.player)
                 },
                 duration: Duration.UntilEndOfPhase,
-                effectDescription: 'give Ambush to the next unit they play this phase',
+                effectDescription: `give ${TextHelper.Ambush} to the next unit they play this phase`,
                 immediateEffect: AbilityHelper.immediateEffects.cardLastingEffect((innerContext) => ({
                     target: innerContext.events.find((event) => this.isUnitPlayedEvent(event, context.player)).card,
                     effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush),

--- a/server/game/cards/05_LOF/units/DookuItIsTooLate.ts
+++ b/server/game/cards/05_LOF/units/DookuItIsTooLate.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityRestriction, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DookuItIsTooLate extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DookuItIsTooLate extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Each friendly unit with Hidden can\'t be attacked this phase',
+            title: `Each friendly unit with ${TextHelper.Hidden} can't be attacked this phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.player.getArenaUnits({ condition: (card) => card.hasSomeKeyword(KeywordName.Hidden) }),
                 effect: AbilityHelper.ongoingEffects.cardCannot(AbilityRestriction.BeAttacked)

--- a/server/game/cards/05_LOF/units/InvasionControlShip.ts
+++ b/server/game/cards/05_LOF/units/InvasionControlShip.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class InvasionControlShip extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class InvasionControlShip extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Friendly Droid units gain Raid 2',
+            title: `Friendly Droid units gain ${TextHelper.Raid(2)}`,
             targetController: RelativePlayer.Self,
             matchTarget: (card) => card.hasSomeTrait(Trait.Droid),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 }),

--- a/server/game/cards/05_LOF/units/JediSentinel.ts
+++ b/server/game/cards/05_LOF/units/JediSentinel.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class JediSentinel extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class JediSentinel extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While the Force is with you, this unit gains Sentinel.',
+            title: `While the Force is with you, this unit gains ${TextHelper.Sentinel}.`,
             condition: (context) => context.player.hasTheForce,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel),
         });

--- a/server/game/cards/05_LOF/units/LifeWindSage.ts
+++ b/server/game/cards/05_LOF/units/LifeWindSage.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LifeWindSage extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class LifeWindSage extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an enemy unit is exhausted, this unit gains Raid 2',
+            title: `While an enemy unit is exhausted, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.opponent.hasSomeArenaUnit({ condition: (card) => card.isUnit() && card.exhausted }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/05_LOF/units/ObiwanKenobiProtectivePadawan.ts
+++ b/server/game/cards/05_LOF/units/ObiwanKenobiProtectivePadawan.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { CardType, KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ObiwanKenobiProtectivePadawan extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ObiwanKenobiProtectivePadawan extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'This unit gains Sentinel for this phase',
+            title: `This unit gains ${TextHelper.Sentinel} for this phase`,
             when: {
                 onCardPlayed: (event, context) => event.cardTypeWhenInPlay === CardType.BasicUnit &&
                   event.card.hasSomeTrait(Trait.Force) &&

--- a/server/game/cards/05_LOF/units/OppoRancisisAncientCouncilor.ts
+++ b/server/game/cards/05_LOF/units/OppoRancisisAncientCouncilor.ts
@@ -3,6 +3,7 @@ import * as KeywordHelpers from '../../../core/ability/KeywordHelpers';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { NonParameterKeywordName } from '../../../Interfaces';
 
 export default class OppoRancisisAncientCouncilor extends NonLeaderUnitCard {
@@ -23,13 +24,13 @@ export default class OppoRancisisAncientCouncilor extends NonLeaderUnitCard {
         this.addKeywordCopyAbility(registrar, AbilityHelper, KeywordName.Shielded);
 
         registrar.addConstantAbility({
-            title: 'This unit gains Raid 2 while a friendly unit has Raid',
+            title: `This unit gains ${TextHelper.Raid(2)} while a friendly unit has Raid`,
             condition: (context) => context.player.isKeywordInPlay(KeywordName.Raid, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });
 
         registrar.addConstantAbility({
-            title: 'This unit gains Restore 2 while a friendly unit has Restore',
+            title: `This unit gains ${TextHelper.Restore(2)} while a friendly unit has Restore`,
             condition: (context) => context.player.isKeywordInPlay(KeywordName.Restore, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 })
         });

--- a/server/game/cards/05_LOF/units/PloKoonIDontBelieveInChance.ts
+++ b/server/game/cards/05_LOF/units/PloKoonIDontBelieveInChance.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PloKoonIDontBelieveInChance extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PloKoonIDontBelieveInChance extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While the Force is with you, this unit gains Grit',
+            title: `While the Force is with you, this unit gains ${TextHelper.Grit}`,
             condition: (context) => context.player.hasTheForce,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Grit),
         });

--- a/server/game/cards/05_LOF/units/PraetorianGuard.ts
+++ b/server/game/cards/05_LOF/units/PraetorianGuard.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PraetorianGuard extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PraetorianGuard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a unit with 4 or more power, this unit gains Sentinel',
+            title: `While you control a unit with 4 or more power, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasSomeArenaUnit({ condition: (card) => card.isUnit() && card.getPower() >= 4 }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/05_LOF/units/RefugeeOfThePath.ts
+++ b/server/game/cards/05_LOF/units/RefugeeOfThePath.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RefugeeOfThePath extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RefugeeOfThePath extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give a Shield token to a unit with Sentinel',
+            title: `Give a Shield token to a unit with ${TextHelper.Sentinel}`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/Terentatek.ts
+++ b/server/game/cards/05_LOF/units/Terentatek.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Terentatek extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Terentatek extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an opponent controls a Force unit, this unit gains Ambush.',
+            title: `While an opponent controls a Force unit, this unit gains ${TextHelper.Ambush}.`,
             condition: (context) => context.player.opponent.hasSomeArenaUnit({ trait: Trait.Force }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush),
         });

--- a/server/game/cards/05_LOF/units/TuskenTracker.ts
+++ b/server/game/cards/05_LOF/units/TuskenTracker.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TuskenTracker extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TuskenTracker extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Each enemy unit loses Hidden for this phase',
+            title: `Each enemy unit loses ${TextHelper.Hidden} for this phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.source.controller.opponent.getArenaUnits(),
                 effect: AbilityHelper.ongoingEffects.loseKeyword(KeywordName.Hidden)

--- a/server/game/cards/05_LOF/units/YaddleAChanceToMakeThingsRight.ts
+++ b/server/game/cards/05_LOF/units/YaddleAChanceToMakeThingsRight.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class YaddleAChanceToMakeThingsRight extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class YaddleAChanceToMakeThingsRight extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Each other friendly Jedi unit gains Restore 1 for this phase',
+            title: `Each other friendly Jedi unit gains ${TextHelper.Restore(1)} for this phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.player.getArenaUnits({ trait: Trait.Jedi, otherThan: context.source }),
                 effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 })

--- a/server/game/cards/06_SEC/events/FullyArmedAndOperational.ts
+++ b/server/game/cards/06_SEC/events/FullyArmedAndOperational.ts
@@ -4,6 +4,7 @@ import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrat
 import { EventCard } from '../../../core/card/EventCard';
 import { CardType, KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 import type { ActionsThisPhaseWatcher } from '../../../stateWatchers/ActionsThisPhaseWatcher';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
@@ -29,7 +30,7 @@ export default class FullyArmedAndOperational extends EventCard {
         AbilityHelper: IAbilityHelper
     ) {
         registrar.setEventAbility({
-            title: 'If an opponent attacked your base during their previous action this phase, play a unit from your hand. Give it Ambush for this phase.',
+            title: `If an opponent attacked your base during their previous action this phase, play a unit from your hand. Give it ${TextHelper.Ambush} for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.conditional((context) => ({
                 condition: this.opponentDidAttackBaseLastAction(context),
                 onTrue: AbilityHelper.immediateEffects.selectCard({

--- a/server/game/cards/06_SEC/events/Implicate.ts
+++ b/server/game/cards/06_SEC/events/Implicate.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { AbilityType, KeywordName, WildcardCardType } from '../../../core/Constants';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Implicate extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Implicate extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Choose a unit. For this phase, it gains Sentinel and When this unit is attacked: Create a Spy token"',
+            title: `Choose a unit. For this phase, it gains ${TextHelper.Sentinel} and When this unit is attacked: Create a Spy token"`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({

--- a/server/game/cards/06_SEC/events/OneWayOut.ts
+++ b/server/game/cards/06_SEC/events/OneWayOut.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class OneWayOut extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class OneWayOut extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a unit. It gets +1/+0 and gains Overwhelm for this attack. If it is attacking a unit, the defender loses all abilities for this attack',
+            title: `Attack with a unit. It gets +1/+0 and gains ${TextHelper.Overwhelm} for this attack. If it is attacking a unit, the defender loses all abilities for this attack`,
             initiateAttack: {
                 attackerLastingEffects: [
                     { effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm) },

--- a/server/game/cards/06_SEC/events/WhenHasBecomeNow.ts
+++ b/server/game/cards/06_SEC/events/WhenHasBecomeNow.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WhenHasBecomeNow extends EventCard {
     protected override getImplementationId() {
@@ -13,9 +14,9 @@ export default class WhenHasBecomeNow extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Play a card with Plot from your resources. If you do, put the top card of your deck into play as a resource',
+            title: `Play a card with ${TextHelper.Plot} from your resources. If you do, put the top card of your deck into play as a resource`,
             targetResolver: {
-                activePromptTitle: 'Choose a card with Plot',
+                activePromptTitle: `Choose a card with ${TextHelper.Plot}`,
                 zoneFilter: ZoneName.Resource,
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Playable,

--- a/server/game/cards/06_SEC/leaders/ChancellorPalpatineHowLibertyDies.ts
+++ b/server/game/cards/06_SEC/leaders/ChancellorPalpatineHowLibertyDies.ts
@@ -14,7 +14,7 @@ export default class ChancellorPalpatineHowLibertyDies extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Search the top 5 cards of your deck for a Plot card, reveal it, and draw it.',
+            title: `Search the top 5 cards of your deck for a ${TextHelper.Plot} card, reveal it, and draw it.`,
             cost: [AbilityHelper.costs.exhaustSelf(), AbilityHelper.costs.abilityActivationResourceCost(1)],
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,
@@ -29,7 +29,7 @@ export default class ChancellorPalpatineHowLibertyDies extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: `The next card you play using Plot this phase costs ${TextHelper.resource(3)} less.`,
+            title: `The next card you play using ${TextHelper.Plot} this phase costs ${TextHelper.resource(3)} less.`,
             when: {
                 onLeaderDeployed: (event, context) => event.card === context.source
             },

--- a/server/game/cards/06_SEC/leaders/DedraMeeroNotWastingTime.ts
+++ b/server/game/cards/06_SEC/leaders/DedraMeeroNotWastingTime.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, NamedAction, RelativePlayer, TargetMode, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DedraMeeroNotWastingTime extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -47,7 +48,7 @@ export default class DedraMeeroNotWastingTime extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you have more cards in hand than an opponent, this unit gains Raid 2',
+            title: `While you have more cards in hand than an opponent, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.hand.length > context.player.opponent.hand.length,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/06_SEC/leaders/DrydenVosINeverAskTwice.ts
+++ b/server/game/cards/06_SEC/leaders/DrydenVosINeverAskTwice.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class DrydenVosINeverAskTwice extends LeaderUnitCard {
@@ -17,7 +18,7 @@ export default class DrydenVosINeverAskTwice extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Play a unit that costs 5 or less from your hand. It gains Ambush for this phase.',
+            title: `Play a unit that costs 5 or less from your hand. It gains ${TextHelper.Ambush} for this phase.`,
             cost: [AbilityHelper.costs.exhaustSelf(), AbilityHelper.costs.discardCardFromOwnHand({
                 cardCondition: (card) => card.hasCost() && card.cost >= 6
             })],
@@ -41,7 +42,7 @@ export default class DrydenVosINeverAskTwice extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Play a unit from your hand. It gains Ambush for this phase.',
+            title: `Play a unit from your hand. It gains ${TextHelper.Ambush} for this phase.`,
             cost: [AbilityHelper.costs.discardCardFromOwnHand()],
             cannotTargetFirst: true,
             targetResolver: {

--- a/server/game/cards/06_SEC/units/AlexsandrKallusWithNewPurpose.ts
+++ b/server/game/cards/06_SEC/units/AlexsandrKallusWithNewPurpose.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, TargetMode, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AlexsandrKallusWithNewPurpose extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class AlexsandrKallusWithNewPurpose extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you have the initiative, each other friendly unique unit gains Raid 2',
+            title: `While you have the initiative, each other friendly unique unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.hasInitiative(),
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.unique && card.controller === context.player,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })

--- a/server/game/cards/06_SEC/units/AnakinSkywalkerSecretHusband.ts
+++ b/server/game/cards/06_SEC/units/AnakinSkywalkerSecretHusband.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AnakinSkywalkerSecretHusband extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class AnakinSkywalkerSecretHusband extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control Padmé Amidala, this unit gains Raid 2.',
+            title: `While you control Padmé Amidala, this unit gains ${TextHelper.Raid(2)}.`,
             condition: (context) => context.player.controlsLeaderUnitOrUpgradeWithTitle('Padmé Amidala'),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/06_SEC/units/B2EMOThatsTwoLies.ts
+++ b/server/game/cards/06_SEC/units/B2EMOThatsTwoLies.ts
@@ -16,10 +16,10 @@ export default class B2EMOThatsTwoLies extends NonLeaderUnitCard {
         const aspects = [Aspect.Heroism, Aspect.Heroism];
 
         registrar.addOnAttackAbility({
-            title: `Disclose ${TextHelper.aspectList(aspects)} to give a unit Sentinel for this phase`,
+            title: `Disclose ${TextHelper.aspectList(aspects)} to give a unit ${TextHelper.Sentinel} for this phase`,
             immediateEffect: abilityHelper.immediateEffects.disclose({ aspects }),
             ifYouDo: {
-                title: 'Give a unit Sentinel for this phase',
+                title: `Give a unit ${TextHelper.Sentinel} for this phase`,
                 targetResolver: {
                     cardTypeFilter: WildcardCardType.Unit,
                     immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect({

--- a/server/game/cards/06_SEC/units/CaptainRexIntoTheFirefight.ts
+++ b/server/game/cards/06_SEC/units/CaptainRexIntoTheFirefight.ts
@@ -5,6 +5,7 @@ import { EventName, KeywordName, RelativePlayer, WildcardCardType } from '../../
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import * as AttackHelpers from '../../../core/attack/AttackHelpers';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CaptainRexIntoTheFirefight extends NonLeaderUnitCard {
     private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
@@ -22,7 +23,7 @@ export default class CaptainRexIntoTheFirefight extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give this unit and an enemy unit Sentinel for this phase',
+            title: `Give this unit and an enemy unit ${TextHelper.Sentinel} for this phase`,
             when: {
                 whenPlayed: true,
                 onAttackEnd: (event, context) => event.attack.attacker === context.source,

--- a/server/game/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.ts
+++ b/server/game/cards/06_SEC/units/ChancellorPalpatineIAmTheSenate.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ChancellorPalpatineIAmTheSenate extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,13 +14,13 @@ export default class ChancellorPalpatineIAmTheSenate extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Create 2 Spy tokens and give those tokens Sentinel for this phase',
+            title: `Create 2 Spy tokens and give those tokens ${TextHelper.Sentinel} for this phase`,
             immediateEffect: abilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.hasSomeArenaCard({ type: WildcardCardType.LeaderUnit }),
                 onTrue: abilityHelper.immediateEffects.createSpy({ amount: 2 }),
             }),
             ifYouDo: (ifYouDoContext) => ({
-                title: 'Give those tokens Sentinel for this phase',
+                title: `Give those tokens ${TextHelper.Sentinel} for this phase`,
                 immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect({
                     target: ifYouDoContext.resolvedEvents[0]?.generatedTokens,
                     effect: abilityHelper.ongoingEffects.gainKeyword({

--- a/server/game/cards/06_SEC/units/CoronetStatelyVessel.ts
+++ b/server/game/cards/06_SEC/units/CoronetStatelyVessel.ts
@@ -14,7 +14,7 @@ export default class CoronetStatelyVessel extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each other friendly ${TextHelper.Heroism} unit gains Restore 1`,
+            title: `Each other friendly ${TextHelper.Heroism} unit gains ${TextHelper.Restore(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit(),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 })
         });

--- a/server/game/cards/06_SEC/units/CorruptPolitician.ts
+++ b/server/game/cards/06_SEC/units/CorruptPolitician.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CorruptPolitician extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CorruptPolitician extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control more units than an opponent, this unit gains Sentinel',
+            title: `While you control more units than an opponent, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.getArenaUnits().length > context.player.opponent.getArenaUnits().length,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/06_SEC/units/DiplomaticEnvoy.ts
+++ b/server/game/cards/06_SEC/units/DiplomaticEnvoy.ts
@@ -16,17 +16,17 @@ export default class DiplomaticEnvoy extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         const aspects = [Aspect.Command];
         registrar.addWhenPlayedAbility({
-            title: `Disclose ${TextHelper.aspectList(aspects)} to give Ambush for this phase for the next unit you play this phase`,
+            title: `Disclose ${TextHelper.aspectList(aspects)} to give ${TextHelper.Ambush} for this phase for the next unit you play this phase`,
             immediateEffect: abilityHelper.immediateEffects.disclose({ aspects }),
             ifYouDo: {
-                title: 'The next unit you play this phase gains Ambush for this phase',
+                title: `The next unit you play this phase gains ${TextHelper.Ambush} for this phase`,
                 immediateEffect: abilityHelper.immediateEffects.delayedPlayerEffect({
-                    title: 'The next unit you play this phase gains Ambush',
+                    title: `The next unit you play this phase gains ${TextHelper.Ambush}`,
                     when: {
                         onCardPlayed: (event, context) => this.isUnitPlayedEvent(event, context)
                     },
                     duration: Duration.UntilEndOfPhase,
-                    effectDescription: 'give Ambush to the next unit they play this phase',
+                    effectDescription: `give ${TextHelper.Ambush} to the next unit they play this phase`,
                     immediateEffect: abilityHelper.immediateEffects.cardLastingEffect((context) => ({
                         target: context.events.find((event) => this.isUnitPlayedEvent(event, context)).card,
                         effect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush),

--- a/server/game/cards/06_SEC/units/HighCommandCouncilor.ts
+++ b/server/game/cards/06_SEC/units/HighCommandCouncilor.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HighCommandCouncilor extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HighCommandCouncilor extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Official unit, this unit gains Raid 2',
+            title: `While you control another Official unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Official, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })

--- a/server/game/cards/06_SEC/units/HondoOhnakaYouBetterHurry.ts
+++ b/server/game/cards/06_SEC/units/HondoOhnakaYouBetterHurry.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HondoOhnakaYouBetterHurry extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HondoOhnakaYouBetterHurry extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Raid 1',
+            title: `Each other friendly unit gains ${TextHelper.Raid(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit(),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/06_SEC/units/HuntingAssassinDroid.ts
+++ b/server/game/cards/06_SEC/units/HuntingAssassinDroid.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HuntingAssassinDroid extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HuntingAssassinDroid extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an enemy unit is damaged, this unit gains Raid 2',
+            title: `While an enemy unit is damaged, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.opponent.hasSomeArenaUnit({ condition: (card) => card.isUnit() && card.damage > 0 }),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/06_SEC/units/KyloRensCommandShuttleIconOfAuthority.ts
+++ b/server/game/cards/06_SEC/units/KyloRensCommandShuttleIconOfAuthority.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KyloRensCommandShuttleIconOfAuthority extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class KyloRensCommandShuttleIconOfAuthority extends NonLeaderUnit
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly ground unit with Sentinel gets +0/+2.',
+            title: `Each friendly ground unit with ${TextHelper.Sentinel} gets +0/+2.`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             targetZoneFilter: ZoneName.GroundArena,

--- a/server/game/cards/06_SEC/units/MirajScintelTheWeakDeserveToKneel.ts
+++ b/server/game/cards/06_SEC/units/MirajScintelTheWeakDeserveToKneel.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MirajScintelTheWeakDeserveToKneel extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -23,7 +24,7 @@ export default class MirajScintelTheWeakDeserveToKneel extends NonLeaderUnitCard
         });
 
         registrar.addConstantAbility({
-            title: 'While a friendly unit is attacking a damaged unit, the attacker gains Overwhelm',
+            title: `While a friendly unit is attacking a damaged unit, the attacker gains ${TextHelper.Overwhelm}`,
             matchTarget: (card, context) =>
                 card.controller === context.player &&
                 card.isUnit() && card.isInPlay() && card.isAttacking() &&

--- a/server/game/cards/06_SEC/units/NabooRoyalStarshipFitForAQueen.ts
+++ b/server/game/cards/06_SEC/units/NabooRoyalStarshipFitForAQueen.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NabooRoyalStarshipFitForAQueen extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NabooRoyalStarshipFitForAQueen extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly leader unit gains Raid 2 and Overwhelm',
+            title: `Each friendly leader unit gains ${TextHelper.Raid(2)} and ${TextHelper.Overwhelm}`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.LeaderUnit,
             ongoingEffect: [

--- a/server/game/cards/06_SEC/units/NabooSecurityForce.ts
+++ b/server/game/cards/06_SEC/units/NabooSecurityForce.ts
@@ -15,14 +15,14 @@ export default class NabooSecurityForce extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         const aspects = [Aspect.Command];
         registrar.addTriggeredAbility({
-            title: `Disclose ${TextHelper.aspectList(aspects)} to give a friendly unit Sentinel for this phase`,
+            title: `Disclose ${TextHelper.aspectList(aspects)} to give a friendly unit ${TextHelper.Sentinel} for this phase`,
             when: {
                 whenPlayed: true,
                 whenDefeated: true,
             },
             immediateEffect: abilityHelper.immediateEffects.disclose({ aspects }),
             ifYouDo: {
-                title: 'Give a friendly unit Sentinel for this phase',
+                title: `Give a friendly unit ${TextHelper.Sentinel} for this phase`,
                 targetResolver: {
                     controller: RelativePlayer.Self,
                     cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/06_SEC/units/NubianStarSkiff.ts
+++ b/server/game/cards/06_SEC/units/NubianStarSkiff.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NubianStarSkiff extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NubianStarSkiff extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control an Official unit, this unit gains Restore 2',
+            title: `While you control an Official unit, this unit gains ${TextHelper.Restore(2)}`,
             condition: (context) => context.player.hasSomeArenaUnit({ trait: Trait.Official }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 }),
         });

--- a/server/game/cards/06_SEC/units/NuteGunrayEscapingJustice.ts
+++ b/server/game/cards/06_SEC/units/NuteGunrayEscapingJustice.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NuteGunrayEscapingJustice extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NuteGunrayEscapingJustice extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give another friendly Official unit Sentinel for this phase',
+            title: `Give another friendly Official unit ${TextHelper.Sentinel} for this phase`,
             optional: true,
             when: {
                 onAttack: true,

--- a/server/game/cards/06_SEC/units/PopulistAdvisor.ts
+++ b/server/game/cards/06_SEC/units/PopulistAdvisor.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { DamageType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PopulistAdvisor extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class PopulistAdvisor extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'This unit gains Sentinel for this phase',
+            title: `This unit gains ${TextHelper.Sentinel} for this phase`,
             when: {
                 onDamageDealt: (event, context) =>
                     event.damageSource?.attack?.attacker?.controller !== context.player &&

--- a/server/game/cards/06_SEC/units/PunishingOneTakesNoPrisoners.ts
+++ b/server/game/cards/06_SEC/units/PunishingOneTakesNoPrisoners.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PunishingOneTakesNoPrisoners extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class PunishingOneTakesNoPrisoners extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'This unit gains Raid 1 for each damaged enemy unit',
+            title: `This unit gains ${TextHelper.Raid(1)} for each damaged enemy unit`,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword((_, context) => ({
                 keyword: KeywordName.Raid,
                 amount: context.player.opponent.getArenaUnits({ condition: (card) => card.isUnit() && card.damage > 0 }).length

--- a/server/game/cards/06_SEC/units/RebelPropagandist.ts
+++ b/server/game/cards/06_SEC/units/RebelPropagandist.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RebelPropagandist extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RebelPropagandist extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give another friendly unit +1/+0 and Saboteur for this phase',
+            title: `Give another friendly unit +1/+0 and ${TextHelper.Saboteur} for this phase`,
             when: {
                 whenPlayed: true,
                 whenDefeated: true,

--- a/server/game/cards/06_SEC/units/RemoteEscortTank.ts
+++ b/server/game/cards/06_SEC/units/RemoteEscortTank.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RemoteEscortTank extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RemoteEscortTank extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give a unit Sentinel for this phase',
+            title: `Give a unit ${TextHelper.Sentinel} for this phase`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({

--- a/server/game/cards/06_SEC/units/RotundaSenateGuards.ts
+++ b/server/game/cards/06_SEC/units/RotundaSenateGuards.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RotundaSenateGuards extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class RotundaSenateGuards extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit is undamaged, it gains Sentinel',
+            title: `While this unit is undamaged, it gains ${TextHelper.Sentinel}`,
             condition: (context) => context.source.damage === 0,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/06_SEC/units/ScreechingTieFighter.ts
+++ b/server/game/cards/06_SEC/units/ScreechingTieFighter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ScreechingTieFighter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -16,14 +17,14 @@ export default class ScreechingTieFighter extends NonLeaderUnitCard {
         AbilityHelper: IAbilityHelper
     ) {
         registrar.addOnAttackAbility({
-            title: 'Select a ground unit to lose all Keywords for this phase',
+            title: `Select a ground unit to lose all ${TextHelper.Keywords} for this phase`,
             optional: true,
             targetResolver: {
                 zoneFilter: ZoneName.GroundArena,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.loseAllKeywords(),
-                    ongoingEffectDescription: 'remove all Keywords from',
+                    ongoingEffectDescription: `remove all ${TextHelper.Keywords} from`,
                 })
             }
         });

--- a/server/game/cards/06_SEC/units/SenatorChuchiVoiceForTheVoiceless.ts
+++ b/server/game/cards/06_SEC/units/SenatorChuchiVoiceForTheVoiceless.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SenatorChuchiVoiceForTheVoiceless extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class SenatorChuchiVoiceForTheVoiceless extends NonLeaderUnitCard
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give another friendly Official unit Restore 2 for this phase',
+            title: `Give another friendly Official unit ${TextHelper.Restore(2)} for this phase`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/06_SEC/units/TalaDurithICanGetYouInside.ts
+++ b/server/game/cards/06_SEC/units/TalaDurithICanGetYouInside.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TalaDurithICanGetYouInside extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TalaDurithICanGetYouInside extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Hidden.',
+            title: `Each other friendly unit gains ${TextHelper.Hidden}.`,
             matchTarget: (card, context) => card !== context.source && card.isUnit(),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Hidden })
         });

--- a/server/game/cards/06_SEC/units/ZamWesellInconspicuousAssassin.ts
+++ b/server/game/cards/06_SEC/units/ZamWesellInconspicuousAssassin.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ZamWesellInconspicuousAssassin extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ZamWesellInconspicuousAssassin extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit is upgraded, she gains Grit',
+            title: `While this unit is upgraded, she gains ${TextHelper.Grit}`,
             condition: (context) => context.source.isUpgraded(),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Grit)
         });

--- a/server/game/cards/06_SEC/upgrades/DisciplesDevotion.ts
+++ b/server/game/cards/06_SEC/upgrades/DisciplesDevotion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DisciplesDevotion extends UpgradeCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class DisciplesDevotion extends UpgradeCard {
 
     public override setupCardAbilities (registrar: IUpgradeAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbilityTargetingAttached({
-            title: 'While attached unit is exhausted, it gains Sentinel',
+            title: `While attached unit is exhausted, it gains ${TextHelper.Sentinel}`,
             condition: (context) => context.source.parentCard.exhausted,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/06_SEC/upgrades/ExiledFromTheForce.ts
+++ b/server/game/cards/06_SEC/upgrades/ExiledFromTheForce.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ExiledFromTheForce extends UpgradeCard {
     protected override getImplementationId() {
@@ -17,7 +18,7 @@ export default class ExiledFromTheForce extends UpgradeCard {
     ) {
         registrar.addGainKeywordTargetingAttached({ keyword: KeywordName.Grit });
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Attached unit loses the Force trait and all abilities except Grit',
+            title: `Attached unit loses the Force trait and all abilities except ${TextHelper.Grit}`,
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.loseTrait(Trait.Force),
                 AbilityHelper.ongoingEffects.loseAllOtherAbilities({ exceptKeyword: KeywordName.Grit })

--- a/server/game/cards/06_SEC/upgrades/FigureOfUnity.ts
+++ b/server/game/cards/06_SEC/upgrades/FigureOfUnity.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FigureOfUnity extends UpgradeCard {
     protected override getImplementationId () {
@@ -15,7 +16,7 @@ export default class FigureOfUnity extends UpgradeCard {
         registrar.setAttachCondition((context) => context.attachTarget.unique);
 
         registrar.addGainConstantAbilityTargetingAttached({
-            title: 'While this unit is ready, each other friendly unit gains Overwhelm, Raid 1, and Restore 1',
+            title: `While this unit is ready, each other friendly unit gains ${TextHelper.Overwhelm}, ${TextHelper.Raid(1)}, and ${TextHelper.Restore(1)}`,
             condition: (context) => !context.source.exhausted,
             matchTarget: (card, context) => card !== context.source && card.controller === context.player,
             ongoingEffect: [

--- a/server/game/cards/07_LAW/events/CommenceTheFestivities.ts
+++ b/server/game/cards/07_LAW/events/CommenceTheFestivities.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CommenceTheFestivities extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class CommenceTheFestivities extends EventCard {
 
     public override setupCardAbilities (registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a unit. It gains Saboteur for this attack. If you control fewer resources than an opponent, it gets +2/+0 for this attack.',
+            title: `Attack with a unit. It gains ${TextHelper.Saboteur} for this attack. If you control fewer resources than an opponent, it gets +2/+0 for this attack.`,
             initiateAttack: {
                 attackerLastingEffects: [
                     { effect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur) },

--- a/server/game/cards/07_LAW/events/FlashTheVents.ts
+++ b/server/game/cards/07_LAW/events/FlashTheVents.ts
@@ -4,6 +4,7 @@ import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrat
 import { DamageType, KeywordName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { DamageDealtThisPhaseWatcher } from '../../../stateWatchers/DamageDealtThisPhaseWatcher';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FlashTheVents extends EventCard {
     private damageDealtThisPhaseWatcher: DamageDealtThisPhaseWatcher;
@@ -21,7 +22,7 @@ export default class FlashTheVents extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a unit. It gets +2/+0 and gains Overwhelm for this attack. After completing this attack, if that unit damaged a base, defeat that unit.',
+            title: `Attack with a unit. It gets +2/+0 and gains ${TextHelper.Overwhelm} for this attack. After completing this attack, if that unit damaged a base, defeat that unit.`,
             initiateAttack: {
                 attackerLastingEffects: {
                     effect: [

--- a/server/game/cards/07_LAW/leaders/JabbaTheHuttCrimeBoss.ts
+++ b/server/game/cards/07_LAW/leaders/JabbaTheHuttCrimeBoss.ts
@@ -3,6 +3,7 @@ import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { EventName, GameStateChangeRequired, KeywordName, RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 
 export default class JabbaTheHuttCrimeBoss extends LeaderUnitCard {
@@ -44,8 +45,8 @@ export default class JabbaTheHuttCrimeBoss extends LeaderUnitCard {
                         playAsType: WildcardCardType.Unit
                     }),
                     AbilityHelper.immediateEffects.delayedCardEffect((outerContext) => ({
-                        title: 'It gains Ambush for the phase if a Credit token was used to pay its cost',
-                        effectDescription: 'conditionally give it Ambush for the phase',
+                        title: `It gains ${TextHelper.Ambush} for the phase if a Credit token was used to pay its cost`,
+                        effectDescription: `conditionally give it ${TextHelper.Ambush} for the phase`,
                         limit: AbilityHelper.limit.perGame(1),
                         when: {
                             onCardPlayed: (event) =>

--- a/server/game/cards/07_LAW/leaders/SawGerreraBringDownTheEmpire.ts
+++ b/server/game/cards/07_LAW/leaders/SawGerreraBringDownTheEmpire.ts
@@ -2,6 +2,7 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { ResolutionMode } from '../../../gameSystems/SimultaneousOrSequentialSystem';
 
 export default class SawGerreraBringDownTheEmpire extends LeaderUnitCard {
@@ -14,7 +15,7 @@ export default class SawGerreraBringDownTheEmpire extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a unit. It gets +2/+0 and gains Overwhelm for this attack. After completing this attack, defeat it.',
+            title: `Attack with a unit. It gets +2/+0 and gains ${TextHelper.Overwhelm} for this attack. After completing this attack, defeat it.`,
             cost: [AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -40,7 +41,7 @@ export default class SawGerreraBringDownTheEmpire extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
-            title: 'Attack with another unit. It gets +2/+0 and gains Overwhelm for this attack. After completing this attack, defeat it.',
+            title: `Attack with another unit. It gets +2/+0 and gains ${TextHelper.Overwhelm} for this attack. After completing this attack, defeat it.`,
             attackerMustSurvive: true,
             optional: true,
             targetResolver: {

--- a/server/game/cards/07_LAW/leaders/SebulbaEspeciallyDangerousDug.ts
+++ b/server/game/cards/07_LAW/leaders/SebulbaEspeciallyDangerousDug.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SebulbaEspeciallyDangerousDug extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,13 +14,13 @@ export default class SebulbaEspeciallyDangerousDug extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper): void {
         registrar.addActionAbility({
-            title: 'A friendly unit gains Raid 1 for this phase',
+            title: `A friendly unit gains ${TextHelper.Raid(1)} for this phase`,
             cost: [
                 AbilityHelper.costs.exhaustSelf(),
                 AbilityHelper.costs.discardFromOwnDeck()
             ],
             targetResolver: {
-                activePromptTitle: 'Select a friendly unit to gain Raid 1 for this phase',
+                activePromptTitle: `Select a friendly unit to gain ${TextHelper.Raid(1)} for this phase`,
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({

--- a/server/game/cards/07_LAW/units/4-LOMDevious.ts
+++ b/server/game/cards/07_LAW/units/4-LOMDevious.ts
@@ -12,6 +12,7 @@ export default class _4LOMDevious extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar) {
         registrar.addWhenPlayedAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait, not the Bounty keyword
             title: 'Attack with a friendly Bounty Hunter unit, even if it\'s exhausted. It can\'t attack bases for this attack.',
             optional: true,
             initiateAttack: {

--- a/server/game/cards/07_LAW/units/AsajjVentressReluctantHunter.ts
+++ b/server/game/cards/07_LAW/units/AsajjVentressReluctantHunter.ts
@@ -13,6 +13,7 @@ export default class AsajjVentressReluctantHunter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait, not the Bounty keyword
             title: 'Ready another Bounty Hunter unit',
             optional: true,
             targetResolver: {

--- a/server/game/cards/07_LAW/units/BodhiRookCreatingADiversion.ts
+++ b/server/game/cards/07_LAW/units/BodhiRookCreatingADiversion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BodhiRookCreatingADiversion extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BodhiRookCreatingADiversion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give a friendly Rebel unit Sentinel for this phase',
+            title: `Give a friendly Rebel unit ${TextHelper.Sentinel} for this phase`,
             optional: true,
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/07_LAW/units/GalenErsoDestroyingHisCreation.ts
+++ b/server/game/cards/07_LAW/units/GalenErsoDestroyingHisCreation.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GalenErsoDestroyingHisCreation extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -22,7 +23,7 @@ export default class GalenErsoDestroyingHisCreation extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'Enemy units gain Raid 1 and Saboteur',
+            title: `Enemy units gain ${TextHelper.Raid(1)} and ${TextHelper.Saboteur}`,
             targetController: RelativePlayer.Opponent,
             targetCardTypeFilter: WildcardCardType.Unit,
             ongoingEffect: [

--- a/server/game/cards/07_LAW/units/RioDurantBeckettsRightHands.ts
+++ b/server/game/cards/07_LAW/units/RioDurantBeckettsRightHands.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
 import { KeywordName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 
 export default class RioDurantBeckettsRightHands extends NonLeaderUnitCard {
@@ -23,7 +24,7 @@ export default class RioDurantBeckettsRightHands extends NonLeaderUnitCard {
             },
             then: (thenContext) => ({
                 thenCondition: () => thenContext.target,
-                title: `Play ${thenContext.target?.title} for free. It gains Shielded for this phase`,
+                title: `Play ${thenContext.target?.title} for free. It gains ${TextHelper.Shielded} for this phase`,
                 optional: true,
                 // TODO: Update this to use a GameSystem that lets the opponent play a card
                 canBeTriggeredBy: EnumHelpers.asRelativePlayer(thenContext.player, thenContext.target?.owner),

--- a/server/game/cards/07_LAW/units/UndercityHuntingTeam.ts
+++ b/server/game/cards/07_LAW/units/UndercityHuntingTeam.ts
@@ -13,6 +13,7 @@ export default class UndercityHuntingTeam extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
+            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait, not the Bounty keyword
             title: 'Search the top 5 cards of you deck for a Bounty Hunter unit, reveal it, and draw it',
             immediateEffect: abilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,

--- a/server/game/cards/07_LAW/units/WeazelFightingBack.ts
+++ b/server/game/cards/07_LAW/units/WeazelFightingBack.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WeazelFightingBack extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class WeazelFightingBack extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give Raid 2 to a friendly unit',
+            title: `Give ${TextHelper.Raid(2)} to a friendly unit`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardCondition: (card, context) => card !== context.source && card.isUnit(),

--- a/server/game/cards/07_LAW/upgrades/VeiledStrength.ts
+++ b/server/game/cards/07_LAW/upgrades/VeiledStrength.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class VeiledStrength extends UpgradeCard {
     protected override getImplementationId () {
@@ -15,7 +16,7 @@ export default class VeiledStrength extends UpgradeCard {
         registrar.setAttachCondition((context) => context.attachTarget.isNonLeaderUnit());
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Attached unit gains Grit',
+            title: `Attached unit gains ${TextHelper.Grit}`,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Grit)
         });
     }

--- a/server/game/cards/07_TS26/events/TakeAim.ts
+++ b/server/game/cards/07_TS26/events/TakeAim.ts
@@ -19,7 +19,7 @@ export default class TakeAim extends EventCard {
         });
 
         registrar.setEventAbility({
-            title: 'Attack with a unit. It gets +2/+0 and gains Saboteur for this attack.',
+            title: `Attack with a unit. It gets +2/+0 and gains ${TextHelper.Saboteur} for this attack.`,
             initiateAttack: {
                 attackerLastingEffects: [
                     { effect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur) },

--- a/server/game/cards/07_TS26/leaders/MaulCollectiveAmbition.ts
+++ b/server/game/cards/07_TS26/leaders/MaulCollectiveAmbition.ts
@@ -4,6 +4,7 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import type { IUnitCard } from '../../../core/card/propertyMixins/UnitProperties';
 import { WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MaulCollectiveAmbition extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -15,10 +16,10 @@ export default class MaulCollectiveAmbition extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper): void {
         registrar.addActionAbility({
-            title: 'Give an Experience token and deal 1 damage to a unit with more Keywords than Experience tokens',
+            title: `Give an Experience token and deal 1 damage to a unit with more ${TextHelper.Keywords} than Experience tokens`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
-                activePromptTitle: 'Choose a unit. If it has more Keywords than Experience tokens, give it an Experience token and deal 1 damage to it',
+                activePromptTitle: `Choose a unit. If it has more ${TextHelper.Keywords} than Experience tokens, give it an Experience token and deal 1 damage to it`,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
                     condition: (context) => this.targetHasMoreKeywordsThanExperienceTokens(context),
@@ -34,13 +35,13 @@ export default class MaulCollectiveAmbition extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper): void {
         registrar.addTriggeredAbility({
-            title: 'Give an Experience token and deal 1 damage to a unit with more Keywords than Experience tokens',
+            title: `Give an Experience token and deal 1 damage to a unit with more ${TextHelper.Keywords} than Experience tokens`,
             when: {
                 onLeaderDeployed: (event, context) => event.card === context.source,
                 onAttack: true
             },
             targetResolver: {
-                activePromptTitle: 'Choose a unit. If it has more Keywords than Experience tokens, give it an Experience token and deal 1 damage to it',
+                activePromptTitle: `Choose a unit. If it has more ${TextHelper.Keywords} than Experience tokens, give it an Experience token and deal 1 damage to it`,
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.conditional({
                     condition: (context) => this.targetHasMoreKeywordsThanExperienceTokens(context),

--- a/server/game/cards/07_TS26/leaders/SavageOpressYouMustHaveYourRevenge.ts
+++ b/server/game/cards/07_TS26/leaders/SavageOpressYouMustHaveYourRevenge.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SavageOpressYouMustHaveYourRevenge extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SavageOpressYouMustHaveYourRevenge extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly unit with the most power among friendly units gains Overwhelm',
+            title: `Each friendly unit with the most power among friendly units gains ${TextHelper.Overwhelm}`,
             matchTarget: (card, context) => {
                 return card.isUnit() && card.getPower() === context.player.getArenaUnits().map((x) => x.getPower())
                     .reduce((p, c) => (p > c ? p : c), 0);
@@ -24,7 +25,7 @@ export default class SavageOpressYouMustHaveYourRevenge extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Overwhelm',
+            title: `Each other friendly unit gains ${TextHelper.Overwhelm}`,
             matchTarget: (card, context) => card.isUnit() && card.controller === context.player && card !== context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Overwhelm })
         });

--- a/server/game/cards/07_TS26/units/501stVeteran.ts
+++ b/server/game/cards/07_TS26/units/501stVeteran.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class _501stVeteran extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class _501stVeteran extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit is undamaged, it gains Sentinel',
+            title: `While this unit is undamaged, it gains ${TextHelper.Sentinel}`,
             condition: (context) => context.source.damage === 0,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/07_TS26/units/GeneralGrievousCrushThem.ts
+++ b/server/game/cards/07_TS26/units/GeneralGrievousCrushThem.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralGrievousCrushThem extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -21,7 +22,7 @@ export default class GeneralGrievousCrushThem extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'While this unit is undamaged, he gains Sentinel',
+            title: `While this unit is undamaged, he gains ${TextHelper.Sentinel}`,
             condition: (context) => context.source.damage === 0,
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/07_TS26/units/JangoFettGuardingTheCount.ts
+++ b/server/game/cards/07_TS26/units/JangoFettGuardingTheCount.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class JangoFettGuardingTheCount extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an enemy unit has attacked your base this phase, this unit gains Ambush',
+            title: `While an enemy unit has attacked your base this phase, this unit gains ${TextHelper.Ambush}`,
             condition: (context) => this.attacksThisPhaseWatcher.someUnitAttackedControlledByPlayer({ controller: context.player.opponent, filter: (entry) => entry.targets.includes(context.player.base) }),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/07_TS26/units/KingKatuunkoGreatKingOfToydaria.ts
+++ b/server/game/cards/07_TS26/units/KingKatuunkoGreatKingOfToydaria.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KingKatuunkoGreatKingOfToydaria extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class KingKatuunkoGreatKingOfToydaria extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'All units gain Restore 1 for this phase',
+            title: `All units gain ${TextHelper.Restore(1)} for this phase`,
             immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 effect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 }),
                 target: context.game.getArenaUnits(),

--- a/server/game/cards/07_TS26/units/ObiWanKenobiSteadfastKnight.ts
+++ b/server/game/cards/07_TS26/units/ObiWanKenobiSteadfastKnight.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ObiWanKenobiSteadfastKnight extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ObiWanKenobiSteadfastKnight extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly Republic units gain Restore 1',
+            title: `Other friendly Republic units gain ${TextHelper.Restore(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Republic),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 })
         });

--- a/server/game/cards/07_TS26/units/YodaBegunTheCloneWarHas.ts
+++ b/server/game/cards/07_TS26/units/YodaBegunTheCloneWarHas.ts
@@ -20,14 +20,14 @@ export default class YodaBegunTheCloneWarHas extends NonLeaderUnitCard {
         });
 
         registrar.addTriggeredAbility({
-            title: 'Create a Clone Trooper token and give it Sentinel for this phase',
+            title: `Create a Clone Trooper token and give it ${TextHelper.Sentinel} for this phase`,
             when: {
                 whenPlayed: true,
                 whenDefeated: true,
             },
             immediateEffect: abilityHelper.immediateEffects.createCloneTrooper((context) => ({ amount: 1, target: context.player })),
             then: (thenContext) => ({
-                title: 'Give it Sentinel for this phase',
+                title: `Give it ${TextHelper.Sentinel} for this phase`,
                 immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel }),
                     target: thenContext.resolvedEvents[0]?.generatedTokens

--- a/server/game/cards/08_ASH/events/BuyTime.ts
+++ b/server/game/cards/08_ASH/events/BuyTime.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BuyTime extends EventCard {
     protected override getImplementationId() {
@@ -13,10 +14,10 @@ export default class BuyTime extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Create a Mandalorian token and give it Sentinel for this Phase',
+            title: `Create a Mandalorian token and give it ${TextHelper.Sentinel} for this Phase`,
             immediateEffect: AbilityHelper.immediateEffects.createMandalorian((context) => ({ amount: 1, target: context.player })),
             then: (thenContext) => ({
-                title: 'Give it Sentinel for this phase',
+                title: `Give it ${TextHelper.Sentinel} for this phase`,
                 immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel }),
                     target: thenContext.resolvedEvents[0]?.generatedTokens

--- a/server/game/cards/08_ASH/leaders/BaylanSkollPowerBeyondDream.ts
+++ b/server/game/cards/08_ASH/leaders/BaylanSkollPowerBeyondDream.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BaylanSkollPowerBeyondDream extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -36,7 +37,7 @@ export default class BaylanSkollPowerBeyondDream extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give a friendly unit +2/+2 and Sentinel for this phase',
+            title: `Give a friendly unit +2/+2 and ${TextHelper.Sentinel} for this phase`,
             optional: true,
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.ts
+++ b/server/game/cards/08_ASH/leaders/GrandAdmiralSloaneHoldingTheEmpireTogether.ts
@@ -3,6 +3,7 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import type { Arena } from '../../../core/Constants';
 import { KeywordName, TargetMode, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrandAdmiralSloaneHoldingTheEmpireTogether extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class GrandAdmiralSloaneHoldingTheEmpireTogether extends LeaderUn
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Choose an arena. Give each unit in that arena Sentinel and Overwhelm for this phase',
+            title: `Choose an arena. Give each unit in that arena ${TextHelper.Sentinel} and ${TextHelper.Overwhelm} for this phase`,
             cost: abilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 mode: TargetMode.Select,
@@ -29,7 +30,7 @@ export default class GrandAdmiralSloaneHoldingTheEmpireTogether extends LeaderUn
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly unit gains Overwhelm and Sentinel',
+            title: `Each other friendly unit gains ${TextHelper.Overwhelm} and ${TextHelper.Sentinel}`,
             matchTarget: (card, context) => card.isUnit() && card.controller === context.player && card !== context.source,
             ongoingEffect: [
                 abilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm),

--- a/server/game/cards/08_ASH/leaders/GrandAdmiralThrawnVictoryIsMine.ts
+++ b/server/game/cards/08_ASH/leaders/GrandAdmiralThrawnVictoryIsMine.ts
@@ -4,6 +4,7 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import { Helpers } from '../../../core/utils/Helpers';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrandAdmiralThrawnVictoryIsMine extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class GrandAdmiralThrawnVictoryIsMine extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a unit. It gains Restore 2 for this attack if you control the same number of units as the defending player.',
+            title: `Attack with a unit. It gains ${TextHelper.Restore(2)} for this attack if you control the same number of units as the defending player.`,
             contextTitle: (context) => this.actionTitle(context),
             cost: AbilityHelper.costs.exhaustSelf(),
             initiateAttack: {
@@ -50,6 +51,6 @@ export default class GrandAdmiralThrawnVictoryIsMine extends LeaderUnitCard {
         const opponentUnits = context.player.opponent.getArenaUnits().length;
         return opponentUnits === 0
             ? 'Attack with a unit.'
-            : `Attack with a unit. It gains Restore 2 for this attack if you control ${Helpers.pluralize(opponentUnits, '1 unit', 'units')}.`;
+            : `Attack with a unit. It gains ${TextHelper.Restore(2)} for this attack if you control ${Helpers.pluralize(opponentUnits, '1 unit', 'units')}.`;
     }
 }

--- a/server/game/cards/08_ASH/leaders/SabineWrenBargainingOnBelief.ts
+++ b/server/game/cards/08_ASH/leaders/SabineWrenBargainingOnBelief.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { CardType, Duration, EventName, KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 
 export default class SabineWrenBargainingOnBelief extends LeaderUnitCard {
@@ -17,10 +18,10 @@ export default class SabineWrenBargainingOnBelief extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'An opponent gives 2 Advantage tokens to a unit they control. If they do, the next unit you play this phase gains Shielded for this phase',
+            title: `An opponent gives 2 Advantage tokens to a unit they control. If they do, the next unit you play this phase gains ${TextHelper.Shielded} for this phase`,
             cost: abilityHelper.costs.exhaustSelf(),
             targetResolver: {
-                activePromptTitle: 'Choose a unit to give 2 Advantage tokens. The next unit your opponent plays this phase gains Shielded for this phase',
+                activePromptTitle: `Choose a unit to give 2 Advantage tokens. The next unit your opponent plays this phase gains ${TextHelper.Shielded} for this phase`,
                 waitingPromptTitle: 'Waiting for opponent to select a unit for Sabine Wren\'s ability',
                 cardTypeFilter: WildcardCardType.Unit,
                 choosingPlayer: RelativePlayer.Opponent,
@@ -30,14 +31,14 @@ export default class SabineWrenBargainingOnBelief extends LeaderUnitCard {
             effect: 'have {1} give 2 Advantage tokens to {0} to create a delayed effect',
             effectArgs: (context) => [context.player.opponent.name],
             ifYouDo: {
-                title: 'The next unit you play this phase gains Shielded for this phase',
+                title: `The next unit you play this phase gains ${TextHelper.Shielded} for this phase`,
                 immediateEffect: abilityHelper.immediateEffects.delayedPlayerEffect({
-                    title: 'The next unit you play this phase gains Shielded for this phase',
+                    title: `The next unit you play this phase gains ${TextHelper.Shielded} for this phase`,
                     when: {
                         onCardPlayed: (event, context) => this.isUnitPlayedEvent(event, context),
                     },
                     duration: Duration.UntilEndOfPhase,
-                    effectDescription: 'give Shielded to the next unit they play this phase',
+                    effectDescription: `give ${TextHelper.Shielded} to the next unit they play this phase`,
                     immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                         target: context.events.find((event) => this.isUnitPlayedEvent(event, context)).card,
                         effect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Shielded),
@@ -49,14 +50,14 @@ export default class SabineWrenBargainingOnBelief extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'The next unit you play this phase gains Shielded',
+            title: `The next unit you play this phase gains ${TextHelper.Shielded}`,
             immediateEffect: abilityHelper.immediateEffects.delayedPlayerEffect({
-                title: 'The next unit you play this phase gains Shielded',
+                title: `The next unit you play this phase gains ${TextHelper.Shielded}`,
                 when: {
                     onCardPlayed: (event, context) => this.isUnitPlayedEvent(event, context),
                 },
                 duration: Duration.UntilEndOfPhase,
-                effectDescription: 'give Shielded to the next unit they play this phase',
+                effectDescription: `give ${TextHelper.Shielded} to the next unit they play this phase`,
                 immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     target: context.events.find((event) => this.isUnitPlayedEvent(event, context)).card,
                     effect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Shielded),

--- a/server/game/cards/08_ASH/units/AT-STRaider.ts
+++ b/server/game/cards/08_ASH/units/AT-STRaider.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ATSTRaider extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ATSTRaider extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Gain Ambush while you control another non-unique unit',
+            title: `Gain ${TextHelper.Ambush} while you control another non-unique unit`,
             condition: (context) => context.player.getArenaUnits({ otherThan: context.source }).some((unit) => !unit.unique),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/08_ASH/units/B-WingRearguard.ts
+++ b/server/game/cards/08_ASH/units/B-WingRearguard.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BWingRearguard extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BWingRearguard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a ground unit, this unit gains Sentinel',
+            title: `While you control a ground unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasSomeArenaUnit({ arena: ZoneName.GroundArena }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/08_ASH/units/BoKatanKryzeForAllOfMandalore.ts
+++ b/server/game/cards/08_ASH/units/BoKatanKryzeForAllOfMandalore.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BoKatanKryzeForAllOfMandalore extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BoKatanKryzeForAllOfMandalore extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Mandalorian unit, this unit gains Raid 2',
+            title: `While you control another Mandalorian unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Mandalorian, context.source),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/08_ASH/units/CaptainPellaeonPlottingFromTheShadows.ts
+++ b/server/game/cards/08_ASH/units/CaptainPellaeonPlottingFromTheShadows.ts
@@ -5,6 +5,7 @@ import { KeywordName } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CaptainPellaeonPlottingFromTheShadows extends NonLeaderUnitCard {
     private cardsDefeatedThisPhaseWatcher: CardsDefeatedThisPhaseWatcher;
@@ -22,7 +23,7 @@ export default class CaptainPellaeonPlottingFromTheShadows extends NonLeaderUnit
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While a leader unit has been defeated this phase, this unit gains Raid 3',
+            title: `While a leader unit has been defeated this phase, this unit gains ${TextHelper.Raid(3)}`,
             condition: (context) => this.cardsDefeatedThisPhaseWatcher.someUnitDefeatedThisPhase((e) => EnumHelpers.isLeaderUnit(e.lastKnownInformation.type)),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 3 })
         });

--- a/server/game/cards/08_ASH/units/DarthVaderMeetYourDestiny.ts
+++ b/server/game/cards/08_ASH/units/DarthVaderMeetYourDestiny.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DarthVaderMeetYourDestiny extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DarthVaderMeetYourDestiny extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit is ready, it gains Sentinel',
+            title: `While this unit is ready, it gains ${TextHelper.Sentinel}`,
             condition: (context) => !context.source.exhausted,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/08_ASH/units/DomesticatedLothCat.ts
+++ b/server/game/cards/08_ASH/units/DomesticatedLothCat.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DomesticatedLothCat extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DomesticatedLothCat extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Enemy units lose Ambush and Support.',
+            title: `Enemy units lose ${TextHelper.Ambush} and Support.`,
             targetController: RelativePlayer.Opponent,
             targetCardTypeFilter: WildcardCardType.Unit,
             ongoingEffect: [

--- a/server/game/cards/08_ASH/units/GozantiAssaultCarrier.ts
+++ b/server/game/cards/08_ASH/units/GozantiAssaultCarrier.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GozantiAssaultCarrier extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GozantiAssaultCarrier extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'This unit gains Sentinel for this phase',
+            title: `This unit gains ${TextHelper.Sentinel} for this phase`,
             immediateEffect: abilityHelper.immediateEffects.forThisPhaseCardEffect({
                 effect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel),
             }),

--- a/server/game/cards/08_ASH/units/HeroicPurrgil.ts
+++ b/server/game/cards/08_ASH/units/HeroicPurrgil.ts
@@ -1,6 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HeroicPurrgil extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -12,7 +13,7 @@ export default class HeroicPurrgil extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While attacking with Ambush, this unit gets +2/+0',
+            title: `While attacking with ${TextHelper.Ambush}, this unit gets +2/+0`,
             condition: (context) => context.source.isAttacking() && context.source.activeAttack?.isAmbush,
             ongoingEffect: [AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })],
         });

--- a/server/game/cards/08_ASH/units/KoskaReevesWarriorOfMandalore.ts
+++ b/server/game/cards/08_ASH/units/KoskaReevesWarriorOfMandalore.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class KoskaReevesWarriorOfMandalore extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a token unit, this unit gains Sentinel',
+            title: `While you control a token unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasSomeArenaUnit({ condition: (card) => card.isTokenUnit() }),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });

--- a/server/game/cards/08_ASH/units/LothalEWing.ts
+++ b/server/game/cards/08_ASH/units/LothalEWing.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LothalEWing extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class LothalEWing extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While an enemy unit is upgraded, this unit gains Restore 2',
+            title: `While an enemy unit is upgraded, this unit gains ${TextHelper.Restore(2)}`,
             condition: (context) => context.player.opponent.hasSomeArenaUnit({ condition: (card) => card.isUnit() && card.isUpgraded() }),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 })
         });

--- a/server/game/cards/08_ASH/units/MandalorianFlagshipCapturedFromTheEmpire.ts
+++ b/server/game/cards/08_ASH/units/MandalorianFlagshipCapturedFromTheEmpire.ts
@@ -2,6 +2,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MandalorianFlagshipCapturedFromTheEmpire extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MandalorianFlagshipCapturedFromTheEmpire extends NonLeaderU
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a leader unit, this unit gains Ambush',
+            title: `While you control a leader unit, this unit gains ${TextHelper.Ambush}`,
             condition: (context) => context.player.hasSomeArenaUnit({
                 condition: (card) => card.isLeaderUnit()
             }),

--- a/server/game/cards/08_ASH/units/MarrokMysteriousWarrior.ts
+++ b/server/game/cards/08_ASH/units/MarrokMysteriousWarrior.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MarrokMysteriousWarrior extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MarrokMysteriousWarrior extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Gain Saboteur while upgraded',
+            title: `Gain ${TextHelper.Saboteur} while upgraded`,
             condition: (context) => context.source.isUpgraded(),
             ongoingEffect: [AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur), AbilityHelper.ongoingEffects.loseKeyword(KeywordName.Sentinel)]
         });

--- a/server/game/cards/08_ASH/units/OnyxCinderAdventureAwaits.ts
+++ b/server/game/cards/08_ASH/units/OnyxCinderAdventureAwaits.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class OnyxCinderAdventureAwaits extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class OnyxCinderAdventureAwaits extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly units gain Hidden',
+            title: `Other friendly units gain ${TextHelper.Hidden}`,
             matchTarget: (card, context) => card !== context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Hidden)
         });

--- a/server/game/cards/08_ASH/units/PoeDameronIllComeBackForYou.ts
+++ b/server/game/cards/08_ASH/units/PoeDameronIllComeBackForYou.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PoeDameronIllComeBackForYou extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PoeDameronIllComeBackForYou extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'All units lose Sentinel',
+            title: `All units lose ${TextHelper.Sentinel}`,
             matchTarget: () => true,
             targetController: WildcardRelativePlayer.Any,
             ongoingEffect: abilityHelper.ongoingEffects.loseKeyword(KeywordName.Sentinel)

--- a/server/game/cards/08_ASH/units/ShinHatiGoingSomewhere.ts
+++ b/server/game/cards/08_ASH/units/ShinHatiGoingSomewhere.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ShinHatiGoingSomewhere extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ShinHatiGoingSomewhere extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this is the only friendly non-leader ground unit, she gains Sentinel',
+            title: `While this is the only friendly non-leader ground unit, she gains ${TextHelper.Sentinel}`,
             condition: (context) => {
                 const friendlyNonLeaderGroundUnits = context.player.getArenaUnits({
                     arena: ZoneName.GroundArena,

--- a/server/game/cards/08_ASH/units/TheArmorerSecrecyIsOurSurvival.ts
+++ b/server/game/cards/08_ASH/units/TheArmorerSecrecyIsOurSurvival.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheArmorerSecrecyIsOurSurvival extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheArmorerSecrecyIsOurSurvival extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give a Shield token to each friendly unit with Shielded',
+            title: `Give a Shield token to each friendly unit with ${TextHelper.Shielded}`,
             immediateEffect: abilityHelper.immediateEffects.giveShield((context) => ({
                 target: context.player.getArenaUnits({ condition: (c) => c.hasSomeKeyword(KeywordName.Shielded) })
             }))

--- a/server/game/cards/08_ASH/units/TheTwinsWeDontWantWar.ts
+++ b/server/game/cards/08_ASH/units/TheTwinsWeDontWantWar.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheTwinsWeDontWantWar extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -24,7 +25,7 @@ export default class TheTwinsWeDontWantWar extends NonLeaderUnitCard {
         });
 
         registrar.addTriggeredAbility({
-            title: 'Give another friendly unit Sentinel for this phase',
+            title: `Give another friendly unit ${TextHelper.Sentinel} for this phase`,
             optional: true,
             when: {
                 whenPlayed: true,

--- a/server/game/cards/08_ASH/units/WarriorOfClanKryze.ts
+++ b/server/game/cards/08_ASH/units/WarriorOfClanKryze.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WarriorOfClanKryze extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class WarriorOfClanKryze extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another exhausted unit, this unit gains Sentinel',
+            title: `While you control another exhausted unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasSomeArenaUnit({ condition: (card) => card !== context.source && card.canBeExhausted() && card.exhausted }),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/08_ASH/upgrades/DeadlyVulnerability.ts
+++ b/server/game/cards/08_ASH/upgrades/DeadlyVulnerability.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { DamageModificationType, KeywordName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DeadlyVulnerability extends UpgradeCard {
     protected override getImplementationId () {
@@ -19,7 +20,7 @@ export default class DeadlyVulnerability extends UpgradeCard {
         });
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'While attached unit is defending, the attacker loses Overwhelm',
+            title: `While attached unit is defending, the attacker loses ${TextHelper.Overwhelm}`,
             matchTarget: (card, context) => card.isUnit() && card.isInPlay() && card.isAttacking() && card.activeAttack.getAllTargets().includes(context.source.parentCard),
             ongoingEffect: AbilityHelper.ongoingEffects.loseKeyword(KeywordName.Overwhelm)
         });

--- a/server/game/cards/08_ASH/upgrades/SabinesLightsaberNotAlone.ts
+++ b/server/game/cards/08_ASH/upgrades/SabinesLightsaberNotAlone.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SabinesLightsaberNotAlone extends UpgradeCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class SabinesLightsaberNotAlone extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addGainConstantAbilityTargetingAttached({
-            title: 'If attached unit is Sabine Wren or a Force unit, it gains Restore 2',
+            title: `If attached unit is Sabine Wren or a Force unit, it gains ${TextHelper.Restore(2)}`,
             condition: (context) => context.source.hasSomeTrait(Trait.Force) || context.source.title === 'Sabine Wren',
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 })
         });

--- a/server/game/core/ability/CardAbilityStep.ts
+++ b/server/game/core/ability/CardAbilityStep.ts
@@ -3,6 +3,7 @@ import { AbilityType, RelativePlayer, WildcardRelativePlayer, SubStepCheck, Play
 import * as AttackHelper from '../attack/AttackHelpers.js';
 import { Helpers } from '../utils/Helpers.js';
 import { Contract } from '../utils/Contract.js';
+import { TextHelper } from '../utils/TextHelper.js';
 import type { Card } from '../card/Card.js';
 import type { GameSystem } from '../gameSystem/GameSystem.js';
 import type { GameEvent } from '../event/GameEvent.js';
@@ -105,7 +106,7 @@ export abstract class CardAbilityStep extends PlayerOrCardAbility {
                 messageArgs.push('\'s gained ability from ', gainAbilitySource);
             }
         } else if (messageVerb === 'plays' && context.playType === PlayType.Smuggle) {
-            messageArgs.push(' using Smuggle');
+            messageArgs.push(` using ${TextHelper.Smuggle}`);
         }
         const costMessages = this.getCostsMessages(context);
 

--- a/server/game/core/ability/KeywordHelpers.ts
+++ b/server/game/core/ability/KeywordHelpers.ts
@@ -122,6 +122,7 @@ export function keywordFromProperties(properties: IKeywordProperties, card: Card
             return new KeywordInstance(properties.keyword, card);
 
         default:
+            // eslint-disable-next-line forceteki/no-raw-token-text
             throw new Error(`Keyword '${(properties as any).keyword}' is not implemented yet`);
     }
 }
@@ -287,6 +288,7 @@ function getRegexForKeyword(keyword: KeywordName) {
         case KeywordName.Support:
             return /(?:^|(?:\n))Support/g;
         default:
+            // eslint-disable-next-line forceteki/no-raw-token-text
             throw new Error(`Keyword '${keyword}' is not implemented yet`);
     }
 }

--- a/server/game/core/ability/PlayCardAction.ts
+++ b/server/game/core/ability/PlayCardAction.ts
@@ -10,6 +10,7 @@ import { TriggerHandlingMode } from '../event/EventWindow.js';
 import { CostAdjustType, type CostAdjuster } from '../cost/CostAdjuster';
 import { Helpers } from '../utils/Helpers';
 import { Contract } from '../utils/Contract';
+import { TextHelper } from '../utils/TextHelper';
 import { PlayCardResourceCost } from '../../costs/PlayCardResourceCost';
 import { GameEvent } from '../event/GameEvent';
 import { ExploitCostAdjuster } from '../../abilities/keyword/exploit/ExploitCostAdjuster';
@@ -128,13 +129,13 @@ export abstract class PlayCardAction extends PlayerAction {
 
         switch (playType) {
             case PlayType.Piloting:
-                updatedTitle += appendToTitle ? ' with Piloting' : '';
+                updatedTitle += appendToTitle ? ` with ${TextHelper.Piloting}` : '';
                 break;
             case PlayType.Plot:
-                updatedTitle += appendToTitle ? ' with Plot' : '';
+                updatedTitle += appendToTitle ? ` with ${TextHelper.Plot}` : '';
                 break;
             case PlayType.Smuggle:
-                updatedTitle += appendToTitle ? ' with Smuggle' : '';
+                updatedTitle += appendToTitle ? ` with ${TextHelper.Smuggle}` : '';
                 break;
             case PlayType.PlayFromHand:
             case PlayType.PlayFromOutOfPlay:

--- a/server/game/core/card/propertyMixins/UnitProperties.ts
+++ b/server/game/core/card/propertyMixins/UnitProperties.ts
@@ -44,6 +44,7 @@ import type { LeadersDeployedThisPhaseWatcher } from '../../../stateWatchers/Lea
 import type { ConstantAbility } from '../../ability/ConstantAbility';
 import type { OngoingCardEffect } from '../../ongoingEffect/OngoingCardEffect';
 import { getPrintedAttributesOverride } from '../../ongoingEffect/effectImpl/PrintedAttributesOverride';
+import { TextHelper } from '../../utils/TextHelper';
 import type { IInPlayCardAbilityRegistrar } from '../AbilityRegistrationInterfaces';
 import type { ITriggeredAbilityRegistrar } from './TriggeredAbilityRegistration';
 import type Clone from '../../../cards/03_TWI/units/Clone';
@@ -701,7 +702,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
                 const gainedAbilityProps = keywordInstance.abilityProps;
 
                 const coordinateKeywordAbilityProps: IConstantAbilityProps = {
-                    title: `Coordinate: ${gainedAbilityProps.title}`,
+                    title: `${TextHelper.Coordinate}: ${gainedAbilityProps.title}`,
                     condition: (context) => context.player.getArenaUnits().length >= 3 && !keywordInstance.isBlank,
                     ongoingEffect: OngoingEffectLibrary.gainAbility(gainedAbilityProps)
                 };
@@ -714,7 +715,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
             if (this.hasSomeKeyword(KeywordName.Hidden)) {
                 const hiddenKeywordAbilityProps: IConstantAbilityProps<this> = {
-                    title: 'Hidden',
+                    title: `${TextHelper.Hidden}`,
                     condition: (context) =>
                         context.source.isInPlay() &&
                         this.wasPlayedDeployedOrCreatedThisPhase(context.source),
@@ -1030,6 +1031,7 @@ export function WithUnitProperties<TBaseClass extends InPlayCardConstructor>(Bas
 
                 if (this.hasSomeKeyword(KeywordName.Grit)) {
                     const gritModifier = { power: this.damage, hp: 0 };
+                    // eslint-disable-next-line forceteki/no-raw-token-text -- internal stat-modifier provenance label, not player-facing ability text (cf. the sibling 'Raid' label below)
                     wrappedStatsModifiers.push(new StatsModifierWrapper(gritModifier, 'Grit', false, this.type));
                 }
 

--- a/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
+++ b/server/game/core/ongoingEffect/effectImpl/GainAbility.ts
@@ -6,6 +6,7 @@ import { AbilityType } from '../../Constants';
 import type { Game } from '../../Game';
 import type { IGameObjectBaseState } from '../../GameObjectBase';
 import { Contract } from '../../utils/Contract';
+import { TextHelper } from '../../utils/TextHelper';
 import { OngoingEffectValueWrapperBase } from './OngoingEffectValueWrapper';
 import { registerState, stateRef, stateValue, statePrimitive, type GameObjectId } from '../../GameObjectUtils';
 
@@ -41,7 +42,7 @@ export class GainAbility extends OngoingEffectValueWrapperBase<IAbilityPropsWith
                 triggers.push('When Played');
             }
             if (props.when.whenPlayedUsingSmuggle) {
-                triggers.push('When Played using Smuggle');
+                triggers.push(`When Played using ${TextHelper.Smuggle}`);
             }
             if (props.when.onAttack) {
                 triggers.push('On Attack');

--- a/server/game/core/ongoingEffect/effectImpl/GainKeyword.ts
+++ b/server/game/core/ongoingEffect/effectImpl/GainKeyword.ts
@@ -7,15 +7,16 @@ import type { Game } from '../../Game';
 import type { FormatMessage } from '../../chat/GameChat';
 
 import { registerState } from '../../GameObjectUtils';
+import { TextHelper } from '../../utils/TextHelper';
 
 @registerState()
 export class GainKeyword extends OngoingEffectValueWrapperBase<IKeywordProperties | IKeywordProperties[]> {
     public constructor(game: Game, keywordProps: KeywordNameOrProperties | KeywordNameOrProperties[]) {
         const effectDescription: FormatMessage = {
             format: 'give {0}',
-            args: Helpers.asArray(keywordProps).map((keyword) => {
-                return KeywordHelpers.keywordDescription(keyword);
-            })
+            args: Helpers.asArray(keywordProps).map((keyword) =>
+                TextHelper.keyword(keyword)
+            )
         };
 
         if (Array.isArray(keywordProps)) {

--- a/server/game/core/utils/TextHelper.ts
+++ b/server/game/core/utils/TextHelper.ts
@@ -2,7 +2,7 @@
 import { Helpers } from './Helpers';
 import { Aspect, KeywordName } from '../Constants';
 import type { Conjunction } from '../Constants';
-import type { INumericKeywordProperties, NonNumericKeywordName } from '../../Interfaces';
+import type { INumericKeywordProperties, KeywordNameOrProperties } from '../../Interfaces';
 
 /**
  * Helper functions for generating formatted text or inserting special tokens to be replaced on the client side with icons or special formatting.
@@ -43,6 +43,8 @@ export namespace TextHelper {
     export const Overwhelm = keyword(KeywordName.Overwhelm);
     /** The display representation of the Saboteur keyword, stylized on the client side */
     export const Saboteur = keyword(KeywordName.Saboteur);
+    /** The display representation of the Sentinel keyword, stylized on the client side */
+    export const Sentinel = keyword(KeywordName.Sentinel);
     /** The display representation of the Shielded keyword, stylized on the client side */
     export const Shielded = keyword(KeywordName.Shielded);
     /** The display representation of the Bounty keyword, stylized on the client side */
@@ -93,19 +95,28 @@ export namespace TextHelper {
      * Returns the display representation of a keyword. In test environments, this will return a human-readable string (e.g. "Restore 2") for readability,
      * but in production, it returns a token like `{keyword:restore:2}` which the client can replace with stylized text.
      *
+     * Accepts any {@link KeywordNameOrProperties} value — a bare keyword name string or any keyword properties object.
+     * For numeric keywords (those with an `amount`), the amount is included in the output.
+     *
      * @example
      * // In tests: "Restore 2"
      * // Otherwise: "{keyword:restore:2}"
      * const ex = `${TextHelper.keyword({ keyword: KeywordName.Restore, amount: 2 })}`;
      *
-     * @param keyword The keyword to display, either as a simple name or with an amount for numeric keywords
+     * @param keyword The keyword to display — a keyword name, or a keyword properties object (numeric or otherwise)
      * @returns A string representing the keyword, either as plain text (in tests) or a replacement token
      */
-    export function keyword(keyword: NonNumericKeywordName | INumericKeywordProperties): string {
+    export function keyword(keyword: KeywordNameOrProperties | KeywordName | INumericKeywordProperties): string {
         if (typeof keyword === 'object') {
+            if ('amount' in keyword) {
+                return process.env.NODE_ENV === 'test'
+                    ? `${Helpers.capitalize(keyword.keyword)} ${keyword.amount}`
+                    : `{keyword:${keyword.keyword}:${keyword.amount}}`;
+            }
+
             return process.env.NODE_ENV === 'test'
-                ? `${Helpers.capitalize(keyword.keyword)} ${keyword.amount}`
-                : `{keyword:${keyword.keyword}:${keyword.amount}}`;
+                ? Helpers.capitalize(keyword.keyword)
+                : `{keyword:${keyword.keyword}}`;
         }
 
         return process.env.NODE_ENV === 'test'

--- a/server/game/core/utils/TextHelper.ts
+++ b/server/game/core/utils/TextHelper.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @stylistic/lines-around-comment */
 import { Helpers } from './Helpers';
-import { Aspect } from '../Constants';
+import { Aspect, KeywordName } from '../Constants';
 import type { Conjunction } from '../Constants';
+import type { INumericKeywordProperties, NonNumericKeywordName } from '../../Interfaces';
 
 /**
  * Helper functions for generating formatted text or inserting special tokens to be replaced on the client side with icons or special formatting.
@@ -9,7 +10,9 @@ import type { Conjunction } from '../Constants';
  */
 export namespace TextHelper {
 
-    // Quick access to specific aspects
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Aspects
+    // ─────────────────────────────────────────────────────────────────────────────
 
     /** The display representation of the Vigilance aspect, replaced by the icon on the client side */
     export const Vigilance = aspect(Aspect.Vigilance);
@@ -23,6 +26,49 @@ export namespace TextHelper {
     export const Villainy = aspect(Aspect.Villainy);
     /** The display representation of the Heroism aspect, replaced by the icon on the client side */
     export const Heroism = aspect(Aspect.Heroism);
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Keywords
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /** The display representation of the meta-term Keyword, stylized on the client side */
+    export const Keyword = process.env.NODE_ENV === 'test' ? 'Keyword' : '{keyword:keyword}';
+    /** The display representation of the meta-term Keywords, stylized on the client side */
+    export const Keywords = process.env.NODE_ENV === 'test' ? 'Keywords' : '{keyword:keywords}';
+    /** The display representation of the Ambush keyword, stylized on the client side */
+    export const Ambush = keyword(KeywordName.Ambush);
+    /** The display representation of the Grit keyword, stylized on the client side */
+    export const Grit = keyword(KeywordName.Grit);
+    /** The display representation of the Overwhelm keyword, stylized on the client side */
+    export const Overwhelm = keyword(KeywordName.Overwhelm);
+    /** The display representation of the Saboteur keyword, stylized on the client side */
+    export const Saboteur = keyword(KeywordName.Saboteur);
+    /** The display representation of the Shielded keyword, stylized on the client side */
+    export const Shielded = keyword(KeywordName.Shielded);
+    /** The display representation of the Bounty keyword, stylized on the client side */
+    export const Bounty = keyword(KeywordName.Bounty);
+    /** The display representation of the Smuggle keyword, stylized on the client side */
+    export const Smuggle = keyword(KeywordName.Smuggle);
+    /** The display representation of the Coordinate keyword, stylized on the client side */
+    export const Coordinate = keyword(KeywordName.Coordinate);
+    /** The display representation of the Piloting keyword, stylized on the client side */
+    export const Piloting = keyword(KeywordName.Piloting);
+    /** The display representation of the Hidden keyword, stylized on the client side */
+    export const Hidden = keyword(KeywordName.Hidden);
+    /** The display representation of the Plot keyword, stylized on the client side */
+    export const Plot = keyword(KeywordName.Plot);
+    /** The display representation of the Raid keyword, stylized on the client side */
+    export function Raid(amount: number) {
+        return keyword({ keyword: KeywordName.Raid, amount });
+    }
+    /** The display representation of the Restore keyword, stylized on the client side */
+    export function Restore(amount: number) {
+        return keyword({ keyword: KeywordName.Restore, amount });
+    }
+    /** The display representation of the Exploit keyword, stylized on the client side */
+    export function Exploit(amount: number) {
+        return keyword({ keyword: KeywordName.Exploit, amount });
+    }
 
     /**
      * Returns the display representation of a resource amount. In test environments, this will return a string
@@ -41,6 +87,30 @@ export namespace TextHelper {
         return process.env.NODE_ENV === 'test'
             ? `${amount} resource${amount !== 1 ? 's' : ''}`
             : `{resource:${amount}}`;
+    }
+
+    /**
+     * Returns the display representation of a keyword. In test environments, this will return a human-readable string (e.g. "Restore 2") for readability,
+     * but in production, it returns a token like `{keyword:restore:2}` which the client can replace with stylized text.
+     *
+     * @example
+     * // In tests: "Restore 2"
+     * // Otherwise: "{keyword:restore:2}"
+     * const ex = `${TextHelper.keyword({ keyword: KeywordName.Restore, amount: 2 })}`;
+     *
+     * @param keyword The keyword to display, either as a simple name or with an amount for numeric keywords
+     * @returns A string representing the keyword, either as plain text (in tests) or a replacement token
+     */
+    export function keyword(keyword: NonNumericKeywordName | INumericKeywordProperties): string {
+        if (typeof keyword === 'object') {
+            return process.env.NODE_ENV === 'test'
+                ? `${Helpers.capitalize(keyword.keyword)} ${keyword.amount}`
+                : `{keyword:${keyword.keyword}:${keyword.amount}}`;
+        }
+
+        return process.env.NODE_ENV === 'test'
+            ? Helpers.capitalize(keyword)
+            : `{keyword:${keyword}}`;
     }
 
     /**

--- a/server/game/core/utils/TextHelper.ts
+++ b/server/game/core/utils/TextHelper.ts
@@ -92,7 +92,7 @@ export namespace TextHelper {
     }
 
     /**
-     * Returns the display representation of a keyword. In test environments, this will return a human-readable string (e.g. "Restore 2") for readability,
+     * Returns the display representation of a keyword. In test environments, this will return a human-readable string (e.g. "Restore 2"),
      * but in production, it returns a token like `{keyword:restore:2}` which the client can replace with stylized text.
      *
      * Accepts any {@link KeywordNameOrProperties} value — a bare keyword name string or any keyword properties object.

--- a/server/game/gameSystems/CollectBountySystem.ts
+++ b/server/game/gameSystems/CollectBountySystem.ts
@@ -7,6 +7,7 @@ import { BountyAbility } from '../abilities/keyword/BountyAbility';
 import type { IUnitCard } from '../core/card/propertyMixins/UnitProperties';
 import { Contract } from '../core/utils/Contract';
 import { Helpers } from '../core/utils/Helpers';
+import { TextHelper } from '../core/utils/TextHelper';
 
 export interface ICollectBountyProperties extends ICardTargetSystemProperties {
     bountyProperties: ITriggeredAbilityBaseProps | ITriggeredAbilityBaseProps[];
@@ -43,8 +44,8 @@ export class CollectBountySystem<TContext extends AbilityContext = AbilityContex
             const choices = bountyAbilities.map((ability) => ability.properties.title);
 
             const promptProperties = {
-                activePromptTitle: 'Choose a Bounty ability to use',
-                waitingPromptTitle: 'Waiting for opponent to choose a Bounty ability'
+                activePromptTitle: `Choose a ${TextHelper.Bounty} ability to use`,
+                waitingPromptTitle: `Waiting for opponent to choose a ${TextHelper.Bounty} ability`
             };
 
             const handlers = bountyAbilities.map(

--- a/server/game/gameSystems/PlayCardSystem.ts
+++ b/server/game/gameSystems/PlayCardSystem.ts
@@ -5,6 +5,7 @@ import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import { Contract } from '../core/utils/Contract';
 import { EnumHelpers } from '../core/utils/EnumHelpers';
+import { TextHelper } from '../core/utils/TextHelper';
 import { ChatHelpers } from '../core/chat/ChatHelpers';
 import { Helpers } from '../core/utils/Helpers';
 import { AbilityRestriction, CardType, KeywordName, MetaEventName, PlayType, WildcardCardType } from '../core/Constants';
@@ -76,7 +77,7 @@ export class PlayCardSystem<TContext extends AbilityContext = AbilityContext> ex
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         if (properties.playType && properties.playType === PlayType.Plot) {
-            return [`${this.effectDescription}{1} using Plot`, [this.getTargetMessage(properties.target, context), ChatHelpers.getTargetLocationMessage(properties.target, context)]];
+            return [`${this.effectDescription}{1} using ${TextHelper.Plot}`, [this.getTargetMessage(properties.target, context), ChatHelpers.getTargetLocationMessage(properties.target, context)]];
         }
 
         return [`${this.effectDescription}{1}`, [this.getTargetMessage(properties.target, context), ChatHelpers.getTargetLocationMessage(properties.target, context)]];


### PR DESCRIPTION
⚠️  Requires Client PR: SWU-Karabast/forceteki-client#757 ⚠️ 

## Description

- Update `TextHelper` to support keyword replacements: `"Ambush"` becomes `"{keyword:ambush}"`
- Update `no-raw-token-text` lint rule to prevent usage of raw Keyword names
- Update all card abilities to use the `TextHelper` keyword methods instead of raw keyword strings
- Update user-facing strings deeper in the engine to also use the `TextHelper` methods (e.g. append `"using ${TextHelper.Smuggle}"` in PlayCardAction.ts)