### PR TITLE
Replace SeachDeckSystem With ViewCardSystem on Qui-Gon, Influencing Chance

### DIFF
--- a/server/game/cards/07_LAW/units/QuiGonJinnInfluencingChance.ts
+++ b/server/game/cards/07_LAW/units/QuiGonJinnInfluencingChance.ts
@@ -1,6 +1,8 @@
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import { ZoneName } from '../../../core/Constants';
+import { ChatHelpers } from '../../../core/chat/ChatHelpers';
 
 export default class QuiGonJinnInfluencingChance extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -13,27 +15,35 @@ export default class QuiGonJinnInfluencingChance extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
             title: 'Look at the top 3 cards of your deck. You may discard 1 of them. Put the rest back on top in any order.',
+            effect: 'look at the top {1} of their deck',
+            effectArgs: (context) => [ChatHelpers.pluralize(context.player.getTopCardsOfDeck(3).length, 'card', 'cards')],
             when: {
                 onAttack: true,
                 whenPlayed: true,
             },
-            immediateEffect: AbilityHelper.immediateEffects.deckSearch({
-                activePromptTitle: 'Select a card to discard',
-                searchCount: 3,
-                selectCount: 1,
-                shuffleWhenDone: false,
-                optional: true,
-                selectedCardsImmediateEffect: AbilityHelper.immediateEffects.discardSpecificCard(),
-                remainingCardsImmediateEffect: AbilityHelper.immediateEffects.lookAtAndChooseOption({
-                    activePromptTitle: 'Place cards on top of the deck in any order',
-                    perCardButtons: [
-                        {
-                            text: 'Put on top',
-                            arg: 'top',
-                            immediateEffect: AbilityHelper.immediateEffects.moveToTopOfDeck({})
-                        }
-                    ]
-                })
+            immediateEffect: AbilityHelper.immediateEffects.sequential((context) => {
+                const topCards = context.player.getTopCardsOfDeck(3);
+                return [
+                    AbilityHelper.immediateEffects.lookAtAndSelectCard({
+                        activePromptTitle: 'Select a card to discard',
+                        target: topCards,
+                        maxCards: 1,
+                        canChooseFewer: true,
+                        noSelectedCardsButtonText: 'Discard nothing',
+                        immediateEffect: AbilityHelper.immediateEffects.discardSpecificCard()
+                    }),
+                    AbilityHelper.immediateEffects.lookAtAndChooseOption(() => ({
+                        activePromptTitle: 'Place cards on top of the deck in any order',
+                        target: topCards.filter((card) => card.zoneName === ZoneName.Deck),
+                        perCardButtons: [
+                            {
+                                text: 'Put on top',
+                                arg: 'top',
+                                immediateEffect: AbilityHelper.immediateEffects.moveToTopOfDeck({})
+                            }
+                        ]
+                    }))
+                ];
             }),
         });
     }

--- a/server/game/gameSystems/ViewCardSystem.ts
+++ b/server/game/gameSystems/ViewCardSystem.ts
@@ -53,6 +53,9 @@ export interface IViewAndSelectCardsProperties<TContext extends AbilityContext =
     cardCondition?: (card: Card, context: TContext) => boolean;
 
     maxCards?: number;
+
+    /** Overrides the text of the button shown when no cards are selected (default 'Take nothing'). */
+    noSelectedCardsButtonText?: string;
 }
 
 export interface IViewCardWithPerCardButtonsProperties extends IViewCardPropertiesBase {
@@ -164,6 +167,7 @@ export abstract class ViewCardSystem<TContext extends AbilityContext = AbilityCo
                 displayCards: cards,
                 maxCards: properties.maxCards ?? 1,
                 canChooseFewer: properties.canChooseFewer ?? true,
+                noSelectedCardsButtonText: properties.noSelectedCardsButtonText,
                 selectedCardsHandler,
                 displayTextByCardUuid: properties.displayTextByCardUuid,
                 validCardCondition: (card: Card) =>

--- a/test/server/cards/07_LAW/units/QuiGonJinnInfluencingChance.spec.ts
+++ b/test/server/cards/07_LAW/units/QuiGonJinnInfluencingChance.spec.ts
@@ -23,7 +23,7 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
                 context.player1.clickCard(context.p2Base);
 
                 expect(context.player1).toHavePrompt('Select a card to discard');
-                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+                expect(context.player1).toHaveEnabledPromptButton('Discard nothing');
                 expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.maKlounkee, context.porg, context.underworldThug] });
 
                 context.player1.clickCardInDisplayCardPrompt(context.porg);
@@ -42,10 +42,8 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
 
                 expect(context.player2).toBeActivePlayer();
                 expect(context.getChatLogs(4)).toEqual([
-                    // TODO: We can probably update SearchDeckSystem to improve this message ("search" => "look at")
-                    'player1 uses Qui-Gon Jinn to search the top 3 cards of their deck',
-                    // TODO: We can probably update ViewCardSystem to improve this message ("look at" => "choose option for")
-                    'player1 uses Qui-Gon Jinn to discard Porg and to look at 2 cards',
+                    'player1 uses Qui-Gon Jinn to look at the top 3 cards of their deck',
+                    'player1 uses Qui-Gon Jinn to discard Porg',
                     'player1 uses Qui-Gon Jinn to move a card to the top of their deck',
                     'player1 uses Qui-Gon Jinn to move a card to the top of their deck'
                 ]);
@@ -58,10 +56,10 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
                 context.player1.clickCard(context.p2Base);
 
                 expect(context.player1).toHavePrompt('Select a card to discard');
-                expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+                expect(context.player1).toHaveEnabledPromptButton('Discard nothing');
                 expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.maKlounkee, context.porg, context.underworldThug] });
 
-                context.player1.clickPrompt('Take nothing');
+                context.player1.clickPrompt('Discard nothing');
 
                 context.player1.clickDisplayCardPromptButton(context.maKlounkee.uuid, 'top');
                 context.player1.clickDisplayCardPromptButton(context.underworldThug.uuid, 'top');
@@ -73,7 +71,7 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
 
                 expect(context.player2).toBeActivePlayer();
                 expect(context.getChatLogs(4)).toEqual([
-                    'player1 uses Qui-Gon Jinn to discard no cards and to look at 3 cards',
+                    'player1 uses Qui-Gon Jinn to look at the top 3 cards of their deck',
                     'player1 uses Qui-Gon Jinn to move a card to the top of their deck',
                     'player1 uses Qui-Gon Jinn to move a card to the top of their deck',
                     'player1 uses Qui-Gon Jinn to move a card to the top of their deck'
@@ -101,7 +99,7 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
             context.player1.clickCard(context.quigonJinnInfluencingChance);
 
             expect(context.player1).toHavePrompt('Select a card to discard');
-            expect(context.player1).toHaveEnabledPromptButton('Take nothing');
+            expect(context.player1).toHaveEnabledPromptButton('Discard nothing');
             expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.maKlounkee, context.porg, context.forceThrow] });
 
             context.player1.clickCardInDisplayCardPrompt(context.porg);
@@ -127,7 +125,7 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
                 player1: {
                     groundArena: ['doctor-aphra#digging-for-answers', 'quigon-jinn#influencing-chance'],
                     discard: ['wampa', 'battlefield-marine', 'pirated-starfighter', 'force-throw'],
-                    deck: ['ma-klounkee', 'porg'],
+                    deck: ['porg'],
                     resources: ['resupply']
                 },
                 player2: {
@@ -141,22 +139,18 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
             context.player1.clickCard(context.p2Base);
 
             expect(context.player1).toHavePrompt('Select a card to discard');
-            expect(context.player1).toHaveEnabledPromptButton('Take nothing');
-            expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.maKlounkee, context.porg] });
+            expect(context.player1).toHaveEnabledPromptButton('Discard nothing');
+            expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.porg] });
 
             context.player1.clickCardInDisplayCardPrompt(context.porg);
 
-            expect(context.player1).toHavePrompt('Place cards on top of the deck in any order');
-            expect(context.player1).not.toBeAbleToSelect(context.porg);
-
-            expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.maKlounkee] });
-
-            context.player1.clickDisplayCardPromptButton(context.maKlounkee.uuid, 'top');
-
             expect(context.porg).toBeInZone('discard');
-            expect(context.maKlounkee).toBeInZone('deck');
 
             expect(context.player2).toBeActivePlayer();
+            expect(context.getChatLogs(2)).toEqual([
+                'player1 uses Qui-Gon Jinn to look at the top card of their deck',
+                'player1 uses Qui-Gon Jinn to discard Porg',
+            ]);
         });
 
         it('should function as expected when the deck is empty', async function () {
@@ -178,6 +172,36 @@ describe('Qui-Gon Jinn Influencing Chance', function () {
             context.player1.clickCard(context.quigonJinnInfluencingChance);
             context.player1.clickCard(context.p2Base);
 
+            expect(context.player2).toBeActivePlayer();
+            expect(context.getChatLogs()).toEqual(['player1 attacks player2\'s base with Qui-Gon Jinn']);
+        });
+
+        it('should still only look at 3 cards when Arcana Star Map (which doubles deck searches) is attached, since this is a "look at" and not a search', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: [{ card: 'quigon-jinn#influencing-chance', upgrades: ['arcana-star-map#path-to-peridea'] }],
+                    deck: ['ma-klounkee', 'porg', 'underworld-thug', 'moisture-farmer', 'tieln-fighter', 'wampa'],
+                    resources: ['resupply']
+                },
+                player2: {
+                    groundArena: ['atst', 'consular-security-force'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.quigonJinnInfluencingChance);
+            context.player1.clickCard(context.p2Base);
+
+            expect(context.player1).toHavePrompt('Select a card to discard');
+            expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.maKlounkee, context.porg, context.underworldThug] });
+
+            context.player1.clickCardInDisplayCardPrompt(context.porg);
+            context.player1.clickDisplayCardPromptButton(context.maKlounkee.uuid, 'top');
+            context.player1.clickDisplayCardPromptButton(context.underworldThug.uuid, 'top');
+
+            expect(context.porg).toBeInZone('discard');
             expect(context.player2).toBeActivePlayer();
         });
     });


### PR DESCRIPTION
Replace `SearchDeckSystem` with `ViewCardSystem` on Qui-Gon, Influencing Chance.  Search was causing Arcana Star Map to allow user to look at top 6 instead of top 3.

Additional tweaks:

- Added `noSelectedCardsButtonText` to the `ViewCardSystem` system to allow overriding the 'Take nothing' button text (set it to 'Discard nothing' for this card)
- Used custom event log messaging as sequential effect was causing messaged like "look at 3 cards and then to look at 3 cards"

Open to alternatives to either of these.