### PR TITLE
Enable autoSingleTarget as an account preference, fix choosing-player targeting

### DIFF
--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -167,10 +167,11 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
         targetResults.hasEffectiveTargets = true;
 
         // if there's only one target available...
-        if (context.player.autoSingleTarget && legalTargets.length === 1) {
+        // (keyed off the choosing player's setting, which may be the opponent for opponent-chosen targets)
+        if (player.autoSingleTarget && legalTargets.length === 1) {
             // ...and we are an optional resolver, prompt the player if they want to resolve
             if (this.selector.optional) {
-                this.promptForSingleOptionalTarget(context, legalTargets[0]);
+                this.promptForSingleOptionalTarget(player, context, legalTargets[0]);
                 return;
             }
 
@@ -264,12 +265,12 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
         return SelectCardMode.Multiple;
     }
 
-    private promptForSingleOptionalTarget(context: AbilityContext, target: Card) {
+    private promptForSingleOptionalTarget(player: Player, context: AbilityContext, target: Card) {
         const effectName = this.properties.activePromptTitle ? this.properties.activePromptTitle : context.ability.getTitle(context);
 
         const activePromptTitle = `Trigger the effect '${effectName}' on target '${target.title}' or pass${this.selector.appendToDefaultTitle ? ' ' + this.selector.appendToDefaultTitle : ''}`;
 
-        context.game.promptWithHandlerMenu(context.player, {
+        context.game.promptWithHandlerMenu(player, {
             activePromptTitle,
             choices: [`${effectName} -> ${target.title}`, 'Pass'],
             handlers: [

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -275,8 +275,8 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
             choices: [`${effectName} -> ${target.title}`, 'Pass'],
             handlers: [
                 () => this.setTargetResult(context, target),
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                () => {}
+                // finalize the resolution with no target so the resolver doesn't re-prompt (mirrors the "choose nothing" path)
+                () => this.setTargetResult(context, null)
             ]
         });
     }

--- a/server/game/core/ability/abilityTargets/DropdownListTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/DropdownListTargetResolver.ts
@@ -31,6 +31,8 @@ export class DropdownListTargetResolver extends TargetResolver<IDropdownListTarg
             return;
         }
 
+        // A single option is a decision-free menu choice, so we always auto-resolve it regardless of the
+        // player's autoSingleTarget setting (which only governs single *card* target selection, not text menus).
         if (options.length === 1) {
             this.setTargetResult(context, options[0]);
         } else {

--- a/server/game/core/ability/abilityTargets/SelectTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/SelectTargetResolver.ts
@@ -127,6 +127,8 @@ export class SelectTargetResolver extends TargetResolver<ISelectTargetResolver<A
             handlers.push(() => (targetResults.cancelled = true));
         }*/
 
+        // A single legal handler (no pass option) is a decision-free menu choice, so we always auto-resolve it
+        // regardless of the player's autoSingleTarget setting (which only governs single *card* target selection).
         if (handlers.length === 1) {
             handlers[0]();
         } else if (handlers.length > 1) {

--- a/server/game/gameSystems/DistributeAmongTargetsSystem.ts
+++ b/server/game/gameSystems/DistributeAmongTargetsSystem.ts
@@ -175,7 +175,11 @@ export abstract class DistributeAmongTargetsSystem<
         distributeEvent.checkCondition = () => true;
         events.push(distributeEvent);
 
-        // auto-select if there's only one legal target and the player isn't allowed to choose 0 targets
+        // Auto-select if there's only one legal target and the player isn't allowed to choose 0 targets.
+        // The canChooseNoTargets guard also excludes any "distribute less" case (canDistributeLess implies
+        // canChooseNoTargets, enforced below), so this only fires when the full amount must go to the one
+        // target - a decision-free case that always auto-resolves regardless of the autoSingleTarget setting
+        // (which only governs single card target selection).
         if ((!properties.canChooseNoTargets && !context.ability.optional) && legalTargets.length === 1) {
             distributeEvent.card = legalTargets[0];
             const event = this.generateEffectEvent(legalTargets[0], distributeEvent, context, amountToDistribute);

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -1438,7 +1438,8 @@ export class Lobby {
 
     private buildGameSettings(): GameConfiguration {
         const players: IUser[] = this.users.map((user) => {
-            const cosmeticsSelection = user.socket.user.getPreferences()?.cosmetics;
+            const preferences = user.socket.user.getPreferences();
+            const cosmeticsSelection = preferences?.cosmetics;
             const resolvedCosmetics = this.server.cosmeticsService
                 ? this.server.cosmeticsService.resolveActiveCosmetics(cosmeticsSelection)
                 : CosmeticsService.resolveDefaultCosmetics(cosmeticsSelection);
@@ -1448,7 +1449,8 @@ export class Lobby {
                 username: user.username,
                 settings: {
                     optionSettings: {
-                        autoSingleTarget: false,
+                        // Anonymous users have no persisted preferences; default to off to preserve prior behavior.
+                        autoSingleTarget: preferences?.gameOptions?.autoSingleTarget ?? false,
                     }
                 },
                 cosmetics: resolvedCosmetics,

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -1449,8 +1449,10 @@ export class Lobby {
                 username: user.username,
                 settings: {
                     optionSettings: {
-                        // Anonymous users have no persisted preferences; default to off to preserve prior behavior.
-                        autoSingleTarget: preferences?.gameOptions?.autoSingleTarget ?? false,
+                        // Persisted prefs nest prompt-reduction settings under gameOptions.autoResolve;
+                        // the engine keeps optionSettings flat. Anonymous users have no persisted
+                        // preferences; default to off to preserve prior behavior.
+                        autoSingleTarget: preferences?.gameOptions?.autoResolve?.singleTarget ?? false,
                     }
                 },
                 cosmetics: resolvedCosmetics,

--- a/server/services/DynamoDBInterfaces.ts
+++ b/server/services/DynamoDBInterfaces.ts
@@ -83,6 +83,7 @@ export interface IUserPreferences {
         muteChat?: boolean;
         cardLanguage?: CardImageLocale;
         timerVisibility?: TimerVisibility;
+        autoSingleTarget?: boolean;
     };
 }
 

--- a/server/services/DynamoDBInterfaces.ts
+++ b/server/services/DynamoDBInterfaces.ts
@@ -83,7 +83,13 @@ export interface IUserPreferences {
         muteChat?: boolean;
         cardLanguage?: CardImageLocale;
         timerVisibility?: TimerVisibility;
-        autoSingleTarget?: boolean;
+
+        // Prompt-reduction settings: auto-resolve prompts that have only one sensible outcome.
+        // Grouped so future automations (e.g. auto-select opponent for indirect damage,
+        // auto-select the enemy/own base for damage/heal) can live alongside singleTarget.
+        autoResolve?: {
+            singleTarget?: boolean;
+        };
     };
 }
 

--- a/server/services/DynamoDBService.ts
+++ b/server/services/DynamoDBService.ts
@@ -585,28 +585,55 @@ class DynamoDBService {
     }
 
     /**
-     * Check if the error is because of missing keys in the preference object
-     * @param userId the users ID
-     * @param defaultPreferences preference object
+     * Read the stored preferences object for a user (or undefined if none exist yet).
      */
-    private async checkValidationExceptionAsync(userId: string, defaultPreferences: IUserPreferences): Promise<boolean> {
-        const getCommand = new GetCommand({
+    private async getStoredPreferencesAsync(userId: string): Promise<Record<string, any> | undefined> {
+        const result = await this.client.send(new GetCommand({
             TableName: this.tableName,
             Key: { pk: `USER#${userId}`, sk: 'PROFILE' }
-        });
+        }));
 
-        const result = await this.client.send(getCommand);
-        const currentPreferences = result.Item?.preferences;
+        return result.Item?.preferences;
+    }
 
-        let shouldResetToDefaults = false;
-
-        const expectedKeys = Object.keys(defaultPreferences);
-        const missingKeys = expectedKeys.filter((key) => !(key in currentPreferences));
-        if (missingKeys.length > 0) {
-            shouldResetToDefaults = true;
-            logger.info(`User ${userId} is missing preferences keys: ${missingKeys.join(', ')}, will reset to defaults`, { userId });
+    /**
+     * Recursively find dotted key paths that exist in the defaults but are missing from the
+     * stored preferences. A nested update (e.g. SET preferences.gameOptions.autoResolve.singleTarget)
+     * fails when one of these parent paths doesn't yet exist, which is the case we recover from.
+     */
+    private findMissingPreferenceKeyPaths(defaults: Record<string, any>, current: Record<string, any> | undefined, prefix = ''): string[] {
+        const missing: string[] = [];
+        for (const key of Object.keys(defaults)) {
+            const path = prefix ? `${prefix}.${key}` : key;
+            const defaultValue = defaults[key];
+            if (current == null || !(key in current)) {
+                missing.push(path);
+            } else if (typeof defaultValue === 'object' && defaultValue !== null && !Array.isArray(defaultValue)) {
+                missing.push(...this.findMissingPreferenceKeyPaths(defaultValue, current[key], path));
+            }
         }
-        return shouldResetToDefaults;
+        return missing;
+    }
+
+    /**
+     * Deep-merge plain-object preferences. Values from `source` win; nested objects are merged
+     * recursively so partial updates don't clobber unrelated saved settings. `undefined` values
+     * in `source` are skipped.
+     */
+    private deepMergePreferences(target: Record<string, any>, source: Record<string, any>): Record<string, any> {
+        const result: Record<string, any> = { ...target };
+        for (const key in source) {
+            const sourceValue = source[key];
+            if (sourceValue === undefined) {
+                continue;
+            }
+            const targetValue = result[key];
+            const bothPlainObjects =
+              typeof sourceValue === 'object' && sourceValue !== null && !Array.isArray(sourceValue) &&
+              typeof targetValue === 'object' && targetValue !== null && !Array.isArray(targetValue);
+            result[key] = bothPlainObjects ? this.deepMergePreferences(targetValue, sourceValue) : sourceValue;
+        }
+        return result;
     }
 
 
@@ -676,20 +703,23 @@ class DynamoDBService {
             if (validationExceptionOccurred) {
                 logger.info(`Attempting to see whether the validation exception is expected for ${userId}`, { userId });
                 try {
-                    // we read and then attempt
+                    // The nested update failed because a parent path doesn't exist yet in the stored
+                    // preferences (e.g. a newly added nested key like gameOptions.autoResolve). Confirm
+                    // that's the case, then rebuild the preferences with a full replace.
                     const defaultPrefs = getDefaultPreferences();
-                    if (await this.checkValidationExceptionAsync(userId, defaultPrefs)) {
-                        // Get defaults and merge with new preferences
-                        const merged = { ...defaultPrefs, ...preferences };
+                    const currentPrefs = await this.getStoredPreferencesAsync(userId);
+                    const missingKeys = this.findMissingPreferenceKeyPaths(defaultPrefs, currentPrefs);
 
-                        for (const key in preferences) {
-                            if (typeof preferences[key] === 'object' && preferences[key] !== null &&
-                              typeof defaultPrefs[key] === 'object' && defaultPrefs[key] !== null) {
-                                merged[key] = { ...defaultPrefs[key], ...preferences[key] };
-                            }
-                        }
+                    if (missingKeys.length > 0) {
+                        logger.info(`User ${userId} is missing preferences keys: ${missingKeys.join(', ')}, will reset to defaults`, { userId });
 
-                        // Update with the merged preferences (full replace)
+                        // Fill in any missing structure from the defaults, preserve the user's existing
+                        // saved values, then apply the incoming update on top.
+                        const merged = this.deepMergePreferences(
+                            this.deepMergePreferences(defaultPrefs, currentPrefs ?? {}),
+                            preferences
+                        );
+
                         const resetCommand = new UpdateCommand({
                             TableName: this.tableName,
                             Key: { pk: `USER#${userId}`, sk: 'PROFILE' },

--- a/server/services/DynamoDBService.ts
+++ b/server/services/DynamoDBService.ts
@@ -597,25 +597,6 @@ class DynamoDBService {
     }
 
     /**
-     * Recursively find dotted key paths that exist in the defaults but are missing from the
-     * stored preferences. A nested update (e.g. SET preferences.gameOptions.autoResolve.singleTarget)
-     * fails when one of these parent paths doesn't yet exist, which is the case we recover from.
-     */
-    private findMissingPreferenceKeyPaths(defaults: Record<string, any>, current: Record<string, any> | undefined, prefix = ''): string[] {
-        const missing: string[] = [];
-        for (const key of Object.keys(defaults)) {
-            const path = prefix ? `${prefix}.${key}` : key;
-            const defaultValue = defaults[key];
-            if (current == null || !(key in current)) {
-                missing.push(path);
-            } else if (typeof defaultValue === 'object' && defaultValue !== null && !Array.isArray(defaultValue)) {
-                missing.push(...this.findMissingPreferenceKeyPaths(defaultValue, current[key], path));
-            }
-        }
-        return missing;
-    }
-
-    /**
      * Deep-merge plain-object preferences. Values from `source` win; nested objects are merged
      * recursively so partial updates don't clobber unrelated saved settings. `undefined` values
      * in `source` are skipped.
@@ -638,104 +619,34 @@ class DynamoDBService {
 
 
     /**
-     * Update user preferences partially (supports nested updates)
+     * Update user preferences, merging the given partial update into what's already stored.
+     *
+     * Uses a read-merge-replace strategy: load the stored preferences, layer the current defaults
+     * underneath to backfill any keys added since the profile was last written, apply the incoming
+     * update on top, then write the whole object back. This deliberately avoids per-field nested
+     * update expressions, which fail when a parent map (e.g. gameOptions.autoResolve) doesn't yet
+     * exist. As a result, adding a new preference only requires extending getDefaultPreferences().
+     *
+     * Note: this is a non-atomic read-modify-write. Concurrent updates for the same user resolve
+     * last-write-wins, which is acceptable for single-user settings saved from the preferences UI.
+     *
      * @param userId User ID
-     * @param preferences Partial preferences to update
+     * @param preferences Partial preferences to merge in
      */
     public updateUserPreferencesAsync(userId: string, preferences: Partial<IUserPreferences>): Promise<void> {
         return this.executeDbOperationAsync(async () => {
-            const updateExpressions: string[] = [];
-            const expressionAttributeValues: Record<string, any> = {};
-            const expressionAttributeNames: Record<string, string> = {};
+            const currentPrefs = await this.getStoredPreferencesAsync(userId);
+            const merged = this.deepMergePreferences(
+                this.deepMergePreferences(getDefaultPreferences(), currentPrefs ?? {}),
+                preferences
+            );
 
-            const buildNestedUpdate = (obj: any, basePath: string[], valuePrefix: string) => {
-                for (const key in obj) {
-                    const value = obj[key];
-                    if (value !== undefined) {
-                        if (value instanceof Map) {
-                            Contract.fail('Map types are not supported in buildNestedUpdate. Convert to object first.');
-                        }
-                        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-                            // It's a nested object, recurse
-                            buildNestedUpdate(value, [...basePath, key], `${valuePrefix}_${key}`);
-                        } else {
-                            const pathParts = [...basePath, key];
-                            const pathExpression = pathParts.map((part, idx) => {
-                                const attrName = `#${part}`;
-                                expressionAttributeNames[attrName] = part;
-                                return attrName;
-                            }).join('.');
-
-                            const valueName = `:${valuePrefix}_${key}`;
-                            updateExpressions.push(`${pathExpression} = ${valueName}`);
-                            expressionAttributeValues[valueName] = value;
-                        }
-                    }
-                }
-            };
-            buildNestedUpdate(preferences, ['preferences'], 'pref');
-            if (updateExpressions.length === 0) {
-                return;
-            }
-            let validationExceptionOccurred = false;
-            try {
-                const command = new UpdateCommand({
-                    TableName: this.tableName,
-                    Key: { pk: `USER#${userId}`, sk: 'PROFILE' },
-                    UpdateExpression: `SET ${updateExpressions.join(', ')}`,
-                    ExpressionAttributeValues: expressionAttributeValues,
-                    ExpressionAttributeNames: expressionAttributeNames,
-                });
-
-                await this.client.send(command);
-            } catch (error: any) {
-                if (error.name === 'ValidationException' &&
-                  error.message?.includes('document path provided in the update expression is invalid')) {
-                    logger.info(`Detected NULL markers in preferences for user ${userId}, resetting to defaults`, { userId });
-                    validationExceptionOccurred = true;
-                } else {
-                    // Re-throw if it's a different error
-                    logger.error(`An error occured when updating preferences for user ${userId}`, { error: { message: error.message, stack: error.stack }, userId });
-                    throw error;
-                }
-            }
-
-            if (validationExceptionOccurred) {
-                logger.info(`Attempting to see whether the validation exception is expected for ${userId}`, { userId });
-                try {
-                    // The nested update failed because a parent path doesn't exist yet in the stored
-                    // preferences (e.g. a newly added nested key like gameOptions.autoResolve). Confirm
-                    // that's the case, then rebuild the preferences with a full replace.
-                    const defaultPrefs = getDefaultPreferences();
-                    const currentPrefs = await this.getStoredPreferencesAsync(userId);
-                    const missingKeys = this.findMissingPreferenceKeyPaths(defaultPrefs, currentPrefs);
-
-                    if (missingKeys.length > 0) {
-                        logger.info(`User ${userId} is missing preferences keys: ${missingKeys.join(', ')}, will reset to defaults`, { userId });
-
-                        // Fill in any missing structure from the defaults, preserve the user's existing
-                        // saved values, then apply the incoming update on top.
-                        const merged = this.deepMergePreferences(
-                            this.deepMergePreferences(defaultPrefs, currentPrefs ?? {}),
-                            preferences
-                        );
-
-                        const resetCommand = new UpdateCommand({
-                            TableName: this.tableName,
-                            Key: { pk: `USER#${userId}`, sk: 'PROFILE' },
-                            UpdateExpression: 'SET preferences = :p',
-                            ExpressionAttributeValues: { ':p': merged }
-                        });
-
-                        await this.client.send(resetCommand);
-                    } else {
-                        throw new Error(`An unexpected validation exception occured when updating preferences for user ${userId}`);
-                    }
-                } catch (error) {
-                    logger.error(`An error occured when resetting to defaults the validation Exception for user ${userId}`, { error: { message: error.message, stack: error.stack }, userId });
-                    throw error;
-                }
-            }
+            await this.client.send(new UpdateCommand({
+                TableName: this.tableName,
+                Key: { pk: `USER#${userId}`, sk: 'PROFILE' },
+                UpdateExpression: 'SET preferences = :preferences',
+                ExpressionAttributeValues: { ':preferences': merged }
+            }));
         }, 'Error updating user preferences');
     }
 

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -28,6 +28,9 @@ const getDefaultGameOptionsPreferences = () => ({
     muteChat: false,
     cardLanguage: CardImageLocale.English,
     timerVisibility: TimerVisibility.Standard,
+    autoResolve: {
+        singleTarget: false,
+    },
 });
 
 export const getDefaultPreferences = (): IUserPreferences => ({

--- a/test/helpers/GameStateBuilder.js
+++ b/test/helpers/GameStateBuilder.js
@@ -121,10 +121,19 @@ class GameStateBuilder {
         const player1OwnedCards = this.deckBuilder.getOwnedCards(1, options.player1, options.player2);
         const player2OwnedCards = this.deckBuilder.getOwnedCards(2, options.player2, options.player1);
 
+        // Game-level autoSingleTarget sets both players (kept for backwards compatibility of existing tests).
         if (options.hasOwnProperty('autoSingleTarget')) {
             const autoSingleTarget = !!options.autoSingleTarget; // Ensures a boolean value
             context.player1Object.user.settings.optionSettings.autoSingleTarget = autoSingleTarget;
             context.player2Object.user.settings.optionSettings.autoSingleTarget = autoSingleTarget;
+        }
+
+        // Per-player autoSingleTarget overrides the game-level value, so each player can be set independently.
+        if (options.player1.hasOwnProperty('autoSingleTarget')) {
+            context.player1Object.user.settings.optionSettings.autoSingleTarget = !!options.player1.autoSingleTarget;
+        }
+        if (options.player2.hasOwnProperty('autoSingleTarget')) {
+            context.player2Object.user.settings.optionSettings.autoSingleTarget = !!options.player2.autoSingleTarget;
         }
 
         // pass decklists to players. they are initialized into real card objects in the startGame() call
@@ -296,7 +305,8 @@ class GameStateBuilder {
             'deck',
             'resource',
             'hasForceToken',
-            'credits'
+            'credits',
+            'autoSingleTarget'
         ];
         // list of approved property names for setup phase
         const setupPhase = [
@@ -304,7 +314,8 @@ class GameStateBuilder {
             'deck',
             'base',
             'hand',
-            'hasInitiative'
+            'hasInitiative',
+            'autoSingleTarget'
         ];
 
         // Check for unknown properties

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -105,8 +105,16 @@ interface PlayerInfo {
     username: string;
 }
 
-interface SwuSetupTestOptions extends ISerializedGameState {
+type SwuSetupPlayerOptions = import('../../server/game/Interfaces').IPlayerSerializedState & {
+    // Per-player override of the game-level autoSingleTarget setting.
     autoSingleTarget?: boolean;
+};
+
+interface SwuSetupTestOptions extends Omit<ISerializedGameState, 'player1' | 'player2'> {
+    // Game-level default applied to both players (per-player values override it).
+    autoSingleTarget?: boolean;
+    player1?: SwuSetupPlayerOptions;
+    player2?: SwuSetupPlayerOptions;
     phaseTransitionHandler?: (phase: PhaseName) => void;
     testUndo?: boolean;
     enableConfirmationToUndo?: boolean;

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -154,5 +154,108 @@ describe('autoSingleTarget: single-target scenarios', function() {
                 expect(context.disaffectedSenator.damage).toBe(4);
             });
         });
+
+        // Chained single-target auto-resolution within one play: Moral Authority attaches only to a
+        // friendly unique unit (one valid target) and its When Played captures the only enemy non-leader
+        // unit with less remaining HP (a second single target) — both resolve with no prompts.
+        describe('when a played upgrade chains into a single-target When Played ability', function() {
+            it('auto-attaches and auto-captures when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: true,
+                        hand: ['moral-authority'],
+                        groundArena: ['the-armorer#survival-is-strength']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine']
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.moralAuthority);
+
+                expect(context.theArmorer).toHaveExactUpgradeNames(['moral-authority']);
+                expect(context.battlefieldMarine).toBeCapturedBy(context.theArmorer);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('prompts for each target when autoSingleTarget is off', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: false,
+                        hand: ['moral-authority'],
+                        groundArena: ['the-armorer#survival-is-strength']
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine']
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.moralAuthority);
+
+                // choose the unit to attach to (only the friendly unique unit is eligible)
+                expect(context.player1).toBeAbleToSelectExactly([context.theArmorer]);
+                context.player1.clickCard(context.theArmorer);
+
+                // then the When Played capture requires its own target choice
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
+                context.player1.clickCard(context.battlefieldMarine);
+
+                expect(context.battlefieldMarine).toBeCapturedBy(context.theArmorer);
+            });
+        });
+
+        // Deploying a pilot leader as an upgrade: the player still chooses the deploy *mode*
+        // (deploy as a unit vs. attach as a pilot), but once piloting is chosen the single eligible
+        // Vehicle target auto-resolves. (Deploying as a unit has no target, so nothing to auto-resolve there.)
+        describe('when deploying a pilot leader as an upgrade with one eligible vehicle', function() {
+            const pilotAttachPrompt = 'Flip Poe Dameron and attach him as an upgrade to a friendly Vehicle unit without a Pilot on it';
+
+            it('keeps the deploy-mode choice but auto-resolves the vehicle when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: true,
+                        leader: 'poe-dameron#i-can-fly-anything',
+                        spaceArena: ['cartel-spacer'],
+                        resources: 6
+                    },
+                    player2: {}
+                });
+                const { context } = contextRef;
+
+                // the deploy-mode menu still appears (deploy as unit vs. attach as pilot)
+                context.player1.clickCard(context.poeDameron);
+                context.player1.clickPrompt(pilotAttachPrompt);
+
+                // ...but the only eligible vehicle is chosen automatically
+                expect(context.cartelSpacer).toHaveExactUpgradeNames(['poe-dameron#i-can-fly-anything']);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('prompts for the vehicle when autoSingleTarget is off', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: false,
+                        leader: 'poe-dameron#i-can-fly-anything',
+                        spaceArena: ['cartel-spacer'],
+                        resources: 6
+                    },
+                    player2: {}
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.poeDameron);
+                context.player1.clickPrompt(pilotAttachPrompt);
+
+                expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer]);
+                context.player1.clickCard(context.cartelSpacer);
+                expect(context.cartelSpacer).toHaveExactUpgradeNames(['poe-dameron#i-can-fly-anything']);
+            });
+        });
     });
 });

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -53,9 +53,9 @@ describe('autoSingleTarget: single-target scenarios', function() {
             it('auto-attaches to the only unit when autoSingleTarget is on', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { autoSingleTarget: true, hand: ['protector'], groundArena: ['wampa'] },
-                    player2: {}
+                    player1: { autoSingleTarget: true, hand: ['protector'], groundArena: ['wampa'] }
                 });
+
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.protector);
@@ -67,14 +67,15 @@ describe('autoSingleTarget: single-target scenarios', function() {
             it('prompts for the unit when autoSingleTarget is off', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { autoSingleTarget: false, hand: ['protector'], groundArena: ['wampa'] },
-                    player2: {}
+                    player1: { autoSingleTarget: false, hand: ['protector'], groundArena: ['wampa'] }
                 });
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.protector);
 
+                expect(context.player1).toHavePrompt('Attach Protector to a unit');
                 expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+
                 context.player1.clickCard(context.wampa);
                 expect(context.wampa).toHaveExactUpgradeNames(['protector']);
             });
@@ -84,8 +85,7 @@ describe('autoSingleTarget: single-target scenarios', function() {
             it('auto-attacks the enemy base when autoSingleTarget is on', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { autoSingleTarget: true, groundArena: ['wampa'] },
-                    player2: {}
+                    player1: { autoSingleTarget: true, groundArena: ['wampa'] }
                 });
                 const { context } = contextRef;
 
@@ -96,11 +96,25 @@ describe('autoSingleTarget: single-target scenarios', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('auto-attacks a lone sentinel when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: true, groundArena: ['wampa'] },
+                    player2: { groundArena: ['niima-outpost-constables'] }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.wampa);
+
+                // the only legal attack target is the lone sentinel, so it resolves with no prompt
+                expect(context.niimaOutpostConstables.damage).toBe(4);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('prompts for the attack target when autoSingleTarget is off', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { autoSingleTarget: false, groundArena: ['wampa'] },
-                    player2: {}
+                    player1: { autoSingleTarget: false, groundArena: ['wampa'] }
                 });
                 const { context } = contextRef;
 
@@ -112,23 +126,22 @@ describe('autoSingleTarget: single-target scenarios', function() {
             });
         });
 
-        // A single attack can auto-resolve more than one targeting step: the attack's own target
-        // (forced to the lone Sentinel) and the attacker's On Attack ability target (the only enemy
-        // ground unit). The defender has 0 base power (+1 from Protector) so Benthic survives and its
-        // own When Defeated doesn't fire an extra prompt.
         describe('when an attack auto-resolves both the attack target and an On Attack ability', function() {
             it('auto-resolves both targets when autoSingleTarget is on', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { autoSingleTarget: true, groundArena: ['benthic-two-tubes#the-war-has-just-begun'] },
-                    player2: { groundArena: [{ card: 'disaffected-senator', upgrades: ['protector'] }] }
+                    player1: {
+                        autoSingleTarget: true,
+                        groundArena: [{ card: 'benthic-two-tubes#the-war-has-just-begun', upgrades: ['shield'] }]
+                    },
+                    player2: { groundArena: ['niima-outpost-constables'] }
                 });
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.benthicTwoTubes);
 
-                // 1 (On Attack) + 3 (Benthic combat power) = 4 damage, no prompts shown
-                expect(context.disaffectedSenator.damage).toBe(4);
+                // 1 (On Attack ping) + 3 (Benthic power) = 4 damage, no prompts shown
+                expect(context.niimaOutpostConstables.damage).toBe(4);
                 expect(context.benthicTwoTubes).toBeInZone('groundArena');
                 expect(context.player2).toBeActivePlayer();
             });
@@ -136,30 +149,30 @@ describe('autoSingleTarget: single-target scenarios', function() {
             it('prompts for each target when autoSingleTarget is off', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { autoSingleTarget: false, groundArena: ['benthic-two-tubes#the-war-has-just-begun'] },
-                    player2: { groundArena: [{ card: 'disaffected-senator', upgrades: ['protector'] }] }
+                    player1: {
+                        autoSingleTarget: false,
+                        groundArena: [{ card: 'benthic-two-tubes#the-war-has-just-begun', upgrades: ['shield'] }]
+                    },
+                    player2: { groundArena: ['niima-outpost-constables'] }
                 });
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.benthicTwoTubes);
 
                 // Sentinel forces the attack target choice...
-                expect(context.player1).toBeAbleToSelectExactly([context.disaffectedSenator]);
-                context.player1.clickCard(context.disaffectedSenator);
+                expect(context.player1).toBeAbleToSelectExactly([context.niimaOutpostConstables]);
+                context.player1.clickCard(context.niimaOutpostConstables);
 
                 // ...then the On Attack ability requires its own target choice
-                expect(context.player1).toBeAbleToSelectExactly([context.disaffectedSenator]);
-                context.player1.clickCard(context.disaffectedSenator);
+                expect(context.player1).toBeAbleToSelectExactly([context.niimaOutpostConstables]);
+                context.player1.clickCard(context.niimaOutpostConstables);
 
-                expect(context.disaffectedSenator.damage).toBe(4);
+                expect(context.niimaOutpostConstables.damage).toBe(4);
             });
         });
 
-        // Chained single-target auto-resolution within one play: Moral Authority attaches only to a
-        // friendly unique unit (one valid target) and its When Played captures the only enemy non-leader
-        // unit with less remaining HP (a second single target) — both resolve with no prompts.
         describe('when a played upgrade chains into a single-target When Played ability', function() {
-            it('auto-attaches and auto-captures when autoSingleTarget is on', async function() {
+            it('auto-attaches and auto-resolves triggered ability when autoSingleTarget is on', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -208,31 +221,27 @@ describe('autoSingleTarget: single-target scenarios', function() {
             });
         });
 
-        // Deploying a pilot leader as an upgrade: the player still chooses the deploy *mode*
-        // (deploy as a unit vs. attach as a pilot), but once piloting is chosen the single eligible
-        // Vehicle target auto-resolves. (Deploying as a unit has no target, so nothing to auto-resolve there.)
         describe('when deploying a pilot leader as an upgrade with one eligible vehicle', function() {
-            const pilotAttachPrompt = 'Flip Poe Dameron and attach him as an upgrade to a friendly Vehicle unit without a Pilot on it';
+            const pilotDeployPrompt = 'Deploy Kazuda Xiono as a Pilot';
 
             it('keeps the deploy-mode choice but auto-resolves the vehicle when autoSingleTarget is on', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
                         autoSingleTarget: true,
-                        leader: 'poe-dameron#i-can-fly-anything',
+                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy',
                         spaceArena: ['cartel-spacer'],
                         resources: 6
-                    },
-                    player2: {}
+                    }
                 });
                 const { context } = contextRef;
 
-                // the deploy-mode menu still appears (deploy as unit vs. attach as pilot)
-                context.player1.clickCard(context.poeDameron);
-                context.player1.clickPrompt(pilotAttachPrompt);
+                // the modal deploy menu still appears (deploy as a unit vs. as a pilot)
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt(pilotDeployPrompt);
 
                 // ...but the only eligible vehicle is chosen automatically
-                expect(context.cartelSpacer).toHaveExactUpgradeNames(['poe-dameron#i-can-fly-anything']);
+                expect(context.cartelSpacer).toHaveExactUpgradeNames(['kazuda-xiono#best-pilot-in-the-galaxy']);
                 expect(context.player2).toBeActivePlayer();
             });
 
@@ -241,20 +250,19 @@ describe('autoSingleTarget: single-target scenarios', function() {
                     phase: 'action',
                     player1: {
                         autoSingleTarget: false,
-                        leader: 'poe-dameron#i-can-fly-anything',
+                        leader: 'kazuda-xiono#best-pilot-in-the-galaxy',
                         spaceArena: ['cartel-spacer'],
                         resources: 6
-                    },
-                    player2: {}
+                    }
                 });
                 const { context } = contextRef;
 
-                context.player1.clickCard(context.poeDameron);
-                context.player1.clickPrompt(pilotAttachPrompt);
+                context.player1.clickCard(context.kazudaXiono);
+                context.player1.clickPrompt(pilotDeployPrompt);
 
                 expect(context.player1).toBeAbleToSelectExactly([context.cartelSpacer]);
                 context.player1.clickCard(context.cartelSpacer);
-                expect(context.cartelSpacer).toHaveExactUpgradeNames(['poe-dameron#i-can-fly-anything']);
+                expect(context.cartelSpacer).toHaveExactUpgradeNames(['kazuda-xiono#best-pilot-in-the-galaxy']);
             });
         });
     });

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -221,6 +221,87 @@ describe('autoSingleTarget: single-target scenarios', function() {
             });
         });
 
+        describe('when an action ability plays a unit from the hidden hand zone', function() {
+            describe('when the ability has no cost, so playing the unit is mandatory', function() {
+                it('auto-plays the only Underworld unit when autoSingleTarget is on', async function() {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            autoSingleTarget: true,
+                            leader: { card: 'jabba-the-hutt#crime-boss', deployed: true },
+                            hand: ['nihil-marauder']
+                        }
+                    });
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.jabbaTheHutt);
+                    context.player1.clickPrompt('Play an Underworld unit unit from your hand');
+
+                    // the play is mandatory, so the single Underworld unit is auto-played with no target prompt
+                    expect(context.nihilMarauder).toBeInZone('groundArena', context.player1);
+                    expect(context.player2).toBeActivePlayer();
+                });
+            });
+
+            describe('when the ability has an exhaust cost, so playing the unit is optional', function() {
+                const hanSoloAbilityTitle = 'Play a unit from your hand. It costs 1 resource less. Deal 2 damage to it.';
+                const playBattlefieldMarineButton = `${hanSoloAbilityTitle} -> Battlefield Marine`;
+
+                it('offers a play-or-pass choice instead of auto-playing the only unit when autoSingleTarget is on', async function() {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            autoSingleTarget: true,
+                            leader: 'han-solo#worth-the-risk',
+                            hand: ['battlefield-marine'],
+                            resources: 6
+                        }
+                    });
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.hanSolo);
+                    context.player1.clickPrompt(hanSoloAbilityTitle);
+
+                    // the single unit is NOT auto-played; the player is prompted to play it or pass
+                    expect(context.battlefieldMarine).toBeInZone('hand', context.player1);
+                    expect(context.player1).toHaveExactPromptButtons([
+                        playBattlefieldMarineButton,
+                        'Pass'
+                    ]);
+
+                    context.player1.clickPrompt(playBattlefieldMarineButton);
+                    expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
+                    expect(context.battlefieldMarine.damage).toBe(2);
+                    expect(context.hanSolo.exhausted).toBeTrue();
+                    expect(context.player2).toBeActivePlayer();
+                });
+
+                it('lets the player pass on the only unit, leaving it in hand with the leader still exhausted', async function() {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            autoSingleTarget: true,
+                            leader: 'han-solo#worth-the-risk',
+                            hand: ['battlefield-marine'],
+                            resources: 6
+                        }
+                    });
+                    const { context } = contextRef;
+
+                    context.player1.clickCard(context.hanSolo);
+                    context.player1.clickPrompt(hanSoloAbilityTitle);
+
+                    // passing resolves in a single click (the Pass handler finalizes the resolution with no target)
+                    context.player1.clickPrompt('Pass');
+
+                    // the unit stays in hand, but the exhaust-self cost was still paid, so the action was legal
+                    expect(context.battlefieldMarine).toBeInZone('hand', context.player1);
+                    expect(context.hanSolo.exhausted).toBeTrue();
+                    expect(context.player2).toBeActivePlayer();
+                });
+            });
+        });
+
         describe('when deploying a pilot leader as an upgrade with one eligible vehicle', function() {
             const pilotDeployPrompt = 'Deploy Kazuda Xiono as a Pilot';
 

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -1,0 +1,52 @@
+describe('autoSingleTarget: single-target scenarios', function() {
+    integration(function(contextRef) {
+        // When the opponent is the one choosing the target, autoSingleTarget must be keyed off the
+        // *choosing* player's setting, not the ability controller's.
+        describe('when the opponent chooses the only available target', function() {
+            it('auto-resolves when the choosing opponent has autoSingleTarget on, even if the controller has it off', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: false,
+                        hand: ['power-of-the-dark-side']
+                    },
+                    player2: {
+                        autoSingleTarget: true,
+                        groundArena: ['fleet-lieutenant']
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.powerOfTheDarkSide);
+
+                // opponent's single unit is defeated automatically with no selection prompt
+                expect(context.fleetLieutenant).toBeInZone('discard');
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('still prompts when the choosing opponent has autoSingleTarget off, even if the controller has it on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: true,
+                        hand: ['power-of-the-dark-side']
+                    },
+                    player2: {
+                        autoSingleTarget: false,
+                        groundArena: ['fleet-lieutenant']
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.powerOfTheDarkSide);
+
+                // opponent must still be prompted to choose their single unit
+                expect(context.fleetLieutenant).toBeInZone('groundArena');
+                expect(context.player2).toBeAbleToSelectExactly([context.fleetLieutenant]);
+
+                context.player2.clickCard(context.fleetLieutenant);
+                expect(context.fleetLieutenant).toBeInZone('discard');
+            });
+        });
+    });
+});

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -48,5 +48,111 @@ describe('autoSingleTarget: single-target scenarios', function() {
                 expect(context.fleetLieutenant).toBeInZone('discard');
             });
         });
+
+        describe('when playing an upgrade with a single valid target', function() {
+            it('auto-attaches to the only unit when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: true, hand: ['protector'], groundArena: ['wampa'] },
+                    player2: {}
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.protector);
+
+                expect(context.wampa).toHaveExactUpgradeNames(['protector']);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('prompts for the unit when autoSingleTarget is off', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: false, hand: ['protector'], groundArena: ['wampa'] },
+                    player2: {}
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.protector);
+
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa]);
+                context.player1.clickCard(context.wampa);
+                expect(context.wampa).toHaveExactUpgradeNames(['protector']);
+            });
+        });
+
+        describe('when attacking with only one legal target', function() {
+            it('auto-attacks the enemy base when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: true, groundArena: ['wampa'] },
+                    player2: {}
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.wampa);
+
+                // the only legal attack target is the enemy base, so it resolves with no prompt
+                expect(context.p2Base.damage).toBe(4);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('prompts for the attack target when autoSingleTarget is off', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: false, groundArena: ['wampa'] },
+                    player2: {}
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.wampa);
+
+                expect(context.player1).toBeAbleToSelectExactly([context.p2Base]);
+                context.player1.clickCard(context.p2Base);
+                expect(context.p2Base.damage).toBe(4);
+            });
+        });
+
+        // A single attack can auto-resolve more than one targeting step: the attack's own target
+        // (forced to the lone Sentinel) and the attacker's On Attack ability target (the only enemy
+        // ground unit). The defender has 0 base power (+1 from Protector) so Benthic survives and its
+        // own When Defeated doesn't fire an extra prompt.
+        describe('when an attack auto-resolves both the attack target and an On Attack ability', function() {
+            it('auto-resolves both targets when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: true, groundArena: ['benthic-two-tubes#the-war-has-just-begun'] },
+                    player2: { groundArena: [{ card: 'disaffected-senator', upgrades: ['protector'] }] }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.benthicTwoTubes);
+
+                // 1 (On Attack) + 3 (Benthic combat power) = 4 damage, no prompts shown
+                expect(context.disaffectedSenator.damage).toBe(4);
+                expect(context.benthicTwoTubes).toBeInZone('groundArena');
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('prompts for each target when autoSingleTarget is off', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { autoSingleTarget: false, groundArena: ['benthic-two-tubes#the-war-has-just-begun'] },
+                    player2: { groundArena: [{ card: 'disaffected-senator', upgrades: ['protector'] }] }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.benthicTwoTubes);
+
+                // Sentinel forces the attack target choice...
+                expect(context.player1).toBeAbleToSelectExactly([context.disaffectedSenator]);
+                context.player1.clickCard(context.disaffectedSenator);
+
+                // ...then the On Attack ability requires its own target choice
+                expect(context.player1).toBeAbleToSelectExactly([context.disaffectedSenator]);
+                context.player1.clickCard(context.disaffectedSenator);
+
+                expect(context.disaffectedSenator.damage).toBe(4);
+            });
+        });
     });
 });

--- a/test/server/cards/01_SOR/events/PowerOfTheDarkSide.spec.ts
+++ b/test/server/cards/01_SOR/events/PowerOfTheDarkSide.spec.ts
@@ -51,50 +51,5 @@ describe('Power of the Dark Side', function() {
                 expect(context.sabineWren.deployed).toBeFalse();
             });
         });
-
-        // Regression: when the opponent is the one choosing the target, autoSingleTarget must be keyed
-        // off the *choosing* player's setting (the opponent), not the ability controller's setting.
-        describe('when the opponent chooses the only available target', function() {
-            beforeEach(function () {
-                return contextRef.setupTestAsync({
-                    phase: 'action',
-                    player1: {
-                        hand: ['power-of-the-dark-side']
-                    },
-                    player2: {
-                        groundArena: ['fleet-lieutenant']
-                    }
-                });
-            });
-
-            it('auto-resolves when the choosing opponent has autoSingleTarget on, even if the controller has it off', function () {
-                const { context } = contextRef;
-
-                context.player1Object.optionSettings.autoSingleTarget = false;
-                context.player2Object.optionSettings.autoSingleTarget = true;
-
-                context.player1.clickCard(context.powerOfTheDarkSide);
-
-                // opponent's single unit is defeated automatically with no selection prompt
-                expect(context.fleetLieutenant).toBeInZone('discard');
-                expect(context.player2).toBeActivePlayer();
-            });
-
-            it('still prompts when the choosing opponent has autoSingleTarget off, even if the controller has it on', function () {
-                const { context } = contextRef;
-
-                context.player1Object.optionSettings.autoSingleTarget = true;
-                context.player2Object.optionSettings.autoSingleTarget = false;
-
-                context.player1.clickCard(context.powerOfTheDarkSide);
-
-                // opponent must still be prompted to choose their single unit
-                expect(context.fleetLieutenant).toBeInZone('groundArena');
-                expect(context.player2).toBeAbleToSelectExactly([context.fleetLieutenant]);
-
-                context.player2.clickCard(context.fleetLieutenant);
-                expect(context.fleetLieutenant).toBeInZone('discard');
-            });
-        });
     });
 });

--- a/test/server/cards/01_SOR/events/PowerOfTheDarkSide.spec.ts
+++ b/test/server/cards/01_SOR/events/PowerOfTheDarkSide.spec.ts
@@ -51,5 +51,50 @@ describe('Power of the Dark Side', function() {
                 expect(context.sabineWren.deployed).toBeFalse();
             });
         });
+
+        // Regression: when the opponent is the one choosing the target, autoSingleTarget must be keyed
+        // off the *choosing* player's setting (the opponent), not the ability controller's setting.
+        describe('when the opponent chooses the only available target', function() {
+            beforeEach(function () {
+                return contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['power-of-the-dark-side']
+                    },
+                    player2: {
+                        groundArena: ['fleet-lieutenant']
+                    }
+                });
+            });
+
+            it('auto-resolves when the choosing opponent has autoSingleTarget on, even if the controller has it off', function () {
+                const { context } = contextRef;
+
+                context.player1Object.optionSettings.autoSingleTarget = false;
+                context.player2Object.optionSettings.autoSingleTarget = true;
+
+                context.player1.clickCard(context.powerOfTheDarkSide);
+
+                // opponent's single unit is defeated automatically with no selection prompt
+                expect(context.fleetLieutenant).toBeInZone('discard');
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('still prompts when the choosing opponent has autoSingleTarget off, even if the controller has it on', function () {
+                const { context } = contextRef;
+
+                context.player1Object.optionSettings.autoSingleTarget = true;
+                context.player2Object.optionSettings.autoSingleTarget = false;
+
+                context.player1.clickCard(context.powerOfTheDarkSide);
+
+                // opponent must still be prompted to choose their single unit
+                expect(context.fleetLieutenant).toBeInZone('groundArena');
+                expect(context.player2).toBeAbleToSelectExactly([context.fleetLieutenant]);
+
+                context.player2.clickCard(context.fleetLieutenant);
+                expect(context.fleetLieutenant).toBeInZone('discard');
+            });
+        });
     });
 });


### PR DESCRIPTION
Revives the dormant `autoSingleTarget` engine feature (auto-resolve an effect when exactly one legal target exists) and ships it as an opt-in account preference, default off. 

⚠️  Companion client toggle: SWU-Karabast/forceteki-client#782

### What's in it
- **Correctness fix** — `CardTargetResolver` keyed the auto-select off the ability's *controller* instead of the *choosing* player, so it misfired whenever the opponent chooses the target (e.g. Power of the Dark Side). Now keyed off the choosing player.
- **Scope** — the setting gates single **card-target** selection only. Menu / dropdown / distribution resolvers still auto-resolve a lone mandatory option unconditionally; that's decision-free and now documented in-code so it isn't "fixed" later.
- **Persistence** — stored under `gameOptions.autoResolve.singleTarget`, grouped so future prompt-reducers (indirect-damage opponent, damage/heal base) can join. The engine's `Player.optionSettings` stays flat; `Lobby.buildGameSettings` flattens the nested pref in — the same seam that already resolves cosmetics from their persisted form.
- **Tests** — per-player harness support (`player1: { autoSingleTarget: true }`) plus a dedicated scenario spec: opponent-choice, upgrades, attack targeting, compound On Attack, chained triggers (Moral Authority), and modal pilot deploys — each as an on/off pair.
