### PR TITLE
Add chat-only log file

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -468,6 +468,7 @@ export interface ISerializedReportState {
     lobbyId: string;
     timestamp: string;
     messages: ISerializedMessage[];
+    chatMessages?: ISerializedMessage[];
     gameStepsSinceLastUndo: string;
     gameId?: string;
     screenResolution?: { width: number; height: number } | null;

--- a/server/game/core/DiscordDispatcher.ts
+++ b/server/game/core/DiscordDispatcher.ts
@@ -256,6 +256,9 @@ export class DiscordDispatcher implements IDiscordDispatcher {
             this.addGameMessagesToForm(formData, report.messages, report.lobbyId, report.reporter.id, report.opponent.id, timestamp);
         } else {
             this.addGameMessagesToForm(formData, report.messages, report.lobbyId, report.reporter.id, report.opponent.id, timestamp, report.reporter.username, report.opponent.username);
+            if (report.chatMessages) {
+                this.addGameMessagesToForm(formData, report.chatMessages, report.lobbyId, report.reporter.id, report.opponent.id, timestamp, report.reporter.username, report.opponent.username, 'files[2]', 'report-chat-only');
+            }
         }
 
         // Send to Discord webhook with file attachment using our custom function
@@ -286,10 +289,10 @@ export class DiscordDispatcher implements IDiscordDispatcher {
         });
     }
 
-    private addGameMessagesToForm(formData: FormData, messages: ISerializedMessage[], lobbyId: string, reporterId: string, opponentId: string, timestamp: number, reporterUsername = 'Player1', opponentUsername = 'Player2'): void {
+    private addGameMessagesToForm(formData: FormData, messages: ISerializedMessage[], lobbyId: string, reporterId: string, opponentId: string, timestamp: number, reporterUsername = 'Player1', opponentUsername = 'Player2', fileField = 'files[1]', fileNamePrefix = 'report-messages'): void {
         const messagesText = DiscordDispatcher.formatMessagesToText(messages, reporterId, opponentId, reporterUsername, opponentUsername);
-        const fileName = `report-messages-${lobbyId}-${timestamp}.txt`;
-        formData.append('files[1]', Buffer.from(messagesText), {
+        const fileName = `${fileNamePrefix}-${lobbyId}-${timestamp}.txt`;
+        formData.append(fileField, Buffer.from(messagesText), {
             filename: fileName,
             contentType: 'text/plain',
         });
@@ -606,7 +609,8 @@ export class DiscordDispatcher implements IDiscordDispatcher {
         gameStepsSinceLastUndo?: number,
         gameId?: string,
         screenResolution?: { width: number; height: number } | null,
-        viewport?: { width: number; height: number } | null
+        viewport?: { width: number; height: number } | null,
+        chatMessages?: ISerializedMessage[]
     ): ISerializedReportState {
         return {
             description: sanitizeForJson(description),
@@ -625,6 +629,7 @@ export class DiscordDispatcher implements IDiscordDispatcher {
             lobbyId,
             gameId,
             messages,
+            chatMessages,
             timestamp: new Date().toISOString(),
             screenResolution,
             viewport,

--- a/server/game/core/chat/GameChat.ts
+++ b/server/game/core/chat/GameChat.ts
@@ -44,6 +44,29 @@ export class GameChat {
         this.typingState[userId] = isTyping;
     }
 
+    /**
+     * Returns only player chat messages, excluding game log messages and alerts.
+     */
+    public getPlayerChatMessages(): ISerializedMessage[] {
+        return this.messages.filter((messageEntry) => {
+            const message = messageEntry.message;
+
+            // Exclude alert messages
+            if (typeof message === 'object' && message !== null && 'alert' in message) {
+                return false;
+            }
+
+            // Include only messages whose first element is a playerChat marker
+            if (Array.isArray(message) && message.length > 0) {
+                const firstElement = message[0];
+                if (typeof firstElement === 'object' && firstElement && 'type' in firstElement && firstElement['type'] === 'playerChat') {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
     private formatMessage(format: string, args: MsgArg[]): string | string[] {
         if (!format) {
             return '';

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -2341,11 +2341,15 @@ export class Lobby {
                 : { phase: 'action', player1: {}, player2: {} };
 
             let gameMessages: ISerializedMessage[];
+            let chatMessages: ISerializedMessage[] | undefined;
             let opponent: { id: string; username: string };
             if (this.game) {
                 const opponentObject = this.game.getPlayers().find((u) => u.id !== socket.user.getId());
                 opponent = { id: opponentObject.id, username: opponentObject.user.username };
                 gameMessages = reportType === ReportType.BugReport ? this.game.getLogMessages() : this.game.gameChat.messages;
+                if (reportType === ReportType.PlayerReport) {
+                    chatMessages = this.game.gameChat.getPlayerChatMessages();
+                }
             } else {
                 // this is for lobby player reports
                 const opponentObject = this.users.find((u) => u.id !== socket.user.getId());
@@ -2355,6 +2359,7 @@ export class Lobby {
                     throw new Error(`${reportLabel} failed since opponent wasn't found`);
                 }
                 gameMessages = this.gameChat.messages;
+                chatMessages = this.gameChat.getPlayerChatMessages();
             }
 
             const report = this.discordDispatcher.formatReport(
@@ -2370,7 +2375,8 @@ export class Lobby {
                 this.game?.snapshotManager.gameStepsSinceLastUndo,
                 this.game?.id,
                 screenResolution,
-                viewport
+                viewport,
+                chatMessages
             );
 
             const success = await this.discordDispatcher.formatAndSendReportAsync(report, reportType);


### PR DESCRIPTION
Add an additional log file to player reports that has just the player chat with no game log text, to make it easier to find the offending text