### PR TITLE
Fix duplicate decline button on disclose prompts

### DIFF
--- a/server/game/gameSystems/DiscloseAspectsSystem.ts
+++ b/server/game/gameSystems/DiscloseAspectsSystem.ts
@@ -94,6 +94,7 @@ export class DiscloseAspectsSystem<TContext extends AbilityContext = AbilityCont
                         interactMode: ViewCardInteractMode.ViewOnly
                     }),
                     cancelHandler: events ? () => events.forEach((event) => event.cancel()) : null,
+                    showCancelButton: false,
                     onSelectHandler: (cards) => this.updateEventsWithSelectedCards(events, cards),
                     cancelIfNoTargets: true,
                 });
@@ -116,6 +117,7 @@ export class DiscloseAspectsSystem<TContext extends AbilityContext = AbilityCont
                         interactMode: ViewCardInteractMode.ViewOnly
                     }),
                     cancelHandler: events ? () => events.forEach((event) => event.cancel()) : null,
+                    showCancelButton: false,
                     onSelectHandler: (cards) => this.updateEventsWithSelectedCards(events, cards),
                     cancelIfNoTargets: true,
                 });
@@ -137,6 +139,7 @@ export class DiscloseAspectsSystem<TContext extends AbilityContext = AbilityCont
                         interactMode: ViewCardInteractMode.ViewOnly
                     }),
                     cancelHandler: events ? () => events.forEach((event) => event.cancel()) : null,
+                    showCancelButton: false,
                     onSelectHandler: (cards) => this.updateEventsWithSelectedCards(events, cards),
                     cancelIfNoTargets: true,
                 });

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -23,6 +23,7 @@ export type ISelectCardProperties<TContext extends AbilityContext = AbilityConte
       effect?: string;
       effectArgs?: (context) => string[];
       cancelIfNoTargets?: boolean;
+      showCancelButton?: boolean;
   };
 
 /**
@@ -77,7 +78,7 @@ export class SelectCardSystem<TContext extends AbilityContext = AbilityContext> 
         }
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
-        const canCancel = properties.cancelHandler != null;
+        const canCancel = properties.cancelHandler != null && (properties.showCancelButton ?? true);
 
         const targetResolver = this.generateTargetResolver(context, additionalProperties);
         const targetResults = context.ability?.getDefaultTargetResults(context, canCancel) ?? {

--- a/test/server/cards/06_SEC/units/CaptainTyphoAllNecessaryPrecautions.spec.ts
+++ b/test/server/cards/06_SEC/units/CaptainTyphoAllNecessaryPrecautions.spec.ts
@@ -39,6 +39,7 @@ describe('Captain Typho, All Necessary Precautions', function () {
                 context.player2.clickCard(context.captainTypho);
 
                 expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
+                expect(context.player1).not.toHaveEnabledPromptButton('Cancel');
                 context.player1.clickPrompt('Choose nothing');
 
                 expect(context.p1Base.damage).toBe(2);

--- a/test/server/cards/06_SEC/units/MinaBonteriStopThisWar.spec.ts
+++ b/test/server/cards/06_SEC/units/MinaBonteriStopThisWar.spec.ts
@@ -57,6 +57,7 @@ describe('Mina Bonteri, Stop This War', function() {
 
                 // Player can choose not to disclose anything
                 expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
+                expect(context.player1).not.toHaveEnabledPromptButton('Cancel');
 
                 // Choose which cards to disclose
                 context.player1.clickCard(context.command);


### PR DESCRIPTION
## Summary

Fixes disclose prompts showing both `Choose nothing` and `Cancel` when declining the disclose has the same outcome through a cancelable ability flow.

## Root Cause

`DiscloseAspectsSystem` uses `SelectCardSystem` with an internal cancel handler so generated disclose events are cancelled when no cards are selected. `SelectCardSystem` treated the presence of that internal cancel handler as a reason to expose a visible `Cancel` button, while the optional selector also exposed `Choose nothing`.

## Changes

- Added a `showCancelButton` option to `SelectCardSystem` so callers can keep internal cancellation without showing a redundant cancel control.
- Disabled the visible cancel button for disclose selection prompts across all disclose modes.
- Added regression coverage for Captain Typho and Mina Bonteri disclose prompts to ensure `Choose nothing` is available without `Cancel`.

## Validation

- `npm run build-test -- --fast-build`
- `npm run jasmine -- build/test/server/cards/06_SEC/units/CaptainTyphoAllNecessaryPrecautions.spec.js build/test/server/cards/06_SEC/units/MinaBonteriStopThisWar.spec.js build/test/server/gameSystems/DiscloseAspectsSystem.spec.js`