### PR TITLE
test: Zeb Orrelios (ASH) triggers off his own upgrades when he leaves play

### DIFF
--- a/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
+++ b/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
@@ -418,5 +418,153 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 expect(context.p2Base.damage).toBe(0);
             });
         });
+
+        describe('Zeb Orrelios\'s triggered ability when he leaves play with his own upgrades attached (CR8)', function () {
+            it('should trigger from his own upgrades when Zeb himself is defeated by an ability', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['rivals-fall'],
+                        groundArena: [{ card: 'zeb-orrelios#fists-work-every-time', upgrades: ['experience'] }],
+                    },
+                    player2: {
+                        groundArena: ['atst'],
+                    }
+                });
+                const { context } = contextRef;
+
+                // Defeat Zeb (who is carrying his own upgrade) with Rival's Fall
+                context.player1.clickCard(context.rivalsFall);
+                context.player1.clickCard(context.zebOrrelios);
+
+                expect(context.zebOrrelios).toBeInZone('discard');
+
+                // Zeb's own Experience upgrade was defeated simultaneously with him leaving play, so his ability triggers
+                expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+
+                // player1 took the Rival's Fall action, so player2 is active once the trigger resolves
+                expect(context.player2).toBeActivePlayer();
+                expect(context.p2Base.damage).toBe(1);
+            });
+
+            it('should trigger from his own upgrades when Zeb himself is defeated in combat', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'zeb-orrelios#fists-work-every-time', upgrades: ['experience'] }],
+                    },
+                    player2: {
+                        hasInitiative: true,
+                        groundArena: ['separatist-super-tank'],
+                    }
+                });
+                const { context } = contextRef;
+
+                // Separatist Super Tank (8/8) attacks Zeb (5/7 + Experience = 6/8) and defeats him
+                context.player2.clickCard(context.separatistSuperTank);
+                context.player2.clickCard(context.zebOrrelios);
+
+                expect(context.zebOrrelios).toBeInZone('discard');
+
+                // Zeb's own Experience upgrade was defeated when he left play, so his ability triggers
+                expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toBeActivePlayer();
+                expect(context.p2Base.damage).toBe(1);
+            });
+
+            it('should trigger once per upgrade when Zeb himself is defeated with multiple of his own upgrades', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['rivals-fall'],
+                        groundArena: [{ card: 'zeb-orrelios#fists-work-every-time', upgrades: ['experience', 'advantage'] }],
+                    },
+                    player2: {
+                        groundArena: ['atst'],
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.rivalsFall);
+                context.player1.clickCard(context.zebOrrelios);
+
+                expect(context.zebOrrelios).toBeInZone('discard');
+
+                // Both of Zeb's own upgrades were defeated simultaneously with him, triggering his ability twice
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Deal 1 damage to a base: Advantage',
+                    'Deal 1 damage to a base: Experience'
+                ]);
+                context.player1.clickPrompt('Deal 1 damage to a base: Experience');
+                expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+
+                // player1 took the Rival's Fall action, so player2 is active once both triggers resolve
+                expect(context.player2).toBeActivePlayer();
+                expect(context.p2Base.damage).toBe(2);
+            });
+
+            it('should trigger from his own upgrades when Zeb himself is returned to hand', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'zeb-orrelios#fists-work-every-time', upgrades: ['experience'] }],
+                    },
+                    player2: {
+                        hasInitiative: true,
+                        hand: ['waylay'],
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.waylay);
+                context.player2.clickCard(context.zebOrrelios);
+
+                expect(context.zebOrrelios).toBeInZone('hand');
+
+                // Zeb's own Experience upgrade was defeated when he was returned to hand, so his ability triggers
+                expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toBeActivePlayer();
+                expect(context.p2Base.damage).toBe(1);
+            });
+
+            it('should trigger from his own upgrades when Zeb himself is captured', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'zeb-orrelios#fists-work-every-time', upgrades: ['experience'] }],
+                    },
+                    player2: {
+                        hasInitiative: true,
+                        hand: ['take-captive'],
+                        groundArena: ['wampa'],
+                    }
+                });
+                const { context } = contextRef;
+
+                // player2's Wampa captures Zeb; Zeb leaves play and his own Experience upgrade is defeated
+                context.player2.clickCard(context.takeCaptive);
+                context.player2.clickCard(context.wampa);
+                context.player2.clickCard(context.zebOrrelios);
+
+                expect(context.zebOrrelios).toBeCapturedBy(context.wampa);
+
+                // Zeb's ability triggers off his own upgrade being defeated as he leaves play
+                expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+
+                // player2 took the Take Captive action, so player1 is active once the trigger resolves
+                expect(context.player1).toBeActivePlayer();
+                expect(context.p2Base.damage).toBe(1);
+            });
+        });
     });
 });


### PR DESCRIPTION
Per the CR8 clarification, a unit's attached upgrades are now defeated simultaneously with that unit leaving play. This means Zeb Orrelios (ASH #161) triggers from his *own* upgrades being defeated when he himself leaves play while upgraded.

Adds a describe block covering Zeb leaving play with his own upgrades attached:
- defeated by an ability (Rival's Fall)
- defeated in combat
- defeated with multiple of his own upgrades (triggers once per upgrade)
- returned to hand (Waylay)
- captured (Take Captive)

The engine already handles this correctly — no implementation change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)