### PR TITLE
Fix bug with multiple shields on Mandalorian

### DIFF
--- a/server/game/cards/08_ASH/units/TheMandalorianDevotedRescuer.ts
+++ b/server/game/cards/08_ASH/units/TheMandalorianDevotedRescuer.ts
@@ -21,10 +21,15 @@ export default class TheMandalorianDevotedRescuer extends NonLeaderUnitCard {
             shouldCardHaveDamageModification: (card, context) =>
                 card.isUnit() && card.controller === context.player && card !== context.source,
             onlyIfYouDoEffect: AbilityHelper.immediateEffects.defeat((context) => {
-                // Auto-select the shield to defeat, preferring highPriorityRemoval (Jetpack) shields.
-                const shields = context.source.isUnit()
-                    ? context.source.upgrades.filter((u): u is Shield => u.isShield())
-                    : [];
+                // Auto-select the shield to defeat, preferring highPriorityRemoval (Jetpack) shields. During actual
+                // resolution (replacement context) only consider shields not already queued for defeat by another
+                // replacement effect in this window, so that multiple effects resolving in the same window each consume
+                // a distinct shield.
+                const shields = context.isReplacement()
+                    ? context.replacementEffectWindow.getShieldsNotQueuedForDefeat(context.source)
+                    : (context.source.isUnit()
+                        ? context.source.upgrades.filter((u): u is Shield => u.isShield())
+                        : []);
                 const target = shields.find((s) => s.highPriorityRemoval) ?? shields[0];
                 return { target: target ?? undefined };
             })

--- a/server/game/core/gameSteps/abilityWindow/ReplacementEffectWindow.ts
+++ b/server/game/core/gameSteps/abilityWindow/ReplacementEffectWindow.ts
@@ -1,10 +1,10 @@
 import { ReplacementEffectContext } from '../../ability/ReplacementEffectContext';
 import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import type { Card } from '../../card/Card';
-import { AbilityType } from '../../Constants';
+import type { IUnitCard } from '../../card/propertyMixins/UnitProperties';
+import { AbilityType, EventName, SubStepCheck } from '../../Constants';
 import type { EventWindow } from '../../event/EventWindow';
 import type { Game } from '../../Game';
-import type { Player } from '../../Player';
 import { TriggerWindowBase } from './TriggerWindowBase';
 import type Shield from '../../../cards/01_SOR/tokens/Shield';
 import type { GameEvent } from '../../event/GameEvent';
@@ -13,6 +13,13 @@ import type { PlayerOrCardAbility } from '../../ability/PlayerOrCardAbility';
 export class ReplacementEffectWindow extends TriggerWindowBase {
     // starts as true so that we will do the trigger cleanup and initial prompt setup on the first pass
     private newReplacementEvents = true;
+
+    /**
+     * Shield triggers that were consolidated out (we keep at most one per unit in `unresolved`), retained here so that
+     * if the kept trigger's shield is consumed by another effect we can re-select a still-valid alternate. Keyed by the
+     * shielded unit's `uuid`.
+     */
+    private stashedShieldTriggers = new Map<string, TriggeredAbilityContext<Shield>[]>();
 
     public constructor(
         game: Game,
@@ -36,7 +43,26 @@ export class ReplacementEffectWindow extends TriggerWindowBase {
     }
 
     public override shouldCleanUpTriggers(): boolean {
-        return this.newReplacementEvents;
+        if (this.newReplacementEvents) {
+            return true;
+        }
+
+        // If a shield trigger we previously kept has become invalid (its shield was consumed by another effect that
+        // resolved this window, e.g. The Mandalorian's ability defeating a shield) and we have a stashed alternate,
+        // force a cleanup pass so `consolidateShieldTriggers` can swap in the still-valid shield trigger.
+        if (this.stashedShieldTriggers.size === 0) {
+            return false;
+        }
+
+        for (const triggeredAbilities of this.unresolved.values()) {
+            for (const triggeredAbility of triggeredAbilities) {
+                if (triggeredAbility.source.isShield() && !triggeredAbility.ability.hasAnyLegalEffects(triggeredAbility, SubStepCheck.All)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public addReplacementEffectEvent(event: any) {
@@ -79,47 +105,110 @@ export class ReplacementEffectWindow extends TriggerWindowBase {
     // doesn't matter (or they may not even technically control the effect). See Lom Pyke tests for an example.
     /**
      * If there are multiple Shield triggers present, consolidate down to one per unit to reduce prompt noise.
-     * Will randomly choose the Shield to trigger, prioritizing any that have {@link Shield.highPriorityRemoval}` = true`.
+     * Will choose the Shield to trigger, prioritizing any that have {@link Shield.highPriorityRemoval}` = true`.
+     *
+     * The triggers that are not selected are not discarded but stashed in {@link stashedShieldTriggers}, so that if the
+     * selected shield is later consumed by another effect (e.g. The Mandalorian, Devoted Rescuer defeating a shield for
+     * a different unit) we can re-select a still-valid alternate on a subsequent pass instead of losing the prevention.
      */
     private consolidateShieldTriggers() {
-        // pass 1: go through all triggers and select at most 1 shield effect per unit with shield(s)
-        const selectedShieldEffectPerUnit = new Map<Card, TriggeredAbilityContext<Shield>>();
-        for (const [_player, triggeredAbilities] of this.unresolved) {
+        // gather every shield trigger we currently know about: those still in `unresolved` plus any previously stashed
+        const allShieldTriggers: TriggeredAbilityContext<Shield>[] = Array.from(this.stashedShieldTriggers.values()).flat();
+        for (const triggeredAbilities of this.unresolved.values()) {
             for (const triggeredAbility of triggeredAbilities) {
-                const abilitySource = triggeredAbility.source;
-
-                if (abilitySource.isShield()) {
-                    const shieldedUnit = abilitySource.parentCard;
-
-                    const currentlySelectedShieldEffect = selectedShieldEffectPerUnit.get(shieldedUnit);
-
-                    // if there's currently no selected shield effect, or the new one is higher priority, set it as the shield effect to resolve for this unit
-                    if (
-                        currentlySelectedShieldEffect == null ||
-                        (abilitySource.highPriorityRemoval && !currentlySelectedShieldEffect.source.highPriorityRemoval)
-                    ) {
-                        selectedShieldEffectPerUnit.set(shieldedUnit, (triggeredAbility as TriggeredAbilityContext<Shield>));
-                    }
+                if (triggeredAbility.source.isShield()) {
+                    allShieldTriggers.push(triggeredAbility as TriggeredAbilityContext<Shield>);
                 }
             }
         }
 
-        // pass 2: go through all triggers and filter out all shield effects other than those selected in pass 1
-        if (selectedShieldEffectPerUnit.size !== 0) {
-            const selectedShieldEffectsFlat = new Set(Array.from(selectedShieldEffectPerUnit.values()).flat());
-            const postConsolidateUnresolved = new Map<Player, TriggeredAbilityContext[]>();
+        if (allShieldTriggers.length === 0) {
+            return;
+        }
 
-            for (const [player, triggeredAbilities] of this.unresolved) {
-                const postConsolidateAbilities = triggeredAbilities.filter((ability) =>
-                    !ability.source.isShield() ||
-                    selectedShieldEffectsFlat.has(ability as TriggeredAbilityContext<Shield>)
-                );
+        // only consider triggers whose shield can still actually be defeated (skips shields already consumed or whose
+        // damage event was already replaced). This also guarantees `source.parentCard` is safe to access below.
+        const validShieldTriggers = allShieldTriggers.filter((trigger) => trigger.ability.hasAnyLegalEffects(trigger, SubStepCheck.All));
 
-                postConsolidateUnresolved.set(player, postConsolidateAbilities);
+        // select at most 1 shield trigger per unit, preferring highPriorityRemoval shields
+        const selectedShieldEffectPerUnit = new Map<Card, TriggeredAbilityContext<Shield>>();
+        for (const triggeredAbility of validShieldTriggers) {
+            const shieldedUnit = triggeredAbility.source.parentCard;
+            const currentlySelectedShieldEffect = selectedShieldEffectPerUnit.get(shieldedUnit);
+
+            if (
+                currentlySelectedShieldEffect == null ||
+                (triggeredAbility.source.highPriorityRemoval && !currentlySelectedShieldEffect.source.highPriorityRemoval)
+            ) {
+                selectedShieldEffectPerUnit.set(shieldedUnit, triggeredAbility);
+            }
+        }
+
+        const selectedShieldEffects = new Set(selectedShieldEffectPerUnit.values());
+
+        // rebuild `unresolved`: strip all shield triggers, keeping any selected ones in their original position
+        for (const [player, triggeredAbilities] of this.unresolved) {
+            this.unresolved.set(player, triggeredAbilities.filter((ability) =>
+                !ability.source.isShield() ||
+                selectedShieldEffects.has(ability as TriggeredAbilityContext<Shield>)
+            ));
+        }
+
+        // add any selected trigger that came from the stash (not already present in `unresolved`)
+        for (const selected of selectedShieldEffects) {
+            const playerAbilities = this.unresolved.get(selected.player) ?? [];
+            if (!playerAbilities.includes(selected)) {
+                playerAbilities.push(selected);
+                this.unresolved.set(selected.player, playerAbilities);
+            }
+        }
+
+        // stash the valid-but-not-selected alternates for potential later re-selection, keyed by shielded unit
+        this.stashedShieldTriggers = new Map<string, TriggeredAbilityContext<Shield>[]>();
+        for (const trigger of validShieldTriggers) {
+            if (selectedShieldEffects.has(trigger)) {
+                continue;
             }
 
-            this.unresolved = postConsolidateUnresolved;
+            const unitId = trigger.source.parentCard.uuid;
+            const stashedForUnit = this.stashedShieldTriggers.get(unitId) ?? [];
+            stashedForUnit.push(trigger);
+            this.stashedShieldTriggers.set(unitId, stashedForUnit);
         }
+    }
+
+    /**
+     * Helper method to get the shields attached to `unit` that are still legal targets for a defeat effect, i.e. still attached and
+     * not already the target of a defeat event queued in this window's originating {@link EventWindow}.
+     *
+     * Used by effects (e.g. The Mandalorian, Devoted Rescuer) that need to defeat a shield without colliding with a
+     * shield already claimed by another pending replacement effect in the same window.
+     */
+    public getShieldsNotQueuedForDefeat(unit: IUnitCard): Shield[] {
+        const shields = unit.upgrades.filter((upgrade): upgrade is Shield => upgrade.isShield());
+
+        if (shields.length === 0) {
+            return [];
+        }
+
+        const cardsQueuedForDefeat = this.getCardsQueuedForDefeat();
+        return shields.filter((shield) => !cardsQueuedForDefeat.has(shield));
+    }
+
+    private getCardsQueuedForDefeat(): Set<Card> {
+        const cardsQueuedForDefeat = new Set<Card>();
+
+        if (!this.eventWindow) {
+            return cardsQueuedForDefeat;
+        }
+
+        for (const event of this.eventWindow.events) {
+            if (event.name === EventName.OnCardDefeated && !event.isCancelledOrReplaced && event.card) {
+                cardsQueuedForDefeat.add(event.card);
+            }
+        }
+
+        return cardsQueuedForDefeat;
     }
 
     protected resolveAbility(context: TriggeredAbilityContext) {

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -29,6 +29,10 @@ export abstract class TriggerWindowBase extends BaseStep {
 
     protected choosePlayerResolutionOrderComplete = false;
 
+    protected readonly triggerAbilityType: AbilityType.Triggered | AbilityType.ReplacementEffect | AbilityType.DelayedEffect;
+
+    protected readonly eventWindow?: EventWindow;
+
     public get currentlyResolvingPlayer(): Player | null {
         return this.resolvePlayerOrder?.[0] ?? null;
     }
@@ -39,10 +43,13 @@ export abstract class TriggerWindowBase extends BaseStep {
 
     public constructor(
         game: Game,
-        protected readonly triggerAbilityType: AbilityType.Triggered | AbilityType.ReplacementEffect | AbilityType.DelayedEffect,
-        private readonly eventWindow?: EventWindow
+        triggerAbilityType: AbilityType.Triggered | AbilityType.ReplacementEffect | AbilityType.DelayedEffect,
+        eventWindow?: EventWindow
     ) {
         super(game);
+
+        this.triggerAbilityType = triggerAbilityType;
+        this.eventWindow = eventWindow;
 
         if (eventWindow) {
             this.triggeringEvents = [...this.eventWindow.events];

--- a/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
+++ b/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
@@ -375,7 +375,7 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 expect(context.player1).toBeActivePlayer();
             });
 
-            fit('should protect only the allied unit if the ability is triggered due to distributed damage including The Mandalorian as a target', async function () {
+            it('should protect both The Mandalorian and the allied unit from distributed damage when resolving the Shield trigger first', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -403,21 +403,154 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 ]));
 
 
-                // Three triggers: consolidated Shield for Mando's damage, Mando for BFM, Mando for Wampa.
                 expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Defeat Shield to prevent The Mandalorian from taking damage',
                     'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine'
                 ]);
 
-                // Resolve Mando's ability for BFM — auto-defeats shield
+                // Resolve the Shield token's prevention first — it defeats one shield to protect Mando. Mando's ability
+                // must then auto-select the *other* shield (helper excludes shields already queued for defeat).
+                context.player1.clickPrompt('Defeat Shield to prevent The Mandalorian from taking damage');
+                context.player1.clickPrompt('Trigger');
+
+                // Both shields consumed — Mando and BFM both protected
+                expect(context.battlefieldMarine.damage).toBe(0);
+                expect(context.theMandalorian.damage).toBe(0);
+                expect(context.theMandalorian.isUpgraded()).toBeFalse(); // both shields consumed
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should protect both The Mandalorian and the allied unit from distributed damage when resolving Mando\'s ability first', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['open-fire'],
+                        groundArena: [
+                            { card: 'the-mandalorian#devoted-rescuer', upgrades: ['shield', 'shield'] },
+                            'battlefield-marine'
+                        ],
+                    },
+                    player2: {
+                        hand: ['ninth-sister#hulking-inquisitor'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.ninthSister);
+                context.player1.clickCard(context.openFire);
+
+                context.player2.clickPrompt('Trigger');
+                context.player2.setDistributeDamagePromptState(new Map([
+                    [context.theMandalorian, 2],
+                    [context.battlefieldMarine, 1],
+                ]));
+
+
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Shield to prevent The Mandalorian from taking damage',
+                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine'
+                ]);
+
                 context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine');
                 context.player1.clickPrompt('Trigger');
 
-                // Both shields consumed — Mando takes 2 damage, BFM protected
+                // Identical end state to the shield-first order: both shields consumed, both units protected
                 expect(context.battlefieldMarine.damage).toBe(0);
-                expect(context.theMandalorian.damage).toBe(2);
+                expect(context.theMandalorian.damage).toBe(0);
                 expect(context.theMandalorian.isUpgraded()).toBeFalse(); // both shields consumed
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should protect The Mandalorian (BFM takes damage) when resolving the Shield trigger first with a single shield', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['open-fire'],
+                        groundArena: [
+                            { card: 'the-mandalorian#devoted-rescuer', upgrades: ['shield'] },
+                            'battlefield-marine'
+                        ],
+                    },
+                    player2: {
+                        hand: ['ninth-sister#hulking-inquisitor'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.ninthSister);
+                context.player1.clickCard(context.openFire);
+
+                context.player2.clickPrompt('Trigger');
+                context.player2.setDistributeDamagePromptState(new Map([
+                    [context.theMandalorian, 2],
+                    [context.battlefieldMarine, 1],
+                ]));
+
+
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Shield to prevent The Mandalorian from taking damage',
+                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine'
+                ]);
+
+                // Resolve the Shield token first — it defeats the only shield to protect Mando. Mando's ability now has
+                // no shield to defeat, so it is cleared and BFM takes its damage.
+                context.player1.clickPrompt('Defeat Shield to prevent The Mandalorian from taking damage');
+
+                expect(context.theMandalorian.damage).toBe(0); // Mando protected by the shield
+                expect(context.battlefieldMarine.damage).toBe(1); // no shield left for Mando's ability
+                expect(context.theMandalorian.isUpgraded()).toBeFalse(); // the single shield was consumed
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should protect Battlefield Marine (Mando takes damage) when resolving Mando\'s ability first with a single shield', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['open-fire'],
+                        groundArena: [
+                            { card: 'the-mandalorian#devoted-rescuer', upgrades: ['shield'] },
+                            'battlefield-marine'
+                        ],
+                    },
+                    player2: {
+                        hand: ['ninth-sister#hulking-inquisitor'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.ninthSister);
+                context.player1.clickCard(context.openFire);
+
+                context.player2.clickPrompt('Trigger');
+                context.player2.setDistributeDamagePromptState(new Map([
+                    [context.theMandalorian, 2],
+                    [context.battlefieldMarine, 1],
+                ]));
+
+
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Shield to prevent The Mandalorian from taking damage',
+                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine'
+                ]);
+
+                // Resolve Mando's ability first — it defeats the only shield to protect BFM. The Shield token trigger now
+                // has no shield to defeat, so it is cleared and Mando takes its damage.
+                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
+
+                expect(context.battlefieldMarine.damage).toBe(0); // BFM protected by Mando's ability
+                expect(context.theMandalorian.damage).toBe(2); // no shield left to protect Mando
+                expect(context.theMandalorian.isUpgraded()).toBeFalse(); // the single shield was consumed
                 expect(context.player1).toBeActivePlayer();
             });
 

--- a/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
+++ b/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
@@ -381,7 +381,7 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                     player1: {
                         hand: ['open-fire'],
                         groundArena: [
-                            { card: 'the-mandalorian#devoted-rescuer', upgrades: ['shield'] },
+                            { card: 'the-mandalorian#devoted-rescuer', upgrades: ['shield', 'shield'] },
                             'battlefield-marine'
                         ],
                     },
@@ -417,6 +417,7 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 // Both shields consumed — Mando takes 2 damage, BFM protected
                 expect(context.battlefieldMarine.damage).toBe(0);
                 expect(context.theMandalorian.damage).toBe(2);
+                expect(context.theMandalorian.isUpgraded()).toBeFalse(); // both shields consumed
                 expect(context.player1).toBeActivePlayer();
             });
 

--- a/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
+++ b/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
@@ -375,6 +375,51 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 expect(context.player1).toBeActivePlayer();
             });
 
+            fit('should protect only the allied unit if the ability is triggered due to distributed damage including The Mandalorian as a target', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['open-fire'],
+                        groundArena: [
+                            { card: 'the-mandalorian#devoted-rescuer', upgrades: ['shield'] },
+                            'battlefield-marine'
+                        ],
+                    },
+                    player2: {
+                        hand: ['ninth-sister#hulking-inquisitor'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.ninthSister);
+                context.player1.clickCard(context.openFire);
+
+                context.player2.clickPrompt('Trigger');
+                context.player2.setDistributeDamagePromptState(new Map([
+                    [context.theMandalorian, 2],
+                    [context.battlefieldMarine, 1],
+                ]));
+
+
+                // Three triggers: consolidated Shield for Mando's damage, Mando for BFM, Mando for Wampa.
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Shield to prevent The Mandalorian from taking damage',
+                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine'
+                ]);
+
+                // Resolve Mando's ability for BFM — auto-defeats shield
+                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine');
+                context.player1.clickPrompt('Trigger');
+
+                // Both shields consumed — Mando takes 2 damage, BFM protected
+                expect(context.battlefieldMarine.damage).toBe(0);
+                expect(context.theMandalorian.damage).toBe(2);
+                expect(context.player1).toBeActivePlayer();
+            });
+
             it('should not prevent indirect damage even when shield is defeated — indirect damage bypasses prevention', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
We had a bug where if there are two shields on the Mandalorian and damage was dealt to both him and another friendly unit, only one shield would be defeated to protect both himself and the friendly unit.

The root cause is that the Mandalorian's ability always fires first before any standard shield defeats, so it can defeat a shield that's been "claimed" for defeat already.

Fixing this in a real way is going to require some major re-evaluation of how replacement abilities work. As a stopgap, this PR adds some helper methods to make it possible to check what shields have already been "claimed" by another effect. It requires manual work in the ability implementation, which isn't great since we have to remember to do it. However, abilities like this are pretty rare and Mando now functions as a reference on how to do it correctly.