### PR TITLE
Apply text replacement tokens for Traits

### DIFF
--- a/eslint-rules/no-raw-token-text.mjs
+++ b/eslint-rules/no-raw-token-text.mjs
@@ -16,6 +16,33 @@ const TOKEN_CATEGORIES = [
         message: 'Raw aspect name "{{match}}" in string literal. Use the corresponding TextHelper constant (e.g. `TextHelper.Aggression`) or `TextHelper.aspect(Aspect.X)` in a template literal instead, so it can be replaced with an icon on the client side.',
     },
     {
+        // Title-cased trait names, matched case-sensitively so only display-style references are
+        // flagged (e.g. "Force" the trait, not lowercase uses). Keep in sync with the `Trait` enum
+        // in server/game/core/Constants.ts. Some traits are common English words (Item, Plan, Night,
+        // Law, Tank, etc.); when a match is genuinely NOT a trait reference, suppress it with
+        // `// eslint-disable-next-line forceteki/no-raw-token-text -- <reason>`.
+        //
+        // The "the Force" game concept (the Force token) is common and is NOT the Force trait, so it
+        // is auto-ignored via `ignore` below. Genuine trait references like "the Force trait/unit/card"
+        // are still flagged.
+        names: [
+            'Armor', 'Bounty Hunter', 'Bounty', 'Capital Ship', 'Clone', 'Condition', 'Creature',
+            'Disaster', 'Droid', 'Ewok', 'Fighter', 'First Order', 'Force', 'Fringe', 'Gambit',
+            'Gungan', 'Hutt', 'Imperial', 'Innate', 'Inquisitor', 'Item', 'Jawa', 'Jedi', 'Kaminoan',
+            'Law', 'Learned', 'Lightsaber', 'Mandalorian', 'Modification', 'Musician', 'Naboo',
+            'New Republic', 'Night', 'Nihil', 'Official', 'Pilot', 'Plan', 'Rebel', 'Republic',
+            'Resistance', 'Separatist', 'Sith', 'Spectre', 'Speeder', 'Supply', 'Tactic', 'Tank',
+            'Transport', 'Trick', 'Trooper', 'Tusken', 'Twi\'lek', 'Undead', 'Underworld', 'Vehicle',
+            'Walker', 'Weapon', 'Wookiee',
+        ],
+        messageId: 'rawTraitName',
+        message: 'Raw trait name "{{match}}" in string literal. Use the corresponding TextHelper constant (e.g. `TextHelper.Trait.BountyHunter`) or `TextHelper.trait(Trait.X)` in a template literal instead, so it can be styled correctly on the client side. If this is not a trait reference, suppress with an eslint-disable-next-line comment explaining why.',
+        // Skip the "the Force" game concept (but keep flagging "the Force trait/unit/card"). The
+        // token to skip is captured in group 1.
+        ignore: '\\bthe\\s+(Force)\\b(?!\\s+(?:trait|units?|cards?)\\b)',
+        ignoreFlags: 'gi',
+    },
+    {
         pattern: 'Keywords?|Ambush|Grit|Overwhelm|Raid\\s+\\d+|Restore\\s+\\d+|Saboteur|Sentinel|Shielded|Bounty|Smuggle|Coordinate|Exploit\\s+\\d+|Piloting|Hidden|Plot',
         flags: 'g',
         messageId: 'rawKeyword',
@@ -30,15 +57,22 @@ const TOKEN_CATEGORIES = [
         messageId: 'rawResourceCost',
         message: 'Raw resource cost "{{match}}" in string literal. Use `TextHelper.resource(N)` in a template literal instead, so it can be replaced with an icon on the client side.',
     },
-    // Add more categories as needed, e.g. traits, keywords, etc.
+    // Add more categories as needed.
 ];
 
-// Compile each category into a { regex, messageId } entry
+// Compile each category into a { regex, messageId, ignore } entry. An optional `ignore` regex
+// (with the token to skip captured in group 1) suppresses matches in known non-token contexts.
 const compiledCategories = TOKEN_CATEGORIES.map((cat) => {
+    const ignore = cat.ignore ? new RegExp(cat.ignore, cat.ignoreFlags || 'gi') : null;
+
     if (cat.names) {
+        // Sort longest-first so multi-word names win over their prefixes in the alternation
+        // (e.g. "Bounty Hunter" is tried before "Bounty", "New Republic" before "Republic").
+        const alternation = [...cat.names].sort((a, b) => b.length - a.length).join('|');
         return {
-            regex: new RegExp(`\\b(${cat.names.join('|')})\\b`, cat.flags || 'g'),
+            regex: new RegExp(`\\b(${alternation})\\b`, cat.flags || 'g'),
             messageId: cat.messageId,
+            ignore,
         };
     }
     // Wrap in word boundaries so a token is only matched as a whole word — e.g. "Smuggle"
@@ -47,6 +81,7 @@ const compiledCategories = TOKEN_CATEGORIES.map((cat) => {
     return {
         regex: new RegExp(`\\b(${cat.pattern})\\b`, cat.flags || 'gi'),
         messageId: cat.messageId,
+        ignore,
     };
 });
 
@@ -115,9 +150,27 @@ export default {
     create(context) {
         function checkForTokenText(node, value) {
             for (const category of compiledCategories) {
+                // Collect the start indices of token matches that should be ignored (e.g. the
+                // "the Force" game concept). The ignore regex captures the token in group 1, so
+                // its offset within the full ignore match gives the token's start index.
+                const ignoredStarts = new Set();
+                if (category.ignore) {
+                    category.ignore.lastIndex = 0;
+                    let ignoreMatch;
+                    while ((ignoreMatch = category.ignore.exec(value)) !== null) {
+                        ignoredStarts.add(ignoreMatch.index + ignoreMatch[0].indexOf(ignoreMatch[1]));
+                        if (ignoreMatch.index === category.ignore.lastIndex) {
+                            category.ignore.lastIndex++;
+                        }
+                    }
+                }
+
                 category.regex.lastIndex = 0;
                 let match;
                 while ((match = category.regex.exec(value)) !== null) {
+                    if (ignoredStarts.has(match.index)) {
+                        continue;
+                    }
                     context.report({
                         node,
                         messageId: category.messageId,

--- a/eslint-rules/no-raw-token-text.mjs
+++ b/eslint-rules/no-raw-token-text.mjs
@@ -22,9 +22,11 @@ const TOKEN_CATEGORIES = [
         // Law, Tank, etc.); when a match is genuinely NOT a trait reference, suppress it with
         // `// eslint-disable-next-line forceteki/no-raw-token-text -- <reason>`.
         //
-        // The "the Force" game concept (the Force token) is common and is NOT the Force trait, so it
-        // is auto-ignored via `ignore` below. Genuine trait references like "the Force trait/unit/card"
-        // are still flagged.
+        // Some Title-cased words collide with non-trait references and are auto-ignored via `ignore`
+        // below (see there for details): the "the Force" game concept, token unit names ("Battle
+        // Droid", "Clone Trooper", "TIE Fighter", "Mandalorian token"), and proper card/character
+        // names ("Jabba the Hutt", "The Mandalorian", "Swarming Vulture Droid"). Genuine trait
+        // references like "the Force trait" or "Mandalorian unit" are still flagged.
         names: [
             'Armor', 'Bounty Hunter', 'Bounty', 'Capital Ship', 'Clone', 'Condition', 'Creature',
             'Disaster', 'Droid', 'Ewok', 'Fighter', 'First Order', 'Force', 'Fringe', 'Gambit',
@@ -37,10 +39,23 @@ const TOKEN_CATEGORIES = [
         ],
         messageId: 'rawTraitName',
         message: 'Raw trait name "{{match}}" in string literal. Use the corresponding TextHelper constant (e.g. `TextHelper.Trait.BountyHunter`) or `TextHelper.trait(Trait.X)` in a template literal instead, so it can be styled correctly on the client side. If this is not a trait reference, suppress with an eslint-disable-next-line comment explaining why.',
-        // Skip the "the Force" game concept (but keep flagging "the Force trait/unit/card"). The
-        // token to skip is captured in group 1.
-        ignore: '\\bthe\\s+(Force)\\b(?!\\s+(?:trait|units?|cards?)\\b)',
-        ignoreFlags: 'gi',
+        // Any trait word that falls inside a match of one of these patterns is skipped. Each entry
+        // targets a context where a trait word is NOT a trait reference. Matched case-insensitively.
+        ignore: [
+            // The "the Force" game concept (the Force token) — but NOT "the Force trait/unit/card",
+            // which are genuine references and stay flagged.
+            '\\bthe\\s+Force\\b(?!\\s+(?:trait|units?|cards?)\\b)',
+            // Token unit names whose words collide with traits (Droid / Clone / Trooper / Fighter).
+            'Battle Droid',
+            'Clone Trooper',
+            'TIE Fighter',
+            // "Mandalorian" is both a trait and a token; skip only the token ("Mandalorian token(s)").
+            'Mandalorian\\s+tokens?',
+            // Proper card / character names.
+            'Jabba the Hutt',
+            'The Mandalorian',
+            'Swarming Vulture Droid',
+        ],
     },
     {
         pattern: 'Keywords?|Ambush|Grit|Overwhelm|Raid\\s+\\d+|Restore\\s+\\d+|Saboteur|Sentinel|Shielded|Bounty|Smuggle|Coordinate|Exploit\\s+\\d+|Piloting|Hidden|Plot',
@@ -60,10 +75,11 @@ const TOKEN_CATEGORIES = [
     // Add more categories as needed.
 ];
 
-// Compile each category into a { regex, messageId, ignore } entry. An optional `ignore` regex
-// (with the token to skip captured in group 1) suppresses matches in known non-token contexts.
+// Compile each category into a { regex, messageId, ignore } entry. An optional `ignore` array of
+// regex sources suppresses any token match that falls within a match of one of them (so a phrase
+// like "Clone Trooper" can suppress both the "Clone" and "Trooper" trait words at once).
 const compiledCategories = TOKEN_CATEGORIES.map((cat) => {
-    const ignore = cat.ignore ? new RegExp(cat.ignore, cat.ignoreFlags || 'gi') : null;
+    const ignore = cat.ignore ? cat.ignore.map((pattern) => new RegExp(pattern, 'gi')) : null;
 
     if (cat.names) {
         // Sort longest-first so multi-word names win over their prefixes in the alternation
@@ -150,17 +166,20 @@ export default {
     create(context) {
         function checkForTokenText(node, value) {
             for (const category of compiledCategories) {
-                // Collect the start indices of token matches that should be ignored (e.g. the
-                // "the Force" game concept). The ignore regex captures the token in group 1, so
-                // its offset within the full ignore match gives the token's start index.
-                const ignoredStarts = new Set();
+                // Collect [start, end) spans that should be ignored (e.g. the "the Force" game
+                // concept, token unit names, proper card names). A token match is skipped if it
+                // starts inside any ignore span — so a multi-word phrase suppresses every trait
+                // word within it (e.g. "Clone Trooper" covers both "Clone" and "Trooper").
+                const ignoreSpans = [];
                 if (category.ignore) {
-                    category.ignore.lastIndex = 0;
-                    let ignoreMatch;
-                    while ((ignoreMatch = category.ignore.exec(value)) !== null) {
-                        ignoredStarts.add(ignoreMatch.index + ignoreMatch[0].indexOf(ignoreMatch[1]));
-                        if (ignoreMatch.index === category.ignore.lastIndex) {
-                            category.ignore.lastIndex++;
+                    for (const ignoreRegex of category.ignore) {
+                        ignoreRegex.lastIndex = 0;
+                        let ignoreMatch;
+                        while ((ignoreMatch = ignoreRegex.exec(value)) !== null) {
+                            ignoreSpans.push([ignoreMatch.index, ignoreMatch.index + ignoreMatch[0].length]);
+                            if (ignoreMatch.index === ignoreRegex.lastIndex) {
+                                ignoreRegex.lastIndex++;
+                            }
                         }
                     }
                 }
@@ -168,7 +187,7 @@ export default {
                 category.regex.lastIndex = 0;
                 let match;
                 while ((match = category.regex.exec(value)) !== null) {
-                    if (ignoredStarts.has(match.index)) {
+                    if (ignoreSpans.some(([start, end]) => match.index >= start && match.index < end)) {
                         continue;
                     }
                     context.report({

--- a/server/game/cards/01_SOR/events/ForceChoke.ts
+++ b/server/game/cards/01_SOR/events/ForceChoke.ts
@@ -14,7 +14,7 @@ export default class ForceChoke extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `If you control a Force unit, this costs ${TextHelper.resource(1)} less to play`,
+            title: `If you control a ${TextHelper.Trait.Force} unit, this costs ${TextHelper.resource(1)} less to play`,
             amount: 1,
             condition: (context) => context.player.isTraitInPlay(Trait.Force)
         });

--- a/server/game/cards/01_SOR/events/ItBindsAllThings.ts
+++ b/server/game/cards/01_SOR/events/ItBindsAllThings.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ItBindsAllThings extends EventCard {
     protected override getImplementationId () {
@@ -22,7 +23,7 @@ export default class ItBindsAllThings extends EventCard {
                 maxTargets: 1,
             }),
             then: (thenContext) => ({
-                title: 'If you control a Force unit, you may deal that much damage to another unit.',
+                title: `If you control a ${TextHelper.Trait.Force} unit, you may deal that much damage to another unit.`,
                 optional: true,
                 thenCondition: () => thenContext.player.isTraitInPlay(Trait.Force) &&
                   thenContext.events[0].totalDistributed > 0,

--- a/server/game/cards/01_SOR/events/MaximumFirePower.ts
+++ b/server/game/cards/01_SOR/events/MaximumFirePower.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MaximumFirePower extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class MaximumFirePower extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'A friendly Imperial unit deals damage equal to its power to a unit.',
+            title: `A friendly ${TextHelper.Trait.Imperial} unit deals damage equal to its power to a unit.`,
             targetResolvers: {
                 firstImperial: {
                     controller: RelativePlayer.Self,
@@ -33,7 +34,7 @@ export default class MaximumFirePower extends EventCard {
                 }
             },
             then: (thenContext) => ({
-                title: 'Another friendly Imperial unit deals damage equal to its power to the same unit.',
+                title: `Another friendly ${TextHelper.Trait.Imperial} unit deals damage equal to its power to the same unit.`,
                 targetResolver: {
                     controller: RelativePlayer.Self,
                     zoneFilter: WildcardZoneName.AnyArena,

--- a/server/game/cards/01_SOR/events/MedalCeremony.ts
+++ b/server/game/cards/01_SOR/events/MedalCeremony.ts
@@ -4,6 +4,7 @@ import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrat
 import { TargetMode, Trait } from '../../../core/Constants';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MedalCeremony extends EventCard {
     private attacksThisPhaseWatcher: AttacksThisPhaseWatcher;
@@ -21,7 +22,7 @@ export default class MedalCeremony extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give an experience to each of up to three Rebel units that attacked this phase',
+            title: `Give an experience to each of up to three ${TextHelper.Trait.Rebel} units that attacked this phase`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/01_SOR/events/PrecisionFire.ts
+++ b/server/game/cards/01_SOR/events/PrecisionFire.ts
@@ -14,7 +14,7 @@ export default class PrecisionFire extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Attack with a unit. It gains ${TextHelper.Saboteur} for this attack. If it’s a Trooper, it also gets +2/+0 for this attack.`,
+            title: `Attack with a unit. It gains ${TextHelper.Saboteur} for this attack. If it’s a ${TextHelper.Trait.Trooper}, it also gets +2/+0 for this attack.`,
             initiateAttack: {
                 attackerLastingEffects: [
                     { effect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur) },

--- a/server/game/cards/01_SOR/events/PrepareForTakeoff.ts
+++ b/server/game/cards/01_SOR/events/PrepareForTakeoff.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { RelativePlayer, TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PrepareForTakeoff extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PrepareForTakeoff extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Search the top 8 cards for up to 2 Vehicle units, reveal them, and draw them',
+            title: `Search the top 8 cards for up to 2 ${TextHelper.Trait.Vehicle} units, reveal them, and draw them`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 targetMode: TargetMode.UpTo,
                 selectCount: 2,

--- a/server/game/cards/01_SOR/events/RebelAssault.ts
+++ b/server/game/cards/01_SOR/events/RebelAssault.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RebelAssault extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class RebelAssault extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Rebel unit. It gets +1/+0 for this attack',
+            title: `Attack with a ${TextHelper.Trait.Rebel} unit. It gets +1/+0 for this attack`,
             targetResolver: {
                 immediateEffect: AbilityHelper.immediateEffects.attack({
                     attackerCondition: (card) => card.hasSomeTrait(Trait.Rebel),
@@ -23,7 +24,7 @@ export default class RebelAssault extends EventCard {
                 })
             },
             then: (thenContext) => ({
-                title: 'Attack with another Rebel unit. It gets +1/+0 for this attack',
+                title: `Attack with another ${TextHelper.Trait.Rebel} unit. It gets +1/+0 for this attack`,
                 initiateAttack: {
                     attackerCondition: (card) => card.hasSomeTrait(Trait.Rebel) && thenContext.target !== card,
                     attackerLastingEffects: {

--- a/server/game/cards/01_SOR/events/TheForceIsWithMe.ts
+++ b/server/game/cards/01_SOR/events/TheForceIsWithMe.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheForceIsWithMe extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheForceIsWithMe extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give 2 Experience, a Shield if you control a Force unit, and optionally attack',
+            title: `Give 2 Experience, a Shield if you control a ${TextHelper.Trait.Force} unit, and optionally attack`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 immediateEffect: AbilityHelper.immediateEffects.simultaneous([

--- a/server/game/cards/01_SOR/leaders/GrandMoffTarkinOversectorGovernor.ts
+++ b/server/game/cards/01_SOR/leaders/GrandMoffTarkinOversectorGovernor.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrandMoffTarkinOversectorGovernor extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GrandMoffTarkinOversectorGovernor extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Give an experience token to an Imperial unit',
+            title: `Give an experience token to an ${TextHelper.Trait.Imperial} unit`,
             cost: [AbilityHelper.costs.abilityActivationResourceCost(1), AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardCondition: (card) => card.hasSomeTrait(Trait.Imperial),
@@ -24,7 +25,7 @@ export default class GrandMoffTarkinOversectorGovernor extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give an experience token to another Imperial unit',
+            title: `Give an experience token to another ${TextHelper.Trait.Imperial} unit`,
             optional: true,
             targetResolver: {
                 cardCondition: (card, context) => card.hasSomeTrait(Trait.Imperial) && card !== context.source,

--- a/server/game/cards/01_SOR/leaders/HeraSyndullaSpectreTwo.ts
+++ b/server/game/cards/01_SOR/leaders/HeraSyndullaSpectreTwo.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HeraSyndullaSpectreTwo extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class HeraSyndullaSpectreTwo extends LeaderUnitCard {
 
     private buildHeraAbilityProperties(AbilityHelper: IAbilityHelper) {
         return {
-            title: 'Ignore the aspect penalty on Spectre cards you play',
+            title: `Ignore the aspect penalty on ${TextHelper.Trait.Spectre} cards you play`,
             targetController: RelativePlayer.Self,
             ongoingEffect: AbilityHelper.ongoingEffects.ignoreAllAspectPenalties({
                 cardTypeFilter: WildcardCardType.Playable,

--- a/server/game/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.ts
+++ b/server/game/cards/01_SOR/leaders/LeiaOrganaAllianceGeneral.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LeiaOrganaAllianceGeneral extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,13 +14,13 @@ export default class LeiaOrganaAllianceGeneral extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a Rebel unit',
+            title: `Attack with a ${TextHelper.Trait.Rebel} unit`,
             cost: AbilityHelper.costs.exhaustSelf(),
             initiateAttack: {
                 attackerCondition: (card) => card.hasSomeTrait(Trait.Rebel)
             },
             then: (thenContext) => ({
-                title: 'Attack with a second Rebel unit',
+                title: `Attack with a second ${TextHelper.Trait.Rebel} unit`,
                 optional: true,
                 initiateAttack: {
                     attackerCondition: (card) => card.hasSomeTrait(Trait.Rebel) && thenContext.target !== card
@@ -30,7 +31,7 @@ export default class LeiaOrganaAllianceGeneral extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar) {
         registrar.addWhenAttackEndsAbility({
-            title: 'Attack with another Rebel unit',
+            title: `Attack with another ${TextHelper.Trait.Rebel} unit`,
             attackerMustSurvive: true,
             optional: true,
             initiateAttack: {

--- a/server/game/cards/01_SOR/units/AdmiralOzzelOverconfident.ts
+++ b/server/game/cards/01_SOR/units/AdmiralOzzelOverconfident.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AdmiralOzzelOverconfident extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,11 +14,11 @@ export default class AdmiralOzzelOverconfident extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Play an Imperial unit from your hand. It enters play ready',
+            title: `Play an ${TextHelper.Trait.Imperial} unit from your hand. It enters play ready`,
             cost: AbilityHelper.costs.exhaustSelf(),
             immediateEffect: AbilityHelper.immediateEffects.sequential([
                 AbilityHelper.immediateEffects.selectCard({
-                    activePromptTitle: 'Play an Imperial unit from your hand. It enters play ready',
+                    activePromptTitle: `Play an ${TextHelper.Trait.Imperial} unit from your hand. It enters play ready`,
                     // TODO: figure out how to make this assume that the played card must be from hand, unless specified otherwise
                     controller: RelativePlayer.Self,
                     zoneFilter: ZoneName.Hand,

--- a/server/game/cards/01_SOR/units/ChopperMetalMenace.ts
+++ b/server/game/cards/01_SOR/units/ChopperMetalMenace.ts
@@ -29,7 +29,7 @@ export default class ChopperMetalMenace extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: `While you control another Spectre unit, Chopper gains ${TextHelper.Raid(1)}`,
+            title: `While you control another ${TextHelper.Trait.Spectre} unit, Chopper gains ${TextHelper.Raid(1)}`,
             condition: (context) => context.player.hasSomeArenaUnit({ otherThan: context.source, trait: Trait.Spectre }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/01_SOR/units/EmperorsRoyalGuard.ts
+++ b/server/game/cards/01_SOR/units/EmperorsRoyalGuard.ts
@@ -14,7 +14,7 @@ export default class EmperorsRoyalGuard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control an Official unit, this gains ${TextHelper.Sentinel}`,
+            title: `While you control an ${TextHelper.Trait.Official} unit, this gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.hasSomeArenaUnit({ trait: Trait.Official }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel })
         });

--- a/server/game/cards/01_SOR/units/FrontierATRT.ts
+++ b/server/game/cards/01_SOR/units/FrontierATRT.ts
@@ -14,7 +14,7 @@ export default class FrontierATRT extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Gain ${TextHelper.Ambush} while you control another Vehicle unit`,
+            title: `Gain ${TextHelper.Ambush} while you control another ${TextHelper.Trait.Vehicle} unit`,
             condition: (context) => context.player.isTraitInPlay(Trait.Vehicle, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/01_SOR/units/GeneralDodonnaMassassiGroupCommander.ts
+++ b/server/game/cards/01_SOR/units/GeneralDodonnaMassassiGroupCommander.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralDodonnaMassassiGroupCommander extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GeneralDodonnaMassassiGroupCommander extends NonLeaderUnitC
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly Rebel units get +1/+1',
+            title: `Other friendly ${TextHelper.Trait.Rebel} units get +1/+1`,
             targetController: RelativePlayer.Self,
             matchTarget: (card, context) => card !== context.source && card.hasSomeTrait(Trait.Rebel),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 1 })

--- a/server/game/cards/01_SOR/units/GeneralTaggeConcernedCommander.ts
+++ b/server/game/cards/01_SOR/units/GeneralTaggeConcernedCommander.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralTaggeConcernedCommander extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GeneralTaggeConcernedCommander extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give an experience token to each of up to 3 Trooper units',
+            title: `Give an experience token to each of up to 3 ${TextHelper.Trait.Trooper} units`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/01_SOR/units/GeneralVeersBlizzardForceCommander.ts
+++ b/server/game/cards/01_SOR/units/GeneralVeersBlizzardForceCommander.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralVeersBlizzardForceCommander extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GeneralVeersBlizzardForceCommander extends NonLeaderUnitCar
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly Imperial units get +1/+1',
+            title: `Other friendly ${TextHelper.Trait.Imperial} units get +1/+1`,
             targetController: RelativePlayer.Self,
             matchTarget: (card, context) => card !== context.source && card.hasSomeTrait(Trait.Imperial),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 1 })

--- a/server/game/cards/01_SOR/units/GrandMoffTarkinDeathStarOverseer.ts
+++ b/server/game/cards/01_SOR/units/GrandMoffTarkinDeathStarOverseer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrandMoffTarkinDeathStarOverseer extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GrandMoffTarkinDeathStarOverseer extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 5 cards of your deck for up to 2 Imperial cards, then reveal and draw it.',
+            title: `Search the top 5 cards of your deck for up to 2 ${TextHelper.Trait.Imperial} cards, then reveal and draw it.`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 selectCount: 2,
                 searchCount: 5,

--- a/server/game/cards/01_SOR/units/JabbaTheHuttCunningDaimyo.ts
+++ b/server/game/cards/01_SOR/units/JabbaTheHuttCunningDaimyo.ts
@@ -14,7 +14,7 @@ export default class JabbaTheHuttCunningDaimyo extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each Trick event you play costs ${TextHelper.resource(1)} less`,
+            title: `Each ${TextHelper.Trait.Trick} event you play costs ${TextHelper.resource(1)} less`,
             ongoingEffect: AbilityHelper.ongoingEffects.decreaseCost({
                 amount: 1,
                 cardTypeFilter: CardType.Event,
@@ -23,7 +23,7 @@ export default class JabbaTheHuttCunningDaimyo extends NonLeaderUnitCard {
         });
 
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 8 cards of your deck for a Trick event, reveal it, and draw it',
+            title: `Search the top 8 cards of your deck for a ${TextHelper.Trait.Trick} event, reveal it, and draw it`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 8,
                 cardCondition: (card) => card.isEvent() && card.hasSomeTrait(Trait.Trick),

--- a/server/game/cards/01_SOR/units/KananJarrusRevealedJedi.ts
+++ b/server/game/cards/01_SOR/units/KananJarrusRevealedJedi.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { Aspect } from '../../../core/Constants';
 import { EventName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KananJarrusRevealedJedi extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class KananJarrusRevealedJedi extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Discard a card from the defending player\'s deck for each Spectre you control. Heal 1 damage for each aspect among the discarded cards.',
+            title: `Discard a card from the defending player's deck for each ${TextHelper.Trait.Spectre} you control. Heal 1 damage for each aspect among the discarded cards.`,
             contextTitle: (context) => {
                 const count = context.player.getArenaUnits({ trait: Trait.Spectre }).length;
                 return `Discard ${count} ${count === 1 ? 'card' : 'cards'} from the defending player's deck. Heal 1 damage for each aspect among the discarded cards.`;

--- a/server/game/cards/01_SOR/units/MonMothmaVoiceoftheRebellion.ts
+++ b/server/game/cards/01_SOR/units/MonMothmaVoiceoftheRebellion.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MonMothmaVoiceoftheRebellion extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MonMothmaVoiceoftheRebellion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 5 cards of your deck for a Rebel card, then reveal and draw it.',
+            title: `Search the top 5 cards of your deck for a ${TextHelper.Trait.Rebel} card, then reveal and draw it.`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Rebel),

--- a/server/game/cards/01_SOR/units/ObiWanKenobiFollowingFate.ts
+++ b/server/game/cards/01_SOR/units/ObiWanKenobiFollowingFate.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ObiWanKenobiFollowingFate extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ObiWanKenobiFollowingFate extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
+            title: `Give 2 Experience tokens to another friendly unit. If it's a ${TextHelper.Trait.Force} unit, draw a card.`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/01_SOR/units/Snowspeeder.ts
+++ b/server/game/cards/01_SOR/units/Snowspeeder.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName, RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Snowspeeder extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Snowspeeder extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Exhaust an enemy Vehicle ground unit',
+            title: `Exhaust an enemy ${TextHelper.Trait.Vehicle} ground unit`,
             targetResolver: {
                 zoneFilter: ZoneName.GroundArena,
                 controller: RelativePlayer.Opponent,

--- a/server/game/cards/01_SOR/units/TheGhostSpectreHomeBase.ts
+++ b/server/game/cards/01_SOR/units/TheGhostSpectreHomeBase.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheGhostSpectreHomeBase extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheGhostSpectreHomeBase extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give a shield token to another Spectre unit',
+            title: `Give a shield token to another ${TextHelper.Trait.Spectre} unit`,
             when: {
                 onAttack: true,
                 whenPlayed: true,

--- a/server/game/cards/01_SOR/units/TieAdvanced.ts
+++ b/server/game/cards/01_SOR/units/TieAdvanced.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TieAdvanced extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TieAdvanced extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give 2 Experience tokens to a friendly Imperial unit',
+            title: `Give 2 Experience tokens to a friendly ${TextHelper.Trait.Imperial} unit`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardCondition: (card, context) => card.hasSomeTrait(Trait.Imperial) && card !== context.source,

--- a/server/game/cards/01_SOR/units/VolunteerSoldier.ts
+++ b/server/game/cards/01_SOR/units/VolunteerSoldier.ts
@@ -14,7 +14,7 @@ export default class VolunteerSoldier extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `If you control a Trooper unit, this unit costs ${TextHelper.resource(1)} less to play`,
+            title: `If you control a ${TextHelper.Trait.Trooper} unit, this unit costs ${TextHelper.resource(1)} less to play`,
             condition: (context) => context.player.hasSomeArenaUnit({ otherThan: context.source, trait: Trait.Trooper }),
             amount: 1
         });

--- a/server/game/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.ts
+++ b/server/game/cards/01_SOR/units/WedgeAntillesStarOfTheRebellion.ts
@@ -14,7 +14,7 @@ export default class WedgeAntillesStarOfTheRebellion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each friendly Vehicle unit gets +1/+1 and gains ${TextHelper.Ambush}.`,
+            title: `Each friendly ${TextHelper.Trait.Vehicle} unit gets +1/+1 and gains ${TextHelper.Ambush}.`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/01_SOR/units/WingLeader.ts
+++ b/server/game/cards/01_SOR/units/WingLeader.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WingLeader extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class WingLeader extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give 2 Experience tokens to another friendly Rebel unit',
+            title: `Give 2 Experience tokens to another friendly ${TextHelper.Trait.Rebel} unit`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Rebel) && card !== this,

--- a/server/game/cards/02_SHD/events/Commission.ts
+++ b/server/game/cards/02_SHD/events/Commission.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Commission extends EventCard {
     protected override getImplementationId() {
@@ -13,9 +14,9 @@ export default class Commission extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty" here is part of the Bounty Hunter trait, not the Bounty keyword
-            title: 'Search the top 10 cards for a Bounty Hunter, Item, or Transport card, reveal it, and draw it',
+            title: `Search the top 10 cards for a ${TextHelper.Trait.BountyHunter}, ${TextHelper.Trait.Item}, or ${TextHelper.Trait.Transport} card, reveal it, and draw it`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
+                activePromptTitle: `Select a ${TextHelper.Trait.BountyHunter}, ${TextHelper.Trait.Item}, or ${TextHelper.Trait.Transport} card to reveal and draw`,
                 searchCount: 10,
                 cardCondition: (card) => card.hasSomeTrait([Trait.BountyHunter, Trait.Item, Trait.Transport]),
                 selectedCardsImmediateEffect: AbilityHelper.immediateEffects.revealAndDraw({

--- a/server/game/cards/02_SHD/events/LetTheWookieeWin.ts
+++ b/server/game/cards/02_SHD/events/LetTheWookieeWin.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LetTheWookieeWin extends EventCard {
     protected override getImplementationId () {
@@ -13,14 +14,14 @@ export default class LetTheWookieeWin extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'An opponent chooses if you ready up to 6 resources or ready a friendly unit. If it’s a Wookiee unit, attack with it. It gets +2/+0 for this attack',
+            title: `An opponent chooses if you ready up to 6 resources or ready a friendly unit. If it’s a ${TextHelper.Trait.Wookiee} unit, attack with it. It gets +2/+0 for this attack`,
             targetResolver: {
                 mode: TargetMode.Select,
                 choosingPlayer: RelativePlayer.Opponent,
                 choices: (context) => ({
                     [`${context.player.name} readies up to 6 resources`]:
                         AbilityHelper.immediateEffects.readyResources({ amount: 6 }),
-                    [`${context.player.name} readies a friendly unit. If it’s a Wookiee unit, they attack with it and it gets +2/+0 for this attack`]:
+                    [`${context.player.name} readies a friendly unit. If it’s a ${TextHelper.Trait.Wookiee} unit, they attack with it and it gets +2/+0 for this attack`]:
                         AbilityHelper.immediateEffects.selectCard({
                             controller: RelativePlayer.Self,
                             cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/events/MaKlounkee.ts
+++ b/server/game/cards/02_SHD/events/MaKlounkee.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MaKlounkee extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MaKlounkee extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Return a friendly non-leader Underworld unit to its owner\'s hand. If you do, deal 3 damage to a unit',
+            title: `Return a friendly non-leader ${TextHelper.Trait.Underworld} unit to its owner's hand. If you do, deal 3 damage to a unit`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,

--- a/server/game/cards/02_SHD/events/MysticReflection.ts
+++ b/server/game/cards/02_SHD/events/MysticReflection.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MysticReflection extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MysticReflection extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give an enemy unit –2/–0 for this phase. If you control a Force unit, give the enemy unit –2/–2 for this phase instead.',
+            title: `Give an enemy unit –2/–0 for this phase. If you control a ${TextHelper.Trait.Force} unit, give the enemy unit –2/–2 for this phase instead.`,
             targetResolver: {
                 controller: RelativePlayer.Opponent,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/events/PalpatinesReturn.ts
+++ b/server/game/cards/02_SHD/events/PalpatinesReturn.ts
@@ -15,9 +15,9 @@ export default class PalpatinesReturn extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Play a unit from your discard pile. It costs ${TextHelper.resource(6)} less. If it's a Force unit, it costs ${TextHelper.resource(8)} less instead.`,
+            title: `Play a unit from your discard pile. It costs ${TextHelper.resource(6)} less. If it's a ${TextHelper.Trait.Force} unit, it costs ${TextHelper.resource(8)} less instead.`,
             targetResolver: {
-                activePromptTitle: `Play a unit for ${TextHelper.resource(6)} less. If it's a Force unit, it costs ${TextHelper.resource(8)} less instead.`,
+                activePromptTitle: `Play a unit for ${TextHelper.resource(6)} less. If it's a ${TextHelper.Trait.Force} unit, it costs ${TextHelper.resource(8)} less instead.`,
                 mode: TargetMode.Single,
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/02_SHD/events/ThisIsTheWay.ts
+++ b/server/game/cards/02_SHD/events/ThisIsTheWay.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { RelativePlayer, TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ThisIsTheWay extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ThisIsTheWay extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Search the top 8 cards for up to 2 Mandalorian and/or upgrade cards, reveal them, and draw them',
+            title: `Search the top 8 cards for up to 2 ${TextHelper.Trait.Mandalorian} and/or upgrade cards, reveal them, and draw them`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 targetMode: TargetMode.UpTo,
                 selectCount: 2,

--- a/server/game/cards/02_SHD/events/TripleDarkRaid.ts
+++ b/server/game/cards/02_SHD/events/TripleDarkRaid.ts
@@ -15,7 +15,7 @@ export default class TripleDarkRaid extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Search the top 7 cards of your deck for a Vehicle and play it. It costs ${TextHelper.resource(5)} less and enters play ready. Return it to its owner's hand at the end of the phase`,
+            title: `Search the top 7 cards of your deck for a ${TextHelper.Trait.Vehicle} and play it. It costs ${TextHelper.resource(5)} less and enters play ready. Return it to its owner's hand at the end of the phase`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 7,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.ts
+++ b/server/game/cards/02_SHD/leaders/BoKatanKryzePrincessInExile.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class BoKatanKryzePrincessInExile extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'If you attacked with a Mandalorian unit this phase, deal 1 damage to a unit',
+            title: `If you attacked with a ${TextHelper.Trait.Mandalorian} unit this phase, deal 1 damage to a unit`,
             cost: [AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/units/BountyGuildInitiate.ts
+++ b/server/game/cards/02_SHD/units/BountyGuildInitiate.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { ZoneName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BountyGuildInitiate extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,8 +14,7 @@ export default class BountyGuildInitiate extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait reference, not the Bounty keyword
-            title: 'Deal 2 damage to a ground unit if you control another Bounty Hunter unit',
+            title: `Deal 2 damage to a ground unit if you control another ${TextHelper.Trait.BountyHunter} unit`,
             optional: true,
             targetResolver: {
                 zoneFilter: ZoneName.GroundArena,

--- a/server/game/cards/02_SHD/units/MandalorianWarrior.ts
+++ b/server/game/cards/02_SHD/units/MandalorianWarrior.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MandalorianWarrior extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class MandalorianWarrior extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give 1 experience to another Mandalorian unit',
+            title: `Give 1 experience to another ${TextHelper.Trait.Mandalorian} unit`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/units/MaulShadowCollectiveVisionary.ts
+++ b/server/game/cards/02_SHD/units/MaulShadowCollectiveVisionary.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, DamageModificationType, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
 import { DamageSourceType } from '../../../IDamageOrDefeatSource';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MaulShadowCollectiveVisionary extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class MaulShadowCollectiveVisionary extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Choose another friendly Underworld unit. All combat damage that would be dealt to this unit during this attack is dealt to the chosen unit instead.',
+            title: `Choose another friendly ${TextHelper.Trait.Underworld} unit. All combat damage that would be dealt to this unit during this attack is dealt to the chosen unit instead.`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -26,7 +27,7 @@ export default class MaulShadowCollectiveVisionary extends NonLeaderUnitCard {
                     onTrue: AbilityHelper.immediateEffects.forThisAttackCardEffect((maulContext) => ({
                         target: maulContext.source,
                         effect: AbilityHelper.ongoingEffects.gainDamageModificationAbility({
-                            title: 'Redirect combat damage to another Underworld unit',
+                            title: `Redirect combat damage to another ${TextHelper.Trait.Underworld} unit`,
                             type: AbilityType.DamageModification,
                             modificationType: DamageModificationType.Replace,
                             damageOfType: DamageSourceType.Attack,

--- a/server/game/cards/02_SHD/units/OmegaPartOfTheSquad.ts
+++ b/server/game/cards/02_SHD/units/OmegaPartOfTheSquad.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { CardType, RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class OmegaPartOfTheSquad extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Ignore the aspect penalty on the first Clone unit you play each round',
+            title: `Ignore the aspect penalty on the first ${TextHelper.Trait.Clone} unit you play each round`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: CardType.BasicUnit,
             targetZoneFilter: WildcardZoneName.AnyArena,
@@ -33,7 +34,7 @@ export default class OmegaPartOfTheSquad extends NonLeaderUnitCard {
         });
 
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 5 cards of your deck for a Clone card, then reveal and draw it.',
+            title: `Search the top 5 cards of your deck for a ${TextHelper.Trait.Clone} card, then reveal and draw it.`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Clone),

--- a/server/game/cards/02_SHD/units/PreVizslaPowerHungry.ts
+++ b/server/game/cards/02_SHD/units/PreVizslaPowerHungry.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PreVizslaPowerHungry extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PreVizslaPowerHungry extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Pay the cost of an upgrade attached to another non-Vehicle unit',
+            title: `Pay the cost of an upgrade attached to another non-${TextHelper.Trait.Vehicle} unit`,
             when: {
                 whenPlayed: true,
                 onAttack: true,

--- a/server/game/cards/02_SHD/units/SmugglersStarfighter.ts
+++ b/server/game/cards/02_SHD/units/SmugglersStarfighter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SmugglersStarfighter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SmugglersStarfighter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give -3/-0 to an enemy unit if you control another Underworld unit',
+            title: `Give -3/-0 to an enemy unit if you control another ${TextHelper.Trait.Underworld} unit`,
             targetResolver: {
                 controller: RelativePlayer.Opponent,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/02_SHD/units/StreetGangRecruiter.ts
+++ b/server/game/cards/02_SHD/units/StreetGangRecruiter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class StreetGangRecruiter extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class StreetGangRecruiter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Return an Underworld card from your discard pile to your hand.',
+            title: `Return an ${TextHelper.Trait.Underworld} card from your discard pile to your hand.`,
             optional: true,
             targetResolver: {
                 cardCondition: (card) => card.hasSomeTrait(Trait.Underworld),

--- a/server/game/cards/02_SHD/units/TheArmorerSurvivalIsStrength.ts
+++ b/server/game/cards/02_SHD/units/TheArmorerSurvivalIsStrength.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheArmorerSurvivalIsStrength extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheArmorerSurvivalIsStrength extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give a shield token to each of up to 3 Mandalorian units',
+            title: `Give a shield token to each of up to 3 ${TextHelper.Trait.Mandalorian} units`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/02_SHD/units/XanaduBloodCadBanesReward.ts
+++ b/server/game/cards/02_SHD/units/XanaduBloodCadBanesReward.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class XanaduBloodCadBanesReward extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class XanaduBloodCadBanesReward extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Return another friendly non-leader Underworld unit to its owner’s hand. If you do, exhaust an enemy unit or resource',
+            title: `Return another friendly non-leader ${TextHelper.Trait.Underworld} unit to its owner’s hand. If you do, exhaust an enemy unit or resource`,
             when: {
                 whenPlayed: true,
                 onAttack: true,

--- a/server/game/cards/02_SHD/upgrades/Foundling.ts
+++ b/server/game/cards/02_SHD/upgrades/Foundling.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Foundling extends UpgradeCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class Foundling extends UpgradeCard {
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Give the Mandalorian trait to the attached card',
+            title: `Give the ${TextHelper.Trait.Mandalorian} trait to the attached card`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainTrait(Trait.Mandalorian),
         });
     }

--- a/server/game/cards/02_SHD/upgrades/TheDarksaber.ts
+++ b/server/game/cards/02_SHD/upgrades/TheDarksaber.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheDarksaber extends UpgradeCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class TheDarksaber extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addGainOnAttackAbilityTargetingAttached({
-            title: 'Give an Experience token to each other friendly Mandalorian unit',
+            title: `Give an Experience token to each other friendly ${TextHelper.Trait.Mandalorian} unit`,
             immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => {
                 const mandalorians = context.player.getArenaUnits().filter((unit) => unit.hasSomeTrait(Trait.Mandalorian) && unit !== context.source);
                 return { target: mandalorians };
@@ -23,7 +24,7 @@ export default class TheDarksaber extends UpgradeCard {
         });
 
         registrar.addIgnoreAllAspectPenaltiesAbility({
-            title: 'Ignore aspect penalties while playing this on a Mandalorian',
+            title: `Ignore aspect penalties while playing this on a ${TextHelper.Trait.Mandalorian}`,
             attachTargetCondition: (attachTarget) => attachTarget.hasSomeTrait(Trait.Mandalorian)
         });
     }

--- a/server/game/cards/03_TWI/events/ExecuteOrder66.ts
+++ b/server/game/cards/03_TWI/events/ExecuteOrder66.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import type { Card } from '../../../core/card/Card';
 import type { Player } from '../../../core/Player';
@@ -16,7 +17,7 @@ export default class ExecuteOrder66 extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Deal 6 damage to each Jedi unit.',
+            title: `Deal 6 damage to each ${TextHelper.Trait.Jedi} unit.`,
             immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({
                 amount: 6,
                 target: this.getJedisInPlay(context)

--- a/server/game/cards/03_TWI/events/HeroesOnBothSides.ts
+++ b/server/game/cards/03_TWI/events/HeroesOnBothSides.ts
@@ -17,7 +17,7 @@ export default class HeroesOnBothSides extends EventCard {
             title: `Give each chosen unit +2/+2 and ${TextHelper.Saboteur} for this phase`,
             targetResolvers: {
                 republicUnit: {
-                    activePromptTitle: 'Choose a Republic unit',
+                    activePromptTitle: `Choose a ${TextHelper.Trait.Republic} unit`,
                     mode: TargetMode.Exactly,
                     numCards: 1,
                     canChooseNoCards: true,
@@ -31,7 +31,7 @@ export default class HeroesOnBothSides extends EventCard {
                     })
                 },
                 separatistUnit: {
-                    activePromptTitle: 'Choose a Separatist unit',
+                    activePromptTitle: `Choose a ${TextHelper.Trait.Separatist} unit`,
                     mode: TargetMode.Exactly,
                     numCards: 1,
                     canChooseNoCards: true,

--- a/server/game/cards/03_TWI/events/InDefenseOfKamino.ts
+++ b/server/game/cards/03_TWI/events/InDefenseOfKamino.ts
@@ -14,7 +14,7 @@ export default class InDefenseOfKamino extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `For this phase, each friendly Republic unit gains ${TextHelper.Restore(2)} and: "When Defeated: Create a Clone Trooper token"`,
+            title: `For this phase, each friendly ${TextHelper.Trait.Republic} unit gains ${TextHelper.Restore(2)} and: "When Defeated: Create a Clone Trooper token"`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 effect: [
                     AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 }),

--- a/server/game/cards/03_TWI/events/NowThereAreTwoOfThem.ts
+++ b/server/game/cards/03_TWI/events/NowThereAreTwoOfThem.ts
@@ -15,11 +15,11 @@ export default class NowThereAreTwoOfThem extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `If you control exactly one unit, play a non-Vehicle unit from your hand that shares a Trait with the unit you control. It costs ${TextHelper.resource(5)} less.`,
+            title: `If you control exactly one unit, play a non-${TextHelper.Trait.Vehicle} unit from your hand that shares a Trait with the unit you control. It costs ${TextHelper.resource(5)} less.`,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.getArenaUnits().length === 1,
                 onTrue: AbilityHelper.immediateEffects.selectCard({
-                    activePromptTitle: `Play a non-Vehicle unit from your hand that shared a Trait with the unit you control. It costs ${TextHelper.resource(5)} less.`,
+                    activePromptTitle: `Play a non-${TextHelper.Trait.Vehicle} unit from your hand that shared a Trait with the unit you control. It costs ${TextHelper.resource(5)} less.`,
                     zoneFilter: ZoneName.Hand,
                     cardCondition: (card, context) =>
                         !card.hasSomeTrait(Trait.Vehicle) &&

--- a/server/game/cards/03_TWI/events/PrisonerOfWar.ts
+++ b/server/game/cards/03_TWI/events/PrisonerOfWar.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PrisonerOfWar extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PrisonerOfWar extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'A friendly unit captures an enemy non-leader, non-Vehicle unit. If the enemy unit costs less than the friendly unit, create 2 Battle Droid tokens.',
+            title: `A friendly unit captures an enemy non-leader, non-${TextHelper.Trait.Vehicle} unit. If the enemy unit costs less than the friendly unit, create 2 Battle Droid tokens.`,
             targetResolvers: {
                 friendlyUnit: {
                     controller: RelativePlayer.Self,

--- a/server/game/cards/03_TWI/events/SwordAndShieldManeuver.ts
+++ b/server/game/cards/03_TWI/events/SwordAndShieldManeuver.ts
@@ -14,7 +14,7 @@ export default class SwordAndShieldManeuver extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Give each friendly Trooper unit ${TextHelper.Raid(1)} for this phase. Give each friendly Jedi unit ${TextHelper.Sentinel} for this phase.`,
+            title: `Give each friendly ${TextHelper.Trait.Trooper} unit ${TextHelper.Raid(1)} for this phase. Give each friendly ${TextHelper.Trait.Jedi} unit ${TextHelper.Sentinel} for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 }),

--- a/server/game/cards/03_TWI/leaders/CaptainRexFightingForHisBrothers.ts
+++ b/server/game/cards/03_TWI/leaders/CaptainRexFightingForHisBrothers.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 
@@ -42,7 +43,7 @@ export default class CaptainRexFightingForHisBrothers extends LeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'Each other friendly Trooper unit gets +0/+1.',
+            title: `Each other friendly ${TextHelper.Trait.Trooper} unit gets +0/+1.`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Trooper),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 0, hp: 1 })
         });

--- a/server/game/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.ts
+++ b/server/game/cards/03_TWI/leaders/CountDookuFaceOfTheConfederacy.ts
@@ -14,7 +14,7 @@ export default class CountDookuFaceOfTheConfederacy extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Play a Separatist card from your hand. It gains ${TextHelper.Exploit(1)}.`,
+            title: `Play a ${TextHelper.Trait.Separatist} card from your hand. It gains ${TextHelper.Exploit(1)}.`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 controller: RelativePlayer.Self,
@@ -30,7 +30,7 @@ export default class CountDookuFaceOfTheConfederacy extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `The next Separatist card you play this phase gains ${TextHelper.Exploit(3)}`,
+            title: `The next ${TextHelper.Trait.Separatist} card you play this phase gains ${TextHelper.Exploit(3)}`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.addExploit({
                     match: (card) => card.hasSomeTrait(Trait.Separatist),

--- a/server/game/cards/03_TWI/leaders/GeneralGrievousGeneralOfTheDroidArmies.ts
+++ b/server/game/cards/03_TWI/leaders/GeneralGrievousGeneralOfTheDroidArmies.ts
@@ -14,7 +14,7 @@ export default class GeneralGrievousGeneralOfTheDroidArmies extends LeaderUnitCa
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Give a Droid unit ${TextHelper.Sentinel} for this phase`,
+            title: `Give a ${TextHelper.Trait.Droid} unit ${TextHelper.Sentinel} for this phase`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -28,7 +28,7 @@ export default class GeneralGrievousGeneralOfTheDroidArmies extends LeaderUnitCa
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `Give a Droid unit +1/+0 and ${TextHelper.Sentinel} for this phase`,
+            title: `Give a ${TextHelper.Trait.Droid} unit +1/+0 and ${TextHelper.Sentinel} for this phase`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/03_TWI/leaders/NalaSeCloneEngineer.ts
+++ b/server/game/cards/03_TWI/leaders/NalaSeCloneEngineer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { AbilityType, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NalaSeCloneEngineer extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NalaSeCloneEngineer extends LeaderUnitCard {
 
     private buildIgnoreCloneAspectAbility(AbilityHelper: IAbilityHelper) {
         return {
-            title: 'Ignore the aspect penalty on Clone units you play',
+            title: `Ignore the aspect penalty on ${TextHelper.Trait.Clone} units you play`,
             targetController: RelativePlayer.Self,
             ongoingEffect: AbilityHelper.ongoingEffects.ignoreAllAspectPenalties({
                 cardTypeFilter: WildcardCardType.Unit,
@@ -30,7 +31,7 @@ export default class NalaSeCloneEngineer extends LeaderUnitCard {
         registrar.addConstantAbility(this.buildIgnoreCloneAspectAbility(AbilityHelper));
 
         registrar.addConstantAbility({
-            title: 'Each friendly Clone gains When Defeated: Heal 2 damage from your base',
+            title: `Each friendly ${TextHelper.Trait.Clone} gains When Defeated: Heal 2 damage from your base`,
             matchTarget: (card, context) => card.isUnit() && card.hasSomeTrait(Trait.Clone) && card.controller === context.player,
             ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
                 type: AbilityType.Triggered,

--- a/server/game/cards/03_TWI/leaders/PadmeAmidalaServingTheRepublic.ts
+++ b/server/game/cards/03_TWI/leaders/PadmeAmidalaServingTheRepublic.ts
@@ -3,6 +3,7 @@ import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbi
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { AbilityType, RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { GameSystem } from '../../../core/gameSystem/GameSystem';
 
 export default class PadmeAmidalaServingTheRepublic extends LeaderUnitCard {
@@ -16,7 +17,7 @@ export default class PadmeAmidalaServingTheRepublic extends LeaderUnitCard {
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Action,
-            title: 'Search the top 3 cards of your deck for a Republic card, reveal it, and draw it',
+            title: `Search the top 3 cards of your deck for a ${TextHelper.Trait.Republic} card, reveal it, and draw it`,
             cost: [AbilityHelper.costs.exhaustSelf(), AbilityHelper.costs.abilityActivationResourceCost(1)],
             immediateEffect: this.buildCoordinateAbilityEffect(AbilityHelper),
         });
@@ -25,7 +26,7 @@ export default class PadmeAmidalaServingTheRepublic extends LeaderUnitCard {
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addCoordinateAbility({
             type: AbilityType.Triggered,
-            title: 'Search the top 3 cards of your deck for a Republic card, reveal it, and draw it',
+            title: `Search the top 3 cards of your deck for a ${TextHelper.Trait.Republic} card, reveal it, and draw it`,
             when: {
                 onAttack: true,
             },

--- a/server/game/cards/03_TWI/units/AsajjVentressCountDookusAssassin.ts
+++ b/server/game/cards/03_TWI/units/AsajjVentressCountDookusAssassin.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class AsajjVentressCountDookusAssassin extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'If you\'ve attacked with another Separatist unit this phase, this unit gets +3/+0 for this phase.',
+            title: `If you've attacked with another ${TextHelper.Trait.Separatist} unit this phase, this unit gets +3/+0 for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => this.attacksThisPhaseWatcher.someUnitAttackedControlledByPlayer({
                     controller: context.player,

--- a/server/game/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.ts
+++ b/server/game/cards/03_TWI/units/BoKatanKryzeDeathWatchLieutenant.ts
@@ -14,7 +14,7 @@ export default class BoKatanKryzeDeathWatchLieutenant extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Mandalorian unit, this unit gains ${TextHelper.Overwhelm} and ${TextHelper.Saboteur}`,
+            title: `While you control another ${TextHelper.Trait.Mandalorian} unit, this unit gains ${TextHelper.Overwhelm} and ${TextHelper.Saboteur}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Mandalorian, context.source),
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Overwhelm),
@@ -23,7 +23,7 @@ export default class BoKatanKryzeDeathWatchLieutenant extends NonLeaderUnitCard 
         });
 
         registrar.addConstantAbility({
-            title: 'While you control another Trooper unit, this unit gets +1/+0',
+            title: `While you control another ${TextHelper.Trait.Trooper} unit, this unit gets +1/+0`,
             condition: (context) => context.player.isTraitInPlay(Trait.Trooper, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 })
         });

--- a/server/game/cards/03_TWI/units/Clone.ts
+++ b/server/game/cards/03_TWI/units/Clone.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Duration, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Clone extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -21,7 +22,7 @@ export default class Clone extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper): void {
         registrar.addPreEnterPlayAbility({
-            title: 'This unit enters play as a copy of a non-leader, non-Vehicle unit in play, except it gains the Clone trait and is not unique',
+            title: `This unit enters play as a copy of a non-leader, non-${TextHelper.Trait.Vehicle} unit in play, except it gains the ${TextHelper.Trait.Clone} trait and is not unique`,
             optional: true,
             targetResolver: {
                 activePromptTitle: 'Choose a unit to clone',

--- a/server/game/cards/03_TWI/units/DroidCommando.ts
+++ b/server/game/cards/03_TWI/units/DroidCommando.ts
@@ -14,7 +14,7 @@ export default class DroidCommando extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Separatist unit, this unit gains ${TextHelper.Ambush}`,
+            title: `While you control another ${TextHelper.Trait.Separatist} unit, this unit gains ${TextHelper.Ambush}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Separatist, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush)
         });

--- a/server/game/cards/03_TWI/units/FivesInSearchOfTruth.ts
+++ b/server/game/cards/03_TWI/units/FivesInSearchOfTruth.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FivesInSearchOfTruth extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class FivesInSearchOfTruth extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Put a Clone unit from your discard pile on the bottom of your deck. If you do, draw a card',
+            title: `Put a ${TextHelper.Trait.Clone} unit from your discard pile on the bottom of your deck. If you do, draw a card`,
             when: {
                 onCardPlayed: (event, context) => event.card.isEvent() && event.player === context.player
             },

--- a/server/game/cards/03_TWI/units/GeneralGrievousTrophyCollector.ts
+++ b/server/game/cards/03_TWI/units/GeneralGrievousTrophyCollector.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GeneralGrievousTrophyCollector extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GeneralGrievousTrophyCollector extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Ignore the aspect penalty on each Lightsaber upgrade you play on this unit',
+            title: `Ignore the aspect penalty on each ${TextHelper.Trait.Lightsaber} upgrade you play on this unit`,
             ongoingEffect: AbilityHelper.ongoingEffects.ignoreAllAspectPenalties({
                 cardTypeFilter: WildcardCardType.Playable,
                 attachTargetCondition: (target, _, source) => target === source,

--- a/server/game/cards/03_TWI/units/LowAltitudeGunship.ts
+++ b/server/game/cards/03_TWI/units/LowAltitudeGunship.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LowAltitudeGunship extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class LowAltitudeGunship extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Deal 1 damage to an enemy unit for each friendly Republic unit',
+            title: `Deal 1 damage to an enemy unit for each friendly ${TextHelper.Trait.Republic} unit`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Opponent,

--- a/server/game/cards/03_TWI/units/MagnaguardWingLeader.ts
+++ b/server/game/cards/03_TWI/units/MagnaguardWingLeader.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MagnaguardWingLeader extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,19 +14,19 @@ export default class MagnaguardWingLeader extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a Droid unit',
+            title: `Attack with a ${TextHelper.Trait.Droid} unit`,
             limit: AbilityHelper.limit.perRound(1),
             targetResolver: {
-                activePromptTitle: 'Choose a Droid unit',
+                activePromptTitle: `Choose a ${TextHelper.Trait.Droid} unit`,
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Self,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Droid),
                 immediateEffect: AbilityHelper.immediateEffects.attack(),
             },
             then: (thenContext) => ({
-                title: 'Attack with another Droid unit',
+                title: `Attack with another ${TextHelper.Trait.Droid} unit`,
                 targetResolver: {
-                    activePromptTitle: 'Choose a Droid unit',
+                    activePromptTitle: `Choose a ${TextHelper.Trait.Droid} unit`,
                     cardTypeFilter: WildcardCardType.Unit,
                     controller: RelativePlayer.Self,
                     cardCondition: (card) => card.hasSomeTrait(Trait.Droid) && card !== thenContext.target,

--- a/server/game/cards/03_TWI/units/ObedientVanguard.ts
+++ b/server/game/cards/03_TWI/units/ObedientVanguard.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ObedientVanguard extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ObedientVanguard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Give a Trooper unit +2/+2 for this phase',
+            title: `Give a ${TextHelper.Trait.Trooper} unit +2/+2 for this phase`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/03_TWI/units/OutspokenRepresentative.ts
+++ b/server/game/cards/03_TWI/units/OutspokenRepresentative.ts
@@ -14,7 +14,7 @@ export default class OutspokenRepresentative extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Republic unit, this unit gains ${TextHelper.Sentinel}.`,
+            title: `While you control another ${TextHelper.Trait.Republic} unit, this unit gains ${TextHelper.Sentinel}.`,
             condition: (context) => context.player.isTraitInPlay(Trait.Republic, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Sentinel })
         });

--- a/server/game/cards/03_TWI/units/PadawanStarFighter.ts
+++ b/server/game/cards/03_TWI/units/PadawanStarFighter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PadawanStarFighter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PadawanStarFighter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a Force unit or a Force upgrade, this unit gets +1/+1',
+            title: `While you control a ${TextHelper.Trait.Force} unit or a ${TextHelper.Trait.Force} upgrade, this unit gets +1/+1`,
             condition: (context) => context.player.hasSomeArenaCard({ trait: Trait.Force }),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 1 }),
         });

--- a/server/game/cards/03_TWI/units/RelentlessRocketDroid.ts
+++ b/server/game/cards/03_TWI/units/RelentlessRocketDroid.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RelentlessRocketDroid extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RelentlessRocketDroid extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Trooper unit, this unit gets +2/+0.',
+            title: `While you control another ${TextHelper.Trait.Trooper} unit, this unit gets +2/+0.`,
             condition: (context) => context.player.hasSomeArenaUnit({ otherThan: context.source, trait: Trait.Trooper }),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })
         });

--- a/server/game/cards/03_TWI/units/SeparatistCommando.ts
+++ b/server/game/cards/03_TWI/units/SeparatistCommando.ts
@@ -14,7 +14,7 @@ export default class SeparatistCommando extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Separatist unit, this unit gains ${TextHelper.Raid(2)}`,
+            title: `While you control another ${TextHelper.Trait.Separatist} unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Separatist, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/03_TWI/units/SoullessOneCustomizedForGrievous.ts
+++ b/server/game/cards/03_TWI/units/SoullessOneCustomizedForGrievous.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SoullessOneCustomizedForGrievous extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class SoullessOneCustomizedForGrievous extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Exhaust a friendly Droid unit or General Grievous. If you do, this unit gets +2/+0 for this attack',
+            title: `Exhaust a friendly ${TextHelper.Trait.Droid} unit or General Grievous. If you do, this unit gets +2/+0 for this attack`,
             optional: true,
             targetResolver: {
                 cardCondition: (card, context) =>

--- a/server/game/cards/03_TWI/units/SteelaGerreraBelovedTactician.ts
+++ b/server/game/cards/03_TWI/units/SteelaGerreraBelovedTactician.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SteelaGerreraBelovedTactician extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SteelaGerreraBelovedTactician extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Deal 2 damage to your base. If you do, search the top 8 cards of your deck for a Tactic card, reveal it, and draw it',
+            title: `Deal 2 damage to your base. If you do, search the top 8 cards of your deck for a ${TextHelper.Trait.Tactic} card, reveal it, and draw it`,
             when: {
                 whenPlayed: true,
                 whenDefeated: true
@@ -24,7 +25,7 @@ export default class SteelaGerreraBelovedTactician extends NonLeaderUnitCard {
                 target: context.player.base
             })),
             ifYouDo: {
-                title: 'Search the top 8 cards of your deck for a Tactic card, reveal it, and draw it',
+                title: `Search the top 8 cards of your deck for a ${TextHelper.Trait.Tactic} card, reveal it, and draw it`,
                 immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                     searchCount: 8,
                     cardCondition: (card) => card.hasSomeTrait(Trait.Tactic),

--- a/server/game/cards/03_TWI/units/TheInvisibleHandImposingFlagship.ts
+++ b/server/game/cards/03_TWI/units/TheInvisibleHandImposingFlagship.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheInvisibleHandImposingFlagship extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -18,7 +19,7 @@ export default class TheInvisibleHandImposingFlagship extends NonLeaderUnitCard 
         });
 
         registrar.addOnAttackAbility({
-            title: 'Exhaust any number of friendly Separatist units',
+            title: `Exhaust any number of friendly ${TextHelper.Trait.Separatist} units`,
             optional: true,
             targetResolver: {
                 mode: TargetMode.Unlimited,

--- a/server/game/cards/03_TWI/units/TranquilityInspiringFlagship.ts
+++ b/server/game/cards/03_TWI/units/TranquilityInspiringFlagship.ts
@@ -14,7 +14,7 @@ export default class TranquilityInspiringFlagship extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Return a Republic unit from your discard pile to your hand',
+            title: `Return a ${TextHelper.Trait.Republic} unit from your discard pile to your hand`,
             optional: true,
             targetResolver: {
                 zoneFilter: ZoneName.Discard,
@@ -25,7 +25,7 @@ export default class TranquilityInspiringFlagship extends NonLeaderUnitCard {
         });
 
         registrar.addOnAttackAbility({
-            title: `Each of the next 3 Republic cards you play this phase costs ${TextHelper.resource(1)} less`,
+            title: `Each of the next 3 ${TextHelper.Trait.Republic} cards you play this phase costs ${TextHelper.resource(1)} less`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: AbilityHelper.ongoingEffects.decreaseCost({
                     match: (card) => card.hasSomeTrait(Trait.Republic),

--- a/server/game/cards/03_TWI/units/WolfPackEscort.ts
+++ b/server/game/cards/03_TWI/units/WolfPackEscort.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WolfPackEscort extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class WolfPackEscort extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Return a friendly non-leader, non-Vehicle unit to its owner\'s hand.',
+            title: `Return a friendly non-leader, non-${TextHelper.Trait.Vehicle} unit to its owner's hand.`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,

--- a/server/game/cards/03_TWI/upgrades/ForTheRepublic.ts
+++ b/server/game/cards/03_TWI/upgrades/ForTheRepublic.ts
@@ -14,7 +14,7 @@ export default class ForTheRepublic extends UpgradeCard {
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `If you control 3 or more Republic units, this upgrade costs ${TextHelper.resource(2)} less to play.`,
+            title: `If you control 3 or more ${TextHelper.Trait.Republic} units, this upgrade costs ${TextHelper.resource(2)} less to play.`,
             amount: 2,
             condition: (context) => context.player.getArenaUnits({ trait: Trait.Republic }).length >= 3,
         });

--- a/server/game/cards/03_TWI/upgrades/SquadSupport.ts
+++ b/server/game/cards/03_TWI/upgrades/SquadSupport.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SquadSupport extends UpgradeCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class SquadSupport extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.isLeader());
 
         registrar.addGainConstantAbilityTargetingAttached({
-            title: 'This unit gets +1/+1 for each Trooper unit you control.',
+            title: `This unit gets +1/+1 for each ${TextHelper.Trait.Trooper} unit you control.`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((target) => {
                 const trooperUnits = target.controller.getArenaUnits({ trait: Trait.Trooper });
                 return {

--- a/server/game/cards/04_JTL/events/Commandeer.ts
+++ b/server/game/cards/04_JTL/events/Commandeer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { PhaseName, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Commandeer extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Commandeer extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Take control of a non-leader Vehicle unit that costs 6 or less without a Pilot on it and ready it. At the start of the regroup phase, return that unit to its owner\'s hand.',
+            title: `Take control of a non-leader ${TextHelper.Trait.Vehicle} unit that costs 6 or less without a ${TextHelper.Trait.Pilot} on it and ready it. At the start of the regroup phase, return that unit to its owner's hand.`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Vehicle) && card.isUnit() && card.cost <= 6 && !card.upgrades.some((u) => u.hasSomeTrait(Trait.Pilot)),

--- a/server/game/cards/04_JTL/events/DirectHit.ts
+++ b/server/game/cards/04_JTL/events/DirectHit.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DirectHit extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DirectHit extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Defeat a non-leader Vehicle unit',
+            title: `Defeat a non-leader ${TextHelper.Trait.Vehicle} unit`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/04_JTL/events/Eject.ts
+++ b/server/game/cards/04_JTL/events/Eject.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Eject extends EventCard {
     protected override getImplementationId() {
@@ -13,10 +14,10 @@ export default class Eject extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Detach a Pilot upgrade, move it to the ground arena as a unit, and exhaust it. Draw a card.',
+            title: `Detach a ${TextHelper.Trait.Pilot} upgrade, move it to the ground arena as a unit, and exhaust it. Draw a card.`,
             immediateEffect: abilityHelper.immediateEffects.simultaneous([
                 abilityHelper.immediateEffects.selectCard({
-                    activePromptTitle: 'Detach a Pilot upgrade, move it to the ground arena as a unit, and exhaust it',
+                    activePromptTitle: `Detach a ${TextHelper.Trait.Pilot} upgrade, move it to the ground arena as a unit, and exhaust it`,
                     cardTypeFilter: WildcardCardType.UnitUpgrade,
                     cardCondition: (card) => card.hasSomeTrait(Trait.Pilot),
                     immediateEffect: abilityHelper.immediateEffects.sequential([

--- a/server/game/cards/04_JTL/events/ElectromagneticPulse.ts
+++ b/server/game/cards/04_JTL/events/ElectromagneticPulse.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ElectromagneticPulse extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ElectromagneticPulse extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Deal 2 damage to a Droid or Vehicle unit and exhaust it.',
+            title: `Deal 2 damage to a ${TextHelper.Trait.Droid} or ${TextHelper.Trait.Vehicle} unit and exhaust it.`,
             targetResolver: {
                 cardCondition: (card) => card.isUnit() && card.hasSomeTrait([Trait.Droid, Trait.Vehicle]),
                 immediateEffect: AbilityHelper.immediateEffects.sequential([

--- a/server/game/cards/04_JTL/events/FlyCasual.ts
+++ b/server/game/cards/04_JTL/events/FlyCasual.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FlyCasual extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class FlyCasual extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Ready a Vehicle unit. It can\'t attack bases for this phase',
+            title: `Ready a ${TextHelper.Trait.Vehicle} unit. It can't attack bases for this phase`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/04_JTL/events/FocusFire.ts
+++ b/server/game/cards/04_JTL/events/FocusFire.ts
@@ -3,6 +3,7 @@ import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FocusFire extends EventCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class FocusFire extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Choose a unit. Each friendly Vehicle unit in the same arena deals damage equal to its power that unit',
+            title: `Choose a unit. Each friendly ${TextHelper.Trait.Vehicle} unit in the same arena deals damage equal to its power that unit`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: AbilityHelper.immediateEffects.simultaneous((context) => (this.getDamageFromContext(context, AbilityHelper))),

--- a/server/game/cards/04_JTL/events/IHaveYouNow.ts
+++ b/server/game/cards/04_JTL/events/IHaveYouNow.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { AbilityType, DamageModificationType, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class IHaveYouNow extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class IHaveYouNow extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Vehicle unit',
+            title: `Attack with a ${TextHelper.Trait.Vehicle} unit`,
             initiateAttack: {
                 attackerCondition: (card, context) => card.controller === context.source.controller && card.hasSomeTrait(Trait.Vehicle),
                 attackerLastingEffects: [{ effect: AbilityHelper.ongoingEffects.gainAbility({

--- a/server/game/cards/04_JTL/events/KoiogranTurn.ts
+++ b/server/game/cards/04_JTL/events/KoiogranTurn.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KoiogranTurn extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class KoiogranTurn extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Ready a Fighter or Transport unit with 6 or less power',
+            title: `Ready a ${TextHelper.Trait.Fighter} or ${TextHelper.Trait.Transport} unit with 6 or less power`,
             targetResolver: {
                 cardCondition: (card) => card.isUnit() && card.getPower() <= 6 && (card.hasSomeTrait([Trait.Fighter, Trait.Transport])),
                 immediateEffect: AbilityHelper.immediateEffects.ready(),

--- a/server/game/cards/04_JTL/events/PlanetaryBombardment.ts
+++ b/server/game/cards/04_JTL/events/PlanetaryBombardment.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PlanetaryBombardment extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PlanetaryBombardment extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Deal 8 indirect damage to a player. If you control a Capital Ship unit, deal 12 indirect damage instead',
+            title: `Deal 8 indirect damage to a player. If you control a ${TextHelper.Trait.CapitalShip} unit, deal 12 indirect damage instead`,
             contextTitle: (c) => `Deal ${c.player.hasSomeArenaUnit({ trait: Trait.CapitalShip }) ? 12 : 8} indirect damage to a player`,
             targetResolver: {
                 mode: TargetMode.Player,

--- a/server/game/cards/04_JTL/events/PunchIt.ts
+++ b/server/game/cards/04_JTL/events/PunchIt.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PunchIt extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class PunchIt extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Vehicle unit. It gets +2/+0 for this attack',
+            title: `Attack with a ${TextHelper.Trait.Vehicle} unit. It gets +2/+0 for this attack`,
             initiateAttack: {
                 attackerCondition: (card) => card.hasSomeTrait(Trait.Vehicle),
                 attackerLastingEffects: {

--- a/server/game/cards/04_JTL/events/Salvage.ts
+++ b/server/game/cards/04_JTL/events/Salvage.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Salvage extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Salvage extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Play a Vehicle unit from your discard pile (paying its cost)',
+            title: `Play a ${TextHelper.Trait.Vehicle} unit from your discard pile (paying its cost)`,
             targetResolver: {
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/04_JTL/events/StayonTarget.ts
+++ b/server/game/cards/04_JTL/events/StayonTarget.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, AbilityType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { DamageSourceType } from '../../../IDamageOrDefeatSource';
 
 export default class StayonTarget extends EventCard {
@@ -14,7 +15,7 @@ export default class StayonTarget extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Vehicle unit. For this attack, it gets +2/+0 and gains: "When this unit deals damage to a base: Draw a card"',
+            title: `Attack with a ${TextHelper.Trait.Vehicle} unit. For this attack, it gets +2/+0 and gains: "When this unit deals damage to a base: Draw a card"`,
             initiateAttack: {
                 attackerCondition: (card) => card.hasSomeTrait(Trait.Vehicle),
                 attackerLastingEffects: [

--- a/server/game/cards/04_JTL/events/TheyHateThatShip.ts
+++ b/server/game/cards/04_JTL/events/TheyHateThatShip.ts
@@ -22,7 +22,7 @@ export default class TheyHateThatShip extends EventCard {
                 target: context.player.opponent
             })),
             then: {
-                title: `Play a Vehicle unit from your hand. It costs ${TextHelper.resource(3)} less`,
+                title: `Play a ${TextHelper.Trait.Vehicle} unit from your hand. It costs ${TextHelper.resource(3)} less`,
                 targetResolver: {
                     zoneFilter: ZoneName.Hand,
                     controller: RelativePlayer.Self,

--- a/server/game/cards/04_JTL/events/TrenchRun.ts
+++ b/server/game/cards/04_JTL/events/TrenchRun.ts
@@ -3,6 +3,7 @@ import type { Card } from '../../../core/card/Card';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { AbilityType, EventName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { Contract } from '../../../core/utils/Contract';
 
 export default class TrenchRun extends EventCard {
@@ -15,7 +16,7 @@ export default class TrenchRun extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Fighter unit. For this attack, it gets +4/+0 and gains: "On Attack: Discard 2 cards from the defending player\'s deck. Deal unpreventable damage equal to the difference in the discarded cards\' costs to this unit."',
+            title: `Attack with a ${TextHelper.Trait.Fighter} unit. For this attack, it gets +4/+0 and gains: "On Attack: Discard 2 cards from the defending player's deck. Deal unpreventable damage equal to the difference in the discarded cards' costs to this unit."`,
             targetResolver: {
                 cardCondition: (card) => card.hasSomeTrait(Trait.Fighter),
                 immediateEffect: AbilityHelper.immediateEffects.attack({

--- a/server/game/cards/04_JTL/leaders/AdmiralHoldoWereNotAlone.ts
+++ b/server/game/cards/04_JTL/leaders/AdmiralHoldoWereNotAlone.ts
@@ -3,6 +3,7 @@ import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
 import type { IUnitCard } from '../../../core/card/propertyMixins/UnitProperties';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AdmiralHoldoWereNotAlone extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class AdmiralHoldoWereNotAlone extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Give a Resistance unit or a unit with a Resistance upgrade on it +2/+2 for this phase',
+            title: `Give a ${TextHelper.Trait.Resistance} unit or a unit with a ${TextHelper.Trait.Resistance} upgrade on it +2/+2 for this phase`,
             cost: [AbilityHelper.costs.abilityActivationResourceCost(1), AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -28,7 +29,7 @@ export default class AdmiralHoldoWereNotAlone extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give another Resistance unit or a unit with a Resistance upgrade on it +2/+2 for this phase',
+            title: `Give another ${TextHelper.Trait.Resistance} unit or a unit with a ${TextHelper.Trait.Resistance} upgrade on it +2/+2 for this phase`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/04_JTL/leaders/AdmiralPiettCommandingTheArmada.ts
+++ b/server/game/cards/04_JTL/leaders/AdmiralPiettCommandingTheArmada.ts
@@ -15,10 +15,10 @@ export default class AdmiralPiettCommandingTheArmada extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Play a Capital Ship unit from your hand. It costs ${TextHelper.resource(1)} less`,
+            title: `Play a ${TextHelper.Trait.CapitalShip} unit from your hand. It costs ${TextHelper.resource(1)} less`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
-                activePromptTitle: 'Choose a Capital Ship',
+                activePromptTitle: `Choose a ${TextHelper.Trait.CapitalShip}`,
                 cardCondition: (card) => card.hasSomeTrait(Trait.CapitalShip),
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,
@@ -32,7 +32,7 @@ export default class AdmiralPiettCommandingTheArmada extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each Capital Ship unit you play costs ${TextHelper.resource(2)} less`,
+            title: `Each ${TextHelper.Trait.CapitalShip} unit you play costs ${TextHelper.resource(2)} less`,
             targetController: RelativePlayer.Self,
             ongoingEffect: AbilityHelper.ongoingEffects.decreaseCost({
                 match: (card) => card.hasSomeTrait(Trait.CapitalShip),

--- a/server/game/cards/04_JTL/leaders/CaptainPhasmaChromeDome.ts
+++ b/server/game/cards/04_JTL/leaders/CaptainPhasmaChromeDome.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { CardType, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class CaptainPhasmaChromeDome extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'If you played a First Order card this phase, deal 1 damage to a base',
+            title: `If you played a ${TextHelper.Trait.FirstOrder} card this phase, deal 1 damage to a base`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: CardType.Base,

--- a/server/game/cards/04_JTL/leaders/LukeSkywalkerHeroOfYavin.ts
+++ b/server/game/cards/04_JTL/leaders/LukeSkywalkerHeroOfYavin.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { AbilityType, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import { DefeatSourceType } from '../../../IDamageOrDefeatSource';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
@@ -24,7 +25,7 @@ export default class LukeSkywalkerHeroOfYavin extends LeaderUnitCard {
         registrar.addPilotDeploy();
 
         registrar.addActionAbility({
-            title: 'If you attacked with a Fighter unit this phase, deal 1 damage to a unit',
+            title: `If you attacked with a ${TextHelper.Trait.Fighter} unit this phase, deal 1 damage to a unit`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/04_JTL/leaders/MajorVonregRedBaron.ts
+++ b/server/game/cards/04_JTL/leaders/MajorVonregRedBaron.ts
@@ -9,6 +9,7 @@ import {
     WildcardZoneName,
     ZoneName
 } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MajorVonregRedBaron extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -22,7 +23,7 @@ export default class MajorVonregRedBaron extends LeaderUnitCard {
         registrar.addPilotDeploy();
 
         registrar.addActionAbility({
-            title: 'Play a Vehicle unit from your hand. If you do, give another unit +1/+0 for this phase.',
+            title: `Play a ${TextHelper.Trait.Vehicle} unit from your hand. If you do, give another unit +1/+0 for this phase.`,
             cost: [AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardCondition: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/04_JTL/leaders/PoeDameronICanFlyAnything.ts
+++ b/server/game/cards/04_JTL/leaders/PoeDameronICanFlyAnything.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { RelativePlayer, Trait, AbilityType, WildcardZoneName, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PoeDameronICanFlyAnything extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PoeDameronICanFlyAnything extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Flip ${this.title} and attach him as an upgrade to a friendly Vehicle unit without a Pilot on it`,
+            title: `Flip ${this.title} and attach him as an upgrade to a friendly ${TextHelper.Trait.Vehicle} unit without a ${TextHelper.Trait.Pilot} on it`,
             cost: [
                 AbilityHelper.costs.exhaustSelf(),
                 AbilityHelper.costs.abilityActivationResourceCost(1),
@@ -32,7 +33,7 @@ export default class PoeDameronICanFlyAnything extends LeaderUnitCard {
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addPilotingAbility({
             type: AbilityType.Action,
-            title: 'Attach this upgrade to a friendly Vehicle unit without a Pilot on it',
+            title: `Attach this upgrade to a friendly ${TextHelper.Trait.Vehicle} unit without a ${TextHelper.Trait.Pilot} on it`,
             cost: AbilityHelper.costs.abilityActivationResourceCost(1),
             limit: AbilityHelper.limit.perRound(1),
             zoneFilter: WildcardZoneName.AnyArena,

--- a/server/game/cards/04_JTL/leaders/RoseTicoSavingWhatWeLove.ts
+++ b/server/game/cards/04_JTL/leaders/RoseTicoSavingWhatWeLove.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class RoseTicoSavingWhatWeLove extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Heal 2 damage from a Vehicle unit that attacked this phase',
+            title: `Heal 2 damage from a ${TextHelper.Trait.Vehicle} unit that attacked this phase`,
             cost: AbilityHelper.costs.exhaustSelf(),
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -36,7 +37,7 @@ export default class RoseTicoSavingWhatWeLove extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Heal 2 damage from a Vehicle unit',
+            title: `Heal 2 damage from a ${TextHelper.Trait.Vehicle} unit`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/04_JTL/leaders/WedgeAntillesLeaderOfRedSquadron.ts
+++ b/server/game/cards/04_JTL/leaders/WedgeAntillesLeaderOfRedSquadron.ts
@@ -43,7 +43,7 @@ export default class WedgeAntillesLeaderOfRedSquadron extends LeaderUnitCard {
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addPilotingGainAbilityTargetingAttached({
             type: AbilityType.Triggered,
-            title: `The next Pilot you play this phase costs ${TextHelper.resource(1)} less`,
+            title: `The next ${TextHelper.Trait.Pilot} you play this phase costs ${TextHelper.resource(1)} less`,
             when: {
                 onAttack: true,
             },

--- a/server/game/cards/04_JTL/units/AdmiralYularenFleetCoordinator.ts
+++ b/server/game/cards/04_JTL/units/AdmiralYularenFleetCoordinator.ts
@@ -21,8 +21,8 @@ export default class AdmiralYularenFleetCoordinator extends NonLeaderUnitCard {
         const shielded = TextHelper.Shielded;
 
         registrar.addWhenPlayedAbility({
-            title: `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}. While ${this.title} is in play, each friendly Vehicle unit gains the chosen keyword.`,
-            contextTitle: (context) => `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}. While ${context.source.title} is in play, each friendly Vehicle unit gains the chosen keyword.`,
+            title: `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}. While ${this.title} is in play, each friendly ${TextHelper.Trait.Vehicle} unit gains the chosen keyword.`,
+            contextTitle: (context) => `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}. While ${context.source.title} is in play, each friendly ${TextHelper.Trait.Vehicle} unit gains the chosen keyword.`,
             targetResolver: {
                 mode: TargetMode.Select,
                 activePromptTitle: `Choose ${grit}, ${restore1}, ${sentinel}, or ${shielded}`,
@@ -42,10 +42,10 @@ export default class AdmiralYularenFleetCoordinator extends NonLeaderUnitCard {
     private buildYularenEffect(choice: KeywordNameOrProperties, AbilityHelper: IAbilityHelper, playedByPlayer: Player) {
         return AbilityHelper.immediateEffects.whileSourceInPlayCardEffect({
             ongoingEffectDescription: `give ${TextHelper.keyword(choice)} to`,
-            ongoingEffectTargetDescription: 'each friendly Vehicle unit',
+            ongoingEffectTargetDescription: `each friendly ${TextHelper.Trait.Vehicle} unit`,
             effect: AbilityHelper.ongoingEffects.gainAbility({
                 type: AbilityType.Constant,
-                title: `Friendly Vehicle units gains ${TextHelper.keyword(choice)}`,
+                title: `Friendly ${TextHelper.Trait.Vehicle} units gains ${TextHelper.keyword(choice)}`,
                 targetController: WildcardRelativePlayer.Any,
                 targetCardTypeFilter: WildcardCardType.Unit,
                 matchTarget: (card) => card.hasSomeTrait(Trait.Vehicle) && card.controller === playedByPlayer,

--- a/server/game/cards/04_JTL/units/BB8HappyBeeps.ts
+++ b/server/game/cards/04_JTL/units/BB8HappyBeeps.ts
@@ -18,16 +18,16 @@ export default class BB8HappyBeeps extends NonLeaderUnitCard {
             when: {
                 whenPlayed: true,
             },
-            title: `Pay ${TextHelper.resource(2)} to ready a Resistance unit`,
+            title: `Pay ${TextHelper.resource(2)} to ready a ${TextHelper.Trait.Resistance} unit`,
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.payResources((context) => ({
                 amount: 2,
                 target: context.player
             })),
             ifYouDo: {
-                title: 'Ready a Resistance unit',
+                title: `Ready a ${TextHelper.Trait.Resistance} unit`,
                 targetResolver: {
-                    activePromptTitle: 'Choose a Resistance unit to ready',
+                    activePromptTitle: `Choose a ${TextHelper.Trait.Resistance} unit to ready`,
                     cardTypeFilter: WildcardCardType.Unit,
                     cardCondition: (card) => card.hasSomeTrait(Trait.Resistance),
                     immediateEffect: AbilityHelper.immediateEffects.ready()

--- a/server/game/cards/04_JTL/units/BiggsDarklighterTheyllNeverStopUs.ts
+++ b/server/game/cards/04_JTL/units/BiggsDarklighterTheyllNeverStopUs.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BiggsDarklighterTheyllNeverStopUs extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -23,7 +24,7 @@ export default class BiggsDarklighterTheyllNeverStopUs extends NonLeaderUnitCard
         });
 
         registrar.addPilotingConstantAbilityTargetingAttached({
-            title: 'Transport attached unit gets +0/+1',
+            title: `${TextHelper.Trait.Transport} attached unit gets +0/+1`,
             condition: (context) => context.source.parentCard.hasSomeTrait(Trait.Transport),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({
                 hp: 1, power: 0

--- a/server/game/cards/04_JTL/units/BobaFettFearedBountyHunter.ts
+++ b/server/game/cards/04_JTL/units/BobaFettFearedBountyHunter.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BobaFettFearedBountyHunter extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,7 +15,7 @@ export default class BobaFettFearedBountyHunter extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addPilotingAbility({
             type: AbilityType.Triggered,
-            title: 'Deal 1 damage to a unit. If attached unit is a Transport, deal 2 damage instead.',
+            title: `Deal 1 damage to a unit. If attached unit is a ${TextHelper.Trait.Transport}, deal 2 damage instead.`,
             contextTitle: (context) => `Deal ${context.source.parentCard.hasSomeTrait(Trait.Transport) ? 2 : 1} damage to a unit`,
             when: {
                 whenPlayed: true,

--- a/server/game/cards/04_JTL/units/BunkerDefender.ts
+++ b/server/game/cards/04_JTL/units/BunkerDefender.ts
@@ -14,7 +14,7 @@ export default class BunkerDefender extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control a Vehicle unit, this unit gains ${TextHelper.Sentinel}`,
+            title: `While you control a ${TextHelper.Trait.Vehicle} unit, this unit gains ${TextHelper.Sentinel}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Vehicle),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Sentinel)

--- a/server/game/cards/04_JTL/units/CaptainPhasmaOnMyCommand.ts
+++ b/server/game/cards/04_JTL/units/CaptainPhasmaOnMyCommand.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { WildcardCardType, WildcardZoneName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CaptainPhasmaOnMyCommand extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class CaptainPhasmaOnMyCommand extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give another First Order unit +2/+2 for this phase',
+            title: `Give another ${TextHelper.Trait.FirstOrder} unit +2/+2 for this phase`,
             optional: true,
             when: {
                 onAttack: true,

--- a/server/game/cards/04_JTL/units/CaptainTarkinFullForwardAssault.ts
+++ b/server/game/cards/04_JTL/units/CaptainTarkinFullForwardAssault.ts
@@ -14,7 +14,7 @@ export default class CaptainTarkinFullForwardAssault extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each friendly Vehicle unit gets +1/+0 and gains ${TextHelper.Overwhelm}`,
+            title: `Each friendly ${TextHelper.Trait.Vehicle} unit gets +1/+0 and gains ${TextHelper.Overwhelm}`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card) => card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/04_JTL/units/CorvusInfernoSquadronRaider.ts
+++ b/server/game/cards/04_JTL/units/CorvusInfernoSquadronRaider.ts
@@ -2,6 +2,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CorvusInfernoSquadronRaider extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,8 +14,8 @@ export default class CorvusInfernoSquadronRaider extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Attach a friendly Pilot unit or upgrade to this unit',
-            contextTitle: (context) => `Attach a friendly Pilot unit or upgrade to ${context.source.title}`,
+            title: `Attach a friendly ${TextHelper.Trait.Pilot} unit or upgrade to this unit`,
+            contextTitle: (context) => `Attach a friendly ${TextHelper.Trait.Pilot} unit or upgrade to ${context.source.title}`,
             optional: true,
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/04_JTL/units/DengarCrudeAndSlovenly.ts
+++ b/server/game/cards/04_JTL/units/DengarCrudeAndSlovenly.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DengarCrudeAndSlovenly extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,7 +15,7 @@ export default class DengarCrudeAndSlovenly extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addPilotingGainAbilityTargetingAttached({
             type: AbilityType.Triggered,
-            title: 'Deal 2 indirect damage to a player. If attached unit is Underworld, deal 3 indirect damage instead.',
+            title: `Deal 2 indirect damage to a player. If attached unit is ${TextHelper.Trait.Underworld}, deal 3 indirect damage instead.`,
             contextTitle: (context) => `Deal ${context.source.hasSomeTrait(Trait.Underworld) ? 3 : 2} indirect damage to a player`,
             when: {
                 onAttack: true,

--- a/server/game/cards/04_JTL/units/DorneanGunship.ts
+++ b/server/game/cards/04_JTL/units/DorneanGunship.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DorneanGunship extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DorneanGunship extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Deal indirect damage to a player equal to the number of Vehicle units you control',
+            title: `Deal indirect damage to a player equal to the number of ${TextHelper.Trait.Vehicle} units you control`,
             contextTitle: (context) => `Deal ${context.player.getArenaUnits({ condition: (card) => card.hasSomeTrait(Trait.Vehicle) }).length} indirect damage to a player`,
             targetResolver: {
                 mode: TargetMode.Player,

--- a/server/game/cards/04_JTL/units/EchoBaseEngineer.ts
+++ b/server/game/cards/04_JTL/units/EchoBaseEngineer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class EchoBaseEngineer extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class EchoBaseEngineer extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give a Shield token to a damaged Vehicle unit',
+            title: `Give a Shield token to a damaged ${TextHelper.Trait.Vehicle} unit`,
             optional: true,
             targetResolver: {
                 cardCondition: (card) => card.isUnit() && card.damage !== 0 && card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/04_JTL/units/FlankingFangFighter.ts
+++ b/server/game/cards/04_JTL/units/FlankingFangFighter.ts
@@ -14,7 +14,7 @@ export default class FlankingFangFighter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Fighter unit, this unit gains ${TextHelper.Raid(2)}`,
+            title: `While you control another ${TextHelper.Trait.Fighter} unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Fighter, context.source),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/04_JTL/units/GeneralHuxNoTermsNoSurrender.ts
+++ b/server/game/cards/04_JTL/units/GeneralHuxNoTermsNoSurrender.ts
@@ -22,7 +22,7 @@ export default class GeneralHuxNoTermsNoSurrender extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Each other friendly First Order unit gains ${TextHelper.Raid(1)}`,
+            title: `Each other friendly ${TextHelper.Trait.FirstOrder} unit gains ${TextHelper.Raid(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.FirstOrder),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 })
         });

--- a/server/game/cards/04_JTL/units/HondoOhnakaSuperfluousSwindler.ts
+++ b/server/game/cards/04_JTL/units/HondoOhnakaSuperfluousSwindler.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardRelativePlayer } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class HondoOhnakaSuperfluousSwindler extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,11 +14,11 @@ export default class HondoOhnakaSuperfluousSwindler extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Take control of a non-Pilot upgrade on a unit and attach it to a different eligible unit',
+            title: `Take control of a non-${TextHelper.Trait.Pilot} upgrade on a unit and attach it to a different eligible unit`,
             optional: true,
             targetResolvers: {
                 upgrade: {
-                    activePromptTitle: 'Choose a non-Pilot upgrade to take control of',
+                    activePromptTitle: `Choose a non-${TextHelper.Trait.Pilot} upgrade to take control of`,
                     controller: WildcardRelativePlayer.Any,
                     cardTypeFilter: WildcardCardType.Upgrade,
                     cardCondition: (card) => !card.hasSomeTrait(Trait.Pilot),

--- a/server/game/cards/04_JTL/units/InvincibleNavalAdversary.ts
+++ b/server/game/cards/04_JTL/units/InvincibleNavalAdversary.ts
@@ -14,7 +14,7 @@ export default class InvincibleNavalAdversary extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `If you control a unique Separatist card, this unit costs ${TextHelper.resource(1)} less to play`,
+            title: `If you control a unique ${TextHelper.Trait.Separatist} card, this unit costs ${TextHelper.resource(1)} less to play`,
             condition: (context) => context.player.controlsCardWithTrait(Trait.Separatist, true),
             amount: 1
         });

--- a/server/game/cards/04_JTL/units/L337GetOutOfMySeat.ts
+++ b/server/game/cards/04_JTL/units/L337GetOutOfMySeat.ts
@@ -3,6 +3,7 @@ import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbi
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class L337GetOutOfMySeat extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,9 +15,9 @@ export default class L337GetOutOfMySeat extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'If this unit would be defeated, you may instead attach her as an upgrade to a friendly Vehicle unit without a Pilot on it.',
+            title: `If this unit would be defeated, you may instead attach her as an upgrade to a friendly ${TextHelper.Trait.Vehicle} unit without a ${TextHelper.Trait.Pilot} on it.`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainAbility({
-                title: 'Attach to a friendly Vehicle unit without a pilot on it',
+                title: `Attach to a friendly ${TextHelper.Trait.Vehicle} unit without a pilot on it`,
                 type: AbilityType.ReplacementEffect,
                 when: {
                     onCardDefeated: (event, context) => event.card === context.source,

--- a/server/game/cards/04_JTL/units/LeiaOrganaPilotsToYourStations.ts
+++ b/server/game/cards/04_JTL/units/LeiaOrganaPilotsToYourStations.ts
@@ -14,7 +14,7 @@ export default class LeiaOrganaPilotsToYourStations extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: `Attack with a Pilot unit or a unit with a Pilot on it. It gets +1/+0 and gains ${TextHelper.Restore(1)} for this attack.`,
+            title: `Attack with a ${TextHelper.Trait.Pilot} unit or a unit with a ${TextHelper.Trait.Pilot} on it. It gets +1/+0 and gains ${TextHelper.Restore(1)} for this attack.`,
             optional: true,
             initiateAttack: {
                 attackerCondition: (card) => card.isUnit() && (card.hasSomeTrait(Trait.Pilot) || card.upgrades.some((upgrade) => upgrade.hasSomeTrait(Trait.Pilot))),

--- a/server/game/cards/04_JTL/units/MassassiTacticalOfficer.ts
+++ b/server/game/cards/04_JTL/units/MassassiTacticalOfficer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MassassiTacticalOfficer extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class MassassiTacticalOfficer extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a Fighter unit. It get +2/+0 for this attack',
+            title: `Attack with a ${TextHelper.Trait.Fighter} unit. It get +2/+0 for this attack`,
             cost: AbilityHelper.costs.exhaustSelf(),
             initiateAttack: {
                 attackerCondition: (card) => card.hasSomeTrait(Trait.Fighter),

--- a/server/game/cards/04_JTL/units/MillenniumFalconGetOutAndPush.ts
+++ b/server/game/cards/04_JTL/units/MillenniumFalconGetOutAndPush.ts
@@ -3,6 +3,7 @@ import type { Card } from '../../../core/card/Card';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MillenniumFalconGetOutAndPush extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -14,12 +15,12 @@ export default class MillenniumFalconGetOutAndPush extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'You may play or deploy 1 additional Pilot on this unit',
+            title: `You may play or deploy 1 additional ${TextHelper.Trait.Pilot} on this unit`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyPilotingLimit({ amount: 1 })
         });
 
         registrar.addConstantAbility({
-            title: 'This unit gets +1/+0 for each Pilot on it',
+            title: `This unit gets +1/+0 for each ${TextHelper.Trait.Pilot} on it`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((target) => ({
                 power: target.upgrades.reduce((count: number, upgrade: Card) => count + (upgrade.hasSomeTrait(Trait.Pilot) ? 1 : 0), 0),
                 hp: 0

--- a/server/game/cards/04_JTL/units/NienNunbLoyalCoPilot.ts
+++ b/server/game/cards/04_JTL/units/NienNunbLoyalCoPilot.ts
@@ -3,6 +3,7 @@ import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NienNunbLoyalCoPilot extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -19,14 +20,14 @@ export default class NienNunbLoyalCoPilot extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'This unit gets +1/+0 for each other friendly Pilot unit and upgrade.',
+            title: `This unit gets +1/+0 for each other friendly ${TextHelper.Trait.Pilot} unit and upgrade.`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((_target, context) => ({
                 power: this.getOtherFriendlyPilotUnitsAndUpgradesCount(context), hp: 0
             }))
         });
 
         registrar.addPilotingConstantAbilityTargetingAttached({
-            title: 'Attached unit gets +1/+0 for each other friendly Pilot unit and upgrade.',
+            title: `Attached unit gets +1/+0 for each other friendly ${TextHelper.Trait.Pilot} unit and upgrade.`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((_target, context) => ({
                 power: this.getOtherFriendlyPilotUnitsAndUpgradesCount(context), hp: 0
             }))

--- a/server/game/cards/04_JTL/units/PantoranStarshipThief.ts
+++ b/server/game/cards/04_JTL/units/PantoranStarshipThief.ts
@@ -14,16 +14,16 @@ export default class PantoranStarshipThief extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: `Pay ${TextHelper.resource(3)} to attach this unit as an upgrade to a Fighter or Transport unit without a Pilot on it. Take control of that unit`,
-            contextTitle: (context) => `Pay ${TextHelper.resource(3)} to attach ${context.source.title} as an upgrade to a Fighter or Transport unit without a Pilot on it. Take control of that unit`,
+            title: `Pay ${TextHelper.resource(3)} to attach this unit as an upgrade to a ${TextHelper.Trait.Fighter} or ${TextHelper.Trait.Transport} unit without a ${TextHelper.Trait.Pilot} on it. Take control of that unit`,
+            contextTitle: (context) => `Pay ${TextHelper.resource(3)} to attach ${context.source.title} as an upgrade to a ${TextHelper.Trait.Fighter} or ${TextHelper.Trait.Transport} unit without a ${TextHelper.Trait.Pilot} on it. Take control of that unit`,
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.payResources((context) => ({
                 amount: 3,
                 target: context.player
             })),
             ifYouDo: {
-                title: 'Attach this unit as an upgrade to a Fighter or Transport unit without a Pilot on it. Take control of that unit',
-                contextTitle: (context) => `Attach ${context.source.title} as an upgrade to a Fighter or Transport unit without a Pilot on it. Take control of that unit`,
+                title: `Attach this unit as an upgrade to a ${TextHelper.Trait.Fighter} or ${TextHelper.Trait.Transport} unit without a ${TextHelper.Trait.Pilot} on it. Take control of that unit`,
+                contextTitle: (context) => `Attach ${context.source.title} as an upgrade to a ${TextHelper.Trait.Fighter} or ${TextHelper.Trait.Transport} unit without a ${TextHelper.Trait.Pilot} on it. Take control of that unit`,
                 targetResolver: {
                     controller: WildcardRelativePlayer.Any,
                     cardCondition: (card) => card.isUnit() &&

--- a/server/game/cards/04_JTL/units/PoeDameronOneHellOfAPilot.ts
+++ b/server/game/cards/04_JTL/units/PoeDameronOneHellOfAPilot.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PoeDameronOneHellOfAPilot extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -18,7 +19,7 @@ export default class PoeDameronOneHellOfAPilot extends NonLeaderUnitCard {
                 amount: 1
             }),
             then: (thenContext) => ({
-                title: 'Attach this unit as an upgrade to a friendly Vehicle unit without a Pilot on it',
+                title: `Attach this unit as an upgrade to a friendly ${TextHelper.Trait.Vehicle} unit without a ${TextHelper.Trait.Pilot} on it`,
                 optional: true,
                 thenCondition: (context) => context.source.isInPlay(),
                 targetResolver: {

--- a/server/game/cards/04_JTL/units/R2D2Artooooooooo.ts
+++ b/server/game/cards/04_JTL/units/R2D2Artooooooooo.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class R2D2Artooooooooo extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,13 +14,13 @@ export default class R2D2Artooooooooo extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addPilotingGainAbilityTargetingAttached({
-            title: 'You may play or deploy 1 additional Pilot on this unit',
+            title: `You may play or deploy 1 additional ${TextHelper.Trait.Pilot} on this unit`,
             type: AbilityType.Constant,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyPilotingLimit({ amount: 1 })
         });
 
         registrar.addConstantAbility({
-            title: 'This upgrade can be played on a friendly Vehicle unit with a Pilot on it.',
+            title: `This upgrade can be played on a friendly ${TextHelper.Trait.Vehicle} unit with a ${TextHelper.Trait.Pilot} on it.`,
             sourceZoneFilter: WildcardZoneName.Any,
             ongoingEffect: AbilityHelper.ongoingEffects.ignorePilotingPilotLimit(),
         });

--- a/server/game/cards/04_JTL/units/RedLeaderFormUp.ts
+++ b/server/game/cards/04_JTL/units/RedLeaderFormUp.ts
@@ -14,7 +14,7 @@ export default class RedLeaderFormUp extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `This unit costs ${TextHelper.resource(1)} less to play for each friendly Pilot unit and upgrade`,
+            title: `This unit costs ${TextHelper.resource(1)} less to play for each friendly ${TextHelper.Trait.Pilot} unit and upgrade`,
             amount: (_card, player) =>
                 player.getArenaUnits({
                     condition: (card) => card.hasSomeTrait(Trait.Pilot)

--- a/server/game/cards/04_JTL/units/ResistanceXWing.ts
+++ b/server/game/cards/04_JTL/units/ResistanceXWing.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ResistanceXWing extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ResistanceXWing extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While this unit has a Pilot on it, it gets +1/+1',
+            title: `While this unit has a ${TextHelper.Trait.Pilot} on it, it gets +1/+1`,
             condition: (context) => context.source.isUpgraded() && context.source.upgrades.some((upgrade) => upgrade.hasSomeTrait(Trait.Pilot)),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 1 })
         });

--- a/server/game/cards/04_JTL/units/SidonIthanoTheCrimsonCorsair.ts
+++ b/server/game/cards/04_JTL/units/SidonIthanoTheCrimsonCorsair.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SidonIthanoTheCrimsonCorsair extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,8 +14,8 @@ export default class SidonIthanoTheCrimsonCorsair extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Attach this unit as an upgrade to an enemy Vehicle unit without a Pilot on it',
-            contextTitle: (context) => `Attach ${context.source.title} as an upgrade to an enemy Vehicle unit without a Pilot on it`,
+            title: `Attach this unit as an upgrade to an enemy ${TextHelper.Trait.Vehicle} unit without a ${TextHelper.Trait.Pilot} on it`,
+            contextTitle: (context) => `Attach ${context.source.title} as an upgrade to an enemy ${TextHelper.Trait.Vehicle} unit without a ${TextHelper.Trait.Pilot} on it`,
             optional: true,
             targetResolver: {
                 controller: RelativePlayer.Opponent,

--- a/server/game/cards/04_JTL/units/SnapWexleyResistanceReconFlier.ts
+++ b/server/game/cards/04_JTL/units/SnapWexleyResistanceReconFlier.ts
@@ -14,7 +14,7 @@ export default class SnapWexleyResistanceReconFlier extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: `The next Resistance card you play this phase costs ${TextHelper.resource(1)} less`,
+            title: `The next ${TextHelper.Trait.Resistance} card you play this phase costs ${TextHelper.resource(1)} less`,
             when: {
                 whenPlayed: true,
                 onAttack: true,
@@ -30,7 +30,7 @@ export default class SnapWexleyResistanceReconFlier extends NonLeaderUnitCard {
         });
 
         registrar.addPilotingAbility({
-            title: 'Search the top 5 cards of your deck for a Resistance card, reveal it, and draw it',
+            title: `Search the top 5 cards of your deck for a ${TextHelper.Trait.Resistance} card, reveal it, and draw it`,
             type: AbilityType.Triggered,
             when: {
                 whenPlayed: true,

--- a/server/game/cards/04_JTL/units/TheGhostHeartOfTheFamily.ts
+++ b/server/game/cards/04_JTL/units/TheGhostHeartOfTheFamily.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheGhostHeartOfTheFamily extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheGhostHeartOfTheFamily extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each other friendly Spectre unit gains this unit\'s keywords',
+            title: `Each other friendly ${TextHelper.Trait.Spectre} unit gains this unit's keywords`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Spectre),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeywords((_, context) =>
                 context.source.keywords.map((k) => k.toProperties())

--- a/server/game/cards/04_JTL/units/TheInvisibleHandCrawlingWithVultures.ts
+++ b/server/game/cards/04_JTL/units/TheInvisibleHandCrawlingWithVultures.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EventName, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 import type { CardsDefeatedThisPhaseWatcher } from '../../../stateWatchers/CardsDefeatedThisPhaseWatcher';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
@@ -23,7 +24,7 @@ export default class TheInvisibleHandCrawlingWithVultures extends NonLeaderUnitC
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Search the top 8 cards of your deck for a Droid unit, reveal it, and draw it. If it costs 2 or less, you may play it for free.',
+            title: `Search the top 8 cards of your deck for a ${TextHelper.Trait.Droid} unit, reveal it, and draw it. If it costs 2 or less, you may play it for free.`,
             when: {
                 whenPlayed: true,
                 onAttackEnd: (event, context) => event.attack.attacker === context.source

--- a/server/game/cards/04_JTL/units/UWingLander.ts
+++ b/server/game/cards/04_JTL/units/UWingLander.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class UWingLander extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -21,7 +22,7 @@ export default class UWingLander extends NonLeaderUnitCard {
         });
 
         registrar.addWhenAttackEndsAbility({
-            title: 'Attach an upgrade on this unit to another eligible friendly Vehicle unit',
+            title: `Attach an upgrade on this unit to another eligible friendly ${TextHelper.Trait.Vehicle} unit`,
             attackerMustSurvive: true,
             optional: true,
             targetResolvers: {

--- a/server/game/cards/04_JTL/units/WingGuardSecurityTeam.ts
+++ b/server/game/cards/04_JTL/units/WingGuardSecurityTeam.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WingGuardSecurityTeam extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class WingGuardSecurityTeam extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give a Shield token to each of up to 2 Fringe units',
+            title: `Give a Shield token to each of up to 2 ${TextHelper.Trait.Fringe} units`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 2,

--- a/server/game/cards/05_LOF/events/AlwaysTwo.ts
+++ b/server/game/cards/05_LOF/events/AlwaysTwo.ts
@@ -3,6 +3,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
 import type { AbilityContext } from '../../../core/ability/AbilityContext';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AlwaysTwo extends EventCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class AlwaysTwo extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Choose 2 friendly unique Sith units. Give 2 Shield tokens and 2 Experience tokens to each chosen unit.',
+            title: `Choose 2 friendly unique ${TextHelper.Trait.Sith} units. Give 2 Shield tokens and 2 Experience tokens to each chosen unit.`,
             customConfirmation: (context) => this.checkWarnHasSufficientTargets(context),
             targetResolver: {
                 mode: TargetMode.Exactly,
@@ -46,7 +47,7 @@ export default class AlwaysTwo extends EventCard {
 
         const legalTargets = playerUnits.filter((card) => card.unique && card.hasSomeTrait(Trait.Sith));
         return legalTargets.length < 2
-            ? 'You do not have enough *unique* Sith units to target. All units you control will be defeated. Proceed?'
+            ? `You do not have enough *unique* ${TextHelper.Trait.Sith} units to target. All units you control will be defeated. Proceed?`
             : null;
     }
 }

--- a/server/game/cards/05_LOF/events/AtaruOnslaught.ts
+++ b/server/game/cards/05_LOF/events/AtaruOnslaught.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AtaruOnslaught extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class AtaruOnslaught extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Ready a Force unit with 4 or less power',
+            title: `Ready a ${TextHelper.Trait.Force} unit with 4 or less power`,
             targetResolver: {
                 cardCondition: (card) => card.isUnit() && card.hasSomeTrait(Trait.Force) && card.getPower() <= 4,
                 immediateEffect: AbilityHelper.immediateEffects.ready(),

--- a/server/game/cards/05_LOF/events/DeathField.ts
+++ b/server/game/cards/05_LOF/events/DeathField.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DeathField extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DeathField extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Deal 2 damage to each non-Vehicle enemy unit. If you control a Force unit, draw a card',
+            title: `Deal 2 damage to each non-${TextHelper.Trait.Vehicle} enemy unit. If you control a ${TextHelper.Trait.Force} unit, draw a card`,
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.damage((context) => ({
                     amount: 2,

--- a/server/game/cards/05_LOF/events/FlightOfTheInquisitor.ts
+++ b/server/game/cards/05_LOF/events/FlightOfTheInquisitor.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FlightOfTheInquisitor extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class FlightOfTheInquisitor extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Return a Force unit and Lightsaber upgrade from your discard pile to your hand.',
+            title: `Return a ${TextHelper.Trait.Force} unit and ${TextHelper.Trait.Lightsaber} upgrade from your discard pile to your hand.`,
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.simultaneous(
                 [

--- a/server/game/cards/05_LOF/events/FocusDeterminesReality.ts
+++ b/server/game/cards/05_LOF/events/FocusDeterminesReality.ts
@@ -14,7 +14,7 @@ export default class FocusDeterminesReality extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Each friendly Force unit gains ${TextHelper.Raid(1)} and ${TextHelper.Saboteur} for this phase.`,
+            title: `Each friendly ${TextHelper.Trait.Force} unit gains ${TextHelper.Raid(1)} and ${TextHelper.Saboteur} for this phase.`,
             immediateEffect: AbilityHelper.immediateEffects.simultaneous([
                 AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                     effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 1 }),

--- a/server/game/cards/05_LOF/events/FollowingThePath.ts
+++ b/server/game/cards/05_LOF/events/FollowingThePath.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FollowingThePath extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class FollowingThePath extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Search the top 8 cards for up to 2 Force units, reveal them, and put them on top of your deck in any order',
+            title: `Search the top 8 cards for up to 2 ${TextHelper.Trait.Force} units, reveal them, and put them on top of your deck in any order`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 targetMode: TargetMode.UpTo,
                 selectCount: 2,

--- a/server/game/cards/05_LOF/events/LightsaberThrow.ts
+++ b/server/game/cards/05_LOF/events/LightsaberThrow.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LightsaberThrow extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class LightsaberThrow extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Discard a Lightsaber card from your hand. If you do, deal 4 damage to a ground unit and draw a card.',
+            title: `Discard a ${TextHelper.Trait.Lightsaber} card from your hand. If you do, deal 4 damage to a ground unit and draw a card.`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 zoneFilter: ZoneName.Hand,

--- a/server/game/cards/05_LOF/events/LuminousBeings.ts
+++ b/server/game/cards/05_LOF/events/LuminousBeings.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LuminousBeings extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class LuminousBeings extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Put up to 3 Force units from your discard pile on the bottom of your deck in a random order. Give that many units +4/+4 for this phase.',
+            title: `Put up to 3 ${TextHelper.Trait.Force} units from your discard pile on the bottom of your deck in a random order. Give that many units +4/+4 for this phase.`,
             targetResolvers: {
                 discard: {
                     mode: TargetMode.UpTo,

--- a/server/game/cards/05_LOF/events/MindTrick.ts
+++ b/server/game/cards/05_LOF/events/MindTrick.ts
@@ -3,6 +3,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
 import type { IUnitCard } from '../../../core/card/propertyMixins/UnitProperties';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MindTrick extends EventCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class MindTrick extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Exhaust any number of units with a combined power of 4 or less. If you control a Force unit, those units lose all abilities and can\'t gain abilities for this phase',
+            title: `Exhaust any number of units with a combined power of 4 or less. If you control a ${TextHelper.Trait.Force} unit, those units lose all abilities and can't gain abilities for this phase`,
             targetResolver: {
                 mode: TargetMode.Unlimited,
                 canChooseNoCards: true,

--- a/server/game/cards/05_LOF/events/NimanStrike.ts
+++ b/server/game/cards/05_LOF/events/NimanStrike.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NimanStrike extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NimanStrike extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Force unit, even if it\'s exhausted. It gets +1/+0 and can\'t attack bases for this attack.',
+            title: `Attack with a ${TextHelper.Trait.Force} unit, even if it's exhausted. It gets +1/+0 and can't attack bases for this attack.`,
             initiateAttack: {
                 attackerCondition: (attacker) => attacker.hasSomeTrait(Trait.Force),
                 targetCondition: (target) => target.isUnit(),

--- a/server/game/cards/05_LOF/events/Pounce.ts
+++ b/server/game/cards/05_LOF/events/Pounce.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Pounce extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class Pounce extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Attack with a Creature unit. It gets +4/+0 for this attack',
+            title: `Attack with a ${TextHelper.Trait.Creature} unit. It gets +4/+0 for this attack`,
             initiateAttack: {
                 attackerCondition: (card) => card.hasSomeTrait(Trait.Creature),
                 attackerLastingEffects: {

--- a/server/game/cards/05_LOF/events/ProtectThePod.ts
+++ b/server/game/cards/05_LOF/events/ProtectThePod.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ProtectThePod extends EventCard {
     protected override getImplementationId () {
@@ -13,10 +14,10 @@ export default class ProtectThePod extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'A friendly non-Vehicle unit deals damage equal to its remaining HP to an enemy unit',
+            title: `A friendly non-${TextHelper.Trait.Vehicle} unit deals damage equal to its remaining HP to an enemy unit`,
             contextTitle: (context) => (context.targets.friendlyUnit
                 ? `${context.targets.friendlyUnit.title} deals ${context.targets.friendlyUnit.remainingHp} damage to an enemy unit`
-                : 'A friendly non-Vehicle unit deals damage equal to its remaining HP to an enemy unit'),
+                : `A friendly non-${TextHelper.Trait.Vehicle} unit deals damage equal to its remaining HP to an enemy unit`),
             targetResolvers: {
                 friendlyUnit: {
                     controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/events/Rampage.ts
+++ b/server/game/cards/05_LOF/events/Rampage.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Rampage extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Rampage extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give all friendly Creature units +2/+2 for the phase',
+            title: `Give all friendly ${TextHelper.Trait.Creature} units +2/+2 for the phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.player.getArenaUnits({ trait: Trait.Creature }),
                 effect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })

--- a/server/game/cards/05_LOF/events/ShienFlurry.ts
+++ b/server/game/cards/05_LOF/events/ShienFlurry.ts
@@ -23,7 +23,7 @@ export default class ShienFlurry extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Play a Force unit from your hand. It gains ${TextHelper.Ambush} for this phase. The next time it would be dealt damage this phase prevent 2 of that damage`,
+            title: `Play a ${TextHelper.Trait.Force} unit from your hand. It gains ${TextHelper.Ambush} for this phase. The next time it would be dealt damage this phase prevent 2 of that damage`,
             cannotTargetFirst: true,
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/events/SoresuStance.ts
+++ b/server/game/cards/05_LOF/events/SoresuStance.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SoresuStance extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SoresuStance extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Play a Force unit from your hand and give a Shield token to it',
+            title: `Play a ${TextHelper.Trait.Force} unit from your hand and give a Shield token to it`,
             targetResolver: {
                 zoneFilter: ZoneName.Hand,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/events/TheBurdenOfMasters.ts
+++ b/server/game/cards/05_LOF/events/TheBurdenOfMasters.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheBurdenOfMasters extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class TheBurdenOfMasters extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Put a Force unit from your discard on the bottom of your deck. If you do, play a unit from your hand and give 2 Experience tokens to it',
+            title: `Put a ${TextHelper.Trait.Force} unit from your discard on the bottom of your deck. If you do, play a unit from your hand and give 2 Experience tokens to it`,
             targetResolver: {
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/events/WhirlwindOfPower.ts
+++ b/server/game/cards/05_LOF/events/WhirlwindOfPower.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class WhirlwindOfPower extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class WhirlwindOfPower extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give a unit –2/–2 for this phase. If you control a Force unit, give it –3/–3 instead.',
+            title: `Give a unit –2/–2 for this phase. If you control a ${TextHelper.Trait.Force} unit, give it –3/–3 instead.`,
             contextTitle: (context) => `Give a unit ${context.player.isTraitInPlay(Trait.Force) ? '–3/–3' : '–2/–2'} for this phase`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/leaders/KananJarrusHelpUsSurvive.ts
+++ b/server/game/cards/05_LOF/leaders/KananJarrusHelpUsSurvive.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KananJarrusHelpUsSurvive extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class KananJarrusHelpUsSurvive extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Give a Shield token to a Creature or Spectre unit.',
+            title: `Give a Shield token to a ${TextHelper.Trait.Creature} or ${TextHelper.Trait.Spectre} unit.`,
             cost: [
                 AbilityHelper.costs.abilityActivationResourceCost(1),
                 AbilityHelper.costs.exhaustSelf(),
@@ -27,7 +28,7 @@ export default class KananJarrusHelpUsSurvive extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Creature or Spectre unit, this unit gets +2/+2.',
+            title: `While you control another ${TextHelper.Trait.Creature} or ${TextHelper.Trait.Spectre} unit, this unit gets +2/+2.`,
             condition: (context) => context.player.hasSomeArenaUnit({ trait: [Trait.Creature, Trait.Spectre], otherThan: context.source }),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })
         });

--- a/server/game/cards/05_LOF/leaders/KitFistoFocusedJediMaster.ts
+++ b/server/game/cards/05_LOF/leaders/KitFistoFocusedJediMaster.ts
@@ -4,6 +4,7 @@ import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { AttacksThisPhaseWatcher } from '../../../stateWatchers/AttacksThisPhaseWatcher';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KitFistoFocusedJediMaster extends LeaderUnitCard {
     private attacksThisPhaseWatcher: AttacksThisPhaseWatcher;
@@ -21,7 +22,7 @@ export default class KitFistoFocusedJediMaster extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'If you attacked with a Jedi unit this phase, deal 2 damage to a unit',
+            title: `If you attacked with a ${TextHelper.Trait.Jedi} unit this phase, deal 2 damage to a unit`,
             cost: [AbilityHelper.costs.abilityActivationResourceCost(1), AbilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -39,7 +40,7 @@ export default class KitFistoFocusedJediMaster extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'This unit gets +1/+0 for each other friendly Jedi unit.',
+            title: `This unit gets +1/+0 for each other friendly ${TextHelper.Trait.Jedi} unit.`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((target) => {
                 const jediUnitCount = target.controller.getArenaUnits({
                     condition: (card) => card.hasSomeTrait(Trait.Jedi),

--- a/server/game/cards/05_LOF/units/AsajjVentressHardenYourHeart.ts
+++ b/server/game/cards/05_LOF/units/AsajjVentressHardenYourHeart.ts
@@ -2,6 +2,7 @@ import { NonLeaderUnitCard } from '../../../../../server/game/core/card/NonLeade
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AsajjVentressHardenYourHeart extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class AsajjVentressHardenYourHeart extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give another friendly Force unit +2/+0 for this phase',
+            title: `Give another friendly ${TextHelper.Trait.Force} unit +2/+0 for this phase`,
             when: {
                 whenPlayed: true,
                 onAttack: true,

--- a/server/game/cards/05_LOF/units/BabuFrikHeyyy.ts
+++ b/server/game/cards/05_LOF/units/BabuFrikHeyyy.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BabuFrikHeyyy extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BabuFrikHeyyy extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Attack with a friendly Droid unit. For this attack, it deals damage equal to its remaining HP instead of its power.',
+            title: `Attack with a friendly ${TextHelper.Trait.Droid} unit. For this attack, it deals damage equal to its remaining HP instead of its power.`,
             cost: AbilityHelper.costs.exhaustSelf(),
             optional: true,
             initiateAttack: {

--- a/server/game/cards/05_LOF/units/CaptainEnochCaptainOfTheGuard.ts
+++ b/server/game/cards/05_LOF/units/CaptainEnochCaptainOfTheGuard.ts
@@ -2,6 +2,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CaptainEnochCaptainOfTheGuard extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class CaptainEnochCaptainOfTheGuard extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'This unit gets +1/+0 for each Trooper unit in your discard pile',
+            title: `This unit gets +1/+0 for each ${TextHelper.Trait.Trooper} unit in your discard pile`,
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats((target) => ({
                 power: target.controller.discardZone.cards.filter((x) => x.isUnit() && x.hasSomeTrait(Trait.Trooper)).length,
                 hp: 0,

--- a/server/game/cards/05_LOF/units/CinDralligEsteemedBlademaster.ts
+++ b/server/game/cards/05_LOF/units/CinDralligEsteemedBlademaster.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class CinDralligEsteemedBlademaster extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class CinDralligEsteemedBlademaster extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'You may play a Lightsaber upgrade from your hand for free on this unit',
+            title: `You may play a ${TextHelper.Trait.Lightsaber} upgrade from your hand for free on this unit`,
             targetResolver: {
                 zoneFilter: ZoneName.Hand,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/05_LOF/units/DagoyanMaster.ts
+++ b/server/game/cards/05_LOF/units/DagoyanMaster.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DagoyanMaster extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DagoyanMaster extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Use the Force. If you do, search the top 5 cards of your deck for a Force unit, reveal it, and draw it',
+            title: `Use the Force. If you do, search the top 5 cards of your deck for a ${TextHelper.Trait.Force} unit, reveal it, and draw it`,
             optional: true,
             when: {
                 whenPlayed: true,
@@ -21,7 +22,7 @@ export default class DagoyanMaster extends NonLeaderUnitCard {
             },
             immediateEffect: AbilityHelper.immediateEffects.useTheForce(),
             ifYouDo: {
-                title: 'Search the top 5 cards of your deck for a Force unit, reveal it, and draw it',
+                title: `Search the top 5 cards of your deck for a ${TextHelper.Trait.Force} unit, reveal it, and draw it`,
                 immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                     selectCount: 1,
                     searchCount: 5,

--- a/server/game/cards/05_LOF/units/DarthSidiousThePhantomMenace.ts
+++ b/server/game/cards/05_LOF/units/DarthSidiousThePhantomMenace.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DarthSidiousThePhantomMenace extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,11 +14,11 @@ export default class DarthSidiousThePhantomMenace extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Use The Force to defeat each non-Sith unit with 3 or less remaining HP',
+            title: `Use The Force to defeat each non-${TextHelper.Trait.Sith} unit with 3 or less remaining HP`,
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.useTheForce(),
             ifYouDo: {
-                title: 'Defeat each non-Sith unit with 3 or less remaining HP',
+                title: `Defeat each non-${TextHelper.Trait.Sith} unit with 3 or less remaining HP`,
                 immediateEffect: AbilityHelper.immediateEffects.defeat((context) => ({
                     target: context.game.getArenaUnits({
                         condition: (card) => card.isUnit() &&

--- a/server/game/cards/05_LOF/units/DumeRedeemTheFuture.ts
+++ b/server/game/cards/05_LOF/units/DumeRedeemTheFuture.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { PhaseName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DumeRedeemTheFuture extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DumeRedeemTheFuture extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give an Experience token to each other friendly non-Vehicle unit.',
+            title: `Give an Experience token to each other friendly non-${TextHelper.Trait.Vehicle} unit.`,
             when: {
                 onPhaseStarted: (context) => context.phase === PhaseName.Regroup
             },

--- a/server/game/cards/05_LOF/units/EzraBridgerAttunedWithLife.ts
+++ b/server/game/cards/05_LOF/units/EzraBridgerAttunedWithLife.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class EzraBridgerAttunedWithLife extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class EzraBridgerAttunedWithLife extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give an Experience token to another Creature or Spectre unit.',
+            title: `Give an Experience token to another ${TextHelper.Trait.Creature} or ${TextHelper.Trait.Spectre} unit.`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/GrandInquisitorYoureRightToBeAfraid.ts
+++ b/server/game/cards/05_LOF/units/GrandInquisitorYoureRightToBeAfraid.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { KeywordName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrandInquisitorYoureRightToBeAfraid extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GrandInquisitorYoureRightToBeAfraid extends NonLeaderUnitCa
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly Inquisitor units gain hidden.',
+            title: `Other friendly ${TextHelper.Trait.Inquisitor} units gain hidden.`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Inquisitor),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Hidden })
         });

--- a/server/game/cards/05_LOF/units/InvasionControlShip.ts
+++ b/server/game/cards/05_LOF/units/InvasionControlShip.ts
@@ -14,7 +14,7 @@ export default class InvasionControlShip extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Friendly Droid units gain ${TextHelper.Raid(2)}`,
+            title: `Friendly ${TextHelper.Trait.Droid} units gain ${TextHelper.Raid(2)}`,
             targetController: RelativePlayer.Self,
             matchTarget: (card) => card.hasSomeTrait(Trait.Droid),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 }),

--- a/server/game/cards/05_LOF/units/JediVector.ts
+++ b/server/game/cards/05_LOF/units/JediVector.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class JediVector extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,13 +14,13 @@ export default class JediVector extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control another Jedi unit, this unit gets +1/+0',
+            title: `While you control another ${TextHelper.Trait.Jedi} unit, this unit gets +1/+0`,
             condition: (context) => context.player.hasSomeArenaUnit({ otherThan: context.source, trait: Trait.Jedi }),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 }),
         });
 
         registrar.addConstantAbility({
-            title: 'While you control a Lightsaber upgrade, this unit gets +1/+0',
+            title: `While you control a ${TextHelper.Trait.Lightsaber} upgrade, this unit gets +1/+0`,
             condition: (context) => context.player.hasSomeArenaUpgrade({ trait: Trait.Lightsaber }),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 }),
         });

--- a/server/game/cards/05_LOF/units/MalakiliLovingRancorKeeper.ts
+++ b/server/game/cards/05_LOF/units/MalakiliLovingRancorKeeper.ts
@@ -23,7 +23,7 @@ export default class MalakiliLovingRancorKeeper extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `The first Creature unit you play each phase costs ${TextHelper.resource(1)} less`,
+            title: `The first ${TextHelper.Trait.Creature} unit you play each phase costs ${TextHelper.resource(1)} less`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             targetZoneFilter: WildcardZoneName.AnyArena,
@@ -36,7 +36,7 @@ export default class MalakiliLovingRancorKeeper extends NonLeaderUnitCard {
         });
 
         registrar.addDamageModificationAbility({
-            title: 'If a friendly Creature unit would deal damage to a friendly unit, prevent that damage',
+            title: `If a friendly ${TextHelper.Trait.Creature} unit would deal damage to a friendly unit, prevent that damage`,
             modificationType: DamageModificationType.PreventAll,
             shouldCardHaveDamageModification: (card, context) => this.isDamageFromFriendlyCreatureUnit(card, context),
         });

--- a/server/game/cards/05_LOF/units/MazKanataTheLightGuides.ts
+++ b/server/game/cards/05_LOF/units/MazKanataTheLightGuides.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MazKanataTheLightGuides extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MazKanataTheLightGuides extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Attack with a Force unit. It gets +2/+0 for this attack.',
+            title: `Attack with a ${TextHelper.Trait.Force} unit. It gets +2/+0 for this attack.`,
             optional: true,
             initiateAttack: {
                 attackerCondition: (card) => card.hasSomeTrait(Trait.Force),

--- a/server/game/cards/05_LOF/units/MythosaurFolkloreAwakened.ts
+++ b/server/game/cards/05_LOF/units/MythosaurFolkloreAwakened.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { AbilityType, EventName, RelativePlayer, Trait, WildcardCardType, WildcardZoneName, ZoneName } from '../../../core/Constants';
 import { ExhaustSourceType } from '../../../IDamageOrDefeatSource';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MythosaurFolkloreAwakened extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -43,7 +44,7 @@ export default class MythosaurFolkloreAwakened extends NonLeaderUnitCard {
         });
 
         registrar.addConstantAbility({
-            title: 'Friendly leaders gain the Mandalorian trait',
+            title: `Friendly leaders gain the ${TextHelper.Trait.Mandalorian} trait`,
             targetZoneFilter: WildcardZoneName.Any,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Any,

--- a/server/game/cards/05_LOF/units/NamelessTerror.ts
+++ b/server/game/cards/05_LOF/units/NamelessTerror.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NamelessTerror extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NamelessTerror extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Exhaust a Force unit',
+            title: `Exhaust a ${TextHelper.Trait.Force} unit`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
@@ -23,7 +24,7 @@ export default class NamelessTerror extends NonLeaderUnitCard {
         });
 
         registrar.addOnAttackAbility({
-            title: 'Each enemy unit loses the Force trait for this phase',
+            title: `Each enemy unit loses the ${TextHelper.Trait.Force} trait for this phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.source.controller.opponent.getArenaUnits(),
                 effect: AbilityHelper.ongoingEffects.loseTrait(Trait.Force),

--- a/server/game/cards/05_LOF/units/OldDakaOldestAndWisest.ts
+++ b/server/game/cards/05_LOF/units/OldDakaOldestAndWisest.ts
@@ -6,6 +6,7 @@ import type { INonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EventName, RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class OldDakaOldestAndWisest extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -17,7 +18,7 @@ export default class OldDakaOldestAndWisest extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Defeat a friendly Night unit not named Old Daka',
+            title: `Defeat a friendly ${TextHelper.Trait.Night} unit not named Old Daka`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/OwenLarsDevotedUncle.ts
+++ b/server/game/cards/05_LOF/units/OwenLarsDevotedUncle.ts
@@ -2,6 +2,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class OwenLarsDevotedUncle extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class OwenLarsDevotedUncle extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Search the top 5 of your deck for a Force unit, reveal it, and draw it',
+            title: `Search the top 5 of your deck for a ${TextHelper.Trait.Force} unit, reveal it, and draw it`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,
                 cardCondition: (card) => card.isUnit() && card.hasSomeTrait(Trait.Force),

--- a/server/game/cards/05_LOF/units/PaladinTrainingCorvette.ts
+++ b/server/game/cards/05_LOF/units/PaladinTrainingCorvette.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PaladinTrainingCorvette extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PaladinTrainingCorvette extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give an Experience token to each of up to 3 Force units',
+            title: `Give an Experience token to each of up to 3 ${TextHelper.Trait.Force} units`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/05_LOF/units/PeliMottoIShouldChargeYouMore.ts
+++ b/server/game/cards/05_LOF/units/PeliMottoIShouldChargeYouMore.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PeliMottoIShouldChargeYouMore extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PeliMottoIShouldChargeYouMore extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give an Experience token to a friendly Vehicle or Droid unit.',
+            title: `Give an Experience token to a friendly ${TextHelper.Trait.Vehicle} or ${TextHelper.Trait.Droid} unit.`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardCondition: (card) => card.hasSomeTrait([Trait.Vehicle, Trait.Droid]),

--- a/server/game/cards/05_LOF/units/PointRainReclaimer.ts
+++ b/server/game/cards/05_LOF/units/PointRainReclaimer.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PointRainReclaimer extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PointRainReclaimer extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'If you control a Jedi unit, give an Experience token to this unit',
+            title: `If you control a ${TextHelper.Trait.Jedi} unit, give an Experience token to this unit`,
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.isTraitInPlay(Trait.Jedi),

--- a/server/game/cards/05_LOF/units/PurgeTrooper.ts
+++ b/server/game/cards/05_LOF/units/PurgeTrooper.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class PurgeTrooper extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class PurgeTrooper extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Deal 2 damage to a Force unit',
+            title: `Deal 2 damage to a ${TextHelper.Trait.Force} unit`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/ScytheIntimidatingSilhouette.ts
+++ b/server/game/cards/05_LOF/units/ScytheIntimidatingSilhouette.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ScytheIntimidatingSilhouette extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ScytheIntimidatingSilhouette extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Give another friendly Inquisitor unit +2/+0 for this phase',
+            title: `Give another friendly ${TextHelper.Trait.Inquisitor} unit +2/+0 for this phase`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/SecondSisterSeekingTheHolocron.ts
+++ b/server/game/cards/05_LOF/units/SecondSisterSeekingTheHolocron.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EventName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SecondSisterSeekingTheHolocron extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SecondSisterSeekingTheHolocron extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Discard 2 cards from your deck. For each Force card discarded this way, ready a resource',
+            title: `Discard 2 cards from your deck. For each ${TextHelper.Trait.Force} card discarded this way, ready a resource`,
             optional: true,
             immediateEffect: AbilityHelper.immediateEffects.sequential([
                 AbilityHelper.immediateEffects.discardFromDeck((context) => ({

--- a/server/game/cards/05_LOF/units/SifoDyasCommissioningAnArmy.ts
+++ b/server/game/cards/05_LOF/units/SifoDyasCommissioningAnArmy.ts
@@ -6,6 +6,7 @@ import { TargetMode, Trait } from '../../../core/Constants';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { CardsPlayedThisPhaseWatcher } from '../../../stateWatchers/CardsPlayedThisPhaseWatcher';
 import { Contract } from '../../../core/utils/Contract';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SifoDyasCommissioningAnArmy extends NonLeaderUnitCard {
     private cardsPlayedThisPhaseWatcher: CardsPlayedThisPhaseWatcher;
@@ -23,7 +24,7 @@ export default class SifoDyasCommissioningAnArmy extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Search the top 8 cards of your deck for any number of Clone units with combined cost 4 or less and discard them. For this phase, you may play those cards from your discard pile for free.',
+            title: `Search the top 8 cards of your deck for any number of ${TextHelper.Trait.Clone} units with combined cost 4 or less and discard them. For this phase, you may play those cards from your discard pile for free.`,
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 8,
                 targetMode: TargetMode.Unlimited,

--- a/server/game/cards/05_LOF/units/SupremacyOfUnimaginableSize.ts
+++ b/server/game/cards/05_LOF/units/SupremacyOfUnimaginableSize.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SupremacyOfUnimaginableSize extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SupremacyOfUnimaginableSize extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly Vehicle units gets +6/+6',
+            title: `Other friendly ${TextHelper.Trait.Vehicle} units gets +6/+6`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card, context) => card !== context.source && card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/05_LOF/units/Tauntaun.ts
+++ b/server/game/cards/05_LOF/units/Tauntaun.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Tauntaun extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Tauntaun extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'You may give a Shield token to a damaged non-Vehicle unit.',
+            title: `You may give a Shield token to a damaged non-${TextHelper.Trait.Vehicle} unit.`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/05_LOF/units/Terentatek.ts
+++ b/server/game/cards/05_LOF/units/Terentatek.ts
@@ -14,7 +14,7 @@ export default class Terentatek extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While an opponent controls a Force unit, this unit gains ${TextHelper.Ambush}.`,
+            title: `While an opponent controls a ${TextHelper.Trait.Force} unit, this unit gains ${TextHelper.Ambush}.`,
             condition: (context) => context.player.opponent.hasSomeArenaUnit({ trait: Trait.Force }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Ambush),
         });

--- a/server/game/cards/05_LOF/units/YaddleAChanceToMakeThingsRight.ts
+++ b/server/game/cards/05_LOF/units/YaddleAChanceToMakeThingsRight.ts
@@ -14,7 +14,7 @@ export default class YaddleAChanceToMakeThingsRight extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `Each other friendly Jedi unit gains ${TextHelper.Restore(1)} for this phase`,
+            title: `Each other friendly ${TextHelper.Trait.Jedi} unit gains ${TextHelper.Restore(1)} for this phase`,
             immediateEffect: AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
                 target: context.player.getArenaUnits({ trait: Trait.Jedi, otherThan: context.source }),
                 effect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 })

--- a/server/game/cards/05_LOF/upgrades/InquisitorsLightsaber.ts
+++ b/server/game/cards/05_LOF/upgrades/InquisitorsLightsaber.ts
@@ -2,6 +2,7 @@ import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistr
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class InquisitorsLightsaber extends UpgradeCard {
     protected override getImplementationId() {
@@ -15,7 +16,7 @@ export default class InquisitorsLightsaber extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'While attacking a Force unit, this unit gets +2/+0.',
+            title: `While attacking a ${TextHelper.Trait.Force} unit, this unit gets +2/+0.`,
             condition: (context) => context.source.parentCard.isAttacking() && context.source.parentCard.activeAttack?.targetIsUnit((card) => card.hasSomeTrait(Trait.Force), true),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 0 })
         });

--- a/server/game/cards/05_LOF/upgrades/JediTrials.ts
+++ b/server/game/cards/05_LOF/upgrades/JediTrials.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class JediTrials extends UpgradeCard {
     protected override getImplementationId() {
@@ -20,7 +21,7 @@ export default class JediTrials extends UpgradeCard {
         });
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'While attached unit has 4 or more upgrades on it, it gains the Jedi trait',
+            title: `While attached unit has 4 or more upgrades on it, it gains the ${TextHelper.Trait.Jedi} trait`,
             condition: (context) => context.source.parentCard.upgrades.length >= 4,
             ongoingEffect: AbilityHelper.ongoingEffects.gainTrait(Trait.Jedi)
         });

--- a/server/game/cards/05_LOF/upgrades/SizeMattersNot.ts
+++ b/server/game/cards/05_LOF/upgrades/SizeMattersNot.ts
@@ -14,7 +14,7 @@ export default class SizeMattersNot extends UpgradeCard {
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `If you control a Force unit, this upgrade costs ${TextHelper.resource(1)} less to play.`,
+            title: `If you control a ${TextHelper.Trait.Force} unit, this upgrade costs ${TextHelper.resource(1)} less to play.`,
             amount: 1,
             condition: (context) => context.player.getArenaUnits({ trait: Trait.Force }).length > 0,
         });

--- a/server/game/cards/06_SEC/events/BudgetScheming.ts
+++ b/server/game/cards/06_SEC/events/BudgetScheming.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BudgetScheming extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BudgetScheming extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Give an Experience token to up to 3 Official units',
+            title: `Give an Experience token to up to 3 ${TextHelper.Trait.Official} units`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 3,

--- a/server/game/cards/06_SEC/events/ContemptForCulture.ts
+++ b/server/game/cards/06_SEC/events/ContemptForCulture.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ContemptForCulture extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ContemptForCulture extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Deal 2 damage to a non-Vehicle unit. Create a Spy token.',
+            title: `Deal 2 damage to a non-${TextHelper.Trait.Vehicle} unit. Create a Spy token.`,
             immediateEffect: abilityHelper.immediateEffects.simultaneous([
                 abilityHelper.immediateEffects.createSpy(),
                 abilityHelper.immediateEffects.selectCard({

--- a/server/game/cards/06_SEC/events/ConveneTheSenate.ts
+++ b/server/game/cards/06_SEC/events/ConveneTheSenate.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ConveneTheSenate extends EventCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class ConveneTheSenate extends EventCard {
 
     public override setupCardAbilities (registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Search the top 8 cards of your deck for up to 2 Official units, reveal them, and draw them. Create a Spy token',
+            title: `Search the top 8 cards of your deck for up to 2 ${TextHelper.Trait.Official} units, reveal them, and draw them. Create a Spy token`,
             immediateEffect: abilityHelper.immediateEffects.simultaneous([
                 abilityHelper.immediateEffects.createSpy(),
                 abilityHelper.immediateEffects.deckSearch({

--- a/server/game/cards/06_SEC/events/NoOneEverKnew.ts
+++ b/server/game/cards/06_SEC/events/NoOneEverKnew.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NoOneEverKnew extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class NoOneEverKnew extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'For each friendly Official unit, exhaust an enemy unit',
+            title: `For each friendly ${TextHelper.Trait.Official} unit, exhaust an enemy unit`,
             targetResolver: {
                 mode: TargetMode.ExactlyVariable,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/06_SEC/leaders/LamaSuWeModifiedTheirGenetics.ts
+++ b/server/game/cards/06_SEC/leaders/LamaSuWeModifiedTheirGenetics.ts
@@ -18,7 +18,7 @@ export default class LamaSuWeModifiedTheirGenetics extends LeaderUnitCard {
 
     protected override setupLeaderSideAbilities(registrar: ILeaderUnitLeaderSideAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: `Play an upgrade from your hand on a friendly non-Vehicle unit. It costs ${TextHelper.resource(1)} less. If you do, deal 1 damage to that unit.`,
+            title: `Play an upgrade from your hand on a friendly non-${TextHelper.Trait.Vehicle} unit. It costs ${TextHelper.resource(1)} less. If you do, deal 1 damage to that unit.`,
             cost: [abilityHelper.costs.exhaustSelf()],
             targetResolver: {
                 // TODO remove cardTypeFilter but fix Choose nothing button before
@@ -45,7 +45,7 @@ export default class LamaSuWeModifiedTheirGenetics extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
-            title: `Play an upgrade from your discard pile on a friendly non-Vehicle unit. It costs ${TextHelper.resource(1)} less.`,
+            title: `Play an upgrade from your discard pile on a friendly non-${TextHelper.Trait.Vehicle} unit. It costs ${TextHelper.resource(1)} less.`,
             optional: true,
             attackerMustSurvive: true,
             targetResolver: {

--- a/server/game/cards/06_SEC/leaders/MonMothmaFormingACoalition.ts
+++ b/server/game/cards/06_SEC/leaders/MonMothmaFormingACoalition.ts
@@ -17,7 +17,7 @@ export default class MonMothmaFormingACoalition extends LeaderUnitCard {
 
     private buildMonMothmaAbilityProperties(abilityHelper: IAbilityHelper) {
         return {
-            title: `Ignore the aspect penalty on non-${TextHelper.Villainy} Official units you play`,
+            title: `Ignore the aspect penalty on non-${TextHelper.Villainy} ${TextHelper.Trait.Official} units you play`,
             targetController: RelativePlayer.Self,
             ongoingEffect: abilityHelper.ongoingEffects.ignoreAllAspectPenalties({
                 cardTypeFilter: WildcardCardType.Unit,
@@ -34,7 +34,7 @@ export default class MonMothmaFormingACoalition extends LeaderUnitCard {
         registrar.addConstantAbility(this.buildMonMothmaAbilityProperties(abilityHelper));
 
         registrar.addConstantAbility({
-            title: 'Each other friendly Official unit gets +0/+1',
+            title: `Each other friendly ${TextHelper.Trait.Official} unit gets +0/+1`,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,
             matchTarget: (card, context) => card !== context.source && card.hasSomeTrait(Trait.Official),

--- a/server/game/cards/06_SEC/units/DarthNihilusLordOfHunger.ts
+++ b/server/game/cards/06_SEC/units/DarthNihilusLordOfHunger.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DarthNihilusLordOfHunger extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DarthNihilusLordOfHunger extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Deal 3 damage to the unit with the least remaining HP among other units. (If multiple units are tied, choose one.). If it\'s a non-Vehicle unit, give an Experience token to this unit.',
+            title: `Deal 3 damage to the unit with the least remaining HP among other units. (If multiple units are tied, choose one.). If it's a non-${TextHelper.Trait.Vehicle} unit, give an Experience token to this unit.`,
             when: {
                 whenPlayed: true,
                 onAttack: true,

--- a/server/game/cards/06_SEC/units/EscapePod.ts
+++ b/server/game/cards/06_SEC/units/EscapePod.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class EscapePod extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class EscapePod extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Escape Pod captures a friendly non-Vehicle, non-leader unit',
+            title: `Escape Pod captures a friendly non-${TextHelper.Trait.Vehicle}, non-leader unit`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,

--- a/server/game/cards/06_SEC/units/GrandMoffTarkinTakingKrennicsAchievement.ts
+++ b/server/game/cards/06_SEC/units/GrandMoffTarkinTakingKrennicsAchievement.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GrandMoffTarkinTakingKrennicsAchievement extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GrandMoffTarkinTakingKrennicsAchievement extends NonLeaderU
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Take control of an enemy non-leader Vehicle unit. When this unit leaves play, that unit\'s owner takes control of that unit',
+            title: `Take control of an enemy non-leader ${TextHelper.Trait.Vehicle} unit. When this unit leaves play, that unit's owner takes control of that unit`,
             targetResolver: {
                 controller: RelativePlayer.Opponent,
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,

--- a/server/game/cards/06_SEC/units/HighCommandCouncilor.ts
+++ b/server/game/cards/06_SEC/units/HighCommandCouncilor.ts
@@ -14,7 +14,7 @@ export default class HighCommandCouncilor extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Official unit, this unit gains ${TextHelper.Raid(2)}`,
+            title: `While you control another ${TextHelper.Trait.Official} unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Official, context.source),
             matchTarget: (card, context) => card === context.source,
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })

--- a/server/game/cards/06_SEC/units/InspiringSenator.ts
+++ b/server/game/cards/06_SEC/units/InspiringSenator.ts
@@ -14,7 +14,7 @@ export default class InspiringSenator extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: `The next Official unit you play this phase costs ${TextHelper.resource(1)} less`,
+            title: `The next ${TextHelper.Trait.Official} unit you play this phase costs ${TextHelper.resource(1)} less`,
             immediateEffect: abilityHelper.immediateEffects.forThisPhasePlayerEffect({
                 effect: abilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/06_SEC/units/MaarvaAndorWeveBeenSleeping.ts
+++ b/server/game/cards/06_SEC/units/MaarvaAndorWeveBeenSleeping.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MaarvaAndorWeveBeenSleeping extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MaarvaAndorWeveBeenSleeping extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Give an Experience token to each friendly Rebel unit',
+            title: `Give an Experience token to each friendly ${TextHelper.Trait.Rebel} unit`,
             immediateEffect: abilityHelper.immediateEffects.giveExperience((context) => ({
                 amount: 1,
                 target: context.player.getArenaUnits({ trait: Trait.Rebel }),

--- a/server/game/cards/06_SEC/units/MajorPartagazHealthcareProvider.ts
+++ b/server/game/cards/06_SEC/units/MajorPartagazHealthcareProvider.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EventName, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MajorPartagazHealthcareProvider extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MajorPartagazHealthcareProvider extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'When another friendly Official unit attacks: This unit gets +2/+2 for this phase.',
+            title: `When another friendly ${TextHelper.Trait.Official} unit attacks: This unit gets +2/+2 for this phase.`,
             when: {
                 [EventName.OnAttackDeclared]: (event, context) =>
                     event.attack.attacker !== context.source &&

--- a/server/game/cards/06_SEC/units/MasAmeddaAccompliceToPower.ts
+++ b/server/game/cards/06_SEC/units/MasAmeddaAccompliceToPower.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MasAmeddaAccompliceToPower extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MasAmeddaAccompliceToPower extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give an Experience token to each of up to 2 other Official units',
+            title: `Give an Experience token to each of up to 2 other ${TextHelper.Trait.Official} units`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 canChooseNoCards: true,

--- a/server/game/cards/06_SEC/units/NubianStarSkiff.ts
+++ b/server/game/cards/06_SEC/units/NubianStarSkiff.ts
@@ -14,7 +14,7 @@ export default class NubianStarSkiff extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control an Official unit, this unit gains ${TextHelper.Restore(2)}`,
+            title: `While you control an ${TextHelper.Trait.Official} unit, this unit gains ${TextHelper.Restore(2)}`,
             condition: (context) => context.player.hasSomeArenaUnit({ trait: Trait.Official }),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 }),
         });

--- a/server/game/cards/06_SEC/units/NuteGunrayEscapingJustice.ts
+++ b/server/game/cards/06_SEC/units/NuteGunrayEscapingJustice.ts
@@ -14,7 +14,7 @@ export default class NuteGunrayEscapingJustice extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: `Give another friendly Official unit ${TextHelper.Sentinel} for this phase`,
+            title: `Give another friendly ${TextHelper.Trait.Official} unit ${TextHelper.Sentinel} for this phase`,
             optional: true,
             when: {
                 onAttack: true,

--- a/server/game/cards/06_SEC/units/OrnFreeTaaPoliticalPowerBroker.ts
+++ b/server/game/cards/06_SEC/units/OrnFreeTaaPoliticalPowerBroker.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
 import type { IPlayableCard } from '../../../core/card/baseClasses/PlayableOrDeployableCard';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class OrnFreeTaaPoliticalPowerBroker extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class OrnFreeTaaPoliticalPowerBroker extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'This unit gets +1/+0 for each Law card in your discard pile',
+            title: `This unit gets +1/+0 for each ${TextHelper.Trait.Law} card in your discard pile`,
             ongoingEffect: abilityHelper.ongoingEffects.modifyStats((_, context) => ({
                 power: context.player.discard?.filter((x: IPlayableCard) => x.hasSomeTrait(Trait.Law)).length ?? 0,
                 hp: 0,
@@ -22,7 +23,7 @@ export default class OrnFreeTaaPoliticalPowerBroker extends NonLeaderUnitCard {
         });
 
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 10 cards of your deck for a Law card, reveal it, and draw it',
+            title: `Search the top 10 cards of your deck for a ${TextHelper.Trait.Law} card, reveal it, and draw it`,
             immediateEffect: abilityHelper.immediateEffects.deckSearch({
                 searchCount: 10,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Law),

--- a/server/game/cards/06_SEC/units/RenownedDignitaries.ts
+++ b/server/game/cards/06_SEC/units/RenownedDignitaries.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RenownedDignitaries extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RenownedDignitaries extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Heal 2 damage from your base for each friendly Official unit',
+            title: `Heal 2 damage from your base for each friendly ${TextHelper.Trait.Official} unit`,
             immediateEffect: abilityHelper.immediateEffects.heal((context) => ({
                 target: context.player.base,
                 amount: 2 * context.player.getArenaUnits({ trait: Trait.Official }).length,

--- a/server/game/cards/06_SEC/units/SenatorChuchiVoiceForTheVoiceless.ts
+++ b/server/game/cards/06_SEC/units/SenatorChuchiVoiceForTheVoiceless.ts
@@ -14,7 +14,7 @@ export default class SenatorChuchiVoiceForTheVoiceless extends NonLeaderUnitCard
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `Give another friendly Official unit ${TextHelper.Restore(2)} for this phase`,
+            title: `Give another friendly ${TextHelper.Trait.Official} unit ${TextHelper.Restore(2)} for this phase`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/06_SEC/units/VuutunPalaaDroidControlShip.ts
+++ b/server/game/cards/06_SEC/units/VuutunPalaaDroidControlShip.ts
@@ -14,12 +14,12 @@ export default class VuutunPalaaDroidControlShip extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper): void {
         registrar.addDecreaseCostAbility({
-            title: `This unit costs ${TextHelper.resource(1)} less to play for each friendly Droid unit`,
+            title: `This unit costs ${TextHelper.resource(1)} less to play for each friendly ${TextHelper.Trait.Droid} unit`,
             amount: (_, player) => player.getArenaUnits({ trait: Trait.Droid }).length
         });
 
         registrar.addConstantAbility({
-            title: 'Each friendly Droid unit may be exhausted to pay costs as if it were a resource',
+            title: `Each friendly ${TextHelper.Trait.Droid} unit may be exhausted to pay costs as if it were a resource`,
             ongoingEffect: AbilityHelper.ongoingEffects.canExhaustUnitsInsteadOfResources({
                 canExhaustUnitCondition: (card, _) => card.hasSomeTrait(Trait.Droid)
             })

--- a/server/game/cards/06_SEC/upgrades/ExiledFromTheForce.ts
+++ b/server/game/cards/06_SEC/upgrades/ExiledFromTheForce.ts
@@ -18,7 +18,7 @@ export default class ExiledFromTheForce extends UpgradeCard {
     ) {
         registrar.addGainKeywordTargetingAttached({ keyword: KeywordName.Grit });
         registrar.addConstantAbilityTargetingAttached({
-            title: `Attached unit loses the Force trait and all abilities except ${TextHelper.Grit}`,
+            title: `Attached unit loses the ${TextHelper.Trait.Force} trait and all abilities except ${TextHelper.Grit}`,
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.loseTrait(Trait.Force),
                 AbilityHelper.ongoingEffects.loseAllOtherAbilities({ exceptKeyword: KeywordName.Grit })

--- a/server/game/cards/06_SEC/upgrades/NemiksManifesto.ts
+++ b/server/game/cards/06_SEC/upgrades/NemiksManifesto.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class NemiksManifesto extends UpgradeCard {
     protected override getImplementationId () {
@@ -15,11 +16,11 @@ export default class NemiksManifesto extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Give the Rebel trait to the attached card',
+            title: `Give the ${TextHelper.Trait.Rebel} trait to the attached card`,
             ongoingEffect: AbilityHelper.ongoingEffects.gainTrait(Trait.Rebel),
         });
         registrar.addGainWhenDefeatedAbilityTargetingAttached({
-            title: 'Deal 1 damage to each enemy base for each other friendly Rebel unit',
+            title: `Deal 1 damage to each enemy base for each other friendly ${TextHelper.Trait.Rebel} unit`,
             contextTitle: (context) => `Deal ${context.player.getArenaUnits({ otherThan: context.source, condition: (card) => card.isUnit() && card.hasSomeTrait(Trait.Rebel) }).length} damage to each enemy base`,
             immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({
                 amount: context.player.getArenaUnits({ otherThan: context.source, condition: (card) => card.isUnit() && card.hasSomeTrait(Trait.Rebel) }).length,

--- a/server/game/cards/07_LAW/events/FireAcrossTheGalaxy.ts
+++ b/server/game/cards/07_LAW/events/FireAcrossTheGalaxy.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, TargetMode, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class FireAcrossTheGalaxy extends EventCard {
     protected override getImplementationId () {
@@ -13,9 +14,9 @@ export default class FireAcrossTheGalaxy extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Use any number of When Played abilities on friendly Spectre units',
+            title: `Use any number of When Played abilities on friendly ${TextHelper.Trait.Spectre} units`,
             targetResolver: {
-                activePromptTitle: 'Choose Spectre units with a "When Played" ability to activate',
+                activePromptTitle: `Choose ${TextHelper.Trait.Spectre} units with a "When Played" ability to activate`,
                 mode: TargetMode.Unlimited,
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/07_LAW/events/SalvagedMaterials.ts
+++ b/server/game/cards/07_LAW/events/SalvagedMaterials.ts
@@ -15,7 +15,7 @@ export default class SalvagedMaterials extends EventCard {
 
     public override setupCardAbilities (registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: `Play an Item upgrade from your discard pile. It costs ${TextHelper.resource(3)} less. At the start of the next regroup phase, defeat it.`,
+            title: `Play an ${TextHelper.Trait.Item} upgrade from your discard pile. It costs ${TextHelper.resource(3)} less. At the start of the next regroup phase, defeat it.`,
             targetResolver: {
                 zoneFilter: ZoneName.Discard,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/07_LAW/leaders/JabbaTheHuttCrimeBoss.ts
+++ b/server/game/cards/07_LAW/leaders/JabbaTheHuttCrimeBoss.ts
@@ -21,7 +21,7 @@ export default class JabbaTheHuttCrimeBoss extends LeaderUnitCard {
                 AbilityHelper.costs.abilityActivationResourceCost(1),
                 AbilityHelper.costs.exhaustSelf(),
                 AbilityHelper.costs.returnToHandFromPlay({
-                    activePromptTitle: 'Return a friendly Underworld unit to hand',
+                    activePromptTitle: `Return a friendly ${TextHelper.Trait.Underworld} unit to hand`,
                     controller: RelativePlayer.Self,
                     cardTypeFilter: WildcardCardType.Unit,
                     cardCondition: (card) => card.hasSomeTrait(Trait.Underworld)
@@ -33,7 +33,7 @@ export default class JabbaTheHuttCrimeBoss extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addActionAbility({
-            title: 'Play an Underworld unit unit from your hand',
+            title: `Play an ${TextHelper.Trait.Underworld} unit unit from your hand`,
             targetResolver: {
                 zoneFilter: ZoneName.Hand,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/07_LAW/units/AsajjVentressReluctantHunter.ts
+++ b/server/game/cards/07_LAW/units/AsajjVentressReluctantHunter.ts
@@ -2,6 +2,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AsajjVentressReluctantHunter extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,8 +14,7 @@ export default class AsajjVentressReluctantHunter extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            // eslint-disable-next-line forceteki/no-raw-token-text -- "Bounty Hunter" is a trait, not the Bounty keyword
-            title: 'Ready another Bounty Hunter unit',
+            title: `Ready another ${TextHelper.Trait.BountyHunter} unit`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/07_LAW/units/BlackSunCabalist.ts
+++ b/server/game/cards/07_LAW/units/BlackSunCabalist.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BlackSunCabalist extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class BlackSunCabalist extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Give an Experience token to another friendly Underworld unit',
+            title: `Give an Experience token to another friendly ${TextHelper.Trait.Underworld} unit`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/07_LAW/units/BodhiRookCreatingADiversion.ts
+++ b/server/game/cards/07_LAW/units/BodhiRookCreatingADiversion.ts
@@ -14,7 +14,7 @@ export default class BodhiRookCreatingADiversion extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: `Give a friendly Rebel unit ${TextHelper.Sentinel} for this phase`,
+            title: `Give a friendly ${TextHelper.Trait.Rebel} unit ${TextHelper.Sentinel} for this phase`,
             optional: true,
             targetResolver: {
                 controller: RelativePlayer.Self,

--- a/server/game/cards/07_LAW/units/DoctorAphraDiggingForAnswers.ts
+++ b/server/game/cards/07_LAW/units/DoctorAphraDiggingForAnswers.ts
@@ -2,6 +2,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventName, RelativePlayer, Trait, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DoctorAphraDiggingForAnswers extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class DoctorAphraDiggingForAnswers extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addOnAttackAbility({
-            title: 'Discard the top 3 cards of your deck. You may return an Underworld card discarded this way to your hand',
+            title: `Discard the top 3 cards of your deck. You may return an ${TextHelper.Trait.Underworld} card discarded this way to your hand`,
             immediateEffect: AbilityHelper.immediateEffects.discardFromDeck((context) => ({
                 amount: 3,
                 target: context.player
@@ -25,7 +26,7 @@ export default class DoctorAphraDiggingForAnswers extends NonLeaderUnitCard {
                     .filter((card) => card.hasSomeTrait(Trait.Underworld));
 
                 return {
-                    title: 'Return a discarded Underworld card to your hand',
+                    title: `Return a discarded ${TextHelper.Trait.Underworld} card to your hand`,
                     optional: true,
                     targetResolver: {
                         controller: RelativePlayer.Self,

--- a/server/game/cards/07_LAW/units/KhetannaUponTheDuneSea.ts
+++ b/server/game/cards/07_LAW/units/KhetannaUponTheDuneSea.ts
@@ -15,13 +15,13 @@ export default class KhetannaUponTheDuneSea extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: `The next Underworld unit you play this phase costs ${TextHelper.resource(1)} less`,
+            title: `The next ${TextHelper.Trait.Underworld} unit you play this phase costs ${TextHelper.resource(1)} less`,
             when: {
                 whenPlayed: true,
                 onAttack: true,
             },
             immediateEffect: abilityHelper.immediateEffects.forThisPhasePlayerEffect({
-                ongoingEffectDescription: 'discount the next Underworld unit played by',
+                ongoingEffectDescription: `discount the next ${TextHelper.Trait.Underworld} unit played by`,
                 ongoingEffectTargetDescription: 'them',
                 effect: abilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/07_LAW/units/L337RadicalInstigator.ts
+++ b/server/game/cards/07_LAW/units/L337RadicalInstigator.ts
@@ -4,6 +4,7 @@ import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { Card } from '../../../core/card/Card';
 import { Contract } from '../../../core/utils/Contract';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class L337RadicalInstigator extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -15,9 +16,9 @@ export default class L337RadicalInstigator extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 10 cards of your deck for any number of Droid units with combined cost 5 or less and play each of them for free',
+            title: `Search the top 10 cards of your deck for any number of ${TextHelper.Trait.Droid} units with combined cost 5 or less and play each of them for free`,
             immediateEffect: abilityHelper.immediateEffects.playMultipleCardsFromDeck({
-                activePromptTitle: 'Choose any Droid units with combined cost 5 or less to play for free',
+                activePromptTitle: `Choose any ${TextHelper.Trait.Droid} units with combined cost 5 or less to play for free`,
                 searchCount: 10,
                 selectCount: 10,
                 canChooseFewer: true,

--- a/server/game/cards/07_LAW/units/MalakiliKeeperOfTheMenagerie.ts
+++ b/server/game/cards/07_LAW/units/MalakiliKeeperOfTheMenagerie.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MalakiliKeeperOfTheMenagerie extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class MalakiliKeeperOfTheMenagerie extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly Creature unit and each Creature unit you own that isn\'t in play gains the Underworld trait',
+            title: `Each friendly ${TextHelper.Trait.Creature} unit and each ${TextHelper.Trait.Creature} unit you own that isn't in play gains the ${TextHelper.Trait.Underworld} trait`,
             targetZoneFilter: WildcardZoneName.Any,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/07_LAW/units/MazKanataWheresMyBoyfriend.ts
+++ b/server/game/cards/07_LAW/units/MazKanataWheresMyBoyfriend.ts
@@ -15,7 +15,7 @@ export default class MazKanataWheresMyBoyfriend extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenAttackEndsAbility({
-            title: `If this unit survived, search the top 5 cards of your deck for an Underworld unit and play it. It costs ${TextHelper.resource(4)} less and enters play ready. At the start of the regroup phase, put that unit on the bottom of your deck`,
+            title: `If this unit survived, search the top 5 cards of your deck for an ${TextHelper.Trait.Underworld} unit and play it. It costs ${TextHelper.resource(4)} less and enters play ready. At the start of the regroup phase, put that unit on the bottom of your deck`,
             attackerMustSurvive: true,
             immediateEffect: abilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,

--- a/server/game/cards/07_LAW/units/ScarifLieutenant.ts
+++ b/server/game/cards/07_LAW/units/ScarifLieutenant.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ScarifLieutenant extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class ScarifLieutenant extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Give an Experience token to a friendly Rebel unit.',
+            title: `Give an Experience token to a friendly ${TextHelper.Trait.Rebel} unit.`,
             targetResolver: {
                 controller: RelativePlayer.Self,
                 cardCondition: (card) => card.hasSomeTrait([Trait.Rebel]),

--- a/server/game/cards/07_LAW/units/SyndicateSpiceRunner.ts
+++ b/server/game/cards/07_LAW/units/SyndicateSpiceRunner.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SyndicateSpiceRunner extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SyndicateSpiceRunner extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 3 cards of your deck for an Underworld unit, reveal it, and draw it',
+            title: `Search the top 3 cards of your deck for an ${TextHelper.Trait.Underworld} unit, reveal it, and draw it`,
             immediateEffect: abilityHelper.immediateEffects.deckSearch({
                 searchCount: 3,
                 cardCondition: (card) => card.isUnit() && card.hasSomeTrait(Trait.Underworld),

--- a/server/game/cards/07_LAW/units/TheMasterCodebreakerHighStakes.ts
+++ b/server/game/cards/07_LAW/units/TheMasterCodebreakerHighStakes.ts
@@ -23,7 +23,7 @@ export default class TheMasterCodebreakerHighStakes extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `The first Gambit card you play each round costs ${TextHelper.resource(1)} less`,
+            title: `The first ${TextHelper.Trait.Gambit} card you play each round costs ${TextHelper.resource(1)} less`,
             ongoingEffect: abilityHelper.ongoingEffects.decreaseCost({
                 amount: 1,
                 match: (card, source) => card.hasSomeTrait(Trait.Gambit) && this.isFirstGambitYouPlayedThisPhase(source.controller)
@@ -31,7 +31,7 @@ export default class TheMasterCodebreakerHighStakes extends NonLeaderUnitCard {
         });
 
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 8 cards of your deck for a Gambit card, reveal it, and draw it',
+            title: `Search the top 8 cards of your deck for a ${TextHelper.Trait.Gambit} card, reveal it, and draw it`,
             immediateEffect: abilityHelper.immediateEffects.deckSearch({
                 searchCount: 8,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Gambit),

--- a/server/game/cards/07_LAW/upgrades/Fulcrum.ts
+++ b/server/game/cards/07_LAW/upgrades/Fulcrum.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Fulcrum extends UpgradeCard {
     protected override getImplementationId () {
@@ -15,12 +16,12 @@ export default class Fulcrum extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Attached unit gains the Rebel trait',
+            title: `Attached unit gains the ${TextHelper.Trait.Rebel} trait`,
             ongoingEffect: abilityHelper.ongoingEffects.gainTrait(Trait.Rebel)
         });
 
         registrar.addGainConstantAbilityTargetingAttached({
-            title: 'Each other friendly Rebel unit gets +2/+2',
+            title: `Each other friendly ${TextHelper.Trait.Rebel} unit gets +2/+2`,
             matchTarget: (card, context) => card !== context.source && card.controller === context.player && card.hasSomeTrait(Trait.Rebel),
             ongoingEffect: abilityHelper.ongoingEffects.modifyStats({ power: 2, hp: 2 })
         });

--- a/server/game/cards/07_LAW/upgrades/LeiasDisguise.ts
+++ b/server/game/cards/07_LAW/upgrades/LeiasDisguise.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LeiasDisguise extends UpgradeCard {
     protected override getImplementationId () {
@@ -15,7 +16,7 @@ export default class LeiasDisguise extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Attached unit gains the Underworld trait',
+            title: `Attached unit gains the ${TextHelper.Trait.Underworld} trait`,
             ongoingEffect: abilityHelper.ongoingEffects.gainTrait(Trait.Underworld)
         });
 

--- a/server/game/cards/07_TS26/events/KouhunAssassination.ts
+++ b/server/game/cards/07_TS26/events/KouhunAssassination.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class KouhunAssassination extends EventCard {
     protected override getImplementationId() {
@@ -13,11 +14,11 @@ export default class KouhunAssassination extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper): void {
         registrar.setEventAbility({
-            title: 'Your opponent may discard a card from their hand. If they do, give a non-Vehicle unit -8/-8 for this phase',
-            contextTitle: (context) => `${context.player.opponent.name} discards a card from hand. If they do, ${context.player.name} give a non-Vehicle unit -8/-8 for this phase`,
+            title: `Your opponent may discard a card from their hand. If they do, give a non-${TextHelper.Trait.Vehicle} unit -8/-8 for this phase`,
+            contextTitle: (context) => `${context.player.opponent.name} discards a card from hand. If they do, ${context.player.name} give a non-${TextHelper.Trait.Vehicle} unit -8/-8 for this phase`,
             immediateEffect: abilityHelper.immediateEffects.discardCardsFromOpponentsHand({ amount: 1, optional: true }),
             ifYouDo: {
-                title: 'Give a non-Vehicle unit –8/–8 for this phase',
+                title: `Give a non-${TextHelper.Trait.Vehicle} unit –8/–8 for this phase`,
                 targetResolver: {
                     cardTypeFilter: WildcardCardType.Unit,
                     cardCondition: (card) => !card.hasSomeTrait(Trait.Vehicle),

--- a/server/game/cards/07_TS26/events/Mechanize.ts
+++ b/server/game/cards/07_TS26/events/Mechanize.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class Mechanize extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class Mechanize extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper): void {
         registrar.setEventAbility({
-            title: 'Play a non-Vehicle unit from your discard pile and give an Experience token to it',
+            title: `Play a non-${TextHelper.Trait.Vehicle} unit from your discard pile and give an Experience token to it`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Self,

--- a/server/game/cards/07_TS26/events/RemoveTheChip.ts
+++ b/server/game/cards/07_TS26/events/RemoveTheChip.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class RemoveTheChip extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class RemoveTheChip extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper): void {
         registrar.setEventAbility({
-            title: 'Deal 2 damage to a unit. If it\'s a Clone, ready it',
+            title: `Deal 2 damage to a unit. If it's a ${TextHelper.Trait.Clone}, ready it`,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,
                 immediateEffect: abilityHelper.immediateEffects.simultaneous([

--- a/server/game/cards/07_TS26/events/SecretMarriage.ts
+++ b/server/game/cards/07_TS26/events/SecretMarriage.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
 import { TargetMode, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SecretMarriage extends EventCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class SecretMarriage extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper): void {
         registrar.setEventAbility({
-            title: 'Give a Shield token to each of up to 2 non-Vehicle units. If you give a Shield to an enemy unit this way, draw a card',
+            title: `Give a Shield token to each of up to 2 non-${TextHelper.Trait.Vehicle} units. If you give a Shield to an enemy unit this way, draw a card`,
             targetResolver: {
                 mode: TargetMode.UpTo,
                 numCards: 2,

--- a/server/game/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.ts
+++ b/server/game/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait } from '../../../core/Constants';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers.js';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class DarthSidiousUnderACloakOfDarkness extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class DarthSidiousUnderACloakOfDarkness extends NonLeaderUnitCard
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Each friendly Separatist unit gets +1/+0.',
+            title: `Each friendly ${TextHelper.Trait.Separatist} unit gets +1/+0.`,
             targetController: RelativePlayer.Self,
             matchTarget: (card, context) => card !== context.source && card.hasSomeTrait(Trait.Separatist),
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 })

--- a/server/game/cards/07_TS26/units/DookusSolarSailerBeautifulAndExpensive.ts
+++ b/server/game/cards/07_TS26/units/DookusSolarSailerBeautifulAndExpensive.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import type { BasesHealedThisPhaseWatcher } from '../../../stateWatchers/BasesHealedThisPhaseWatcher';
 
@@ -21,7 +22,7 @@ export default class DookusSolarSailerBeautifulAndExpensive extends NonLeaderUni
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
-            title: 'Give an Experience token to another Separatist unit',
+            title: `Give an Experience token to another ${TextHelper.Trait.Separatist} unit`,
             when: {
                 whenPlayed: true,
                 onAttack: true,

--- a/server/game/cards/07_TS26/units/JediGeneral.ts
+++ b/server/game/cards/07_TS26/units/JediGeneral.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class JediGeneral extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class JediGeneral extends NonLeaderUnitCard {
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         // THIS IMPLEMENTATION IS NOT ACCURATE FOR TWIN SUNS
         registrar.addWhenPlayedAbility({
-            title: 'If you control a Republic leader, create a Clone Trooper and give an Experience token to it',
+            title: `If you control a ${TextHelper.Trait.Republic} leader, create a Clone Trooper and give an Experience token to it`,
             immediateEffect: abilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.hasSomeLeaderCard({ trait: Trait.Republic }),
                 onTrue: abilityHelper.immediateEffects.createCloneTrooper(),

--- a/server/game/cards/07_TS26/units/ObiWanKenobiSteadfastKnight.ts
+++ b/server/game/cards/07_TS26/units/ObiWanKenobiSteadfastKnight.ts
@@ -14,7 +14,7 @@ export default class ObiWanKenobiSteadfastKnight extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Other friendly Republic units gain ${TextHelper.Restore(1)}`,
+            title: `Other friendly ${TextHelper.Trait.Republic} units gain ${TextHelper.Restore(1)}`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Republic),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 1 })
         });

--- a/server/game/cards/07_TS26/upgrades/AbandonedTheOrder.ts
+++ b/server/game/cards/07_TS26/upgrades/AbandonedTheOrder.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { KeywordName, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class AbandonedTheOrder extends UpgradeCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class AbandonedTheOrder extends UpgradeCard {
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addGainKeywordTargetingAttached({ keyword: KeywordName.Restore, amount: 1 });
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Attached unit loses the Jedi trait',
+            title: `Attached unit loses the ${TextHelper.Trait.Jedi} trait`,
             ongoingEffect: AbilityHelper.ongoingEffects.loseTrait(Trait.Jedi)
         });
 

--- a/server/game/cards/08_ASH/events/ChooseYourPath.ts
+++ b/server/game/cards/08_ASH/events/ChooseYourPath.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ChooseYourPath extends EventCard {
     protected override getImplementationId () {
@@ -13,18 +14,18 @@ export default class ChooseYourPath extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Choose one: If you control a Force Unit, heal 5 damage from your base. If you control a Mandalorian unit, create a Mandalorian token and give an Advantage token to it.',
+            title: `Choose one: If you control a ${TextHelper.Trait.Force} Unit, heal 5 damage from your base. If you control a ${TextHelper.Trait.Mandalorian} unit, create a Mandalorian token and give an Advantage token to it.`,
             // TODO investigate why sequential doesn't work with chooseModalEffect in this case
             targetResolver: {
                 mode: TargetMode.Select,
                 showUnresolvable: true,
                 choices: {
-                    ['If you control a Force unit, heal 5 damage from your base']:
+                    [`If you control a ${TextHelper.Trait.Force} unit, heal 5 damage from your base`]:
                         abilityHelper.immediateEffects.conditional({
                             condition: (c) => c.player.hasSomeArenaUnit({ trait: Trait.Force }),
                             onTrue: abilityHelper.immediateEffects.heal((context) => ({ amount: 5, target: context.player.base }))
                         }),
-                    ['If you control a Mandalorian unit, create a Mandalorian token and give an Advantage token to it']:
+                    [`If you control a ${TextHelper.Trait.Mandalorian} unit, create a Mandalorian token and give an Advantage token to it`]:
                         abilityHelper.immediateEffects.conditional({
                             condition: (c) => c.player.hasSomeArenaUnit({ trait: Trait.Mandalorian }),
                             onTrue: abilityHelper.immediateEffects.sequential([

--- a/server/game/cards/08_ASH/events/DathomiriMagicks.ts
+++ b/server/game/cards/08_ASH/events/DathomiriMagicks.ts
@@ -15,13 +15,13 @@ export default class DathomiriMagicks extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `If you control a Force unit, this event costs ${TextHelper.resource(1)} less to play`,
+            title: `If you control a ${TextHelper.Trait.Force} unit, this event costs ${TextHelper.resource(1)} less to play`,
             amount: 1,
             condition: (context) => context.player.isTraitInPlay(Trait.Force)
         });
 
         registrar.setEventAbility({
-            title: 'Play up to 3 non-Vehicle units that each cost 2 or less from your discard pile for free',
+            title: `Play up to 3 non-${TextHelper.Trait.Vehicle} units that each cost 2 or less from your discard pile for free`,
             targetResolver: {
                 activePromptTitle: 'Choose up to 3 units to play for free',
                 mode: TargetMode.UpTo,

--- a/server/game/cards/08_ASH/events/LongLiveTheEmpire.ts
+++ b/server/game/cards/08_ASH/events/LongLiveTheEmpire.ts
@@ -2,6 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { RelativePlayer, Trait, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class LongLiveTheEmpire extends EventCard {
     protected override getImplementationId() {
@@ -13,9 +14,9 @@ export default class LongLiveTheEmpire extends EventCard {
 
     public override setupCardAbilities(registrar: IEventAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.setEventAbility({
-            title: 'Defeat a friendly Imperial unit. If you do, resource the top card of your deck',
+            title: `Defeat a friendly ${TextHelper.Trait.Imperial} unit. If you do, resource the top card of your deck`,
             targetResolver: {
-                activePromptTitle: 'Defeat a friendly Imperial unit',
+                activePromptTitle: `Defeat a friendly ${TextHelper.Trait.Imperial} unit`,
                 cardTypeFilter: WildcardCardType.Unit,
                 controller: RelativePlayer.Self,
                 cardCondition: (card) => card.hasSomeTrait(Trait.Imperial),

--- a/server/game/cards/08_ASH/events/SenseThroughTheForce.ts
+++ b/server/game/cards/08_ASH/events/SenseThroughTheForce.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { RelativePlayer, TargetMode, Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SenseThroughTheForce extends EventCard {
     protected override getImplementationId () {
@@ -33,7 +34,7 @@ export default class SenseThroughTheForce extends EventCard {
                             condition: (context) => context.selectedPromptCards[0].hasCost() && context.selectedPromptCards[0].cost === parseInt(thenContext.select),
                             onTrue: AbilityHelper.immediateEffects.selectCard({
                                 optional: true,
-                                activePromptTitle: 'Give 3 Advantage tokens to a Force unit',
+                                activePromptTitle: `Give 3 Advantage tokens to a ${TextHelper.Trait.Force} unit`,
                                 cardCondition: (card) => card.isUnit() && card.hasSomeTrait(Trait.Force),
                                 immediateEffect: AbilityHelper.immediateEffects.giveAdvantage({ amount: 3 })
                             })

--- a/server/game/cards/08_ASH/leaders/BoKatanKryzeReclaimingMandalore.ts
+++ b/server/game/cards/08_ASH/leaders/BoKatanKryzeReclaimingMandalore.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { Trait, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class BoKatanKryzeReclaimingMandalore extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -33,7 +34,7 @@ export default class BoKatanKryzeReclaimingMandalore extends LeaderUnitCard {
 
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Other friendly Mandalorian units gets +1/+0',
+            title: `Other friendly ${TextHelper.Trait.Mandalorian} units gets +1/+0`,
             matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Mandalorian),
             ongoingEffect: abilityHelper.ongoingEffects.modifyStats({ power: 1, hp: 0 })
         });

--- a/server/game/cards/08_ASH/leaders/MoffGideonIndomitableWarlord.ts
+++ b/server/game/cards/08_ASH/leaders/MoffGideonIndomitableWarlord.ts
@@ -62,7 +62,7 @@ export default class MoffGideonIndomitableWarlord extends LeaderUnitCard {
 
     private addKeywordCopyAbility(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper, keyword: NonParameterKeywordName) {
         registrar.addConstantAbility({
-            title: `This unit gains ${KeywordHelpers.keywordDescription(keyword)} if it is on an Imperial unit in your discard pile`,
+            title: `This unit gains ${KeywordHelpers.keywordDescription(keyword)} if it is on an ${TextHelper.Trait.Imperial} unit in your discard pile`,
             condition: (context) => context.player.discard.some((x) =>
                 x.isUnit() && x.hasSomeTrait(Trait.Imperial) && x.hasSomeKeyword(keyword)
             ),

--- a/server/game/cards/08_ASH/units/BoKatanKryzeForAllOfMandalore.ts
+++ b/server/game/cards/08_ASH/units/BoKatanKryzeForAllOfMandalore.ts
@@ -14,7 +14,7 @@ export default class BoKatanKryzeForAllOfMandalore extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `While you control another Mandalorian unit, this unit gains ${TextHelper.Raid(2)}`,
+            title: `While you control another ${TextHelper.Trait.Mandalorian} unit, this unit gains ${TextHelper.Raid(2)}`,
             condition: (context) => context.player.isTraitInPlay(Trait.Mandalorian, context.source),
             ongoingEffect: abilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Raid, amount: 2 })
         });

--- a/server/game/cards/08_ASH/units/ElzarMannHauntedByAVision.ts
+++ b/server/game/cards/08_ASH/units/ElzarMannHauntedByAVision.ts
@@ -3,6 +3,7 @@ import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityR
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { EffectName, RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 import { OngoingEffectBuilder } from '../../../core/ongoingEffect/OngoingEffectBuilder';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class ElzarMannHauntedByAVision extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +15,7 @@ export default class ElzarMannHauntedByAVision extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'While you control a Force leader, this unit enters play ready',
+            title: `While you control a ${TextHelper.Trait.Force} leader, this unit enters play ready`,
             sourceZoneFilter: WildcardZoneName.Any,
             condition: (context) => context.player.hasSomeLeaderCard({ trait: Trait.Force }),
             ongoingEffect: OngoingEffectBuilder.card.static(EffectName.EntersPlayReady)

--- a/server/game/cards/08_ASH/units/GorianShardsCorsairPirateWarship.ts
+++ b/server/game/cards/08_ASH/units/GorianShardsCorsairPirateWarship.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class GorianShardsCorsairPirateWarship extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,7 +14,7 @@ export default class GorianShardsCorsairPirateWarship extends NonLeaderUnitCard 
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Damage dealt by friendly Underworld cards is unpreventable',
+            title: `Damage dealt by friendly ${TextHelper.Trait.Underworld} cards is unpreventable`,
             targetZoneFilter: WildcardZoneName.Any,
             targetController: RelativePlayer.Self,
             targetCardTypeFilter: WildcardCardType.Any,

--- a/server/game/cards/08_ASH/units/MandalorianFlagshipCapturedFromTheEmpire.ts
+++ b/server/game/cards/08_ASH/units/MandalorianFlagshipCapturedFromTheEmpire.ts
@@ -22,7 +22,7 @@ export default class MandalorianFlagshipCapturedFromTheEmpire extends NonLeaderU
         });
 
         registrar.addConstantAbility({
-            title: 'This unit gets +1/+0 for each other friendly Mandalorian unit',
+            title: `This unit gets +1/+0 for each other friendly ${TextHelper.Trait.Mandalorian} unit`,
             ongoingEffect: abilityHelper.ongoingEffects.modifyStats((target) => {
                 const otherMandalorianUnits = target.controller.getArenaUnits({
                     otherThan: target,

--- a/server/game/cards/08_ASH/units/MoffGideonRemnantCommander.ts
+++ b/server/game/cards/08_ASH/units/MoffGideonRemnantCommander.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { RelativePlayer, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class MoffGideonRemnantCommander extends NonLeaderUnitCard {
     protected override getImplementationId () {
@@ -13,7 +14,7 @@ export default class MoffGideonRemnantCommander extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenDefeatedAbility({
-            title: 'Return a non-unique Imperial unit from your discard pile to your hand.',
+            title: `Return a non-unique ${TextHelper.Trait.Imperial} unit from your discard pile to your hand.`,
             optional: true,
             targetResolver: {
                 cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/08_ASH/units/MouseDroid.ts
+++ b/server/game/cards/08_ASH/units/MouseDroid.ts
@@ -14,9 +14,9 @@ export default class MouseDroid extends NonLeaderUnitCard {
 
     public override setupCardAbilities (registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: `The next unit Imperial you play this phase costs ${TextHelper.resource(1)} less`,
+            title: `The next unit ${TextHelper.Trait.Imperial} you play this phase costs ${TextHelper.resource(1)} less`,
             immediateEffect: abilityHelper.immediateEffects.forThisPhasePlayerEffect({
-                ongoingEffectDescription: 'discount the next Imperial unit played by',
+                ongoingEffectDescription: `discount the next ${TextHelper.Trait.Imperial} unit played by`,
                 ongoingEffectTargetDescription: 'them',
                 effect: abilityHelper.ongoingEffects.decreaseCost({
                     cardTypeFilter: WildcardCardType.Unit,

--- a/server/game/cards/08_ASH/upgrades/FaithInTheEmpire.ts
+++ b/server/game/cards/08_ASH/upgrades/FaithInTheEmpire.ts
@@ -14,7 +14,7 @@ export default class FaithInTheEmpire extends UpgradeCard {
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `This upgrade costs ${TextHelper.resource(1)} less to play on an Imperial unit`,
+            title: `This upgrade costs ${TextHelper.resource(1)} less to play on an ${TextHelper.Trait.Imperial} unit`,
             amount: 1,
             attachTargetCondition: (card) => card.hasSomeTrait(Trait.Imperial)
         });

--- a/server/game/cards/08_ASH/upgrades/SabinesLightsaberNotAlone.ts
+++ b/server/game/cards/08_ASH/upgrades/SabinesLightsaberNotAlone.ts
@@ -16,7 +16,7 @@ export default class SabinesLightsaberNotAlone extends UpgradeCard {
         registrar.setAttachCondition((context) => !context.attachTarget.hasSomeTrait(Trait.Vehicle));
 
         registrar.addGainConstantAbilityTargetingAttached({
-            title: `If attached unit is Sabine Wren or a Force unit, it gains ${TextHelper.Restore(2)}`,
+            title: `If attached unit is Sabine Wren or a ${TextHelper.Trait.Force} unit, it gains ${TextHelper.Restore(2)}`,
             condition: (context) => context.source.hasSomeTrait(Trait.Force) || context.source.title === 'Sabine Wren',
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Restore, amount: 2 })
         });

--- a/server/game/cards/08_ASH/upgrades/TheDarksaberIconOfLeadership.ts
+++ b/server/game/cards/08_ASH/upgrades/TheDarksaberIconOfLeadership.ts
@@ -2,6 +2,7 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { UpgradeCard } from '../../../core/card/UpgradeCard';
 import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class TheDarksaberIconOfLeadership extends UpgradeCard {
     protected override getImplementationId() {
@@ -17,7 +18,7 @@ export default class TheDarksaberIconOfLeadership extends UpgradeCard {
         );
 
         registrar.addConstantAbilityTargetingAttached({
-            title: 'Attached unit is a leader unit and gains the Mandalorian trait',
+            title: `Attached unit is a leader unit and gains the ${TextHelper.Trait.Mandalorian} trait`,
             ongoingEffect: [
                 AbilityHelper.ongoingEffects.isLeader(),
                 AbilityHelper.ongoingEffects.gainTrait(Trait.Mandalorian),

--- a/server/game/cards/08_ASH/upgrades/TheWayOfTheMandalor.ts
+++ b/server/game/cards/08_ASH/upgrades/TheWayOfTheMandalor.ts
@@ -14,7 +14,7 @@ export default class TheWayOfTheMandalor extends UpgradeCard {
 
     public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addDecreaseCostAbility({
-            title: `This upgrade costs ${TextHelper.resource(1)} less to play on an Mandalorian unit`,
+            title: `This upgrade costs ${TextHelper.resource(1)} less to play on an ${TextHelper.Trait.Mandalorian} unit`,
             amount: 1,
             attachTargetCondition: (card) => card.hasSomeTrait(Trait.Mandalorian)
         });

--- a/server/game/core/card/LeaderUnitCard.ts
+++ b/server/game/core/card/LeaderUnitCard.ts
@@ -5,6 +5,7 @@ import { AbilityType, ZoneName } from '../Constants';
 import type { IUnitAbilityRegistrar, IUnitCard } from './propertyMixins/UnitProperties';
 import { WithUnitProperties } from './propertyMixins/UnitProperties';
 import { EnumHelpers } from '../utils/EnumHelpers';
+import { TextHelper } from '../utils/TextHelper';
 import type { IActionAbilityProps, IConstantAbilityProps, IReplacementEffectAbilityProps, ITriggeredAbilityProps, IAbilityPropsWithType } from '../../Interfaces';
 import { Helpers } from '../utils/Helpers';
 import { Contract } from '../utils/Contract';
@@ -185,7 +186,7 @@ export class LeaderUnitCard extends LeaderUnitCardParent implements IDeployableL
         }
 
         this.deployEpicActions.push(registrar.addActionAbility({
-            title: `Deploy ${this.title} as a Pilot`,
+            title: `Deploy ${this.title} as a ${TextHelper.Trait.Pilot}`,
             requiresConfirmation: true,
             limit: this.deployEpicActionLimit,
             condition: (context) => context.player.resources.length >= context.source.cost,

--- a/server/game/core/utils/EnumHelpers.ts
+++ b/server/game/core/utils/EnumHelpers.ts
@@ -310,6 +310,7 @@ export namespace EnumHelpers {
         [TokenUnitName.XWing]: 'X-Wing',
         [TokenUnitName.TIEFighter]: 'TIE Fighter',
         [TokenUnitName.Spy]: 'Spy',
+        // eslint-disable-next-line forceteki/no-raw-token-text -- token display name, not a trait reference
         [TokenUnitName.Mandalorian]: 'Mandalorian',
         [TokenUpgradeName.Shield]: 'Shield',
         [TokenUpgradeName.Experience]: 'Experience',

--- a/server/game/core/utils/TextHelper.ts
+++ b/server/game/core/utils/TextHelper.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @stylistic/lines-around-comment */
 import { Helpers } from './Helpers';
-import { Aspect, KeywordName } from '../Constants';
+import { Aspect, KeywordName, Trait as TraitEnum } from '../Constants';
 import type { Conjunction } from '../Constants';
 import type { INumericKeywordProperties, KeywordNameOrProperties } from '../../Interfaces';
 
@@ -139,6 +139,46 @@ export namespace TextHelper {
             ? Helpers.capitalize(asp)
             : `:${asp}:`;
     }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Traits
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the display representation of a trait name for use in string interpolation.
+     * In test environments, returns the trait in Title Case (e.g. "Bounty Hunter") for readability.
+     * In production, returns a token (e.g. `{trait:bounty-hunter}`) which the client replaces with
+     * stylized text. Multi-word traits are kebab-cased in the token so the payload contains no spaces.
+     *
+     * Prefer the {@link TextHelper.Trait} shorthand (e.g. `TextHelper.Trait.BountyHunter`) at call
+     * sites; this function is for dynamic trait values that aren't known at author time.
+     *
+     * @example
+     * // In tests: "Ready another Bounty Hunter unit"
+     * // Otherwise: "Ready another {trait:bounty-hunter} unit"
+     * const ex = `Ready another ${TextHelper.trait(TraitEnum.BountyHunter)} unit`;
+     *
+     * @param trait The trait to display — a {@link TraitEnum} value or its lowercase string value
+     * @returns A string representing the trait, either as Title Case text (in tests) or a replacement token
+     */
+    export function trait(trait: TraitEnum | string): string {
+        return process.env.NODE_ENV === 'test'
+            ? trait.split(' ').map(Helpers.capitalize)
+                .join(' ')
+            : `{trait:${trait.replace(/ /g, '-')}}`;
+    }
+
+    /**
+     * Shorthand display representations of each {@link TraitEnum} value, keyed by the enum's member
+     * names (e.g. `TextHelper.Trait.BountyHunter`). Each entry produces the same output as
+     * `TextHelper.trait(TraitEnum.X)` — Title Case text in tests, a `{trait:...}` token otherwise.
+     * Nested under `Trait` to avoid collisions with keyword shorthands (e.g. `TextHelper.Bounty`).
+     */
+    export const Trait = Object.freeze(
+        Object.fromEntries(
+            Object.entries(TraitEnum).map(([key, value]) => [key, trait(value)])
+        )
+    ) as Record<keyof typeof TraitEnum, string>;
 
     /**
      * Creates a formatted list of aspect names with an optional conjunction for the last item. This also performs

--- a/test/server/cards/02_SHD/events/Commission.spec.ts
+++ b/test/server/cards/02_SHD/events/Commission.spec.ts
@@ -16,7 +16,7 @@ describe('Commission', function () {
                     const { context } = contextRef;
 
                     context.player1.clickCard(context.commission);
-                    expect(context.player1).toHavePrompt('Select a card');
+                    expect(context.player1).toHavePrompt('Select a Bounty Hunter, Item, or Transport card to reveal and draw');
                     expect(context.player1).toHaveExactDisplayPromptCards({
                         invalid: [context.viperProbeDroid, context.confiscate, context.iAmYourFather, context.surpriseStrike, context.cellBlockGuard, context.tieAdvanced],
                         selectable: [context.frontlineShuttle, context.electrostaff, context.greedo, context.mandalorianArmor]
@@ -124,7 +124,7 @@ describe('Commission', function () {
                     const { context } = contextRef;
 
                     context.player1.clickCard(context.commission);
-                    expect(context.player1).toHavePrompt('Select a card');
+                    expect(context.player1).toHavePrompt('Select a Bounty Hunter, Item, or Transport card to reveal and draw');
                     expect(context.player1).toHaveExactDisplayPromptCards({
                         invalid: [
                             context.disarm,


### PR DESCRIPTION
⚠️ Client PR: SWU-Karabast/forceteki-client#770 ⚠️ 

## Description

- Update `TextHelper` to support Trait replacements: `"Bounty Hunter"` becomes `"{trait:bounty-hunter}"`
- Update `no-raw-token-text` lint rule to prevent usage of raw Trait names, with exceptions to ignore token names (Clone Trooper, Battle Droid, TIE Fighter, Mandalorian all share words with Trait names) and specific card names (Jabba the Hutt, The Mandalorian, etc)
- Update all card abilities to use the `TextHelper` trait helpers instead of raw trait strings