### PR TITLE
Bugfix: exclude upgrade attach targets when the upgrade can't be afforded on them

### DIFF
--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -3,7 +3,7 @@ import type { IPlayCardActionProperties, PlayCardContext } from '../core/ability
 import { PlayCardAction } from '../core/ability/PlayCardAction';
 import type { Card } from '../core/card/Card';
 import type { UpgradeCard } from '../core/card/UpgradeCard';
-import { AbilityRestriction, CardType, KeywordName, PlayType, RelativePlayer, ZoneName } from '../core/Constants';
+import { AbilityRestriction, CardType, KeywordName, PlayType, RelativePlayer, Stage, ZoneName } from '../core/Constants';
 import type { Restriction } from '../core/ongoingEffect/effectImpl/Restriction';
 import type { Player } from '../core/Player';
 import type { Game } from '../core/Game';
@@ -24,11 +24,19 @@ export class PlayUpgradeAction extends PlayCardAction {
                 ...properties,
                 targetResolver: {
                     activePromptTitle: `Attach ${card.title} to a unit`,
-                    cardCondition: (card, context) => (
-                        properties.attachTargetCondition
-                            ? properties.attachTargetCondition(card, context)
-                            : true
-                    ),
+                    cardCondition: (card, context) => {
+                        if (properties.attachTargetCondition && !properties.attachTargetCondition(card, context)) {
+                            return false;
+                        }
+
+                        // Exclude units the upgrade can't be afforded on when attached to them (see issue #1970).
+                        // Skipped at the post-cost Target stage, where resources are already spent.
+                        if (context.stage !== Stage.Target && !context.ability.canPayCosts(context)) {
+                            return false;
+                        }
+
+                        return true;
+                    },
                     immediateEffect: attachUpgrade<AbilityContext<UpgradeCard>>((context) => ({ upgrade: context.source }))
                 }
             }

--- a/server/game/actions/PlayUpgradeAction.ts
+++ b/server/game/actions/PlayUpgradeAction.ts
@@ -30,8 +30,8 @@ export class PlayUpgradeAction extends PlayCardAction {
                         }
 
                         // Exclude units the upgrade can't be afforded on when attached to them (see issue #1970).
-                        // Skipped at the post-cost Target stage, where resources are already spent.
-                        if (context.stage !== Stage.Target && !context.ability.canPayCosts(context)) {
+                        // Only evaluated at the Pre-Target stage, before resources have been spent.
+                        if (context.stage === Stage.PreTarget && !context.ability.canPayCosts(context)) {
                             return false;
                         }
 

--- a/test/server/cards/01_SOR/units/GuardianOfTheWhills.spec.ts
+++ b/test/server/cards/01_SOR/units/GuardianOfTheWhills.spec.ts
@@ -135,19 +135,16 @@ describe('Guardian of the Whills', function () {
                 expect(context.player1).toBeAbleToSelect(context.constructedLightsaber);
                 context.player1.clickCard(context.constructedLightsaber);
 
-                expect(context.player1).toBeAbleToSelectExactly([
-                    context.guardianOfTheWhills,
-                    // TODO: Jedi Guardian should not even be selectable in this scenario
-                    // https://github.com/SWU-Karabast/forceteki/issues/1970
-                    context.jediGuardian
-                ]);
+                // Only Guardian of the Whills is selectable: attaching to Jedi Guardian costs the full amount,
+                // which the player can't afford, so it is excluded from targeting (issue #1970)
+                expect(context.player1).toBeAbleToSelectExactly([context.guardianOfTheWhills]);
+                expect(context.player1).not.toBeAbleToSelect(context.jediGuardian);
 
-                context.player1.clickCard(context.jediGuardian);
+                context.player1.clickCard(context.guardianOfTheWhills);
 
-                // Action is cancelled because player cannot pay full cost
-                expect(context.player1.exhaustedResourceCount).toBe(0);
-                expect(context.jediGuardian).toHaveExactUpgradeNames([]);
-                expect(context.player1).toBeActivePlayer();
+                // Constructed Lightsaber is played on Guardian with the cost reduction
+                expect(context.guardianOfTheWhills).toHaveExactUpgradeNames(['constructed-lightsaber']);
+                expect(context.player1.exhaustedResourceCount).toBe(2);
             });
         });
     });

--- a/test/server/cards/02_SHD/upgrades/TheDarksaber.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/TheDarksaber.spec.ts
@@ -108,19 +108,16 @@ describe('The Darksaber', function() {
 
                     context.player1.clickCard(context.theDarksaber);
 
-                    expect(context.player1).toBeAbleToSelectExactly([
-                        context.clanWrenRescuer,
-                        // TODO: Non-Mandalorian units should not even be selectable in this scenario
-                        // https://github.com/SWU-Karabast/forceteki/issues/1970
-                        context.pykeSentinel
-                    ]);
+                    // Only the Mandalorian unit is selectable: attaching to Pyke Sentinel would require paying
+                    // the aspect penalty, which the player can't afford, so it is excluded from targeting (issue #1970)
+                    expect(context.player1).toBeAbleToSelectExactly([context.clanWrenRescuer]);
+                    expect(context.player1).not.toBeAbleToSelect(context.pykeSentinel);
 
-                    context.player1.clickCard(context.pykeSentinel);
+                    context.player1.clickCard(context.clanWrenRescuer);
 
-                    // Action was cancelled
-                    expect(context.theDarksaber).toBeInZone('hand', context.player1);
-                    expect(context.player1.exhaustedResourceCount).toBe(0);
-                    expect(context.player1).toBeActivePlayer();
+                    // The Darksaber is played on the Mandalorian with the aspect penalty ignored
+                    expect(context.clanWrenRescuer).toHaveExactUpgradeNames(['the-darksaber']);
+                    expect(context.player1.exhaustedResourceCount).toBe(4);
                 });
 
                 it('cannot be played with the discount if there are no Mandalorian non-vehicle units in play', async function () {

--- a/test/server/cards/02_SHD/upgrades/TheDarksaber.spec.ts
+++ b/test/server/cards/02_SHD/upgrades/TheDarksaber.spec.ts
@@ -136,6 +136,27 @@ describe('The Darksaber', function() {
                     expect(context.player1).not.toBeAbleToSelect(context.theDarksaber);
                     context.player1.clickCardNonChecking(context.theDarksaber);
                 });
+
+                it('is not playable when unaffordable on every target, even if two different cost reductions each apply to a different unit', async function () {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            resources: 3,
+                            hand: ['the-darksaber'],
+                            // follower-of-the-way (Mandalorian) makes The Darksaber ignore the aspect penalty -> cost 4
+                            // guardian-of-the-whills discounts the first upgrade played on it by 1, but adds the +2 penalty -> cost 5
+                            groundArena: ['guardian-of-the-whills', 'follower-of-the-way']
+                        }
+                    });
+
+                    const { context } = contextRef;
+
+                    // Neither unit's cost is payable with 3 resources, and the two reductions don't stack on a
+                    // single target, so The Darksaber is not playable at all (issue #1971)
+                    expect(context.player1).not.toBeAbleToSelect(context.theDarksaber);
+                    context.player1.clickCardNonChecking(context.theDarksaber);
+                    expect(context.theDarksaber).toBeInZone('hand', context.player1);
+                });
             });
 
             describe('with more than 4 resources', function () {

--- a/test/server/cards/08_ASH/leaders/TheArmorerSteelShapesUs.spec.ts
+++ b/test/server/cards/08_ASH/leaders/TheArmorerSteelShapesUs.spec.ts
@@ -135,6 +135,42 @@ describe('The Armorer, Steel Shapes Us', function () {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('does not let the player ramp when a targeted cost reduction makes the upgrade unaffordable on its only valid target', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'the-armorer#steel-shapes-us',
+                        hand: ['conveyex-security-captain'],
+                        // Guardian of the Whills gives a cost reduction only when the upgrade is attached to itself,
+                        // but it did not enter play this phase so it isn't a valid attach target for The Armorer
+                        groundArena: ['guardian-of-the-whills'],
+                        resources: ['durasteel-plating', 'dorsal-turret', 'atst', 'atst'],
+                        base: 'data-vault',
+                        deck: ['moisture-farmer']
+                    },
+                    player2: {}
+                });
+
+                const { context } = contextRef;
+
+                // Conveyex Security Captain is the only unit to enter play this phase
+                context.player1.clickCard(context.conveyexSecurityCaptain);
+                context.player2.passAction();
+
+                // Durasteel Plating (cost 2) can't be afforded on Conveyex Security Captain (only 1 ready resource,
+                // and Guardian's reduction doesn't apply there), so the ability has no legal play — it's a soft pass
+                context.player1.clickCard(context.theArmorer);
+                context.player1.clickPrompt('Use it anyway');
+
+                // No upgrade is played and, crucially, no card is resourced from the deck (no ramp)
+                expect(context.theArmorer.exhausted).toBeTrue();
+                expect(context.durasteelPlating).toBeInZone('resource', context.player1);
+                expect(context.conveyexSecurityCaptain).toHaveExactUpgradeNames([]);
+                expect(context.moistureFarmer).toBeInZone('deck', context.player1);
+                expect(context.player1.resources.length).toBe(4);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('can be activated as a soft pass if no units entered play this phase', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
Fixes #1970
Fixes #1971

## Problem

Upgrade target legality only checked `attachTargetCondition`, never per-target affordability. Targeted cost reductions (Guardian of the Whills, The Darksaber) apply only when the upgrade is attached to specific units, but the cost engine computes the *global minimum* cost — it applies a reduction if *any* unit qualifies. As a result:

- **#1970:** units the upgrade couldn't actually be afforded on were still offered as attach targets. Clicking one cancelled the action. Worse, via **The Armorer**'s play-from-resources ability, the play failed after committing costs while the "if you do" (resource the top card) still resolved — letting the player **ramp** a resource for free.
- **#1971:** when two different unit-specific reductions each apply to a different unit (e.g. Guardian's −1 and a Mandalorian's ignore-penalty), the global minimum combined both, so the upgrade appeared **playable from hand** even though it couldn't be afforded on any single target.

## Fix

Add a per-target affordability check to the upgrade attach `cardCondition` in `PlayUpgradeAction`. It's skipped at the post-cost `Target` stage, where resources are already spent and re-checking would incorrectly invalidate the chosen target.

This flows up through `meetsRequirements → hasSomeLegalTarget`, so both the selectable target set (#1970) and whether the card is playable at all (#1971) are now correct.

## Tests

- Updated the two tests that documented these bugs with TODOs (Guardian of the Whills, The Darksaber) to assert unaffordable units are no longer selectable.
- Added a regression test for The Armorer proving no ramp occurs.
- Added a regression test for the non-overlapping-adjuster scenario (#1971).
- Full suite green.