### PR TITLE
Fix crash when a card selector encounters a captured unit

### DIFF
--- a/server/game/core/cardSelector/BaseCardSelector.ts
+++ b/server/game/core/cardSelector/BaseCardSelector.ts
@@ -234,10 +234,6 @@ export abstract class BaseCardSelector<TContext extends AbilityContext> {
         if (controllerProp === RelativePlayer.Opponent && card.controller !== context.player.opponent) {
             return false;
         }
-        // Capture-zone cards are only valid targets for selectors that explicitly opt in by
-        // including ZoneName.Capture in their zoneFilter (see filterCaptureZones / capturedByFilter).
-        // Selectors that don't ask for the capture zone must not consider captured cards, otherwise
-        // captured units (which retain their controller) can leak into cardCondition checks.
         if (!EnumHelpers.cardZoneMatches(card.zoneName, this.zoneFilter)) {
             return false;
         }

--- a/server/game/core/cardSelector/BaseCardSelector.ts
+++ b/server/game/core/cardSelector/BaseCardSelector.ts
@@ -234,7 +234,11 @@ export abstract class BaseCardSelector<TContext extends AbilityContext> {
         if (controllerProp === RelativePlayer.Opponent && card.controller !== context.player.opponent) {
             return false;
         }
-        if (!EnumHelpers.cardZoneMatches(card.zoneName, this.zoneFilter) && card.zoneName !== ZoneName.Capture) {
+        // Capture-zone cards are only valid targets for selectors that explicitly opt in by
+        // including ZoneName.Capture in their zoneFilter (see filterCaptureZones / capturedByFilter).
+        // Selectors that don't ask for the capture zone must not consider captured cards, otherwise
+        // captured units (which retain their controller) can leak into cardCondition checks.
+        if (!EnumHelpers.cardZoneMatches(card.zoneName, this.zoneFilter)) {
             return false;
         }
         return EnumHelpers.cardTypeMatches(card.type, this.cardTypeFilter) && this.cardConditionsAreSatisfied(card, selectedCards, context);

--- a/test/server/cards/06_SEC/events/LetsTalk.spec.ts
+++ b/test/server/cards/06_SEC/events/LetsTalk.spec.ts
@@ -158,6 +158,37 @@ describe('Let\'s Talk', function () {
             expect(context.atst).toBeCapturedBy(context.wampa);
         });
 
+        it('Let\'s Talk does not error when the active player owns a unit captured by the opponent', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    base: 'data-vault',
+                    groundArena: ['wampa'],
+                    hand: ['lets-talk']
+                },
+                player2: {
+                    groundArena: [
+                        { card: 'atst', capturedUnits: ['battlefield-marine'] },
+                        'rebel-pathfinder'
+                    ]
+                }
+            });
+
+            const { context } = contextRef;
+
+            // The captured Battlefield Marine (owned + controlled by player1, in the capture zone)
+            // must not be offered as a captor and must not cause a crash during target resolution.
+            context.player1.clickCard(context.letsTalk);
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+            context.player1.clickCard(context.wampa);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.atst, context.rebelPathfinder]);
+            context.player1.clickCard(context.rebelPathfinder);
+
+            expect(context.rebelPathfinder).toBeCapturedBy(context.wampa);
+            expect(context.battlefieldMarine).toBeCapturedBy(context.atst);
+        });
+
         it('Let\'s Talk claims bounties simultaneously, allowing for collect order', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',

--- a/test/server/cards/06_SEC/events/LetsTalk.spec.ts
+++ b/test/server/cards/06_SEC/events/LetsTalk.spec.ts
@@ -168,15 +168,20 @@ describe('Let\'s Talk', function () {
                 },
                 player2: {
                     groundArena: [
-                        { card: 'atst', capturedUnits: ['battlefield-marine'] },
-                        'rebel-pathfinder'
+                        'rebel-pathfinder',
+                        {
+                            card: 'atst',
+                            capturedUnits: [
+                                { card: 'battlefield-marine', owner: 'player1' }
+                            ]
+                        },
                     ]
                 }
             });
 
             const { context } = contextRef;
 
-            // The captured Battlefield Marine (owned + controlled by player1, in the capture zone)
+            // The captured Battlefield Marine (owned by player1, in the capture zone)
             // must not be offered as a captor and must not cause a crash during target resolution.
             context.player1.clickCard(context.letsTalk);
             expect(context.player1).toBeAbleToSelectExactly([context.wampa]);


### PR DESCRIPTION
## Problem

Playing **Let's Talk** crashed the server with `Contract assertion failure: Zone capture must be an arena` when the active player controlled a unit that had been captured by the opponent.

A captured unit keeps its controller (`moveToCaptureZone` doesn't reset it to owner), so a unit still controlled by the active player passed the selector's `Self`/`Unit` checks. `BaseCardSelector.canTarget` then let `ZoneName.Capture` cards bypass the zone filter, so the captured unit reached Let's Talk's `multiSelectCardCondition`, which asserted its zone was an arena.

## Fix

Removed the capture-zone bypass in `canTarget`. Captured cards are now only considered by selectors that opt in via `ZoneName.Capture` in their `zoneFilter` (which all `capturedByFilter` selectors already do). The bypass was redundant anyway, since `cardZoneMatches(Capture, [Capture])` already returns `true`.

## Testing

Added a regression test reproducing the crash. Full suite on a clean rebuild: 7335 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)