### PR TITLE
BE support for disclose timer

### DIFF
--- a/server/game/core/Game.ts
+++ b/server/game/core/Game.ts
@@ -58,6 +58,8 @@ import { SelectCardPrompt } from './gameSteps/prompts/SelectCardPrompt';
 import { DisplayCardsWithButtonsPrompt } from './gameSteps/prompts/DisplayCardsWithButtonsPrompt';
 import { DisplayCardsForSelectionPrompt } from './gameSteps/prompts/DisplayCardsForSelectionPrompt';
 import { DisplayCardsBasicPrompt } from './gameSteps/prompts/DisplayCardsBasicPrompt';
+import { PassDelayPrompt } from './gameSteps/prompts/PassDelayPrompt';
+import type { IPassDelayPromptProperties } from './gameSteps/prompts/PassDelayPrompt';
 import { validateGameConfiguration, validateGameOptions } from './GameInterfaces';
 import type { GameConfiguration, GameOptions, ICurrentlyResolving } from './GameInterfaces';
 import type { GameObjectBase } from './GameObjectBase';
@@ -1010,6 +1012,17 @@ export class Game extends EventEmitter {
         Contract.assertNotNullLike(player);
 
         this.queueStep(new DisplayCardsBasicPrompt(this, player, properties));
+    }
+
+    /**
+     * Prompts a player with a brief, skippable pause used to mask hidden information (e.g. when
+     * an optional effect that depends on secret cards can't be performed). The wait duration and
+     * skip control are driven entirely by the client so the engine remains deterministic.
+     */
+    public promptForPassDelay(player: Player, properties: IPassDelayPromptProperties): void {
+        Contract.assertNotNullLike(player);
+
+        this.queueStep(new PassDelayPrompt(this, player, properties));
     }
 
     /**

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -22,6 +22,7 @@ export enum PromptType {
     DisplayCards = 'displayCards',
     DistributeAmongTargets = 'distributeAmongTargets',
     TriggerWindow = 'triggerWindow',
+    PassDelay = 'passDelay',
 }
 
 export interface IButton {

--- a/server/game/core/gameSteps/prompts/PassDelayPrompt.ts
+++ b/server/game/core/gameSteps/prompts/PassDelayPrompt.ts
@@ -1,0 +1,63 @@
+import type { Game } from '../../Game';
+import type { OngoingEffectSourceBase } from '../../ongoingEffect/OngoingEffectSource';
+import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
+import type { Player } from '../../Player';
+import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
+import { PromptType, type IButton } from '../PromptInterfaces';
+import { UiPrompt } from './UiPrompt';
+
+export interface IPassDelayPromptProperties {
+    source?: string | OngoingEffectSourceBase;
+    activePromptTitle?: string;
+}
+
+/**
+ * Prompt that blocks the active player with a brief, client-driven, skippable pause.
+ *
+ * Its sole purpose is to mask hidden information: when an optional effect that depends on
+ * secret information (e.g. disclose) cannot be performed, resolving it instantly would leak
+ * to the opponent that the player's hidden cards can't satisfy the requirement. Queuing this
+ * prompt instead makes the interaction indistinguishable from a player who could act but
+ * declined. The randomized wait and Skip control live entirely on the client so the engine
+ * remains deterministic.
+ */
+export class PassDelayPrompt extends UiPrompt {
+    private readonly player: Player;
+    private readonly source: OngoingEffectSourceBase;
+    private readonly activePromptTitle: string;
+    private readonly skipButton: IButton = { text: 'Skip', arg: 'done' };
+
+    public constructor(game: Game, player: Player, properties: IPassDelayPromptProperties) {
+        super(game);
+
+        this.player = player;
+        this.source = typeof properties.source === 'string'
+            ? new OngoingEffectSource(game, properties.source)
+            : properties.source ?? new OngoingEffectSource(game);
+        this.activePromptTitle = properties.activePromptTitle ?? 'Pausing';
+    }
+
+    public override activeCondition(player: Player): boolean {
+        return player === this.player;
+    }
+
+    public override activePromptInternal(): IPlayerPromptStateProperties {
+        return {
+            menuTitle: this.activePromptTitle,
+            buttons: [this.skipButton],
+            promptTitle: this.source.name,
+            promptUuid: this.uuid,
+            promptType: PromptType.PassDelay,
+        };
+    }
+
+    protected override isOpponentRevealNewInfoPrompt(): boolean {
+        return false;
+    }
+
+    public override menuCommand(player: Player, arg: string, uuid: string): boolean {
+        this.checkPlayerAndUuid(player, uuid);
+        this.complete();
+        return true;
+    }
+}

--- a/server/game/gameSystems/DiscloseAspectsSystem.ts
+++ b/server/game/gameSystems/DiscloseAspectsSystem.ts
@@ -36,7 +36,7 @@ export class DiscloseAspectsSystem<TContext extends AbilityContext = AbilityCont
     public override queueGenerateEventGameSteps(events: GameEvent[], context: TContext, additionalProperties: Partial<IDiscloseAspectsProperties> = {}): void {
         const generatedEvents = [];
         for (const target of this.targets(context, additionalProperties)) {
-            if (this.canAffect(target, context, additionalProperties)) {
+            if (target.isPlayer() && this.canSatisfyDisclose(target, context, additionalProperties)) {
                 const event = this.generateRetargetedEvent(target, context, additionalProperties);
                 generatedEvents.push(event);
                 events.push(event);
@@ -48,8 +48,22 @@ export class DiscloseAspectsSystem<TContext extends AbilityContext = AbilityCont
                 // Create new context with the targeted player so the RelativePlayer
                 // is resolved correctly in the SelectCardSystem
                 const newContext = context.copy({ player: target }) as TContext;
-                this.generateSelectCardSystem(newContext, additionalProperties, generatedEvents)
-                    .queueGenerateEventGameSteps(events, newContext);
+                if (this.canSatisfyDisclose(target, context, additionalProperties)) {
+                    this.generateSelectCardSystem(newContext, additionalProperties, generatedEvents)
+                        .queueGenerateEventGameSteps(events, newContext);
+                } else if (this.shouldMaskDisclose(context)) {
+                    // A triggered/automatic disclose can't meet the requirement. Resolving instantly would
+                    // leak to the opponent that this player's hand can't satisfy the requirement, so instead
+                    // queue a brief client-driven pause that is indistinguishable from a player who could
+                    // disclose but declined. No disclose event is generated, so any dependent "if you do"
+                    // effect correctly does not resolve.
+                    newContext.game.promptForPassDelay(target, {
+                        source: context.source.name,
+                        activePromptTitle: 'Pausing for Disclose'
+                    });
+                }
+                // For a player-initiated disclose the player already chose to use the ability (and was warned
+                // it would have no effect), so we resolve with no effect and no masking pause.
             }
         }
     }
@@ -64,12 +78,40 @@ export class DiscloseAspectsSystem<TContext extends AbilityContext = AbilityCont
         additionalProperties?: Partial<IDiscloseAspectsProperties>,
         mustChangeGameState?: GameStateChangeRequired
     ): boolean {
+        // For a triggered/automatic disclose we always treat disclosing as a legal action so that the
+        // ability triggers even when the hand can't satisfy the requirement. This lets us show a masking
+        // pause during resolution (see queueGenerateEventGameSteps) instead of silently passing, which
+        // would leak hidden information to the opponent. For player-initiated abilities (actions, events)
+        // the player provides their own visible interaction, so we report the true legality and preserve
+        // the normal "this ability will have no effect" confirmation flow.
+        if (this.shouldMaskDisclose(context)) {
+            return true;
+        }
+        return this.canSatisfyDisclose(player, context, additionalProperties, mustChangeGameState);
+    }
+
+    // Private helpers
+
+    /** Whether the player's hand contains cards that can be revealed to satisfy the required aspects. */
+    private canSatisfyDisclose(
+        player: Player,
+        context: TContext,
+        additionalProperties?: Partial<IDiscloseAspectsProperties>,
+        mustChangeGameState?: GameStateChangeRequired
+    ): boolean {
         const newContext = context.copy({ player }) as TContext;
         const selectCardSystem = this.generateSelectCardSystem(newContext, additionalProperties);
         return selectCardSystem.hasLegalTarget(newContext, null, mustChangeGameState);
     }
 
-    // Private helpers
+    /**
+     * Whether a disclose that can't meet the requirement should be masked with a pause rather than
+     * resolving instantly. Only triggered/automatic abilities need masking; player-initiated abilities
+     * (actions, events) already involve a visible interaction, so an instant pass reveals nothing new.
+     */
+    private shouldMaskDisclose(context: TContext): boolean {
+        return context.ability?.isTriggeredAbility() === true;
+    }
 
     private generateSelectCardSystem(
         context: TContext,

--- a/test/server/actions/UnitAttack.spec.ts
+++ b/test/server/actions/UnitAttack.spec.ts
@@ -478,6 +478,9 @@ describe('Basic attack', function() {
             context.player1.clickCard(context.val);
             context.player1.clickCard(context.reinforcementWalker);
 
+            // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+            context.player2.clickPrompt('Skip');
+
             // Val is defeated and does not trigger her When Defeated or Bounty abilities
             expect(context.val).toBeInZone('discard', context.player1);
             expect(context.consularSecurityForce.upgrades.length).toBe(0); // No Experience given from When Defeated
@@ -503,6 +506,9 @@ describe('Basic attack', function() {
             // P1 attacks base with Ezra Bridger
             context.player1.clickCard(context.ezraBridger);
             context.player1.clickCard(context.p2Base);
+
+            // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+            context.player2.clickPrompt('Skip');
 
             // No post-attack trigger, it is now P2's turn
             expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/06_SEC/leaders/CassianAndorClimb.spec.ts
+++ b/test/server/cards/06_SEC/leaders/CassianAndorClimb.spec.ts
@@ -525,6 +525,9 @@ describe('Cassian Andor, Climb!', function() {
             context.player1.clickCard(context.cassianAndor);
             context.player1.clickCard(context.darthTyranus);
 
+            // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+            context.player2.clickPrompt('Skip');
+
             // Darth Tyranus should be in play and Cassian should be defeated
             expect(context.darthTyranus).toBeInZone('groundArena');
             expect(context.darthTyranus.damage).toBe(0);

--- a/test/server/cards/06_SEC/leaders/LeiaOrganaOfASecretBloodline.spec.ts
+++ b/test/server/cards/06_SEC/leaders/LeiaOrganaOfASecretBloodline.spec.ts
@@ -272,7 +272,7 @@ describe('Leia Organa, Of a Secret Bloodline', () => {
                 expect(context.player2).toBeActivePlayer();
             });
 
-            it('When no cards are in hand, the ability is automatically skipped', async function () {
+            it('shows a skippable pause instead of resolving when no cards are in hand', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -291,13 +291,18 @@ describe('Leia Organa, Of a Secret Bloodline', () => {
                 context.player1.clickCard(context.leiaOrgana);
                 context.player1.clickCard(context.p2Base);
 
-                // Ability is skipped
+                // Player 1 can't satisfy the disclose requirement, so a skippable masking pause is shown
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                expect(context.player1).toHaveEnabledPromptButton('Skip');
+                context.player1.clickPrompt('Skip');
+
+                // Attack resolves
                 expect(context.player2).toBeActivePlayer();
                 expect(context.p2Base.damage).toBe(4);
                 expect(context.leiaOrgana.exhausted).toBeTrue();
             });
 
-            it('When cards in hand do not have the required aspects, the ability is automatically skipped', async function () {
+            it('shows a skippable pause instead of resolving when cards in hand do not have the required aspects', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -319,7 +324,12 @@ describe('Leia Organa, Of a Secret Bloodline', () => {
                 context.player1.clickCard(context.leiaOrgana);
                 context.player1.clickCard(context.p2Base);
 
-                // Ability is skipped
+                // Player 1 can't satisfy the disclose requirement, so a skippable masking pause is shown
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                expect(context.player1).toHaveEnabledPromptButton('Skip');
+                context.player1.clickPrompt('Skip');
+
+                // Attack resolves
                 expect(context.player2).toBeActivePlayer();
                 expect(context.p2Base.damage).toBe(4);
                 expect(context.leiaOrgana.exhausted).toBeTrue();

--- a/test/server/cards/06_SEC/units/CantwellArrestorCruiser.spec.ts
+++ b/test/server/cards/06_SEC/units/CantwellArrestorCruiser.spec.ts
@@ -104,7 +104,7 @@ describe('Cantwell Arrestor Cruiser\'s when played ability', function() {
         });
 
         describe('When player does not have required aspects in hand', function() {
-            it('The ability is automatically skipped', async function() {
+            it('shows a skippable pause instead of resolving', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -124,7 +124,11 @@ describe('Cantwell Arrestor Cruiser\'s when played ability', function() {
                 // Play Cantwell Arrestor Cruiser
                 context.player1.clickCard(context.cantwellArrestorCruiser);
 
-                // Ability is skipped since player does not have required aspects in hand
+                // Player 1 can't disclose, so a skippable masking pause is shown instead of resolving instantly
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                expect(context.player1).toHaveEnabledPromptButton('Skip');
+                context.player1.clickPrompt('Skip');
+
                 expect(context.player2).toBeActivePlayer();
             });
         });

--- a/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
+++ b/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
@@ -204,7 +204,7 @@ describe('Chairman Papanoida, Undaunted Diplomat', function () {
                 expect(context.player2).toBeActivePlayer();
             });
 
-            it('should not trigger if the hand is empty', function () {
+            it('shows a skippable pause instead of resolving if the hand is empty', function () {
                 const { context } = contextRef;
 
                 context.player1.passAction();
@@ -219,7 +219,12 @@ describe('Chairman Papanoida, Undaunted Diplomat', function () {
 
                 context.player2.clickCard(context.strategicAnalysis);
 
-                context.player1.passAction(); // cannot pass if disclose prompt is up
+                // Player 1's Chairman Papanoida disclose triggers but they can't satisfy it (empty hand),
+                // so a skippable masking pause is shown instead of resolving instantly
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                context.player1.clickPrompt('Skip');
+
+                context.player1.passAction();
                 const spy = context.player1.findCardsByName('spy');
                 expect(spy.length).toBe(0);
 

--- a/test/server/cards/06_SEC/units/EbonHawkCauseAndEffect.spec.ts
+++ b/test/server/cards/06_SEC/units/EbonHawkCauseAndEffect.spec.ts
@@ -212,7 +212,7 @@ describe('Ebon Hawk, Cause and Effect', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
-            it('is automatically skipped if the player has no Heroism or Villainy cards in hand', async function () {
+            it('shows a skippable pause instead of resolving if the player has no Heroism or Villainy cards in hand', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -237,7 +237,12 @@ describe('Ebon Hawk, Cause and Effect', function() {
                 context.player1.clickCard(context.ebonHawk);
                 context.player1.clickCard(context.gracefulPurrgil);
 
-                // Attack resolves immediately
+                // Player 1 can't disclose Heroism or Villainy, so a skippable masking pause is shown
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                expect(context.player1).toHaveEnabledPromptButton('Skip');
+                context.player1.clickPrompt('Skip');
+
+                // Attack resolves
                 expect(context.ebonHawk.damage).toBe(2);
                 expect(context.gracefulPurrgil.damage).toBe(3);
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/06_SEC/units/MinaBonteriStopThisWar.spec.ts
+++ b/test/server/cards/06_SEC/units/MinaBonteriStopThisWar.spec.ts
@@ -114,7 +114,7 @@ describe('Mina Bonteri, Stop This War', function() {
                 expect(context.player1.hand.length).toBe(startingHandSize + 1);
             });
 
-            it('skips the ability prompt if the cards in hand cannot satisfy the required aspects', function() {
+            it('shows a skippable pause instead of resolving if the cards in hand cannot satisfy the required aspects', function() {
                 const { context } = contextRef;
                 const startingHandSize = context.player1.hand.length;
 
@@ -131,7 +131,12 @@ describe('Mina Bonteri, Stop This War', function() {
                 context.player1.clickCard(context.minaBonteri);
                 context.player1.clickCard(context.reinforcementWalker);
 
-                // No ability prompt because cards in hand cannot satisfy required aspects
+                // Player 1 can't satisfy the disclose requirement, so a skippable masking pause is shown
+                // instead of resolving instantly (which would leak hand contents to the opponent).
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                expect(context.player1).toHaveEnabledPromptButton('Skip');
+                context.player1.clickPrompt('Skip');
+
                 expect(context.player2).toBeActivePlayer();
                 expect(context.player1.hand.length).toBe(startingHandSize - 2); // 2 cards discarded, no cards drawn
             });

--- a/test/server/cards/06_SEC/units/WarriorOfClanOrdo.spec.ts
+++ b/test/server/cards/06_SEC/units/WarriorOfClanOrdo.spec.ts
@@ -55,7 +55,7 @@ describe('Warrior of Clan Ordo', function () {
             expect(context.player2).toBeActivePlayer();
         });
 
-        it('Warrior of Clan Ordo\'s ability automatically applies the 2 damage if you cannot disclose the required aspects (no prompt)', async function () {
+        it('Warrior of Clan Ordo\'s ability shows a skippable pause, then applies the 2 damage, if you cannot disclose the required aspects', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -71,6 +71,12 @@ describe('Warrior of Clan Ordo', function () {
 
             context.player1.clickCard(context.warriorOfClanOrdo);
             context.player1.clickCard(context.p2Base);
+
+            // Player 1 can't disclose Aggression, so a skippable masking pause is shown instead of
+            // resolving instantly; after skipping, the "if you do not" effect deals 2 damage to their base.
+            expect(context.player1).toHavePrompt('Pausing for Disclose');
+            expect(context.player1).toHaveEnabledPromptButton('Skip');
+            context.player1.clickPrompt('Skip');
 
             expect(context.p1Base.damage).toBe(2);
             expect(context.player2).toBeActivePlayer();
@@ -94,6 +100,10 @@ describe('Warrior of Clan Ordo', function () {
             context.player1.clickCard(context.warriorOfClanOrdo);
             context.player1.clickCard(context.p2Base);
 
+            // Player 1 can't disclose Aggression, so skip the masking pause before the rest resolves
+            expect(context.player1).toHavePrompt('Pausing for Disclose');
+            context.player1.clickPrompt('Skip');
+
             expect(context.player1).toHavePassAbilityPrompt('Exhaust this leader to deal 1 indirect damage to a player');
             context.player1.clickPrompt('Trigger');
             context.player1.clickPrompt('Deal indirect damage to opponent');
@@ -103,7 +113,7 @@ describe('Warrior of Clan Ordo', function () {
             expect(context.player2).toBeActivePlayer();
         });
 
-        it('Warrior of Clan Ordo\'s ability automatically applies the 2 damage if you do not have any card in hand', async function () {
+        it('Warrior of Clan Ordo\'s ability shows a skippable pause, then applies the 2 damage, if you do not have any card in hand', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -118,6 +128,12 @@ describe('Warrior of Clan Ordo', function () {
 
             context.player1.clickCard(context.warriorOfClanOrdo);
             context.player1.clickCard(context.p2Base);
+
+            // Player 1 has no cards to disclose, so a skippable masking pause is shown; after skipping,
+            // the "if you do not" effect deals 2 damage to their base.
+            expect(context.player1).toHavePrompt('Pausing for Disclose');
+            expect(context.player1).toHaveEnabledPromptButton('Skip');
+            context.player1.clickPrompt('Skip');
 
             expect(context.p1Base.damage).toBe(2);
             expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/06_SEC/upgrades/Condemn.spec.ts
+++ b/test/server/cards/06_SEC/upgrades/Condemn.spec.ts
@@ -52,7 +52,7 @@ describe('Condemn', function () {
                 expect(context.ravenousRathtar.damage).toBe(4);
             });
 
-            it('is automatically skipped if the required aspects cannot be disclosed', async function () {
+            it('shows a skippable pause instead of resolving if the required aspects cannot be disclosed', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -82,8 +82,11 @@ describe('Condemn', function () {
                 context.player2.clickCard(context.ravenousRathtar);
                 context.player2.clickCard(context.awakenedSpecters);
 
-                // P1 is not prompted to disclose Vigilance/Villainy
-                expect(context.player1).not.toHavePrompt(disclosePrompt(context.ravenousRathtar.title));
+                // P1 can't disclose Vigilance/Villainy, so a skippable masking pause is shown instead of
+                // resolving instantly (which would leak to P2 that P1's hand can't satisfy the requirement)
+                expect(context.player1).toHavePrompt('Pausing for Disclose');
+                expect(context.player1).toHaveEnabledPromptButton('Skip');
+                context.player1.clickPrompt('Skip');
 
                 // Attack resolves, defeating Awakened Specters
                 expect(context.awakenedSpecters).toBeInZone('discard', context.player1);
@@ -116,6 +119,9 @@ describe('Condemn', function () {
                 // P1 attacks base with Axe Woves
                 context.player1.clickCard(context.axeWoves);
                 context.player1.clickCard(context.p2Base);
+
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
 
                 // Axe only hits for 3 because his constant ability is removed for the attack
                 expect(context.p2Base.damage).toBe(3);
@@ -150,6 +156,9 @@ describe('Condemn', function () {
                     context.p2Base
                 ]);
                 context.player1.clickCard(context.battlefieldMarine);
+
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
 
                 // It loses the ability to defeat all shields on attack
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames(['shield']);
@@ -192,6 +201,9 @@ describe('Condemn', function () {
                 context.player1.clickCard(context.nihilMarauder);
                 context.player1.clickCard(context.ionCannon);
 
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
+
                 // It loses Raid and does not gain Grit from Grim Resolve, so only deals 2 damage
                 expect(context.ionCannon.damage).toBe(2);
 
@@ -204,6 +216,9 @@ describe('Condemn', function () {
                 // Nihil Marauder attacks Battle Droid
                 context.player1.clickCard(context.nihilMarauder);
                 context.player1.clickCard(context.battleDroid);
+
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
 
                 // It does not have Overwhelm, so no damage goes to base
                 expect(context.p2Base.damage).toBe(0);
@@ -231,6 +246,9 @@ describe('Condemn', function () {
                 // P1 attacks base with Seventh Sister
                 context.player1.clickCard(context.seventhSister);
                 context.player1.clickCard(context.p2Base);
+
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
 
                 // Neither Fallen Lightsaber nor Seventh Sister's triggered ability trigger
                 // Attack ends with no damage dealt to Consular Security Force
@@ -261,6 +279,9 @@ describe('Condemn', function () {
                 context.player1.clickCard(context.val);
                 context.player1.clickCard(context.reinforcementWalker);
 
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
+
                 // Val is defeated and does not trigger her When Defeated or Bounty abilities
                 expect(context.val).toBeInZone('discard', context.player1);
                 expect(context.consularSecurityForce.upgrades.length).toBe(0); // No Experience given from When Defeated
@@ -286,6 +307,9 @@ describe('Condemn', function () {
                 // P1 attacks base with Ezra Bridger
                 context.player1.clickCard(context.ezraBridger);
                 context.player1.clickCard(context.p2Base);
+
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
 
                 // No post-attack trigger, it is now P2's turn
                 expect(context.player2).toBeActivePlayer();

--- a/test/server/cards/06_SEC/upgrades/DiplomaticImmunity.spec.ts
+++ b/test/server/cards/06_SEC/upgrades/DiplomaticImmunity.spec.ts
@@ -228,7 +228,7 @@ describe('Diplomatic Immunity', function() {
                 expect(context.battlefieldMarine.damage).toBe(2);
             });
 
-            it('should not trigger if the hand does not have the disclose cards', function () {
+            it('does not apply -2/-0 if the hand does not have the disclose cards', function () {
                 const { context } = contextRef;
 
                 context.player1.clickCard(context.diplomaticImmunity);
@@ -245,6 +245,11 @@ describe('Diplomatic Immunity', function() {
 
                 context.player2.clickCard(context.rebelPathfinder);
                 context.player2.clickCard(context.battlefieldMarine);
+
+                // Both players now have on-attack triggers; player2 resolves theirs first, then player1 passes
+                // on the optional Diplomatic Immunity ability (their hand can't satisfy the disclose)
+                context.player2.clickPrompt('You');
+                context.player1.clickPrompt('Pass');
 
                 expect(context.rebelPathfinder).toBeInZone('discard');
                 expect(context.battlefieldMarine.damage).toBe(2);

--- a/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
+++ b/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
@@ -139,6 +139,9 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 context.player1.clickCard(context.wampa);
                 context.player1.clickCard(context.atst);
 
+                // Condemn's gained on-attack disclose targets the defender, who can't disclose; skip the pause
+                context.player2.clickPrompt('Skip');
+
                 expect(context.wampa).toBeInZone('discard');
                 expect(context.p2Base.damage).toBe(0);
             });

--- a/test/server/gameSystems/DiscloseAspectsSystem.spec.ts
+++ b/test/server/gameSystems/DiscloseAspectsSystem.spec.ts
@@ -58,7 +58,7 @@ describe('The Disclose aspects mechanic', function() {
             expect(context.player1.hand.length).toBe(3);
         });
 
-        it('is automatically skipped if the required aspects cannot be disclosed with cards in hand', async function() {
+        it('shows a skippable pause instead of resolving instantly if the required aspects cannot be disclosed with cards in hand', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -76,6 +76,13 @@ describe('The Disclose aspects mechanic', function() {
             // Player 2 plays Vanquish to defeat Mina Bonteri
             context.player2.clickCard(context.vanquish);
             context.player2.clickCard(context.minaBonteri);
+
+            // Player 1 can't satisfy the disclose requirement. Instead of resolving instantly (which would
+            // leak that fact to the opponent), a skippable pause is shown that is indistinguishable from a
+            // player who can disclose but declines.
+            expect(context.player1).toHavePrompt('Pausing for Disclose');
+            expect(context.player1).toHaveEnabledPromptButton('Skip');
+            context.player1.clickPrompt('Skip');
 
             expect(context.player1).toBeActivePlayer();
             expect(context.player1.hand.length).toBe(4); // No card drawn
@@ -245,7 +252,7 @@ describe('The Disclose aspects mechanic', function() {
             expect(context.player1.hand.length).toBe(2);
         });
 
-        it('is automatically skipped if the required aspects cannot be disclosed with cards in hand', async function() {
+        it('shows a skippable pause instead of resolving instantly if the required aspects cannot be disclosed with cards in hand', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -263,6 +270,13 @@ describe('The Disclose aspects mechanic', function() {
             // Player 2 plays Vanquish to defeat Mina Bonteri
             context.player2.clickCard(context.vanquish);
             context.player2.clickCard(context.minaBonteri);
+
+            // Player 1 can't satisfy the disclose requirement. Instead of resolving instantly (which would
+            // leak that fact to the opponent), a skippable pause is shown that is indistinguishable from a
+            // player who can disclose but declines.
+            expect(context.player1).toHavePrompt('Pausing for Disclose');
+            expect(context.player1).toHaveEnabledPromptButton('Skip');
+            context.player1.clickPrompt('Skip');
 
             expect(context.player1).toBeActivePlayer();
             expect(context.player1.hand.length).toBe(0); // No card drawn


### PR DESCRIPTION
FE PR: https://github.com/SWU-Karabast/forceteki-client/pull/783

Adds BE support for the disclose timer to mask when a player doesn't have the right cards in hand to disclose. The lifting for the prompt is all done on the FE side, this is basically just sending the custom command for that prompt type and doing some rewiring so that it triggers correctly on Disclose abilities.

One subtlety to note is that the timer prompt only happens on a _triggered_ disclose ability, as opposed to an action ability like the Leia leader.