### PR TITLE
Bugfix: Moff Jerjerrod doubles entire multi-target token creation

### DIFF
--- a/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
+++ b/server/game/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.ts
@@ -50,7 +50,7 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
         context: TriggeredAbilityContext<NonLeaderUnitCard>,
         AbilityHelper: IAbilityHelper
     ): GameSystem<TriggeredAbilityContext<NonLeaderUnitCard>> {
-        const { tokenType, amount, player, card } = context.event;
+        const { tokenType, amount, player } = context.event;
         const doubledUnitTokenProperties: ICreateTokenUnitRequiredProperties & Pick<IPlayerTargetSystemProperties, 'target'> = {
             amount: amount * 2,
             entersReady: context.event.entersReady,
@@ -65,10 +65,11 @@ export default class MoffJerjerrodWeShallRedoubleOurEfforts extends NonLeaderUni
             [TokenUnitName.TIEFighter]: AbilityHelper.immediateEffects.createTieFighter(doubledUnitTokenProperties),
             [TokenUnitName.Spy]: AbilityHelper.immediateEffects.createSpy(doubledUnitTokenProperties),
             [TokenUnitName.Mandalorian]: AbilityHelper.immediateEffects.createMandalorian(doubledUnitTokenProperties),
-            // Upgrades
-            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount: amount * 2, target: card }),
-            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount: amount * 2, target: card }),
-            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount: amount * 2, target: card }),
+            // Upgrades: token upgrades are given as a single creation event spanning every affected unit (event.cards),
+            // so double the amount for all of them at once
+            [TokenUpgradeName.Shield]: AbilityHelper.immediateEffects.giveShield({ amount: amount * 2, target: context.event.cards }),
+            [TokenUpgradeName.Experience]: AbilityHelper.immediateEffects.giveExperience({ amount: amount * 2, target: context.event.cards }),
+            [TokenUpgradeName.Advantage]: AbilityHelper.immediateEffects.giveAdvantage({ amount: amount * 2, target: context.event.cards }),
             // Miscellaneous
             [TokenCardName.Credit]: AbilityHelper.immediateEffects.createCreditToken({ amount: amount * 2, target: player }),
             [TokenCardName.Force]: AbilityHelper.immediateEffects.theForceIsWithYou({ target: player }),

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -174,7 +174,8 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
         return super.canAffectInternal(card, context, additionalProperties, mustChangeGameState);
     }
 
-    protected override addPropertiesToEvent(event, card: Card, context: TContext, additionalProperties: Partial<TProperties> = {}): void {
+    // `card` is typed as a scalar-or-array because some batched systems (e.g. ViewCardSystem) pass an array of targets here
+    protected override addPropertiesToEvent(event, card: Card | Card[], context: TContext, additionalProperties: Partial<TProperties> = {}): void {
         super.addPropertiesToEvent(event, card, context, additionalProperties);
         event.card = card;
     }

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -1,10 +1,12 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
 import type { CardTypeFilter, TokenUpgradeName } from '../core/Constants';
-import { EventName, WildcardCardType } from '../core/Constants';
+import { EventName, GameStateChangeRequired, WildcardCardType } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
+import type { GameEvent } from '../core/event/GameEvent';
 import { Contract } from '../core/utils/Contract';
+import { Helpers } from '../core/utils/Helpers';
 import { ChatHelpers } from '../core/chat/ChatHelpers';
 import { AttachUpgradeSystem } from './AttachUpgradeSystem';
 import type { Player } from '../core/Player';
@@ -49,51 +51,97 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         return super.canAffectInternal(card, context);
     }
 
+    /**
+     * All units receiving a token upgrade from a single ability are part of one creation event. We emit a single
+     * {@link EventName.OnTokensCreated} event covering every target (rather than the default one-event-per-target),
+     * so that effects which replace a token-creation event (e.g. Moff Jerjerrod) see and replace the whole event.
+     */
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties> = {}): void {
+        const { target } = this.generatePropertiesFromContext(context, additionalProperties);
+        const cards = Helpers.asArray(target).filter((card) => this.canAffect(card, context, additionalProperties));
+
+        if (cards.length === 0) {
+            return;
+        }
+
+        const event = this.createEvent(cards[0], context, additionalProperties);
+        this.updateEventForCards(event, cards, context, additionalProperties);
+        events.push(event);
+    }
+
+    // route the single-target generateEvent path (used by e.g. DistributeAmongTargetsSystem) through the batched logic
+    protected override updateEvent(event, card: Card, context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties> = {}): void {
+        this.updateEventForCards(event, Helpers.asArray(card), context, additionalProperties);
+    }
+
+    public override checkEventCondition(event: any, additionalProperties: Partial<IGiveTokenUpgradeProperties> = {}): boolean {
+        return Helpers.asArray(event.cards).some((card: Card) =>
+            this.canAffect(card, event.context, additionalProperties, GameStateChangeRequired.MustFullyResolve));
+    }
+
     protected abstract getTokenType(): TokenUpgradeName;
 
     protected generateToken(context: TContext, owner: Player) {
         return context.game.generateToken(owner, this.getTokenType());
     }
 
-    protected override updateEvent(event, card: Card, context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties>): void {
-        super.updateEvent(event, card, context, additionalProperties);
+    private updateEventForCards(event, cards: Card[], context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties>): void {
+        this.addPropertiesToEvent(event, cards, context, additionalProperties);
+        event.setHandler((event) => this.eventHandler(event));
+        event.condition = () => this.checkEventCondition(event, additionalProperties);
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
         // generate the tokens here so they can be used in the contingent events
         // it's fine if this event ends up being cancelled, unused tokens are cleaned up at the end of every round
         event.generatedTokens = [];
-        for (let i = 0; i < properties.amount; i++) {
-            event.generatedTokens.push(this.generateToken(context, card.controller));
+        const generatedTokensByCard = new Map<Card, any[]>();
+        for (const card of cards) {
+            const tokensForCard = [];
+            for (let i = 0; i < properties.amount; i++) {
+                const token = this.generateToken(context, card.controller);
+                tokensForCard.push(token);
+                event.generatedTokens.push(token);
+            }
+            generatedTokensByCard.set(card, tokensForCard);
         }
 
-        // add contingent events for attaching the generated upgrade token(s)
+        // add contingent events for attaching the generated upgrade token(s) to each affected unit
         event.setContingentEventsGenerator((event) => {
             const events = [];
 
-            for (let i = 0; i < properties.amount; i++) {
-                const attachUpgradeEvent = new AttachUpgradeSystem({
-                    upgrade: event.generatedTokens[i],
-                    target: card
-                }).generateEvent(event.context);
+            for (const [card, tokens] of generatedTokensByCard) {
+                for (const token of tokens) {
+                    const attachUpgradeEvent = new AttachUpgradeSystem({
+                        upgrade: token,
+                        target: card
+                    }).generateEvent(event.context);
 
-                attachUpgradeEvent.order = event.order + 1;
+                    attachUpgradeEvent.order = event.order + 1;
 
-                events.push(attachUpgradeEvent);
+                    events.push(attachUpgradeEvent);
+                }
             }
 
             return events;
         });
     }
 
-    public override addPropertiesToEvent(event: any, card: Card, context: TContext, additionalProperties?: Partial<IGiveTokenUpgradeProperties>): void {
-        Contract.assertTrue(card.isUnit());
-        Contract.assertTrue(card.isInPlay());
+    protected override addPropertiesToEvent(event: any, cards: Card | Card[], context: TContext, additionalProperties?: Partial<IGiveTokenUpgradeProperties>): void {
+        const cardsArray = Helpers.asArray(cards);
 
-        super.addPropertiesToEvent(event, card, context, additionalProperties);
+        Contract.assertTrue(cardsArray.length > 0, 'Attempting to give a token upgrade with no target units');
+        for (const card of cardsArray) {
+            Contract.assertTrue(card.isUnit());
+            Contract.assertTrue(card.isInPlay());
+        }
+
+        // sets event.player and event.contingentSourceEvent (and event.card = cardsArray[0] as the representative target)
+        super.addPropertiesToEvent(event, cardsArray[0], context, additionalProperties);
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
+        event.cards = cardsArray;
         event.amount = properties.amount;
         event.tokenType = this.getTokenType();
     }

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -64,16 +64,13 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
             return;
         }
 
-        const event = this.createEvent(cards, context, additionalProperties);
-        this.updateEventForCards(event, cards, context, additionalProperties);
-        events.push(event);
+        // generateRetargetedEvent does the standard createEvent + updateEvent, but (unlike CardTargetSystem.generateEvent)
+        // without asserting a single target, so it can build one event spanning every affected unit
+        events.push(this.generateRetargetedEvent(cards, context, additionalProperties));
     }
 
-    // route the single-target generateEvent path (used by e.g. DistributeAmongTargetsSystem) through the batched logic
-    protected override updateEvent(event, card: Card, context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties> = {}): void {
-        this.updateEventForCards(event, Helpers.asArray(card), context, additionalProperties);
-    }
-
+    // a batched give can target multiple units, so condition on whether any targeted unit can still be affected
+    // (the base reads the single `event.card`, which is the whole array for a multi-target give)
     public override checkEventCondition(event: any, additionalProperties: Partial<IGiveTokenUpgradeProperties> = {}): boolean {
         return Helpers.asArray(event.cards).some((card: Card) =>
             this.canAffect(card, event.context, additionalProperties, GameStateChangeRequired.MustFullyResolve));
@@ -85,10 +82,11 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         return context.game.generateToken(owner, this.getTokenType());
     }
 
-    private updateEventForCards(event, cards: Card[], context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties>): void {
-        this.addPropertiesToEvent(event, cards, context, additionalProperties);
-        event.setHandler((event) => this.eventHandler(event));
-        event.condition = () => this.checkEventCondition(event, additionalProperties);
+    // standard updateEvent override: let the base set the common properties/handler/condition, then generate the tokens
+    // and the contingent attach events. `cards` is a single card on the single-target generateEvent path (e.g. from
+    // DistributeAmongTargetsSystem) and an array on the batched queueGenerateEventGameSteps path.
+    protected override updateEvent(event, cards: Card | Card[], context: TContext, additionalProperties: Partial<IGiveTokenUpgradeProperties> = {}): void {
+        super.updateEvent(event, cards, context, additionalProperties);
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
@@ -96,7 +94,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         // it's fine if this event ends up being cancelled, unused tokens are cleaned up at the end of every round
         event.generatedTokens = [];
         const generatedTokensByCard = new Map<Card, any[]>();
-        for (const card of cards) {
+        for (const card of Helpers.asArray(cards)) {
             const tokensForCard = [];
             for (let i = 0; i < properties.amount; i++) {
                 const token = this.generateToken(context, card.controller);
@@ -137,16 +135,16 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
             Contract.assertTrue(card.isInPlay());
         }
 
-        // `event.card` is a single-target convention (read by e.g. DistributeAmongTargetsSystem's chat message), so only
-        // populate it when there's genuinely one target. A batched multi-target give exposes its full set via `event.cards`
-        const singleCardTarget = cardsArray.length === 1 ? cardsArray[0] : null;
+        super.addPropertiesToEvent(event, cards, context, additionalProperties);
 
-        // GameSystem sets event.player/event.contingentSourceEvent; CardTargetSystem sets event.card to the passed target
-        super.addPropertiesToEvent(event, singleCardTarget, context, additionalProperties);
+        // A batched give can target multiple units. `event.cards` is the full set of targets; `event.card` keeps the
+        // single-target convention (read as a scalar Card by e.g. DistributeAmongTargetsSystem's chat message and the
+        // replacement-effect prompt title) and is null when several units are targeted, so callers read `event.cards`.
+        event.cards = cardsArray;
+        event.card = cardsArray.length === 1 ? cardsArray[0] : null;
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 
-        event.cards = cardsArray;
         event.amount = properties.amount;
         event.tokenType = this.getTokenType();
     }

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -64,7 +64,7 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
             return;
         }
 
-        const event = this.createEvent(cards[0], context, additionalProperties);
+        const event = this.createEvent(cards, context, additionalProperties);
         this.updateEventForCards(event, cards, context, additionalProperties);
         events.push(event);
     }
@@ -131,13 +131,18 @@ export abstract class GiveTokenUpgradeSystem<TContext extends AbilityContext = A
         const cardsArray = Helpers.asArray(cards);
 
         Contract.assertTrue(cardsArray.length > 0, 'Attempting to give a token upgrade with no target units');
+
         for (const card of cardsArray) {
             Contract.assertTrue(card.isUnit());
             Contract.assertTrue(card.isInPlay());
         }
 
-        // sets event.player and event.contingentSourceEvent (and event.card = cardsArray[0] as the representative target)
-        super.addPropertiesToEvent(event, cardsArray[0], context, additionalProperties);
+        // `event.card` is a single-target convention (read by e.g. DistributeAmongTargetsSystem's chat message), so only
+        // populate it when there's genuinely one target. A batched multi-target give exposes its full set via `event.cards`
+        const singleCardTarget = cardsArray.length === 1 ? cardsArray[0] : null;
+
+        // GameSystem sets event.player/event.contingentSourceEvent; CardTargetSystem sets event.card to the passed target
+        super.addPropertiesToEvent(event, singleCardTarget, context, additionalProperties);
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
 

--- a/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
+++ b/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
@@ -227,9 +227,7 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
 
                 const { context } = contextRef;
 
-                // Play Crucible, giving an experience token to each other friendly unit.
-                // Per the ruling, this is a single creation event, so defeating Jerjerrod once
-                // should double the experience for every affected unit.
+                // Play Crucible, giving an experience token to each other friendly unit
                 context.player1.clickCard(context.crucible);
 
                 // A single replacement prompt should double the whole event
@@ -265,11 +263,11 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
             });
 
             it('should handle simultaneous creation of multiple token types', async function () {
-                // TODO: per the publisher ruling, a single defeat should double the entire creation event, so all
-                // token types should be doubled here. The multi-target case (e.g. Crucible) is fixed by batching a
-                // single GiveTokenUpgradeSystem call into one OnTokensCreated event, but Three Lessons creates the
-                // Experience and Shield via two separate systems (two events), so they still trigger Jerjerrod
-                // independently. Cross-system grouping of one creation event is a separate fix.
+                // TODO: This is incorrect. Per FFG clarification, a single defeat should double the entire creation
+                // event, so all token types should be doubled here. The multi-target case (e.g. Crucible) is fixed
+                // by batching a single GiveTokenUpgradeSystem call into one OnTokensCreated event, but Three Lessons
+                // creates the Experience and Shield via two separate systems (two events), so they still trigger Jerjerrod
+                // independently
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {

--- a/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
+++ b/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
@@ -211,9 +211,7 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
                 expect(context.wampa).toHaveExactUpgradeNames(['shield', 'shield']);
             });
 
-            it('should double token upgrades given to multiple units simultaneously', async function () {
-                // TODO: currently the engine only lets you double tokens for one of the affected units
-                // Revisit this when rules for token-doubling effects are clarified
+            it('should double the entire token creation event when tokens are given to multiple units simultaneously (single defeat doubles all)', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -229,28 +227,20 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
 
                 const { context } = contextRef;
 
-                // Play Crucible, giving an experience token to each other friendly unit
+                // Play Crucible, giving an experience token to each other friendly unit.
+                // Per the ruling, this is a single creation event, so defeating Jerjerrod once
+                // should double the experience for every affected unit.
                 context.player1.clickCard(context.crucible);
 
-                // Jerjerrod's replacement triggers once for each unit - choose one to resolve first
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Defeat Moff Jerjerrod to create 2 Experience tokens instead: Moff Jerjerrod',
-                    'Defeat Moff Jerjerrod to create 2 Experience tokens instead: Wampa',
-                    'Defeat Moff Jerjerrod to create 2 Experience tokens instead: Battlefield Marine',
-                    'Defeat Moff Jerjerrod to create 2 Experience tokens instead: X-Wing'
-                ]);
-
-                // Arbitrarily choose to resolve the effect on Battlefield Marine
-                context.player1.clickPrompt('Defeat Moff Jerjerrod to create 2 Experience tokens instead: Battlefield Marine');
-                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Experience tokens instead: Battlefield Marine');
+                // A single replacement prompt should double the whole event
+                expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Experience tokens instead');
                 context.player1.clickPrompt('Trigger');
 
-                // Jerjerrod is defeated and Battlefield Marine receives 2 experience tokens instead of 1; the other units still receive 1 experience token each
+                // Jerjerrod is defeated once and every other friendly unit receives 2 experience tokens instead of 1
                 expect(context.moffJerjerrod).toBeInZone('discard');
-                expect(context.wampa).toHaveExactUpgradeNames(['experience']);
+                expect(context.wampa).toHaveExactUpgradeNames(['experience', 'experience']);
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['experience', 'experience']);
-                expect(context.xwing).toHaveExactUpgradeNames(['experience']);
+                expect(context.xwing).toHaveExactUpgradeNames(['experience', 'experience']);
             });
 
             it('should not trigger when a friendly effect causes an opponent to create tokens', async function () {
@@ -275,8 +265,11 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
             });
 
             it('should handle simultaneous creation of multiple token types', async function () {
-                // TODO: revisit when official clarification on replacement effect behavior for
-                // simultaneous multi-type token creation (e.g. Three Lessons) is available
+                // TODO: per the publisher ruling, a single defeat should double the entire creation event, so all
+                // token types should be doubled here. The multi-target case (e.g. Crucible) is fixed by batching a
+                // single GiveTokenUpgradeSystem call into one OnTokensCreated event, but Three Lessons creates the
+                // Experience and Shield via two separate systems (two events), so they still trigger Jerjerrod
+                // independently. Cross-system grouping of one creation event is a separate fix.
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {


### PR DESCRIPTION
Crucible (and other "give a token to each friendly unit" effects) didn't work with Moff Jerjerrod. `GiveTokenUpgradeSystem` emitted one `OnTokensCreated` event per target unit, so Jerjerrod's replacement fired per-unit — and since he can only be defeated once, only one unit got doubled.

Fix: a single give-token-upgrade ability now emits one `OnTokensCreated` event covering every affected unit, so one defeat doubles the whole creation event (matches the publisher ruling). Also generalizes to Executor – Final Destruction.

Note: Three Lessons (XP + Shield via two separate systems) is still a separate cross-system grouping issue and is not fixed here.

Refs #2606 (does not fully resolve)