### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,10 @@
 # 2. Allowlist specific folders
 !/build
 !/server
-!/test/json
 !/node_modules
 !/package*.json
+
+# 3. Re-include only test/json
+!/test
+/test/*
+!/test/json


### PR DESCRIPTION
The .dockerignore subfolder syntax is a bit weird, fixed it to correctly allow `/test/json`