### PR TITLE
Bugfix: Introduce a PlayMultipleCardsFromDiscardSystem to fix Dathomiri Magicks

### DIFF
--- a/server/game/cards/05_LOF/leaders/KyloRenWereNotDoneYet.ts
+++ b/server/game/cards/05_LOF/leaders/KyloRenWereNotDoneYet.ts
@@ -1,9 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
-import type { TriggeredAbilityContext } from '../../../core/ability/TriggeredAbilityContext';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
 import { CardType, RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
-import type { IThenAbilityPropsWithSystems } from '../../../Interfaces';
 
 export default class KyloRenWereNotDoneYet extends LeaderUnitCard {
     protected override getImplementationId() {
@@ -34,41 +32,14 @@ export default class KyloRenWereNotDoneYet extends LeaderUnitCard {
     protected override setupLeaderUnitSideAbilities(registrar: ILeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
             title: 'Play any number of Upgrades from your discard pile on this unit',
-            optional: true,
             when: {
                 onLeaderDeployed: (event, context) => event.card === context.source
             },
-            targetResolver: {
+            immediateEffect: AbilityHelper.immediateEffects.playMultipleCardsFromDiscard({
                 cardTypeFilter: CardType.BasicUpgrade,
-                zoneFilter: ZoneName.Discard,
-                controller: RelativePlayer.Self,
-                immediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay((context) => ({
-                    playAsType: WildcardCardType.Upgrade,
-                    canPlayFromAnyZone: true,
-                    attachTargetCondition: (attachTarget) => attachTarget === context.source,
-                    nested: true
-                }))
-            },
-            ifYouDo: () => this.thenPlayAnotherUpgrade(AbilityHelper)
+                playAsType: WildcardCardType.Upgrade,
+                attachTargetCondition: (attachTarget, context) => attachTarget === context.source,
+            })
         });
-    }
-
-    private thenPlayAnotherUpgrade(AbilityHelper: IAbilityHelper): IThenAbilityPropsWithSystems<TriggeredAbilityContext<this>> {
-        return {
-            title: 'Play another Upgrade from your discard pile on this unit',
-            optional: true,
-            targetResolver: {
-                cardTypeFilter: CardType.BasicUpgrade,
-                zoneFilter: ZoneName.Discard,
-                controller: RelativePlayer.Self,
-                immediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay((context) => ({
-                    playAsType: WildcardCardType.Upgrade,
-                    canPlayFromAnyZone: true,
-                    attachTargetCondition: (attachTarget) => attachTarget === context.source,
-                    nested: true
-                }))
-            },
-            ifYouDo: () => this.thenPlayAnotherUpgrade(AbilityHelper)
-        };
     }
 }

--- a/server/game/cards/08_ASH/events/DathomiriMagicks.ts
+++ b/server/game/cards/08_ASH/events/DathomiriMagicks.ts
@@ -1,7 +1,7 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { EventCard } from '../../../core/card/EventCard';
-import { RelativePlayer, TargetMode, Trait, WildcardCardType, ZoneName } from '../../../core/Constants';
+import { Trait, WildcardCardType } from '../../../core/Constants';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 import { TextHelper } from '../../../core/utils/TextHelper';
 
@@ -22,19 +22,14 @@ export default class DathomiriMagicks extends EventCard {
 
         registrar.setEventAbility({
             title: 'Play up to 3 non-Vehicle units that each cost 2 or less from your discard pile for free',
-            targetResolver: {
-                activePromptTitle: 'Choose up to 3 units to play for free',
-                mode: TargetMode.UpTo,
-                numCards: 3,
+            immediateEffect: AbilityHelper.immediateEffects.playMultipleCardsFromDiscard({
+                activePromptTitle: 'Choose a unit to play for free',
+                maxCards: 3,
                 cardTypeFilter: WildcardCardType.Unit,
-                zoneFilter: ZoneName.Discard,
-                controller: RelativePlayer.Self,
                 cardCondition: (card) => card.isUnit() && !card.hasSomeTrait(Trait.Vehicle) && card.cost <= 2,
-                immediateEffect: AbilityHelper.immediateEffects.playCardFromOutOfPlay({
-                    adjustCost: { costAdjustType: CostAdjustType.Free },
-                    playAsType: WildcardCardType.Unit,
-                })
-            }
+                playAsType: WildcardCardType.Unit,
+                adjustCost: { costAdjustType: CostAdjustType.Free },
+            })
         });
     }
 }

--- a/server/game/core/Constants.ts
+++ b/server/game/core/Constants.ts
@@ -368,6 +368,7 @@ export enum MetaEventName {
     Optional = 'optional',
     PayCardPrintedCost = 'payCardPrintedCost',
     PlayCard = 'playCard',
+    PlayMultipleCardsFromDiscard = 'playMultipleCardsFromDiscard',
     RandomSelection = 'randomSelection',
     ReplacementEffect = 'replacementEffect',
     RevealAndDrawCard = 'revealAndDrawCard',

--- a/server/game/gameSystems/GameSystemLibrary.ts
+++ b/server/game/gameSystems/GameSystemLibrary.ts
@@ -91,6 +91,8 @@ import type { IPlayerPhaseLastingEffectProperties } from './PlayerPhaseLastingEf
 import { PlayerPhaseLastingEffectSystem } from './PlayerPhaseLastingEffectSystem';
 import type { IPlayMultipleCardsFromDeckProperties } from './PlayMultipleCardsFromDeckSystem';
 import { PlayMultipleCardsFromDeckSystem } from './PlayMultipleCardsFromDeckSystem';
+import type { IPlayMultipleCardsFromDiscardProperties } from './PlayMultipleCardsFromDiscardSystem';
+import { PlayMultipleCardsFromDiscardSystem } from './PlayMultipleCardsFromDiscardSystem';
 import type { IPutIntoPlayProperties } from './PutIntoPlaySystem';
 import { PutIntoPlaySystem } from './PutIntoPlaySystem';
 import type { IReadyResourcesSystemProperties } from './ReadyResourcesSystem';
@@ -663,6 +665,9 @@ export function playerLastingEffect<TContext extends AbilityContext = AbilityCon
 }
 export function playMultipleCardsFromDeck<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IPlayMultipleCardsFromDeckProperties<TContext>, TContext>) {
     return new PlayMultipleCardsFromDeckSystem<TContext>(propertyFactory);
+}
+export function playMultipleCardsFromDiscard<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<IPlayMultipleCardsFromDiscardProperties<TContext>, TContext>) {
+    return new PlayMultipleCardsFromDiscardSystem<TContext>(propertyFactory);
 }
 export function delayedPlayerEffect<TContext extends AbilityContext = AbilityContext>(propertyFactory: PropsFactory<Omit<IDelayedEffectProperties, 'delayedEffectType'>>) {
     return new DelayedEffectSystem<TContext>(

--- a/server/game/gameSystems/PlayMultipleCardsFromDiscardSystem.ts
+++ b/server/game/gameSystems/PlayMultipleCardsFromDiscardSystem.ts
@@ -1,0 +1,158 @@
+import type { AbilityContext } from '../core/ability/AbilityContext';
+import type { Card } from '../core/card/Card';
+import type { CardTypeFilter } from '../core/Constants';
+import { GameStateChangeRequired, MetaEventName, PlayType, RelativePlayer, TargetMode, ZoneName } from '../core/Constants';
+import type { GameEvent } from '../core/event/GameEvent';
+import type { IGameSystemProperties } from '../core/gameSystem/GameSystem';
+import { GameSystem } from '../core/gameSystem/GameSystem';
+import type { GameObject } from '../core/GameObject';
+import type { Player } from '../core/Player';
+import { Helpers } from '../core/utils/Helpers';
+import type { IPlayCardProperties } from './PlayCardSystem';
+import { PlayCardSystem } from './PlayCardSystem';
+import type { ISelectCardProperties } from './SelectCardSystem';
+import { SelectCardSystem } from './SelectCardSystem';
+
+/**
+ * The subset of {@link IPlayCardProperties} forwarded to the {@link PlayCardSystem} that plays each individual card.
+ * `playType` and `nested` are always set by this system, so they're intentionally not included here.
+ * - `playAsType`: the type each card is played as (unit, upgrade, etc.)
+ * - `adjustCost`: cost adjustment applied to each card (e.g. play for free); omit to pay the printed cost
+ * - `attachTargetCondition`: restricts the unit a played upgrade / pilot may attach to (e.g. "on this unit")
+ */
+type ForwardedPlayCardProperties = Pick<IPlayCardProperties, 'playAsType' | 'adjustCost' | 'attachTargetCondition'>;
+
+export interface IPlayMultipleCardsFromDiscardProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties, ForwardedPlayCardProperties {
+
+    /**
+     * The maximum number of cards that may be played. If omitted, there is no limit and the player may keep
+     * playing eligible cards until they decline (e.g. "play any number of...").
+     */
+    maxCards?: number;
+
+    /** Prompt shown each time the player selects a card to play. */
+    activePromptTitle?: string;
+
+    /** Filters the cards in the discard pile that are eligible to be played. */
+    cardCondition?: (card: Card, context: TContext) => boolean;
+    cardTypeFilter?: CardTypeFilter | CardTypeFilter[];
+}
+
+/**
+ * Plays multiple cards from the discard pile one at a time, fully resolving each card (including any triggered
+ * abilities) before the player selects the next card to play. This is important because playing a card can change
+ * the contents of the discard pile (e.g. a played unit defeats a unit in play, sending it to the discard), and the
+ * player should be able to choose the next card to play based on the updated game state.
+ *
+ * Used by cards such as Dathomiri Magicks ("Play up to 3 non-Vehicle units...") and Kylo Ren - We're Not Done Yet
+ * ("Play any number of Upgrades from your discard pile on this unit").
+ */
+export class PlayMultipleCardsFromDiscardSystem<TContext extends AbilityContext = AbilityContext> extends GameSystem<TContext, IPlayMultipleCardsFromDiscardProperties<TContext>> {
+    public override readonly name = 'playMultipleCardsFromDiscard';
+    public override readonly eventName = MetaEventName.PlayMultipleCardsFromDiscard;
+    public override readonly effectDescription = 'play multiple cards from the discard pile';
+
+    protected override readonly defaultProperties: Partial<IPlayMultipleCardsFromDiscardProperties<TContext>> = {
+        optional: true,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public eventHandler(): void { }
+
+    protected override isTargetTypeValid(): boolean {
+        return false;
+    }
+
+    public override getEffectMessage(context: TContext, additionalProperties: Partial<IPlayMultipleCardsFromDiscardProperties<TContext>> = {}): [string, any[]] {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        return [this.effectDescription, [properties.maxCards]];
+    }
+
+    public override hasLegalTarget(context: TContext, additionalProperties: Partial<IPlayMultipleCardsFromDiscardProperties<TContext>> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        if (properties.maxCards != null && properties.maxCards <= 0) {
+            return false;
+        }
+        return this.buildSelectCardSystem(context, properties, `${this.name}-probe`).hasLegalTarget(context, {}, mustChangeGameState);
+    }
+
+    public override canAffect(target: GameObject | GameObject[], context: TContext, additionalProperties: Partial<IPlayMultipleCardsFromDiscardProperties<TContext>> = {}, mustChangeGameState = GameStateChangeRequired.None): boolean {
+        return this.hasLegalTarget(context, additionalProperties, mustChangeGameState);
+    }
+
+    public override hasTargetsChosenByPlayer(context: TContext, player: Player = context.player, additionalProperties: Partial<IPlayMultipleCardsFromDiscardProperties<TContext>> = {}): boolean {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        return this.buildSelectCardSystem(context, properties, `${this.name}-probe`).hasTargetsChosenByPlayer(context, player);
+    }
+
+    public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<IPlayMultipleCardsFromDiscardProperties<TContext>> = {}): void {
+        const properties = this.generatePropertiesFromContext(context, additionalProperties);
+        const maxCards = properties.maxCards ?? Number.POSITIVE_INFINITY;
+
+        this.queuePlayCardStep(context, properties, 0, maxCards);
+    }
+
+    /**
+     * Queues a single "select a card and play it" step. Once the selected card (and any resulting triggered
+     * abilities) has fully resolved, this recursively queues the next selection step, allowing the player to react
+     * to any changes to the discard pile before choosing the next card.
+     *
+     * Each selection resolves in its own event window (via `resolve`) rather than pushing into the parent ability's
+     * `events` array. This is essential: it guarantees the previously-selected card is fully played and its triggers
+     * resolved before the next selection prompt is shown, so the player sees the up-to-date discard pile.
+     */
+    private queuePlayCardStep(context: TContext, properties: IPlayMultipleCardsFromDiscardProperties<TContext>, cardsPlayed: number, maxCards: number): void {
+        context.game.queueSimpleStep(() => {
+            if (cardsPlayed >= maxCards) {
+                return;
+            }
+
+            const selectName = `${this.name}-${cardsPlayed}`;
+            const selectCardSystem = this.buildSelectCardSystem(context, properties, selectName);
+
+            if (!selectCardSystem.hasLegalTarget(context)) {
+                return;
+            }
+
+            selectCardSystem.resolve(undefined, context);
+
+            context.game.queueSimpleStep(() => {
+                // if the player selected (and played) a card, offer to play another one
+                if (Helpers.asArray(context.targets[selectName]).length > 0) {
+                    this.queuePlayCardStep(context, properties, cardsPlayed + 1, maxCards);
+                }
+            }, 'check for another card to play from the discard pile');
+        }, 'select and play a card from the discard pile');
+    }
+
+    private buildSelectCardSystem(
+        context: TContext,
+        properties: IPlayMultipleCardsFromDiscardProperties<TContext>,
+        selectName: string
+    ): SelectCardSystem<TContext> {
+        const selectProperties: ISelectCardProperties<TContext> = {
+            activePromptTitle: properties.activePromptTitle,
+            mode: TargetMode.Single,
+            optional: true,
+            zoneFilter: ZoneName.Discard,
+            controller: RelativePlayer.Self,
+            cardTypeFilter: properties.cardTypeFilter,
+            cardCondition: properties.cardCondition,
+            name: selectName,
+            immediateEffect: new PlayCardSystem<TContext>({
+                playType: PlayType.PlayFromOutOfPlay,
+                nested: true,
+                playAsType: properties.playAsType,
+                adjustCost: properties.adjustCost,
+                // The play action invokes attachTargetCondition with the played card's own context (where `source` is
+                // the card being played). Card authors expect `context` to refer to this system's ability context (so
+                // that e.g. `context.source` resolves to the ability's source, as with Kylo Ren), so we bind it here.
+                attachTargetCondition: properties.attachTargetCondition
+                    ? (attachTarget) => properties.attachTargetCondition(attachTarget, context)
+                    : undefined,
+            }),
+        };
+
+        return new SelectCardSystem<TContext>(selectProperties);
+    }
+}

--- a/server/game/gameSystems/PlayMultipleCardsFromDiscardSystem.ts
+++ b/server/game/gameSystems/PlayMultipleCardsFromDiscardSystem.ts
@@ -1,6 +1,4 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
-import type { Card } from '../core/card/Card';
-import type { CardTypeFilter } from '../core/Constants';
 import { GameStateChangeRequired, MetaEventName, PlayType, RelativePlayer, TargetMode, ZoneName } from '../core/Constants';
 import type { GameEvent } from '../core/event/GameEvent';
 import type { IGameSystemProperties } from '../core/gameSystem/GameSystem';
@@ -22,20 +20,21 @@ import { SelectCardSystem } from './SelectCardSystem';
  */
 type ForwardedPlayCardProperties = Pick<IPlayCardProperties, 'playAsType' | 'adjustCost' | 'attachTargetCondition'>;
 
-export interface IPlayMultipleCardsFromDiscardProperties<TContext extends AbilityContext = AbilityContext> extends IGameSystemProperties, ForwardedPlayCardProperties {
+/**
+ * The subset of {@link ISelectCardProperties} forwarded to the {@link SelectCardSystem} used to choose each card. These
+ * describe the eligible cards and the selection prompt, and are kept in sync with the selection layer rather than
+ * redeclared (mirroring {@link ForwardedPlayCardProperties}).
+ */
+type ForwardedSelectionProperties<TContext extends AbilityContext> = Pick<ISelectCardProperties<TContext>, 'activePromptTitle' | 'cardCondition' | 'cardTypeFilter'>;
+
+export interface IPlayMultipleCardsFromDiscardProperties<TContext extends AbilityContext = AbilityContext>
+    extends IGameSystemProperties, ForwardedPlayCardProperties, ForwardedSelectionProperties<TContext> {
 
     /**
      * The maximum number of cards that may be played. If omitted, there is no limit and the player may keep
      * playing eligible cards until they decline (e.g. "play any number of...").
      */
     maxCards?: number;
-
-    /** Prompt shown each time the player selects a card to play. */
-    activePromptTitle?: string;
-
-    /** Filters the cards in the discard pile that are eligible to be played. */
-    cardCondition?: (card: Card, context: TContext) => boolean;
-    cardTypeFilter?: CardTypeFilter | CardTypeFilter[];
 }
 
 /**

--- a/test/server/cards/05_LOF/leaders/KyloRenWereNotDoneYet.spec.ts
+++ b/test/server/cards/05_LOF/leaders/KyloRenWereNotDoneYet.spec.ts
@@ -182,7 +182,7 @@ describe('Kylo Ren, We\'re Not Done Yet', function () {
                 ]);
 
                 // Verify we could choose nothing
-                expect(context.player1).toHaveEnabledPromptButton('Pass');
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
 
                 // Choose Fallen Lightsaber
                 context.player1.clickCard(context.fallenLightsaber);
@@ -263,7 +263,7 @@ describe('Kylo Ren, We\'re Not Done Yet', function () {
                 ]);
 
                 // Verify we could choose nothing
-                expect(context.player1).toHaveEnabledPromptButton('Pass');
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
 
                 // Choose Craving Power
                 context.player1.clickCard(context.cravingPower);
@@ -429,10 +429,10 @@ describe('Kylo Ren, We\'re Not Done Yet', function () {
                     context.constructedLightsaber,
                     context.devotion
                 ]);
-                expect(context.player1).toHaveEnabledPromptButton('Pass');
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
 
                 // Choose nothing
-                context.player1.clickPrompt('Pass');
+                context.player1.clickPrompt('Choose nothing');
 
                 // P1's turn ends without attaching any upgrades
                 expect(context.kyloRen).toBeInZone('groundArena');

--- a/test/server/cards/08_ASH/events/DathomiriMagicks.spec.ts
+++ b/test/server/cards/08_ASH/events/DathomiriMagicks.spec.ts
@@ -25,31 +25,31 @@ describe('Dathomiri Magicks', function () {
                 });
             });
 
-            it('should play up to 3 non-Vehicle units that each cost 2 or less from the discard pile for free', function () {
+            it('should play up to 3 non-Vehicle units that each cost 2 or less from the discard pile for free, one at a time', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.dathomiriMagicks);
 
-                expect(context.player1).toHavePrompt('Choose up to 3 units to play for free');
+                expect(context.player1).toHavePrompt('Choose a unit to play for free');
                 expect(context.player1).toBeAbleToSelectExactly([
                     context.battlefieldMarine,
                     context.vanguardInfantry,
                     context.deathStarStormtrooper,
                     context.specforceSoldier
                 ]);
-                expect(context.player1).toHaveEnabledPromptButtons(['Choose nothing', 'Cancel']);
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
 
                 context.player1.clickCard(context.battlefieldMarine);
-                context.player1.clickCard(context.vanguardInfantry);
-                context.player1.clickCard(context.deathStarStormtrooper);
-                context.player1.clickDone();
-
-                // the three selected units are played for free into the ground arena
                 expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
+
+                // after the first play, the player is prompted again for the second card
+                context.player1.clickCard(context.vanguardInfantry);
                 expect(context.vanguardInfantry).toBeInZone('groundArena', context.player1);
+
+                context.player1.clickCard(context.deathStarStormtrooper);
                 expect(context.deathStarStormtrooper).toBeInZone('groundArena', context.player1);
 
-                // unselected / ineligible cards stay in the discard pile
+                // having played the maximum of 3, the event resolves without another prompt
                 expect(context.specforceSoldier).toBeInZone('discard', context.player1);
                 expect(context.wampa).toBeInZone('discard', context.player1);
                 expect(context.tielnFighter).toBeInZone('discard', context.player1);
@@ -60,14 +60,21 @@ describe('Dathomiri Magicks', function () {
                 expect(context.player2).toBeActivePlayer();
             });
 
-            it('should allow choosing fewer than 3 units', function () {
+            it('should let the player play fewer than 3 units and stop early', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.dathomiriMagicks);
                 context.player1.clickCard(context.vanguardInfantry);
-                context.player1.clickDone();
-
                 expect(context.vanguardInfantry).toBeInZone('groundArena', context.player1);
+
+                // the player is prompted for another card but chooses to stop
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.battlefieldMarine,
+                    context.deathStarStormtrooper,
+                    context.specforceSoldier
+                ]);
+                context.player1.clickPrompt('Choose nothing');
+
                 expect(context.battlefieldMarine).toBeInZone('discard', context.player1);
                 expect(context.deathStarStormtrooper).toBeInZone('discard', context.player1);
                 expect(context.specforceSoldier).toBeInZone('discard', context.player1);
@@ -90,9 +97,50 @@ describe('Dathomiri Magicks', function () {
             });
         });
 
+        describe('Dathomiri Magicks\' one-at-a-time resolution', function () {
+            it('makes a unit defeated by an earlier play available to play from the discard pile', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['dathomiri-magicks'],
+                        // fragile friendly unit that will be defeated by Ruthless Assassin's When Played ability
+                        groundArena: ['death-star-stormtrooper'], // 3/1, cost 1
+                        discard: ['ruthless-assassin'],           // 3/3, cost 2, "When Played: Deal 2 damage to a friendly unit"
+                        resources: 10,
+                        base: 'command-center',
+                        leader: 'grand-moff-tarkin#oversector-governor'
+                    },
+                    player2: {
+                        hand: ['waylay']
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.dathomiriMagicks);
+
+                // only Ruthless Assassin is in the discard pile to start
+                expect(context.player1).toBeAbleToSelectExactly([context.ruthlessAssassin]);
+                context.player1.clickCard(context.ruthlessAssassin);
+
+                // Ruthless Assassin's "When Played: Deal 2 damage to a friendly unit" resolves; defeat the Stormtrooper
+                context.player1.clickCard(context.deathStarStormtrooper);
+                expect(context.ruthlessAssassin).toBeInZone('groundArena', context.player1);
+                expect(context.deathStarStormtrooper).toBeInZone('discard', context.player1);
+
+                // the newly-defeated Stormtrooper is now available to play for the next modified play-a-card action
+                expect(context.player1).toBeAbleToSelectExactly([context.deathStarStormtrooper]);
+                context.player1.clickCard(context.deathStarStormtrooper);
+                expect(context.deathStarStormtrooper).toBeInZone('groundArena', context.player1);
+
+                // both units were played for free; only the event cost (6) was paid
+                expect(context.player1.exhaustedResourceCount).toBe(6);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
         describe('Dathomiri Magicks\' cost reduction', function () {
-            it('should cost 1 less when you control a Force unit', function () {
-                return contextRef.setupTestAsync({
+            it('should cost 1 less when you control a Force unit', async function () {
+                await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         hand: ['dathomiri-magicks'],
@@ -105,22 +153,22 @@ describe('Dathomiri Magicks', function () {
                     player2: {
                         hand: ['waylay']
                     }
-                }).then(() => {
-                    const { context } = contextRef;
-
-                    context.player1.clickCard(context.dathomiriMagicks);
-                    context.player1.clickCard(context.battlefieldMarine);
-                    context.player1.clickDone();
-
-                    expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
-                    // event costs 6 - 1 = 5 (Force unit in play), unit played for free
-                    expect(context.player1.exhaustedResourceCount).toBe(5);
-                    expect(context.player2).toBeActivePlayer();
                 });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.dathomiriMagicks);
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
+                // event costs 6 - 1 = 5 (Force unit in play), unit played for free
+                expect(context.player1.exhaustedResourceCount).toBe(5);
+                expect(context.player2).toBeActivePlayer();
             });
 
-            it('should cost full price when you do not control a Force unit', function () {
-                return contextRef.setupTestAsync({
+            it('should cost full price when you do not control a Force unit', async function () {
+                await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         hand: ['dathomiri-magicks'],
@@ -133,18 +181,17 @@ describe('Dathomiri Magicks', function () {
                     player2: {
                         hand: ['waylay']
                     }
-                }).then(() => {
-                    const { context } = contextRef;
-
-                    context.player1.clickCard(context.dathomiriMagicks);
-                    context.player1.clickCard(context.vanguardInfantry);
-                    context.player1.clickDone();
-
-                    expect(context.vanguardInfantry).toBeInZone('groundArena', context.player1);
-                    // event costs the full 6, unit played for free
-                    expect(context.player1.exhaustedResourceCount).toBe(6);
-                    expect(context.player2).toBeActivePlayer();
                 });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.dathomiriMagicks);
+                context.player1.clickCard(context.vanguardInfantry);
+
+                expect(context.vanguardInfantry).toBeInZone('groundArena', context.player1);
+                // event costs the full 6, unit played for free
+                expect(context.player1.exhaustedResourceCount).toBe(6);
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });


### PR DESCRIPTION
## Description

Dathomiri Magics plays multiple cards from discard. Because these modified play-a-card actions happen sequentially, they should each happen after the previous one has fully resolved, possibly adding more cards to the discard pile. The initial implementation of this forced the player to choose all 3 cards they wanted to play at the start of the ability.

Because this type of effect is easy to get wrong, and difficult to do correctly (as evidenced by LOF Kylo Ren leader's implementation), this seemed like a good candidate for a dedicated game system. The system guarantees that the plays happen sequentially, and fully resolve the resulting triggers before choosing the next card to play.

Both Dathomiri Magicks and LOF Kylo Ren leader's implementations have been updated to use the new system, and are massively simplified as a result.
