### PR TITLE
Fix Shin Hati interaction with Darksaber

### DIFF
--- a/server/game/cards/08_ASH/units/ShinHatiGoingSomewhere.ts
+++ b/server/game/cards/08_ASH/units/ShinHatiGoingSomewhere.ts
@@ -14,10 +14,14 @@ export default class ShinHatiGoingSomewhere extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
             title: 'While this is the only friendly non-leader ground unit, she gains Sentinel',
-            condition: (context) => context.player.getArenaUnits({
-                arena: ZoneName.GroundArena,
-                condition: (card) => card.isNonLeaderUnit(),
-            }).length === 1,
+            condition: (context) => {
+                const friendlyNonLeaderGroundUnits = context.player.getArenaUnits({
+                    arena: ZoneName.GroundArena,
+                    condition: (card) => card.isNonLeaderUnit(),
+                });
+
+                return friendlyNonLeaderGroundUnits.length === 1 && friendlyNonLeaderGroundUnits[0] === context.source;
+            },
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)
         });
     }

--- a/test/server/cards/08_ASH/units/ShinHatiGoingSomewhere.spec.ts
+++ b/test/server/cards/08_ASH/units/ShinHatiGoingSomewhere.spec.ts
@@ -1,4 +1,4 @@
-describe('Shin Hati, going Somewhere', function () {
+describe('Shin Hati, Going Somewhere?', function () {
     integration(function (contextRef) {
         it('Shin Hati\'s ability should not give her sentinel if she is not the only friendly non-leader ground unit', async function () {
             await contextRef.setupTestAsync({
@@ -57,6 +57,37 @@ describe('Shin Hati, going Somewhere', function () {
             context.player2.clickCard(context.shinHati);
 
             expect(context.player1).toBeActivePlayer();
+        });
+
+        it('Shin Hati loses sentinel when she is given The Darksaber (Icon of Leadership)', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['the-darksaber#icon-of-leadership', 'secretive-sage'],
+                    groundArena: ['shin-hati#going-somewhere']
+                },
+                player2: {
+                    groundArena: ['battlefield-marine']
+                }
+            });
+
+            const { context } = contextRef;
+
+            expect(context.shinHati.hasSomeKeyword('sentinel')).toBeTrue();
+
+            // Play the Darksaber on Shin Hati
+            context.player1.clickCard(context.theDarksaber);
+            context.player1.clickCard(context.shinHati);
+
+            // She loses sentinel because she is no longer a non-leader unit
+            expect(context.shinHati.hasSomeKeyword('sentinel')).toBeFalse();
+            context.player2.clickCard(context.battlefieldMarine);
+            expect(context.player2).toBeAbleToSelectExactly([context.shinHati, context.p1Base]);
+            context.player2.clickCard(context.p1Base);
+
+            // She does not regain sentinel when P1 plays another non-leader ground unit
+            context.player1.clickCard(context.secretiveSage);
+            expect(context.shinHati.hasSomeKeyword('sentinel')).toBeFalse();
         });
     });
 });


### PR DESCRIPTION
Previously, she could regain Sentinel when the player played another non-leader ground unit because the count would be 1 again.