### PR TITLE
Enable batched resolution for similar triggered abilities in the same window

### DIFF
--- a/server/game/core/PlayerPromptState.ts
+++ b/server/game/core/PlayerPromptState.ts
@@ -1,5 +1,5 @@
 import type { Card } from './card/Card';
-import type { IButton, IDisplayCard, IDistributeAmongTargetsPromptData, INumberPromptData, PromptType, SelectCardMode } from './gameSteps/PromptInterfaces';
+import type { IBatchTriggerResolutionPromptData, IButton, IDisplayCard, IDistributeAmongTargetsPromptData, INumberPromptData, PromptType, SelectCardMode } from './gameSteps/PromptInterfaces';
 import type { Player } from './Player';
 
 export interface IPlayerPromptStateProperties {
@@ -14,6 +14,7 @@ export interface IPlayerPromptStateProperties {
     selectOrder?: boolean;
     selectNumber?: INumberPromptData;
     distributeAmongTargets?: IDistributeAmongTargetsPromptData;
+    batchTriggerResolution?: IBatchTriggerResolutionPromptData;
     dropdownListOptions?: string[];
     displayCards?: IDisplayCard[];
     perCardButtons?: IButton[];
@@ -35,6 +36,7 @@ export class PlayerPromptState {
     public selectOrder = false;
     public selectNumber?: INumberPromptData = null;
     public distributeAmongTargets?: IDistributeAmongTargetsPromptData = null;
+    public batchTriggerResolution?: IBatchTriggerResolutionPromptData = null;
     public menuTitle = '';
     public promptTitle = '';
     public promptUuid = '';
@@ -86,6 +88,7 @@ export class PlayerPromptState {
         this.selectNumber = prompt.selectNumber;
         this.menuTitle = prompt.menuTitle ?? '';
         this.distributeAmongTargets = prompt.distributeAmongTargets;
+        this.batchTriggerResolution = prompt.batchTriggerResolution;
         this.dropdownListOptions = prompt.dropdownListOptions ?? [];
         this.promptUuid = prompt.promptUuid;
         this.buttons = prompt.buttons ?? [];
@@ -134,6 +137,7 @@ export class PlayerPromptState {
             selectOrder: this.selectOrder,
             selectNumber: this.selectNumber,
             distributeAmongTargets: this.distributeAmongTargets,
+            batchTriggerResolution: this.batchTriggerResolution,
             dropdownListOptions: this.dropdownListOptions,
             menuTitle: this.menuTitle,
             promptTitle: this.promptTitle,

--- a/server/game/core/gameSteps/PromptInterfaces.ts
+++ b/server/game/core/gameSteps/PromptInterfaces.ts
@@ -23,6 +23,7 @@ export enum PromptType {
     DistributeAmongTargets = 'distributeAmongTargets',
     TriggerWindow = 'triggerWindow',
     PassDelay = 'passDelay',
+    BatchTriggerResolution = 'batchTriggerResolution',
 }
 
 export interface IButton {
@@ -44,6 +45,36 @@ export interface ITriggerWindowSourceCard {
 export interface ITriggerWindowButton extends IButton {
     sourceCard?: ITriggerWindowSourceCard;
     hasLegalEffects: boolean;
+
+    /** Number of similar triggers this button represents (> 1 when several were grouped into one choice) */
+    count?: number;
+}
+
+/**
+ * A single selectable entry in the "choose which trigger to resolve first" prompt. Usually one per
+ * triggered ability, but a window may collapse several similar triggers into one choice (e.g. all of a
+ * unit's Advantage tokens, or a heal that fires once per defeated unit). Accessors are lazy so they're
+ * only evaluated when a prompt is actually shown — computing a title eagerly can have side effects and
+ * crash for sources that have already left play.
+ */
+export interface IResolutionChoice {
+    getTitle: () => string;
+    getSourceCard: () => ITriggerWindowSourceCard | undefined;
+    hasLegalEffects: () => boolean;
+    handler: () => void;
+
+    /** Number of grouped triggers this choice represents; omitted or 1 for an ungrouped single trigger */
+    count?: number;
+}
+
+/**
+ * Payload for the batch-resolution modal shown after selecting a grouped trigger. Lets the player choose
+ * to resolve just the next instance or all remaining instances of that trigger.
+ */
+export interface IBatchTriggerResolutionPromptData {
+    sourceCard?: ITriggerWindowSourceCard;
+    title: string;
+    remainingCount: number;
 }
 
 export interface INumberPromptData {

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -10,6 +10,8 @@ import { TriggeredAbilityWindowTitle } from './TriggeredAbilityWindowTitle';
 import { BaseStep } from '../BaseStep';
 import type { Game } from '../../Game';
 import { TriggeredAbilityResolutionPrompt } from '../prompts/TriggeredAbilityResolutionPrompt';
+import { BatchTriggerResolutionPrompt } from '../prompts/BatchTriggerResolutionPrompt';
+import type { IResolutionChoice, ITriggerWindowSourceCard } from '../PromptInterfaces';
 
 export abstract class TriggerWindowBase extends BaseStep {
     /** Triggered effects / abilities that have not yet been resolved, organized by owning player */
@@ -28,6 +30,13 @@ export abstract class TriggerWindowBase extends BaseStep {
     protected triggeringEvents: GameEvent[] = [];
 
     protected choosePlayerResolutionOrderComplete = false;
+
+    /**
+     * Set while a player is resolving all remaining instances of a grouped trigger "all at once". Each
+     * matching instance is then resolved without re-prompting, so nested triggers from one instance still
+     * resolve before the next (SWU 7.6.11), and cleared once the group is exhausted.
+     */
+    private pendingBatchResolve?: { player: Player; groupKey: string } = null;
 
     protected readonly triggerAbilityType: AbilityType.Triggered | AbilityType.ReplacementEffect | AbilityType.DelayedEffect;
 
@@ -146,7 +155,7 @@ export abstract class TriggerWindowBase extends BaseStep {
         Contract.assertFalse(this.choosePlayerResolutionOrderComplete, `Attempting to add new triggered ${triggerTypeName} from source '${source.internalName}' to a window that has already started resolution`);
     }
 
-    private promptUnresolvedAbilities() {
+    protected promptUnresolvedAbilities() {
         Contract.assertNotNullLike(this.currentlyResolvingPlayer);
 
         this.choosePlayerResolutionOrderComplete = true;
@@ -204,14 +213,136 @@ export abstract class TriggerWindowBase extends BaseStep {
             }
         }
 
-        // if there's more than one ability still unresolved, prompt for next selection
-        if (abilitiesToResolve.length > 1) {
-            this.promptForNextAbilityToResolve();
+        // if the player chose to resolve a grouped trigger "all at once", keep resolving the next matching
+        // instance without re-prompting until the group is exhausted (nested triggers still interleave)
+        if (this.pendingBatchResolve?.player === this.currentlyResolvingPlayer) {
+            const nextInBatch = abilitiesToResolve.find((context) => this.getGroupKey(context) === this.pendingBatchResolve.groupKey);
+            if (nextInBatch) {
+                this.resolveAbility(nextInBatch);
+                return false;
+            }
+
+            // group exhausted; fall through to normal prompting for any remaining triggers
+            this.pendingBatchResolve = null;
+        }
+
+        const resolutionChoices = this.buildResolutionChoices(abilitiesToResolve);
+
+        // if there's more than one choice still unresolved, prompt for next selection
+        if (resolutionChoices.length > 1) {
+            this.promptForNextAbilityToResolve(resolutionChoices);
             return false;
         }
 
-        this.resolveAbility(abilitiesToResolve[0]);
+        resolutionChoices[0].handler();
         return false;
+    }
+
+    /**
+     * Builds the list of selectable resolution choices for the currently resolving player. Similar triggers
+     * (same base title and source card) are grouped into a single choice so the player isn't asked to order
+     * several identical triggers one at a time; selecting a group lets them resolve the next instance or all
+     * remaining instances at once. Each grouped instance still resolves as its own trigger.
+     */
+    protected buildResolutionChoices(abilitiesToResolve: TriggeredAbilityContext[]): IResolutionChoice[] {
+        const groupsByKey = new Map<string, TriggeredAbilityContext[]>();
+        const orderedKeys: string[] = [];
+
+        for (const context of abilitiesToResolve) {
+            const key = this.getGroupKey(context);
+            if (!groupsByKey.has(key)) {
+                groupsByKey.set(key, []);
+                orderedKeys.push(key);
+            }
+            groupsByKey.get(key).push(context);
+        }
+
+        return orderedKeys.map((key) => {
+            const members = groupsByKey.get(key);
+            return members.length === 1 ? this.buildContextChoice(members[0]) : this.buildGroupChoice(members);
+        });
+    }
+
+    /** Builds the resolution choice for a single triggered ability context. */
+    protected buildContextChoice(context: TriggeredAbilityContext): IResolutionChoice {
+        return {
+            getTitle: () => context.ability.getTitle(context),
+            getSourceCard: () => this.getSourceCardSummary(context.source),
+            hasLegalEffects: () => context.ability.hasAnyLegalEffects(context, SubStepCheck.All),
+            handler: () => this.resolveAbility(context),
+        };
+    }
+
+    /**
+     * Builds a single choice representing several similar triggers. Selecting it opens a modal to resolve
+     * the next instance or all remaining instances. The displayed title uses the ability's grouping title
+     * (see `getGroupingTitle`), so the per-instance override/context suffixes that distinguish individual
+     * triggers are intentionally ignored when they are collapsed into a group.
+     */
+    protected buildGroupChoice(members: TriggeredAbilityContext[]): IResolutionChoice {
+        const first = members[0];
+        return {
+            getTitle: () => this.getGroupingTitle(first),
+            getSourceCard: () => this.getSourceCardSummary(first.source),
+            hasLegalEffects: () => members.some((context) => context.ability.hasAnyLegalEffects(context, SubStepCheck.All)),
+            count: members.length,
+            handler: () => this.promptBatchResolution(members),
+        };
+    }
+
+    /**
+     * Groups similar triggers together. Keyed by the ability's grouping title and the source card's internal
+     * name, which incorporates subtitles so that distinct unique cards sharing a title aren't grouped, while
+     * identical token copies (e.g. Advantage) are.
+     */
+    protected getGroupKey(context: TriggeredAbilityContext): string {
+        const source = context.source;
+        const sourceKey = source?.isCard?.() ? source.internalName : 'no-source-card';
+        return `${this.getGroupingTitle(context)}::${sourceKey}`;
+    }
+
+    /**
+     * The title used to compare and display grouped triggers. It resolves the ability's title with no
+     * context, which yields the statically-authored title and skips both the per-instance override suffix
+     * (e.g. ": <card name>") and any dynamic `contextTitle`. Ignoring those keeps grouping side-effect-free
+     * and safe even when the source has left play (a `contextTitle` may read now-invalid in-play state), and
+     * matches the intent that per-instance differentiation shouldn't split otherwise-identical triggers.
+     */
+    protected getGroupingTitle(context: TriggeredAbilityContext): string {
+        return context.ability.getTitle();
+    }
+
+    private promptBatchResolution(members: TriggeredAbilityContext[]) {
+        const first = members[0];
+        const groupKey = this.getGroupKey(first);
+        const player = this.currentlyResolvingPlayer;
+
+        this.game.queueStep(new BatchTriggerResolutionPrompt(this.game, player, {
+            sourceCard: this.getSourceCardSummary(first.source),
+            title: this.getGroupingTitle(first),
+            remainingCount: members.length,
+            onResolveNext: () => {
+                const next = this.unresolved.get(player)?.find((context) => this.getGroupKey(context) === groupKey);
+                if (next) {
+                    this.resolveAbility(next);
+                }
+            },
+            onResolveAll: () => {
+                this.pendingBatchResolve = { player, groupKey };
+                this.promptUnresolvedAbilities();
+            },
+        }));
+    }
+
+    protected getSourceCardSummary(card: Card): ITriggerWindowSourceCard | undefined {
+        if (!card?.isCard?.()) {
+            return undefined;
+        }
+
+        return {
+            ...card.getShortSummary(),
+            type: card.type
+        };
     }
 
     /** Get the set of yet-unresolved abilities for the player whose turn it is to do resolution */
@@ -258,14 +389,11 @@ export abstract class TriggerWindowBase extends BaseStep {
         return repeatedAbilities;
     }
 
-    private promptForNextAbilityToResolve() {
-        const abilitiesToResolve = this.getCurrentlyResolvingAbilities();
-
+    private promptForNextAbilityToResolve(resolutionChoices: IResolutionChoice[]) {
         this.game.queueStep(new TriggeredAbilityResolutionPrompt(
             this.game,
             this.currentlyResolvingPlayer,
-            abilitiesToResolve,
-            (context) => this.resolveAbility(context)
+            resolutionChoices
         ));
     }
 

--- a/server/game/core/gameSteps/prompts/BatchTriggerResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/BatchTriggerResolutionPrompt.ts
@@ -45,7 +45,7 @@ export class BatchTriggerResolutionPrompt extends UiPrompt {
             menuTitle: `Resolve "${title}"`,
             buttons: [
                 { text: 'Resolve next', arg: 'next' },
-                { text: `Resolve all remaining (${remainingCount})`, arg: 'all' }
+                { text: `Resolve all (${remainingCount})`, arg: 'all' }
             ],
             promptTitle: this.source.name,
             promptUuid: this.uuid,

--- a/server/game/core/gameSteps/prompts/BatchTriggerResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/BatchTriggerResolutionPrompt.ts
@@ -1,0 +1,78 @@
+import type { Player } from '../../Player';
+import type { Game } from '../../Game';
+import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
+import { PromptType, type ITriggerWindowSourceCard } from '../PromptInterfaces';
+import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
+import { UiPrompt } from './UiPrompt';
+
+export interface IBatchTriggerResolutionPromptProperties {
+    sourceCard?: ITriggerWindowSourceCard;
+    title: string;
+    remainingCount: number;
+    onResolveNext: () => void;
+    onResolveAll: () => void;
+}
+
+/**
+ * Modal shown after a player selects a grouped trigger in the resolution-order prompt. It displays the
+ * trigger's card and lets the player choose to resolve just the next instance or all remaining instances
+ * of that trigger at once.
+ */
+export class BatchTriggerResolutionPrompt extends UiPrompt {
+    private readonly source = new OngoingEffectSource(this.game, 'Resolve Grouped Triggers');
+    private readonly player: Player;
+    private readonly properties: IBatchTriggerResolutionPromptProperties;
+
+    public constructor(
+        game: Game,
+        player: Player,
+        properties: IBatchTriggerResolutionPromptProperties
+    ) {
+        super(game);
+
+        this.player = player;
+        this.properties = properties;
+    }
+
+    public override activeCondition(player: Player): boolean {
+        return player === this.player;
+    }
+
+    public override activePromptInternal(): IPlayerPromptStateProperties {
+        const { title, remainingCount, sourceCard } = this.properties;
+
+        return {
+            menuTitle: `Resolve "${title}"`,
+            buttons: [
+                { text: 'Resolve next', arg: 'next' },
+                { text: `Resolve all remaining (${remainingCount})`, arg: 'all' }
+            ],
+            promptTitle: this.source.name,
+            promptUuid: this.uuid,
+            promptType: PromptType.BatchTriggerResolution,
+            batchTriggerResolution: { sourceCard, title, remainingCount }
+        };
+    }
+
+    public override waitingPrompt(): IPlayerPromptStateProperties {
+        return {
+            menuTitle: 'Waiting for opponent',
+            promptUuid: this.uuid
+        };
+    }
+
+    public override menuCommand(_player: Player, arg: string): boolean {
+        switch (arg) {
+            case 'next':
+                this.properties.onResolveNext();
+                this.complete();
+                return true;
+            case 'all':
+                this.properties.onResolveAll();
+                this.complete();
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
+++ b/server/game/core/gameSteps/prompts/TriggeredAbilityResolutionPrompt.ts
@@ -1,44 +1,35 @@
 import type { Player } from '../../Player';
 import type { Game } from '../../Game';
-import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import { OngoingEffectSource } from '../../ongoingEffect/OngoingEffectSource';
-import { PromptType, type ITriggerWindowButton, type ITriggerWindowSourceCard } from '../PromptInterfaces';
+import { PromptType, type IResolutionChoice, type ITriggerWindowButton } from '../PromptInterfaces';
 import type { IPlayerPromptStateProperties } from '../../PlayerPromptState';
 import { UiPrompt } from './UiPrompt';
-import { SubStepCheck } from '../../Constants';
 
 export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     private readonly source = new OngoingEffectSource(this.game, 'Choose Triggered Ability Resolution Order');
     private readonly player: Player;
-    private readonly triggeredAbilities: TriggeredAbilityContext[];
-    private readonly resolveAbility: (context: TriggeredAbilityContext) => void;
+    private readonly choices: IResolutionChoice[];
 
     public constructor(
         game: Game,
         player: Player,
-        triggeredAbilities: TriggeredAbilityContext[],
-        resolveAbility: (context: TriggeredAbilityContext) => void
+        choices: IResolutionChoice[]
     ) {
         super(game);
 
         this.player = player;
-        this.resolveAbility = resolveAbility;
 
-        const sortedAbilities = triggeredAbilities
-            .map((context) => {
-                const hasLegalEffects = context.ability.hasAnyLegalEffects(context, SubStepCheck.All);
-                return { context, hasLegalEffects };
-            })
-            .sort((a, b) => {
-                if (a.hasLegalEffects && !b.hasLegalEffects) {
-                    return -1;
-                } else if (!a.hasLegalEffects && b.hasLegalEffects) {
-                    return 1;
-                }
-                return 0;
-            });
-
-        this.triggeredAbilities = sortedAbilities.map((item) => item.context);
+        // sort so that choices that can actually do something are presented first
+        this.choices = [...choices].sort((a, b) => {
+            const aHasLegalEffects = a.hasLegalEffects();
+            const bHasLegalEffects = b.hasLegalEffects();
+            if (aHasLegalEffects && !bHasLegalEffects) {
+                return -1;
+            } else if (!aHasLegalEffects && bHasLegalEffects) {
+                return 1;
+            }
+            return 0;
+        });
     }
 
     public override activeCondition(player: Player): boolean {
@@ -46,8 +37,7 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
     }
 
     public override activePromptInternal(): IPlayerPromptStateProperties {
-        const buttons = this.triggeredAbilities
-            .map((context, index) => this.makeChoiceButton(context, index));
+        const buttons = this.choices.map((choice, index) => this.makeChoiceButton(choice, index));
 
         return {
             menuTitle: 'You have multiple triggers to resolve. Choose which to resolve first:',
@@ -58,29 +48,19 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
         };
     }
 
-    private getSourceCard(context: TriggeredAbilityContext): ITriggerWindowSourceCard | undefined {
-        if (!context.source?.isCard?.()) {
-            return undefined;
-        }
-
-        return {
-            ...context.source.getShortSummary(),
-            type: context.source.type
-        };
-    }
-
-    private makeChoiceButton(context: TriggeredAbilityContext, num: number): ITriggerWindowButton {
-        const hasLegalEffects = context.ability.hasAnyLegalEffects(context, SubStepCheck.All);
+    private makeChoiceButton(choice: IResolutionChoice, num: number): ITriggerWindowButton {
+        const hasLegalEffects = choice.hasLegalEffects();
 
         // Keep the "(No effect)" prefix for tests so it's easy to tell which abilities have no effect
         const noEffectPrefix = process.env.NODE_ENV === 'test' && !hasLegalEffects ? '(No effect) ' : '';
-        const title = `${noEffectPrefix}${context.ability.getTitle(context)}`;
+        const title = `${noEffectPrefix}${choice.getTitle()}`;
 
         return {
             text: title,
             arg: num.toString(),
-            sourceCard: this.getSourceCard(context),
-            hasLegalEffects
+            sourceCard: choice.getSourceCard(),
+            hasLegalEffects,
+            count: choice.count
         };
     }
 
@@ -98,13 +78,13 @@ export class TriggeredAbilityResolutionPrompt extends UiPrompt {
         }
 
         const selectedIndex = Number(arg);
-        const triggeredAbility = this.triggeredAbilities[selectedIndex];
+        const choice = this.choices[selectedIndex];
 
-        if (!triggeredAbility) {
+        if (!choice) {
             return false;
         }
 
-        this.resolveAbility(triggeredAbility);
+        choice.handler();
         this.complete();
         return true;
     }

--- a/test/scenarios/timingWindows/DefeatTiming.spec.ts
+++ b/test/scenarios/timingWindows/DefeatTiming.spec.ts
@@ -149,8 +149,8 @@ describe('Defeat timing', function() {
                 // selecting the grouped entry opens the resolution modal
                 context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
                 expect(context.player1).toHavePrompt('Resolve "When an opponent\'s unit is defeated, heal 1 from base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
-                context.player1.clickPrompt('Resolve all remaining (3)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
+                context.player1.clickPrompt('Resolve all (3)');
                 // after the grouped heals resolve, the two draw triggers remain
                 context.player1.clickPrompt('Draw a card');
                 // may ability prompts the player whether or not to actually use it before it fully resolves

--- a/test/scenarios/timingWindows/DefeatTiming.spec.ts
+++ b/test/scenarios/timingWindows/DefeatTiming.spec.ts
@@ -140,21 +140,22 @@ describe('Defeat timing', function() {
                 expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
                 context.player1.clickPrompt('You');
                 expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                // the three identical Iden Versio heal triggers are grouped into a single entry
                 expect(context.player1).toHaveExactPromptButtons([
                     'Draw a card',
                     'Draw a card',
-                    'When an opponent\'s unit is defeated, heal 1 from base: Luke Skywalker',
-                    'When an opponent\'s unit is defeated, heal 1 from base: Superlaser Technician',
-                    'When an opponent\'s unit is defeated, heal 1 from base: Yoda'
+                    'When an opponent\'s unit is defeated, heal 1 from base'
                 ]);
-                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base: Luke Skywalker');
-                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base: Superlaser Technician');
+                // selecting the grouped entry opens the resolution modal
+                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base');
+                expect(context.player1).toHavePrompt('Resolve "When an opponent\'s unit is defeated, heal 1 from base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                context.player1.clickPrompt('Resolve all remaining (3)');
+                // after the grouped heals resolve, the two draw triggers remain
                 context.player1.clickPrompt('Draw a card');
                 // may ability prompts the player whether or not to actually use it before it fully resolves
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
                 context.player1.clickPrompt('Trigger');
-                expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'When an opponent\'s unit is defeated, heal 1 from base: Yoda']);
-                context.player1.clickPrompt('When an opponent\'s unit is defeated, heal 1 from base: Yoda');
                 // last trigger is chosen automatically
                 expect(context.player1).toHavePassAbilityPrompt('Draw a card');
                 context.player1.clickPrompt('Pass');

--- a/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
@@ -95,26 +95,23 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                     [context.volunteerSoldier, 1]
                 ]));
 
-                // Choose resolution order
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine',
-                    'Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant',
-                    'Exhaust leader and exhaust the damaged enemy unit: Volunteer Soldier'
-                ]);
+                // The three triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust leader and exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                context.player1.clickPrompt('Resolve all remaining (3)');
 
-                // Pass for Volunteer Soldier
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Volunteer Soldier');
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Volunteer Soldier');
+                // Pass on the first instance; passing does not exhaust the leader
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Pass');
                 expect(context.jangoFett.exhausted).toBeFalse();
 
-                // Resolve for Fleet Lieutenant
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
+                // Trigger the second instance; the leader exhausts and the remaining trigger can no longer be paid
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
-                expect(context.fleetLieutenant.exhausted).toBeTrue();
                 expect(context.jangoFett.exhausted).toBeTrue();
+
+                // The leader can only exhaust once, so exactly one enemy unit was exhausted
+                expect([context.battlefieldMarine, context.fleetLieutenant, context.volunteerSoldier].filter((c) => c.exhausted).length).toBe(1);
 
                 // CASE 5: Trigger Jango's ability from an upgrade's granted ability
 
@@ -130,17 +127,21 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                     [context.fleetLieutenant, 1],
                 ]));
 
-                // Choose resolution order
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
+                // The two on-attack triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust leader and exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
-                // Pass for Fleet Lieutenant
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant');
+                // Pass on the first instance
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Pass');
 
-                // Resolve for Battlefield Marine
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
+                // Trigger the second instance; the leader exhausts
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
-                expect(context.battlefieldMarine.exhausted).toBeTrue();
+
+                // The leader can only exhaust once, so exactly one enemy unit was exhausted
+                expect([context.battlefieldMarine, context.fleetLieutenant].filter((c) => c.exhausted).length).toBe(1);
 
                 // CASE 6: Trigger Jango's ability when a unit is defeated at the end of the phase
 
@@ -292,7 +293,10 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 expect(context.grogu.damage).toBe(1);
             });
 
-            it('should display prompt correctly for exhausting multiple enemy units and only select one', async function() {
+            // Note: the per-target triggers are now grouped into one modal, so the player no longer picks
+            // which enemy to exhaust. Since the leader can only exhaust once, exactly one (engine-ordered)
+            // enemy unit ends up exhausted.
+            it('should group the per-target triggers and exhaust only one enemy unit since the leader exhausts once', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -316,21 +320,17 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                     [context.volunteerSoldier, 1]
                 ]));
 
-                // Choose resolution order
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine',
-                    'Exhaust leader and exhaust the damaged enemy unit: Fleet Lieutenant',
-                    'Exhaust leader and exhaust the damaged enemy unit: Volunteer Soldier'
-                ]);
+                // The three triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust leader and exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
 
-                context.player1.clickPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
-
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust leader and exhaust the damaged enemy unit: Battlefield Marine');
+                // Resolve a single instance; the leader exhausts and only one enemy unit can be exhausted
+                context.player1.clickPrompt('Resolve next');
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
 
-                expect(context.battlefieldMarine.exhausted).toBeTrue();
                 expect(context.jangoFett.exhausted).toBeTrue();
+                expect([context.battlefieldMarine, context.fleetLieutenant, context.volunteerSoldier].filter((c) => c.exhausted).length).toBe(1);
             });
         });
 
@@ -431,38 +431,21 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                     [context.volunteerSoldier, 1]
                 ]));
 
-                // Choose resolution order
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Volunteer Soldier',
-                    'Exhaust the damaged enemy unit: Fleet Lieutenant',
-                    'Exhaust the damaged enemy unit: Battlefield Marine'
-                ]);
+                // The three triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                context.player1.clickPrompt('Resolve all remaining (3)');
 
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
-
-                // Exhaust Volunteer Soldier
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
+                // Resolve each grouped instance (the deployed side does not exhaust the leader, so all resolve)
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+
                 expect(context.volunteerSoldier.exhausted).toBeTrue();
-
-                // Choose resolution order again
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Fleet Lieutenant',
-                    'Exhaust the damaged enemy unit: Battlefield Marine'
-                ]);
-
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
-
-                // Exhaust Fleet Lieutenant
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
-                context.player1.clickPrompt('Trigger');
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
-
-                // Exhaust Battlefield Marine
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
 
                 // CASE 5: Trigger Jango's ability from an upgrade's granted ability
@@ -478,18 +461,18 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                     [context.fleetLieutenant, 1],
                 ]));
 
-                // Choose resolution order
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
+                // The two on-attack (Vambrace) triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
-                // Exhaust Fleet Lieutenant
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
+                // Resolve both grouped instances (Fleet Lieutenant and Battlefield Marine)
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
 
-                // Exhaust for Battlefield Marine
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Trigger');
-
-                // Exhaust Volunteer Soldier
+                // Combat damage to the defending Volunteer Soldier triggers Jango separately (single, ungrouped)
                 expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit');
                 context.player1.clickPrompt('Trigger');
 
@@ -531,38 +514,21 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                     [context.p2Base, 1],
                 ]));
 
-                // Choose resolution order
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Fleet Lieutenant',
-                    'Exhaust the damaged enemy unit: Battlefield Marine',
-                    'Exhaust the damaged enemy unit: Volunteer Soldier',
-                ]);
+                // The three triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                context.player1.clickPrompt('Resolve all remaining (3)');
 
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
-
-                // Exhaust Volunteer Soldier
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Volunteer Soldier');
+                // Resolve each grouped instance (the deployed side does not exhaust the leader, so all resolve)
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+
                 expect(context.volunteerSoldier.exhausted).toBeTrue();
-
-                // Choose resolution order again
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Fleet Lieutenant',
-                    'Exhaust the damaged enemy unit: Battlefield Marine',
-                ]);
-
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-
-                // Exhaust Battlefield Marine
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Battlefield Marine');
-                context.player1.clickPrompt('Trigger');
                 expect(context.battlefieldMarine.exhausted).toBeTrue();
-
-                // Exhaust Fleet Lieutenant
-                expect(context.player1).toHavePassAbilityPrompt('Exhaust the damaged enemy unit: Fleet Lieutenant');
-                context.player1.clickPrompt('Trigger');
                 expect(context.fleetLieutenant.exhausted).toBeTrue();
             });
         });
@@ -643,7 +609,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
         });
 
         describe('Jango Fett\'s deployed leader ability', function() {
-            it('should trigger correctly on multiple targets based on the selected target from the trigger window', async function() {
+            it('should trigger for each enemy unit damaged simultaneously by a friendly unit', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -672,35 +638,24 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
                 context.player1.clickCard(context.admiralPiett);
                 context.player1.clickDone();
 
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Pantoran Starship Thief',
-                    'Exhaust the damaged enemy unit: Admiral Piett',
-                    'Exhaust the damaged enemy unit: Captain Tarkin',
-                    'Exhaust the damaged enemy unit: Quasar TIE Carrier'
-                ]);
+                // All four triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (4)']);
+                context.player1.clickPrompt('Resolve all remaining (4)');
 
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Captain Tarkin');
+                // Resolve each grouped instance (the deployed side does not exhaust the leader, so all resolve)
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickPrompt('Trigger');
+
                 expect(context.captainTarkin.exhausted).toBeTrue();
-
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Pantoran Starship Thief',
-                    'Exhaust the damaged enemy unit: Admiral Piett',
-                    'Exhaust the damaged enemy unit: Quasar TIE Carrier'
-                ]);
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Pantoran Starship Thief');
-                context.player1.clickPrompt('Trigger');
                 expect(context.pantoranStarshipThief.exhausted).toBeTrue();
-
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Exhaust the damaged enemy unit: Admiral Piett',
-                    'Exhaust the damaged enemy unit: Quasar TIE Carrier'
-                ]);
-                context.player1.clickPrompt('Exhaust the damaged enemy unit: Quasar TIE Carrier');
-                context.player1.clickPrompt('Trigger');
                 expect(context.quasarTieCarrier.exhausted).toBeTrue();
-
-                context.player1.clickPrompt('Trigger');
                 expect(context.admiralPiett.exhausted).toBeTrue();
             });
         });

--- a/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
+++ b/test/server/cards/03_TWI/leaders/JangoFettConcealingTheConspiracy.spec.ts
@@ -97,8 +97,8 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // The three triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust leader and exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
-                context.player1.clickPrompt('Resolve all remaining (3)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
+                context.player1.clickPrompt('Resolve all (3)');
 
                 // Pass on the first instance; passing does not exhaust the leader
                 expect(context.player1).toHavePassAbilityButton();
@@ -129,8 +129,8 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // The two on-attack triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust leader and exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Pass on the first instance
                 expect(context.player1).toHavePassAbilityButton();
@@ -322,7 +322,7 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // The three triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust leader and exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
 
                 // Resolve a single instance; the leader exhausts and only one enemy unit can be exhausted
                 context.player1.clickPrompt('Resolve next');
@@ -433,8 +433,8 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // The three triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
-                context.player1.clickPrompt('Resolve all remaining (3)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
+                context.player1.clickPrompt('Resolve all (3)');
 
                 // Resolve each grouped instance (the deployed side does not exhaust the leader, so all resolve)
                 expect(context.player1).toHavePassAbilityButton();
@@ -463,8 +463,8 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // The two on-attack (Vambrace) triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Resolve both grouped instances (Fleet Lieutenant and Battlefield Marine)
                 expect(context.player1).toHavePassAbilityButton();
@@ -516,8 +516,8 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // The three triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
-                context.player1.clickPrompt('Resolve all remaining (3)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
+                context.player1.clickPrompt('Resolve all (3)');
 
                 // Resolve each grouped instance (the deployed side does not exhaust the leader, so all resolve)
                 expect(context.player1).toHavePassAbilityButton();
@@ -640,8 +640,8 @@ describe('Jango Fett, Concealing the Conspiracy', function () {
 
                 // All four triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Exhaust the damaged enemy unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (4)']);
-                context.player1.clickPrompt('Resolve all remaining (4)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (4)']);
+                context.player1.clickPrompt('Resolve all (4)');
 
                 // Resolve each grouped instance (the deployed side does not exhaust the leader, so all resolve)
                 expect(context.player1).toHavePassAbilityButton();

--- a/test/server/cards/03_TWI/units/DarthMaulRevengeAtLast.spec.ts
+++ b/test/server/cards/03_TWI/units/DarthMaulRevengeAtLast.spec.ts
@@ -438,8 +438,8 @@ describe('Darth Maul, Revenge At Last', function() {
 
             // Both Shield triggers are grouped (same token upgrade), opening a resolution modal directly
             expect(context.player2).toHavePrompt('Resolve "Defeat Shield to prevent attached unit from taking damage"');
-            expect(context.player2).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-            context.player2.clickPrompt('Resolve all remaining (2)');
+            expect(context.player2).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+            context.player2.clickPrompt('Resolve all (2)');
 
             expect(context.darthMaul.damage).toBe(4);
             expect(context.moistureFarmer.damage).toBe(0);
@@ -492,8 +492,8 @@ describe('Darth Maul, Revenge At Last', function() {
             expect(context.darthMaul.damage).toBe(0);
             // The two Ruthlessness triggers are grouped, opening a resolution modal directly
             expect(context.player1).toHavePrompt('Resolve "Deal 2 damage to the defending player’s base"');
-            expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-            context.player1.clickPrompt('Resolve all remaining (2)');
+            expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+            context.player1.clickPrompt('Resolve all (2)');
             expect(context.p2Base.damage).toBe(4);
         });
 

--- a/test/server/cards/03_TWI/units/DarthMaulRevengeAtLast.spec.ts
+++ b/test/server/cards/03_TWI/units/DarthMaulRevengeAtLast.spec.ts
@@ -436,7 +436,10 @@ describe('Darth Maul, Revenge At Last', function() {
             context.player1.clickCard(context.moistureFarmer);
             context.player1.clickDone();
 
-            context.player2.clickPrompt('Defeat Shield to prevent Wampa from taking damage');
+            // Both Shield triggers are grouped (same token upgrade), opening a resolution modal directly
+            expect(context.player2).toHavePrompt('Resolve "Defeat Shield to prevent attached unit from taking damage"');
+            expect(context.player2).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+            context.player2.clickPrompt('Resolve all remaining (2)');
 
             expect(context.darthMaul.damage).toBe(4);
             expect(context.moistureFarmer.damage).toBe(0);
@@ -487,8 +490,10 @@ describe('Darth Maul, Revenge At Last', function() {
             context.player1.clickDone();
 
             expect(context.darthMaul.damage).toBe(0);
-            expect(context.player1).toHaveEnabledPromptButtons(['Deal 2 damage to the defending player’s base: Cantina Braggart', 'Deal 2 damage to the defending player’s base: Moisture Farmer']);
-            context.player1.clickPrompt('Deal 2 damage to the defending player’s base: Cantina Braggart');
+            // The two Ruthlessness triggers are grouped, opening a resolution modal directly
+            expect(context.player1).toHavePrompt('Resolve "Deal 2 damage to the defending player’s base"');
+            expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+            context.player1.clickPrompt('Resolve all remaining (2)');
             expect(context.p2Base.damage).toBe(4);
         });
 

--- a/test/server/cards/04_JTL/units/AdmiralYularenFleetCoordinator.spec.ts
+++ b/test/server/cards/04_JTL/units/AdmiralYularenFleetCoordinator.spec.ts
@@ -119,7 +119,7 @@ describe('Admiral Yularen, Fleet Coordinator', function() {
                 context.player2.passAction();
 
                 context.player1.clickCard(context.dedicatedWingmen);
-                context.player1.clickPrompt('Shielded'); // There are two simultaneous Shielded triggers here
+                context.player1.clickPrompt('Resolve all remaining (2)'); // Two simultaneous Shielded triggers, grouped into one modal
 
                 const xwings = context.player1.findCardsByName('xwing');
                 expect(xwings.length).toBe(2);

--- a/test/server/cards/04_JTL/units/AdmiralYularenFleetCoordinator.spec.ts
+++ b/test/server/cards/04_JTL/units/AdmiralYularenFleetCoordinator.spec.ts
@@ -119,7 +119,7 @@ describe('Admiral Yularen, Fleet Coordinator', function() {
                 context.player2.passAction();
 
                 context.player1.clickCard(context.dedicatedWingmen);
-                context.player1.clickPrompt('Resolve all remaining (2)'); // Two simultaneous Shielded triggers, grouped into one modal
+                context.player1.clickPrompt('Resolve all (2)'); // Two simultaneous Shielded triggers, grouped into one modal
 
                 const xwings = context.player1.findCardsByName('xwing');
                 expect(xwings.length).toBe(2);

--- a/test/server/cards/04_JTL/units/AllegiantGeneralPrydeRuthlessAndLoyal.spec.ts
+++ b/test/server/cards/04_JTL/units/AllegiantGeneralPrydeRuthlessAndLoyal.spec.ts
@@ -61,9 +61,9 @@ describe('Allegiant General Pryde, Ruthless and Loyal', function () {
                 // modal appears directly. Resolving all instances runs each per-instance prompt
                 // in sequence (only the Battlefield Marine instance has an eligible upgrade).
                 expect(context.player1).toHavePrompt('Resolve "Defeat a non-unique upgrade on the unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.devotion, context.shield]);
                 expect(context.player1).toHavePassAbilityButton();

--- a/test/server/cards/04_JTL/units/AllegiantGeneralPrydeRuthlessAndLoyal.spec.ts
+++ b/test/server/cards/04_JTL/units/AllegiantGeneralPrydeRuthlessAndLoyal.spec.ts
@@ -56,12 +56,14 @@ describe('Allegiant General Pryde, Ruthless and Loyal', function () {
                     [context.battlefieldMarine, 1],
                 ]));
 
-                expect(context.player1).toHaveEnabledPromptButtons([
-                    'Defeat a non-unique upgrade on the unit: Battlefield Marine',
-                    '(No effect) Defeat a non-unique upgrade on the unit: Crafty Smuggler'
-                ]);
+                // Both units dealt indirect damage trigger Pryde's ability; they share a static
+                // title and source, so they collapse into one grouped entry and the resolution
+                // modal appears directly. Resolving all instances runs each per-instance prompt
+                // in sequence (only the Battlefield Marine instance has an eligible upgrade).
+                expect(context.player1).toHavePrompt('Resolve "Defeat a non-unique upgrade on the unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                context.player1.clickPrompt('Defeat a non-unique upgrade on the unit: Battlefield Marine');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.devotion, context.shield]);
                 expect(context.player1).toHavePassAbilityButton();

--- a/test/server/cards/05_LOF/leaders/DarthRevanScourgeOfTheOldRepublic.spec.ts
+++ b/test/server/cards/05_LOF/leaders/DarthRevanScourgeOfTheOldRepublic.spec.ts
@@ -629,8 +629,8 @@ describe('Darth Revan, Scourge of the Old Republic', function () {
 
                 // The two identical Experience triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Give an Experience token to the attacking unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Resolve the first instance
                 expect(context.player1).toHavePassAbilityButton();

--- a/test/server/cards/05_LOF/leaders/DarthRevanScourgeOfTheOldRepublic.spec.ts
+++ b/test/server/cards/05_LOF/leaders/DarthRevanScourgeOfTheOldRepublic.spec.ts
@@ -627,20 +627,18 @@ describe('Darth Revan, Scourge of the Old Republic', function () {
                 context.player1.clickCard(context.battlefieldMarine);
                 context.player1.clickDone();
 
-                // Choose resolution order
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                // TODO: these names are unintuitive, since it names the attack target and not Maul. Need to find a way to improve this
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Give an Experience token to the attacking unit: Warzone Lieutenant',
-                    'Give an Experience token to the attacking unit: Battlefield Marine'
-                ]);
-                context.player1.clickPrompt('Give an Experience token to the attacking unit: Warzone Lieutenant');
+                // The two identical Experience triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Give an Experience token to the attacking unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
-                expect(context.player1).toHavePassAbilityPrompt('Give an Experience token to the attacking unit: Warzone Lieutenant');
+                // Resolve the first instance
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
                 expect(context.darthMaul).toHaveExactUpgradeNames(['experience']);
 
-                expect(context.player1).toHavePassAbilityPrompt('Give an Experience token to the attacking unit: Battlefield Marine');
+                // Resolve the second instance
+                expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
                 expect(context.darthMaul).toHaveExactUpgradeNames(['experience', 'experience']);
             });

--- a/test/server/cards/05_LOF/units/HK47ExclamationDieMeatbag.spec.ts
+++ b/test/server/cards/05_LOF/units/HK47ExclamationDieMeatbag.spec.ts
@@ -105,7 +105,7 @@ describe('HK-47, Exclamation: Die Meatbag', function() {
                 context.player1.clickCard(context.superlaserBlast);
 
                 // All four defeats trigger the same ability and are grouped — resolve them via the modal
-                context.player1.clickPrompt('Resolve all remaining (4)');
+                context.player1.clickPrompt('Resolve all (4)');
 
                 // Check that all 4 units were defeated and the opponent's base took 4 damage
                 expect(context.player2.discard.length).toBe(4);

--- a/test/server/cards/05_LOF/units/HK47ExclamationDieMeatbag.spec.ts
+++ b/test/server/cards/05_LOF/units/HK47ExclamationDieMeatbag.spec.ts
@@ -1,5 +1,4 @@
 describe('HK-47, Exclamation: Die Meatbag', function() {
-    const prompt = 'Deal 1 damage to its controller\'s base: ';
     integration(function(contextRef) {
         describe('HK-47\'s triggered ability', function() {
             beforeEach(function () {
@@ -105,10 +104,8 @@ describe('HK-47, Exclamation: Die Meatbag', function() {
                 // Defeat multiple enemy units
                 context.player1.clickCard(context.superlaserBlast);
 
-                // Choose resolution order
-                context.player1.clickPrompt(prompt + context.contractedHunter.name);
-                context.player1.clickPrompt(prompt + context.freelanceAssassin.name);
-                context.player1.clickPrompt(prompt + context.deathStarStormtrooper.name);
+                // All four defeats trigger the same ability and are grouped — resolve them via the modal
+                context.player1.clickPrompt('Resolve all remaining (4)');
 
                 // Check that all 4 units were defeated and the opponent's base took 4 damage
                 expect(context.player2.discard.length).toBe(4);

--- a/test/server/cards/05_LOF/units/MalakiliLovingRancorKeeper.spec.ts
+++ b/test/server/cards/05_LOF/units/MalakiliLovingRancorKeeper.spec.ts
@@ -61,15 +61,13 @@ describe('Malakili, Loving Rancor Keeper', function () {
 
             context.player1.clickCard(context.wildRancor);
 
-            const promptTable = [
-                'If a friendly Creature unit would deal damage to a friendly unit, prevent that damage: Malakili',
-                'If a friendly Creature unit would deal damage to a friendly unit, prevent that damage: Wampa',
-                'If a friendly Creature unit would deal damage to a friendly unit, prevent that damage: Battlefield Marine'
-            ];
-
-            expect(context.player1).toHaveExactPromptButtons(promptTable);
-            context.player1.clickPrompt(promptTable[0]);
-            context.player1.clickPrompt(promptTable[1]);
+            // The three simultaneous prevent-damage replacement effects (one per friendly unit)
+            // are grouped into a single entry. Since they are the only triggers, the resolution
+            // modal appears directly. Resolving all of them prevents damage to every friendly unit.
+            const groupedTitle = 'If a friendly Creature unit would deal damage to a friendly unit, prevent that damage';
+            expect(context.player1).toHavePrompt(`Resolve "${groupedTitle}"`);
+            expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+            context.player1.clickPrompt('Resolve all remaining (3)');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.atst.damage).toBe(2);

--- a/test/server/cards/05_LOF/units/MalakiliLovingRancorKeeper.spec.ts
+++ b/test/server/cards/05_LOF/units/MalakiliLovingRancorKeeper.spec.ts
@@ -66,8 +66,8 @@ describe('Malakili, Loving Rancor Keeper', function () {
             // modal appears directly. Resolving all of them prevents damage to every friendly unit.
             const groupedTitle = 'If a friendly Creature unit would deal damage to a friendly unit, prevent that damage';
             expect(context.player1).toHavePrompt(`Resolve "${groupedTitle}"`);
-            expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
-            context.player1.clickPrompt('Resolve all remaining (3)');
+            expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
+            context.player1.clickPrompt('Resolve all (3)');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.atst.damage).toBe(2);

--- a/test/server/cards/05_LOF/units/ReyWithPalpatinesPower.spec.ts
+++ b/test/server/cards/05_LOF/units/ReyWithPalpatinesPower.spec.ts
@@ -273,13 +273,12 @@ describe('Rey, With Palpatine\'s Power', function() {
                 context.player1.clickCard(context.missionBriefing);
                 context.player1.clickPrompt('You');
 
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Reveal Rey to deal 2 damage to a unit and 2 damage to a base',
-                    'Reveal Rey to deal 2 damage to a unit and 2 damage to a base'
-                ]);
+                // the two identical Rey triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Reveal Rey to deal 2 damage to a unit and 2 damage to a base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 // Activate the first Rey's trigger
-                context.player1.clickPrompt('Reveal Rey to deal 2 damage to a unit and 2 damage to a base');
                 expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Trigger');
 
@@ -336,13 +335,12 @@ describe('Rey, With Palpatine\'s Power', function() {
                 context.player1.clickCard(context.missionBriefing);
                 context.player1.clickPrompt('You');
 
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Reveal Rey to deal 2 damage to a unit and 2 damage to a base',
-                    'Reveal Rey to deal 2 damage to a unit and 2 damage to a base'
-                ]);
+                // the two identical Rey triggers are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Reveal Rey to deal 2 damage to a unit and 2 damage to a base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
-                // Activate the first Rey's trigger
-                context.player1.clickPrompt('Reveal Rey to deal 2 damage to a unit and 2 damage to a base');
+                // Pass on the first Rey's trigger
                 expect(context.player1).toHavePassAbilityButton();
                 context.player1.clickPrompt('Pass');
 

--- a/test/server/cards/05_LOF/units/ReyWithPalpatinesPower.spec.ts
+++ b/test/server/cards/05_LOF/units/ReyWithPalpatinesPower.spec.ts
@@ -275,8 +275,8 @@ describe('Rey, With Palpatine\'s Power', function() {
 
                 // the two identical Rey triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Reveal Rey to deal 2 damage to a unit and 2 damage to a base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Activate the first Rey's trigger
                 expect(context.player1).toHavePassAbilityButton();
@@ -337,8 +337,8 @@ describe('Rey, With Palpatine\'s Power', function() {
 
                 // the two identical Rey triggers are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Reveal Rey to deal 2 damage to a unit and 2 damage to a base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Pass on the first Rey's trigger
                 expect(context.player1).toHavePassAbilityButton();

--- a/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
+++ b/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
@@ -101,15 +101,12 @@ describe('Chairman Papanoida, Undaunted Diplomat', function () {
                 expect(context.player1).toHavePassAbilityPrompt('Both players draw a card');
                 context.player1.clickPrompt('Trigger');
 
-                // One trigger per player, choose which one to resolve first
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    disclosePrompt,
-                    disclosePrompt
-                ]);
+                // The two identical draw triggers (one per player's draw) are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt(`Resolve "${disclosePrompt}"`);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                // Resolve one of the triggers first
-                context.player1.clickPrompt(disclosePrompt);
+                // Resolve both grouped triggers, each running its own per-instance disclose prompt
+                context.player1.clickPrompt('Resolve all remaining (2)');
                 expect(context.player1).toHavePrompt(disclosePrompt);
                 expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
                 expect(context.player1).toBeAbleToSelectExactly([

--- a/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
+++ b/test/server/cards/06_SEC/units/ChairmanPapanoidaUndauntedDiplomat.spec.ts
@@ -103,10 +103,10 @@ describe('Chairman Papanoida, Undaunted Diplomat', function () {
 
                 // The two identical draw triggers (one per player's draw) are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt(`Resolve "${disclosePrompt}"`);
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
                 // Resolve both grouped triggers, each running its own per-instance disclose prompt
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
                 expect(context.player1).toHavePrompt(disclosePrompt);
                 expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
                 expect(context.player1).toBeAbleToSelectExactly([

--- a/test/server/cards/07_LAW/units/DengarTakeYourShot.spec.ts
+++ b/test/server/cards/07_LAW/units/DengarTakeYourShot.spec.ts
@@ -263,9 +263,9 @@ describe('Dengar, Take Your Shot', function () {
                 // resolution modal appears directly. Resolving all of them still only creates one
                 // Credit token since the ability is limited to once per round.
                 expect(context.player1).toHavePrompt('Resolve "Create a Credit token"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
                 expect(context.player1.credits).toBe(1);
 
                 // The second instance has no effect since the limit is once per round

--- a/test/server/cards/07_LAW/units/DengarTakeYourShot.spec.ts
+++ b/test/server/cards/07_LAW/units/DengarTakeYourShot.spec.ts
@@ -258,18 +258,17 @@ describe('Dengar, Take Your Shot', function () {
                 expect(context.chandrilanSponsor).toBeInZone('discard');
                 expect(context.battlefieldMarine).toBeInZone('discard');
 
-                // Ability triggers twice since they're both the highest cost
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Create a Credit token: Battlefield Marine',
-                    'Create a Credit token: Chandrilan Sponsor'
-                ]);
+                // Ability triggers twice since both are the highest cost. The two triggers share
+                // a static title and source, so they collapse into one grouped entry and the
+                // resolution modal appears directly. Resolving all of them still only creates one
+                // Credit token since the ability is limited to once per round.
+                expect(context.player1).toHavePrompt('Resolve "Create a Credit token"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                // Arbitrarily pick the first one to resolve
-                context.player1.clickPrompt('Create a Credit token: Battlefield Marine');
+                context.player1.clickPrompt('Resolve all remaining (2)');
                 expect(context.player1.credits).toBe(1);
 
-                // No further action to resolve for the second trigger since the limit is once per round
+                // The second instance has no effect since the limit is once per round
                 expect(context.player2).toBeActivePlayer();
             });
 

--- a/test/server/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.spec.ts
+++ b/test/server/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.spec.ts
@@ -80,7 +80,7 @@ describe('Darth Sidious, Under a Cloak of Darkness', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.superlaserBlast);
-            context.player1.clickPrompt('Resolve all remaining (4)');
+            context.player1.clickPrompt('Resolve all (4)');
             expect(context.player2).toBeActivePlayer();
 
             const battleDroids = context.player1.findCardsByName('battle-droid');

--- a/test/server/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.spec.ts
+++ b/test/server/cards/07_TS26/units/DarthSidiousUnderACloakOfDarkness.spec.ts
@@ -80,9 +80,7 @@ describe('Darth Sidious, Under a Cloak of Darkness', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.superlaserBlast);
-            context.player1.clickPrompt('Create a Battle Droid token: Darth Sidious');
-            context.player1.clickPrompt('Create a Battle Droid token: Sebulba\'s Podracer');
-            context.player1.clickPrompt('Create a Battle Droid token: Battlefield Marine');
+            context.player1.clickPrompt('Resolve all remaining (4)');
             expect(context.player2).toBeActivePlayer();
 
             const battleDroids = context.player1.findCardsByName('battle-droid');

--- a/test/server/cards/08_ASH/events/BuyTime.spec.ts
+++ b/test/server/cards/08_ASH/events/BuyTime.spec.ts
@@ -82,9 +82,9 @@ describe('Buy Time', function () {
                 expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Mandalorian tokens instead');
                 context.player1.clickPrompt('Trigger');
 
-                // Both doubled Mandalorian tokens have Shielded, so their triggers must be ordered
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                context.player1.clickPrompt('Shielded');
+                // Both doubled Mandalorian tokens have Shielded; their grouped triggers resolve via the modal
+                expect(context.player1).toHavePrompt('Resolve "Shielded"');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian', 'groundArena');
                 expect(context.moffJerjerrod).toBeInZone('discard');

--- a/test/server/cards/08_ASH/events/BuyTime.spec.ts
+++ b/test/server/cards/08_ASH/events/BuyTime.spec.ts
@@ -84,7 +84,7 @@ describe('Buy Time', function () {
 
                 // Both doubled Mandalorian tokens have Shielded; their grouped triggers resolve via the modal
                 expect(context.player1).toHavePrompt('Resolve "Shielded"');
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian', 'groundArena');
                 expect(context.moffJerjerrod).toBeInZone('discard');

--- a/test/server/cards/08_ASH/events/ChooseYourPath.spec.ts
+++ b/test/server/cards/08_ASH/events/ChooseYourPath.spec.ts
@@ -162,7 +162,7 @@ describe('Choose Your Path', function() {
 
                 // Both doubled Mandalorian tokens have Shielded; their grouped triggers resolve via the modal
                 expect(context.player1).toHavePrompt('Resolve "Shielded"');
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian', 'groundArena');
                 expect(context.moffJerjerrod).toBeInZone('discard');

--- a/test/server/cards/08_ASH/events/ChooseYourPath.spec.ts
+++ b/test/server/cards/08_ASH/events/ChooseYourPath.spec.ts
@@ -160,9 +160,9 @@ describe('Choose Your Path', function() {
                 expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Mandalorian tokens instead');
                 context.player1.clickPrompt('Trigger');
 
-                // Both doubled Mandalorian tokens have Shielded, so their triggers must be ordered
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                context.player1.clickPrompt('Shielded');
+                // Both doubled Mandalorian tokens have Shielded; their grouped triggers resolve via the modal
+                expect(context.player1).toHavePrompt('Resolve "Shielded"');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian', 'groundArena');
                 expect(context.moffJerjerrod).toBeInZone('discard');

--- a/test/server/cards/08_ASH/events/StrongerTogether.spec.ts
+++ b/test/server/cards/08_ASH/events/StrongerTogether.spec.ts
@@ -11,7 +11,7 @@ describe('Stronger Together', function () {
             const { context } = contextRef;
 
             context.player1.clickCard(context.strongerTogether);
-            context.player1.clickPrompt('Shielded');
+            context.player1.clickPrompt('Resolve all remaining (2)');
 
             expect(context.player2).toBeActivePlayer();
 

--- a/test/server/cards/08_ASH/events/StrongerTogether.spec.ts
+++ b/test/server/cards/08_ASH/events/StrongerTogether.spec.ts
@@ -11,7 +11,7 @@ describe('Stronger Together', function () {
             const { context } = contextRef;
 
             context.player1.clickCard(context.strongerTogether);
-            context.player1.clickPrompt('Resolve all remaining (2)');
+            context.player1.clickPrompt('Resolve all (2)');
 
             expect(context.player2).toBeActivePlayer();
 

--- a/test/server/cards/08_ASH/leaders/GreefKargaGraciousMagistrate.spec.ts
+++ b/test/server/cards/08_ASH/leaders/GreefKargaGraciousMagistrate.spec.ts
@@ -139,7 +139,7 @@ describe('Greef Karga, Gracious Magistrate', function() {
                 context.player1.clickCard(context.dedicatedWingmen);
 
                 // Both tokens trigger simultaneously and are grouped — the resolution modal appears directly
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Accept the trigger for the first X-Wing
                 expect(context.player1).toHavePassAbilityPrompt(`${abilityTitle('X-Wing')}`);
@@ -268,7 +268,7 @@ describe('Greef Karga, Gracious Magistrate', function() {
 
                 // Play an event that creates 2 tokens — both triggers are grouped, so the modal appears directly
                 context.player1.clickCard(context.dedicatedWingmen);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Both X-Wing tokens receive an Advantage token automatically (no exhaust cost)
                 const xwings = context.player1.findCardsByName('xwing');

--- a/test/server/cards/08_ASH/leaders/GreefKargaGraciousMagistrate.spec.ts
+++ b/test/server/cards/08_ASH/leaders/GreefKargaGraciousMagistrate.spec.ts
@@ -138,8 +138,8 @@ describe('Greef Karga, Gracious Magistrate', function() {
                 // Play an event that creates 2 tokens — Greef triggers once per token entering play
                 context.player1.clickCard(context.dedicatedWingmen);
 
-                // Both tokens trigger simultaneously — ordering prompt appears first
-                context.player1.clickPrompt(`${abilityTitle('X-Wing')}`);
+                // Both tokens trigger simultaneously and are grouped — the resolution modal appears directly
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 // Accept the trigger for the first X-Wing
                 expect(context.player1).toHavePassAbilityPrompt(`${abilityTitle('X-Wing')}`);
@@ -182,8 +182,6 @@ describe('Greef Karga, Gracious Magistrate', function() {
         });
 
         describe('his leader unit side ability', function() {
-            const abilityTitle = (unitTitle: string) => `Give an Advantage token to ${unitTitle}`;
-
             describe('when the player plays a unit', function() {
                 beforeEach(async function() {
                     await contextRef.setupTestAsync({
@@ -268,9 +266,9 @@ describe('Greef Karga, Gracious Magistrate', function() {
 
                 const { context } = contextRef;
 
-                // Play an event that creates 2 tokens — ordering prompt appears since both trigger simultaneously
+                // Play an event that creates 2 tokens — both triggers are grouped, so the modal appears directly
                 context.player1.clickCard(context.dedicatedWingmen);
-                context.player1.clickPrompt(`${abilityTitle('X-Wing')}`);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 // Both X-Wing tokens receive an Advantage token automatically (no exhaust cost)
                 const xwings = context.player1.findCardsByName('xwing');

--- a/test/server/cards/08_ASH/tokens/Advantage.spec.ts
+++ b/test/server/cards/08_ASH/tokens/Advantage.spec.ts
@@ -121,7 +121,7 @@ describe('Advantage', function() {
 
                 // The two identical Advantage triggers are grouped into one modal; resolve them one at a time
                 expect(context.player2).toHavePrompt('Resolve "Defeat Advantage token"');
-                expect(context.player2).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player2).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
                 context.player2.clickPrompt('Resolve next');
 
                 // The last remaining token resolves automatically without another prompt
@@ -159,7 +159,7 @@ describe('Advantage', function() {
 
                 // Choosing "Resolve all remaining" resolves every Advantage token without further prompts
                 expect(context.player2).toHavePrompt('Resolve "Defeat Advantage token"');
-                context.player2.clickPrompt('Resolve all remaining (3)');
+                context.player2.clickPrompt('Resolve all (3)');
 
                 // Verify all three Advantage tokens were defeated
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames([]);
@@ -206,7 +206,7 @@ describe('Advantage', function() {
                 // Select the grouped Advantage trigger, then resolve all of them at once from the modal
                 context.player1.clickPrompt('Defeat Advantage token');
                 expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
-                context.player1.clickPrompt('Resolve all remaining (3)');
+                context.player1.clickPrompt('Resolve all (3)');
 
                 // All three Advantage tokens are defeated
                 expect(context.zebOrrelios).toHaveExactUpgradeNames([]);
@@ -237,7 +237,7 @@ describe('Advantage', function() {
 
                 // Resolve a single Advantage token, then return to the ordering prompt
                 context.player1.clickPrompt('Defeat Advantage token');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (3)']);
                 context.player1.clickPrompt('Resolve next');
 
                 // Zeb's ability can be resolved in the middle of the Advantage token defeats
@@ -250,7 +250,7 @@ describe('Advantage', function() {
 
                 // The remaining two Advantage tokens then resolve from the modal
                 expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 expect(context.zebOrrelios).toHaveExactUpgradeNames([]);
                 for (const advantageToken of advantageTokens) {
@@ -293,11 +293,11 @@ describe('Advantage', function() {
 
                 // Player1's two Advantage tokens are their only triggers, so the grouped modal appears directly
                 expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Player2 then resolves their own grouped Advantage tokens
                 expect(context.player2).toHavePrompt('Resolve "Defeat Advantage token"');
-                context.player2.clickPrompt('Resolve all remaining (2)');
+                context.player2.clickPrompt('Resolve all (2)');
 
                 // All Advantage tokens across both units are defeated
                 expect(context.consularSecurityForce).toHaveExactUpgradeNames([]);
@@ -330,7 +330,7 @@ describe('Advantage', function() {
 
                 // Resolve all Advantage tokens at once; each token is still a separate defeat so Zeb fires three times
                 expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
-                context.player1.clickPrompt('Resolve all remaining (3)');
+                context.player1.clickPrompt('Resolve all (3)');
 
                 // The three Zeb triggers fire (one per Advantage token defeated); use non-checking clicks as prompts are identical
                 context.player1.clickCardNonChecking(context.p2Base);

--- a/test/server/cards/08_ASH/tokens/Advantage.spec.ts
+++ b/test/server/cards/08_ASH/tokens/Advantage.spec.ts
@@ -43,7 +43,7 @@ describe('Advantage', function() {
                 context.player1.clickCard(context.battlefieldMarine);
                 context.player1.clickCard(context.trayusAcolyte);
 
-                // Verify the attack went through and the Advantage token was defeated
+                // A single Advantage token defeats without any prompting
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames([]);
                 expect(context.advantage).toBeInZone('outsideTheGame');
 
@@ -94,8 +94,10 @@ describe('Advantage', function() {
                     'player2 uses Advantage to defeat Advantage',
                 ]);
             });
+        });
 
-            it('when multiple copies are attached, they should all be defeated at the end of the attack', async function() {
+        describe('When multiple Advantage tokens are on one unit', function() {
+            it('lets the player resolve them one at a time via the grouped-trigger modal', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -111,18 +113,18 @@ describe('Advantage', function() {
 
                 const { context } = contextRef;
 
-                const advantageTokens = context.player1.findCardsByName('advantage');
+                const advantageTokens = context.player2.findCardsByName('advantage');
 
                 // Trayus Acolyte attacks Battlefield Marine
                 context.player1.clickCard(context.trayusAcolyte);
                 context.player1.clickCard(context.battlefieldMarine);
 
-                // Resolve simultaneous triggers
-                expect(context.player2).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player2).toHaveExactPromptButtons(['Defeat Advantage token', 'Defeat Advantage token']);
-                context.player2.clickPrompt('Defeat Advantage token');
+                // The two identical Advantage triggers are grouped into one modal; resolve them one at a time
+                expect(context.player2).toHavePrompt('Resolve "Defeat Advantage token"');
+                expect(context.player2).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player2.clickPrompt('Resolve next');
 
-                // Verify both Advantage tokens were defeated
+                // The last remaining token resolves automatically without another prompt
                 expect(context.battlefieldMarine).toHaveExactUpgradeNames([]);
                 for (const advantageToken of advantageTokens) {
                     expect(advantageToken).toBeInZone('outsideTheGame');
@@ -131,14 +133,242 @@ describe('Advantage', function() {
                 // Battlefield Marine took 2 damage, and Trayus Acolyte was defeated
                 expect(context.battlefieldMarine.damage).toBe(2);
                 expect(context.trayusAcolyte).toBeInZone('discard');
+            });
 
-                // Chat logs confirm order of events is correct
-                expect(context.getChatLogs(4)).toEqual([
-                    'player1 attacks Battlefield Marine with Trayus Acolyte',
-                    'player1\'s Trayus Acolyte is defeated by player2 due to having no remaining HP',
-                    'player2 uses Advantage to defeat Advantage',
-                    'player2 uses Advantage to defeat Advantage',
+            it('lets the player resolve them all at once', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['trayus-acolyte']
+                    },
+                    player2: {
+                        groundArena: [{
+                            card: 'battlefield-marine',
+                            upgrades: ['advantage', 'advantage', 'advantage']
+                        }]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                const advantageTokens = context.player2.findCardsByName('advantage');
+
+                // Trayus Acolyte attacks Battlefield Marine
+                context.player1.clickCard(context.trayusAcolyte);
+                context.player1.clickCard(context.battlefieldMarine);
+
+                // Choosing "Resolve all remaining" resolves every Advantage token without further prompts
+                expect(context.player2).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player2.clickPrompt('Resolve all remaining (3)');
+
+                // Verify all three Advantage tokens were defeated
+                expect(context.battlefieldMarine).toHaveExactUpgradeNames([]);
+                for (const advantageToken of advantageTokens) {
+                    expect(advantageToken).toBeInZone('outsideTheGame');
+                }
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
+        describe('When a unit has both Advantage tokens and its own "When Attack Ends" ability', function() {
+            beforeEach(async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{
+                            card: 'zeb-orrelios#headstrong-warrior',
+                            upgrades: ['advantage', 'advantage', 'advantage']
+                        }]
+                    },
+                    player2: {
+                        groundArena: ['battlefield-marine']
+                    }
+                });
+            });
+
+            it('resolves all Advantage tokens together when chosen, interleaved with the unit\'s own ability', function() {
+                const { context } = contextRef;
+
+                const advantageTokens = context.player1.findCardsByName('advantage');
+
+                // Zeb attacks and defeats Battlefield Marine
+                context.player1.clickCard(context.zebOrrelios);
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.battlefieldMarine).toBeInZone('discard');
+
+                // The grouped Advantage choice is presented alongside Zeb's own "When Attack Ends" ability
+                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Advantage token',
+                    'If the defender was defeated, you may deal 4 damage to a ground unit'
                 ]);
+
+                // Select the grouped Advantage trigger, then resolve all of them at once from the modal
+                context.player1.clickPrompt('Defeat Advantage token');
+                expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player1.clickPrompt('Resolve all remaining (3)');
+
+                // All three Advantage tokens are defeated
+                expect(context.zebOrrelios).toHaveExactUpgradeNames([]);
+                for (const advantageToken of advantageTokens) {
+                    expect(advantageToken).toBeInZone('outsideTheGame');
+                }
+
+                // Zeb's ability still resolves afterwards
+                expect(context.player1).toHavePrompt('If the defender was defeated, you may deal 4 damage to a ground unit');
+                context.player1.clickPrompt('Pass');
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('lets the Advantage tokens be interleaved with the other trigger when resolved one at a time', function() {
+                const { context } = contextRef;
+
+                const advantageTokens = context.player1.findCardsByName('advantage');
+
+                // Zeb attacks and defeats Battlefield Marine
+                context.player1.clickCard(context.zebOrrelios);
+                context.player1.clickCard(context.battlefieldMarine);
+
+                // The grouped Advantage choice sits alongside Zeb's ability
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Advantage token',
+                    'If the defender was defeated, you may deal 4 damage to a ground unit'
+                ]);
+
+                // Resolve a single Advantage token, then return to the ordering prompt
+                context.player1.clickPrompt('Defeat Advantage token');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (3)']);
+                context.player1.clickPrompt('Resolve next');
+
+                // Zeb's ability can be resolved in the middle of the Advantage token defeats
+                expect(context.player1).toHaveExactPromptButtons([
+                    'Defeat Advantage token',
+                    'If the defender was defeated, you may deal 4 damage to a ground unit'
+                ]);
+                context.player1.clickPrompt('If the defender was defeated, you may deal 4 damage to a ground unit');
+                context.player1.clickPrompt('Pass');
+
+                // The remaining two Advantage tokens then resolve from the modal
+                expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player1.clickPrompt('Resolve all remaining (2)');
+
+                expect(context.zebOrrelios).toHaveExactUpgradeNames([]);
+                for (const advantageToken of advantageTokens) {
+                    expect(advantageToken).toBeInZone('outsideTheGame');
+                }
+            });
+        });
+
+        describe('When both the attacker and defender have multiple Advantage tokens', function() {
+            it('prompts each controlling player for their own grouped-trigger resolution', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{
+                            card: 'consular-security-force',
+                            upgrades: ['advantage', 'advantage']
+                        }]
+                    },
+                    player2: {
+                        groundArena: [{
+                            card: 'outer-rim-mystic',
+                            upgrades: ['advantage', 'advantage']
+                        }]
+                    }
+                });
+
+                const { context } = contextRef;
+                const allAdvantageTokens = [
+                    ...context.player1.findCardsByName('advantage'),
+                    ...context.player2.findCardsByName('advantage')
+                ];
+
+                // Consular Security Force attacks Outer Rim Mystic; both survive so both keep their Advantage tokens through to attack end
+                context.player1.clickCard(context.consularSecurityForce);
+                context.player1.clickCard(context.outerRimMystic);
+
+                // Active player chooses which player resolves their triggers first
+                expect(context.player1).toHavePrompt('Both players have triggered abilities in response. Choose a player to resolve all of their abilities first:');
+                context.player1.clickPrompt('You');
+
+                // Player1's two Advantage tokens are their only triggers, so the grouped modal appears directly
+                expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player1.clickPrompt('Resolve all remaining (2)');
+
+                // Player2 then resolves their own grouped Advantage tokens
+                expect(context.player2).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player2.clickPrompt('Resolve all remaining (2)');
+
+                // All Advantage tokens across both units are defeated
+                expect(context.consularSecurityForce).toHaveExactUpgradeNames([]);
+                expect(context.outerRimMystic).toHaveExactUpgradeNames([]);
+                for (const advantageToken of allAdvantageTokens) {
+                    expect(advantageToken).toBeInZone('outsideTheGame');
+                }
+            });
+        });
+
+        describe('When defeating the Advantage tokens triggers another ability', function() {
+            beforeEach(async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [
+                            'zeb-orrelios#fists-work-every-time',
+                            { card: 'wampa', upgrades: ['advantage', 'advantage', 'advantage'] }
+                        ]
+                    }
+                });
+            });
+
+            it('fires the trigger once per token when resolved all at once', function() {
+                const { context } = contextRef;
+
+                // Wampa attacks the enemy base
+                context.player1.clickCard(context.wampa);
+                context.player1.clickCard(context.p2Base);
+
+                // Resolve all Advantage tokens at once; each token is still a separate defeat so Zeb fires three times
+                expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player1.clickPrompt('Resolve all remaining (3)');
+
+                // The three Zeb triggers fire (one per Advantage token defeated); use non-checking clicks as prompts are identical
+                context.player1.clickCardNonChecking(context.p2Base);
+                context.player1.clickCardNonChecking(context.p2Base);
+                context.player1.clickCardNonChecking(context.p2Base);
+
+                // 7 combat damage + 3 from Zeb's three triggers (one per Advantage token defeated)
+                expect(context.wampa).toHaveExactUpgradeNames([]);
+                expect(context.p2Base.damage).toBe(10);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('fires the trigger once per token when resolved one at a time', function() {
+                const { context } = contextRef;
+
+                // Wampa attacks the enemy base
+                context.player1.clickCard(context.wampa);
+                context.player1.clickCard(context.p2Base);
+
+                // Resolve the Advantage tokens one at a time from the modal
+                expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player1.clickPrompt('Resolve next');
+
+                // Token 1's defeat fires Zeb's trigger (non-checking — prompt is identical to next)
+                context.player1.clickCardNonChecking(context.p2Base);
+
+                // Token 2: choose to defeat it, then resolve Zeb's trigger
+                expect(context.player1).toHavePrompt('Resolve "Defeat Advantage token"');
+                context.player1.clickPrompt('Resolve next');
+                context.player1.clickCardNonChecking(context.p2Base);
+
+                // Token 3 auto-resolves as the last remaining trigger, then resolve Zeb's trigger
+                context.player1.clickCardNonChecking(context.p2Base);
+
+                // 7 combat damage + 3 from Zeb's three triggers (one per Advantage token defeated)
+                expect(context.wampa).toHaveExactUpgradeNames([]);
+                expect(context.p2Base.damage).toBe(10);
+                expect(context.player2).toBeActivePlayer();
             });
         });
     });

--- a/test/server/cards/08_ASH/units/ChildrenOfTheWatch.spec.ts
+++ b/test/server/cards/08_ASH/units/ChildrenOfTheWatch.spec.ts
@@ -11,7 +11,7 @@ describe('Children of the Watch', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.childrenOfTheWatch);
-            context.player1.clickPrompt('Shielded');
+            context.player1.clickPrompt('Resolve all remaining (2)');
 
             expect(context.player2).toBeActivePlayer();
 

--- a/test/server/cards/08_ASH/units/ChildrenOfTheWatch.spec.ts
+++ b/test/server/cards/08_ASH/units/ChildrenOfTheWatch.spec.ts
@@ -11,7 +11,7 @@ describe('Children of the Watch', function() {
             const { context } = contextRef;
 
             context.player1.clickCard(context.childrenOfTheWatch);
-            context.player1.clickPrompt('Resolve all remaining (2)');
+            context.player1.clickPrompt('Resolve all (2)');
 
             expect(context.player2).toBeActivePlayer();
 

--- a/test/server/cards/08_ASH/units/EvisceratorBurnThemAway.spec.ts
+++ b/test/server/cards/08_ASH/units/EvisceratorBurnThemAway.spec.ts
@@ -84,7 +84,7 @@ describe('Eviscerator, Burn Them Away', function() {
             context.player1.clickCard(context.p2Base);
 
             // With Eviscerator gone, Wampa's two Advantage tokens have their abilities back and defeat at attack end
-            context.player1.clickPrompt('All at once');
+            context.player1.clickPrompt('Resolve all remaining (2)');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.wampa).toHaveExactUpgradeNames([]);

--- a/test/server/cards/08_ASH/units/EvisceratorBurnThemAway.spec.ts
+++ b/test/server/cards/08_ASH/units/EvisceratorBurnThemAway.spec.ts
@@ -82,7 +82,9 @@ describe('Eviscerator, Burn Them Away', function() {
 
             context.player1.clickCard(context.wampa);
             context.player1.clickCard(context.p2Base);
-            context.player1.clickPrompt('Defeat Advantage token');
+
+            // With Eviscerator gone, Wampa's two Advantage tokens have their abilities back and defeat at attack end
+            context.player1.clickPrompt('All at once');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.wampa).toHaveExactUpgradeNames([]);

--- a/test/server/cards/08_ASH/units/EvisceratorBurnThemAway.spec.ts
+++ b/test/server/cards/08_ASH/units/EvisceratorBurnThemAway.spec.ts
@@ -84,7 +84,7 @@ describe('Eviscerator, Burn Them Away', function() {
             context.player1.clickCard(context.p2Base);
 
             // With Eviscerator gone, Wampa's two Advantage tokens have their abilities back and defeat at attack end
-            context.player1.clickPrompt('Resolve all remaining (2)');
+            context.player1.clickPrompt('Resolve all (2)');
 
             expect(context.player2).toBeActivePlayer();
             expect(context.wampa).toHaveExactUpgradeNames([]);

--- a/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
+++ b/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
@@ -283,7 +283,7 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
                 context.player1.clickCard(context.wampa);
 
                 // Both token types trigger Jerjerrod simultaneously and are grouped — resolve them via the modal
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Accept the Experience replacement — Jerjerrod is defeated and 2 XP tokens are created
                 expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Experience tokens instead: Wampa');

--- a/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
+++ b/test/server/cards/08_ASH/units/MoffJerjerrodWeShallRedoubleOurEfforts.spec.ts
@@ -282,8 +282,8 @@ describe('Moff Jerjerrod, We Shall Redouble Our Efforts', function () {
                 context.player1.clickCard(context.threeLessons);
                 context.player1.clickCard(context.wampa);
 
-                // Both token types trigger Jerjerrod simultaneously; player must choose which to resolve first
-                context.player1.clickPrompt('Defeat Moff Jerjerrod to create 2 Experience tokens instead: Wampa');
+                // Both token types trigger Jerjerrod simultaneously and are grouped — resolve them via the modal
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 // Accept the Experience replacement — Jerjerrod is defeated and 2 XP tokens are created
                 expect(context.player1).toHavePassAbilityPrompt('Defeat Moff Jerjerrod to create 2 Experience tokens instead: Wampa');

--- a/test/server/cards/08_ASH/units/OutcastMercenaryStarship.spec.ts
+++ b/test/server/cards/08_ASH/units/OutcastMercenaryStarship.spec.ts
@@ -84,8 +84,8 @@ describe('Outcast, Mercenary Starship', function() {
                 // Play Droid Deployment — creates 2 Battle Droid tokens simultaneously
                 context.player1.clickCard(context.droidDeployment);
 
-                // Resolve the trigger ordering prompt for the two simultaneous "enters play" triggers
-                context.player1.clickPrompt('Give Battle Droid +1/+0 for this phase');
+                // The two simultaneous "enters play" triggers are grouped — resolve them via the modal
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 // Each Battle Droid (printed power 1) should have received +1/+0 from Outcast
                 const battleDroids = context.player1.findCardsByName('battle-droid');

--- a/test/server/cards/08_ASH/units/OutcastMercenaryStarship.spec.ts
+++ b/test/server/cards/08_ASH/units/OutcastMercenaryStarship.spec.ts
@@ -85,7 +85,7 @@ describe('Outcast, Mercenary Starship', function() {
                 context.player1.clickCard(context.droidDeployment);
 
                 // The two simultaneous "enters play" triggers are grouped — resolve them via the modal
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Each Battle Droid (printed power 1) should have received +1/+0 from Outcast
                 const battleDroids = context.player1.findCardsByName('battle-droid');

--- a/test/server/cards/08_ASH/units/PazVizslaForABrighterFuture.spec.ts
+++ b/test/server/cards/08_ASH/units/PazVizslaForABrighterFuture.spec.ts
@@ -42,7 +42,7 @@ describe('Paz Vizsla, For a Brighter Future', function() {
                 context.player1.passAction();
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian');
 
@@ -71,7 +71,7 @@ describe('Paz Vizsla, For a Brighter Future', function() {
 
                 context.player2.clickCard(context.noGloryOnlyResults);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
-                context.player2.clickPrompt('Resolve all remaining (2)');
+                context.player2.clickPrompt('Resolve all (2)');
 
                 const mandaloriansP1 = context.player1.findCardsByName('mandalorian');
 
@@ -105,7 +105,7 @@ describe('Paz Vizsla, For a Brighter Future', function() {
                 context.player2.clickCard(context.sabineWren);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian');
 

--- a/test/server/cards/08_ASH/units/PazVizslaForABrighterFuture.spec.ts
+++ b/test/server/cards/08_ASH/units/PazVizslaForABrighterFuture.spec.ts
@@ -42,7 +42,7 @@ describe('Paz Vizsla, For a Brighter Future', function() {
                 context.player1.passAction();
                 context.player2.clickCard(context.vanquish);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
-                context.player1.clickPrompt('Shielded');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian');
 
@@ -71,7 +71,7 @@ describe('Paz Vizsla, For a Brighter Future', function() {
 
                 context.player2.clickCard(context.noGloryOnlyResults);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
-                context.player2.clickPrompt('Shielded');
+                context.player2.clickPrompt('Resolve all remaining (2)');
 
                 const mandaloriansP1 = context.player1.findCardsByName('mandalorian');
 
@@ -105,7 +105,7 @@ describe('Paz Vizsla, For a Brighter Future', function() {
                 context.player2.clickCard(context.sabineWren);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
                 context.player2.clickCard(context.pazVizslaForABrighterFuture);
-                context.player1.clickPrompt('Shielded');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 const mandalorians = context.player1.findCardsByName('mandalorian');
 

--- a/test/server/cards/08_ASH/units/PreVizslaStrongWilledRuler.spec.ts
+++ b/test/server/cards/08_ASH/units/PreVizslaStrongWilledRuler.spec.ts
@@ -110,7 +110,7 @@ describe('Pre Vizsla, Strong-Willed Ruler', function () {
 
             context.player1.clickPrompt('Done');
 
-            context.player1.clickPrompt('Resolve all remaining (6)');
+            context.player1.clickPrompt('Resolve all (6)');
 
             const mandalorians = context.player1.findCardsByName('mandalorian');
 
@@ -249,7 +249,7 @@ describe('Pre Vizsla, Strong-Willed Ruler', function () {
 
             context.player1.clickPrompt('Done');
 
-            context.player1.clickPrompt('Resolve all remaining (6)');
+            context.player1.clickPrompt('Resolve all (6)');
 
             const mandalorians = context.player1.findCardsByName('mandalorian');
 

--- a/test/server/cards/08_ASH/units/PreVizslaStrongWilledRuler.spec.ts
+++ b/test/server/cards/08_ASH/units/PreVizslaStrongWilledRuler.spec.ts
@@ -110,11 +110,7 @@ describe('Pre Vizsla, Strong-Willed Ruler', function () {
 
             context.player1.clickPrompt('Done');
 
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
+            context.player1.clickPrompt('Resolve all remaining (6)');
 
             const mandalorians = context.player1.findCardsByName('mandalorian');
 
@@ -253,11 +249,7 @@ describe('Pre Vizsla, Strong-Willed Ruler', function () {
 
             context.player1.clickPrompt('Done');
 
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
-            context.player1.clickPrompt('Shielded');
+            context.player1.clickPrompt('Resolve all remaining (6)');
 
             const mandalorians = context.player1.findCardsByName('mandalorian');
 

--- a/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
+++ b/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
@@ -309,23 +309,27 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 context.player2.clickPrompt('Ground');
                 context.player2.clickCard(context.concordDawnInterceptors);
 
-                // Three triggers fire simultaneously: Shield token for Mando's own damage,
-                // Mando's ability for BFM, and Mando's ability for Wampa.
+                // Two distinct triggers fire: the Shield token's own damage-prevention for Mando,
+                // and Mando's ability (one instance each for BFM and Wampa). Mando's two instances
+                // share a static title and source, so they collapse into a single grouped entry.
                 expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Defeat Shield to prevent The Mandalorian from taking damage',
-                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine',
-                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Wampa',
+                    'Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit',
                 ]);
 
-                // Player resolves Mando's ability for BFM — shield auto-defeated, no card selection prompt.
-                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine');
+                // Resolve a single instance of Mando's grouped ability. With only one shield,
+                // resolving one instance consumes it, so only one unit can be protected.
+                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit');
+                expect(context.player1).toHavePrompt('Resolve "Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit"');
+                context.player1.clickPrompt('Resolve next');
                 context.player1.clickPrompt('Trigger');
 
-                // Shield is auto-selected and defeated — no card selection prompt shown.
-                // With no shield remaining, all other triggers are automatically cleared.
-                expect(context.battlefieldMarine.damage).toBe(0);
-                expect(context.wampa.damage).toBe(1);
+                // With only one shield, resolving one instance consumes it protecting one unit; the
+                // remaining instance can no longer prevent damage. Grouping means the protected unit is
+                // engine-ordered rather than player-selected, so assert the invariant: exactly one of the
+                // two damaged units is protected (0 damage) and the other takes its 1 damage.
+                expect([context.battlefieldMarine.damage, context.wampa.damage].sort()).toEqual([0, 1]);
                 expect(context.player1).toBeActivePlayer();
             });
 
@@ -352,20 +356,21 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 context.player2.clickPrompt('Ground');
                 context.player2.clickCard(context.concordDawnInterceptors);
 
-                // Three triggers: consolidated Shield for Mando's damage, Mando for BFM, Mando for Wampa.
+                // Two distinct triggers: the Shield token's own damage-prevention for Mando, and
+                // Mando's ability (one instance each for BFM and Wampa) collapsed into a single
+                // grouped entry.
                 expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
                 expect(context.player1).toHaveExactPromptButtons([
                     'Defeat Shield to prevent The Mandalorian from taking damage',
-                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine',
-                    'Defeat a Shield attached to The Mandalorian to prevent all damage to Wampa',
+                    'Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit',
                 ]);
 
-                // Resolve Mando's ability for BFM — auto-defeats first shield.
-                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to Battlefield Marine');
+                // Resolve all instances of Mando's grouped ability. With two shields, both BFM and
+                // Wampa are protected (one shield consumed for each per-instance trigger).
+                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit');
+                expect(context.player1).toHavePrompt('Resolve "Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit"');
+                context.player1.clickPrompt('Resolve all remaining (2)');
                 context.player1.clickPrompt('Trigger');
-
-                // One shield remains — Mando's ability for Wampa is still valid.
-                context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to Wampa');
                 context.player1.clickPrompt('Trigger');
 
                 // Both shields consumed — Mando takes 1 damage, BFM and Wampa protected

--- a/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
+++ b/test/server/cards/08_ASH/units/TheMandalorianDevotedRescuer.spec.ts
@@ -369,7 +369,7 @@ describe('The Mandalorian, Devoted Rescuer', function () {
                 // Wampa are protected (one shield consumed for each per-instance trigger).
                 context.player1.clickPrompt('Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit');
                 expect(context.player1).toHavePrompt('Resolve "Defeat a Shield attached to The Mandalorian to prevent all damage to a friendly unit"');
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
                 context.player1.clickPrompt('Trigger');
                 context.player1.clickPrompt('Trigger');
 

--- a/test/server/cards/08_ASH/units/TheTwinsWeDontWantWar.spec.ts
+++ b/test/server/cards/08_ASH/units/TheTwinsWeDontWantWar.spec.ts
@@ -319,7 +319,7 @@ describe('The Twins, We Don\'t Want War', function() {
 
             context.player2.clickCard(context.superlaserBlast);
 
-            context.player1.clickPrompt('Resolve all remaining (3)');
+            context.player1.clickPrompt('Resolve all (3)');
 
             expect(context.p1Base.damage).toBe(2);
             expect(context.p2Base.damage).toBe(5);

--- a/test/server/cards/08_ASH/units/TheTwinsWeDontWantWar.spec.ts
+++ b/test/server/cards/08_ASH/units/TheTwinsWeDontWantWar.spec.ts
@@ -319,8 +319,7 @@ describe('The Twins, We Don\'t Want War', function() {
 
             context.player2.clickCard(context.superlaserBlast);
 
-            context.player1.clickPrompt('When another friendly unit is defeated, heal 1 damage from your base: Jedi Consular');
-            context.player1.clickPrompt('When another friendly unit is defeated, heal 1 damage from your base: Grand Inquisitor');
+            context.player1.clickPrompt('Resolve all remaining (3)');
 
             expect(context.p1Base.damage).toBe(2);
             expect(context.p2Base.damage).toBe(5);

--- a/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
+++ b/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
@@ -270,9 +270,9 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 // so they collapse into a single grouped entry. Since they are the only triggers,
                 // the resolution modal appears directly.
                 expect(context.player1).toHavePrompt('Resolve "Deal 1 damage to a base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Each grouped instance resolves its own base-selection prompt in sequence
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
@@ -357,9 +357,9 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 // so they collapse into a single grouped entry. Since they are the only triggers,
                 // the resolution modal appears directly.
                 expect(context.player1).toHavePrompt('Resolve "Deal 1 damage to a base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Each grouped instance resolves its own base-selection prompt in sequence
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
@@ -500,8 +500,8 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 // triggers twice; the two triggers share a static title and source and collapse into
                 // a single grouped entry. Since they are the only triggers, the modal appears directly.
                 expect(context.player1).toHavePrompt('Resolve "Deal 1 damage to a base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);

--- a/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
+++ b/test/server/cards/08_ASH/units/ZebOrreliosFistsWorkEveryTime.spec.ts
@@ -266,18 +266,18 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 context.player2.clickCard(context.advantage);
                 context.player2.clickDone();
 
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Deal 1 damage to a base: Advantage',
-                    'Deal 1 damage to a base: Experience'
-                ]);
+                // Zeb's two triggers (one per defeated upgrade) share a static title and source,
+                // so they collapse into a single grouped entry. Since they are the only triggers,
+                // the resolution modal appears directly.
+                expect(context.player1).toHavePrompt('Resolve "Deal 1 damage to a base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                context.player1.clickPrompt('Deal 1 damage to a base: Experience');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
-                // Should prompt to deal 1 damage to a base
+                // Each grouped instance resolves its own base-selection prompt in sequence
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);
 
-                // Should prompt to deal 1 damage to a base
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);
 
@@ -353,18 +353,18 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
                 context.player2.clickCard(context.waylay);
                 context.player2.clickCard(context.wampa);
 
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Deal 1 damage to a base: Advantage',
-                    'Deal 1 damage to a base: Experience'
-                ]);
+                // Zeb's two triggers (one per defeated upgrade) share a static title and source,
+                // so they collapse into a single grouped entry. Since they are the only triggers,
+                // the resolution modal appears directly.
+                expect(context.player1).toHavePrompt('Resolve "Deal 1 damage to a base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                context.player1.clickPrompt('Deal 1 damage to a base: Experience');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
-                // Should prompt to deal 1 damage to a base
+                // Each grouped instance resolves its own base-selection prompt in sequence
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);
 
-                // Should prompt to deal 1 damage to a base
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);
 
@@ -496,12 +496,13 @@ describe('Zeb Orrelios, Fists Work Every Time', function () {
 
                 expect(context.zebOrrelios).toBeInZone('discard');
 
-                // Both of Zeb's own upgrades were defeated simultaneously with him, triggering his ability twice
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Deal 1 damage to a base: Advantage',
-                    'Deal 1 damage to a base: Experience'
-                ]);
-                context.player1.clickPrompt('Deal 1 damage to a base: Experience');
+                // Both of Zeb's own upgrades were defeated simultaneously with him, so his ability
+                // triggers twice; the two triggers share a static title and source and collapse into
+                // a single grouped entry. Since they are the only triggers, the modal appears directly.
+                expect(context.player1).toHavePrompt('Resolve "Deal 1 damage to a base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
+
                 expect(context.player1).toBeAbleToSelectExactly([context.p1Base, context.p2Base]);
                 context.player1.clickCard(context.p2Base);
 

--- a/test/server/cards/08_ASH/upgrades/ImprovisedIdentity.spec.ts
+++ b/test/server/cards/08_ASH/upgrades/ImprovisedIdentity.spec.ts
@@ -656,7 +656,7 @@ describe('Improvised Identity', function() {
                     // Two "Draw a card" triggers fire (printed + gained); they are grouped in the ordering prompt.
                     // Select the grouped entry, then resolve both via the modal.
                     context.player1.clickPrompt('Draw a card');
-                    context.player1.clickPrompt('Resolve all remaining (2)');
+                    context.player1.clickPrompt('Resolve all (2)');
 
                     // Clone Deserter's Bounty — player1 (the defeater) collects it
                     context.player1.clickPrompt('Trigger');

--- a/test/server/cards/08_ASH/upgrades/ImprovisedIdentity.spec.ts
+++ b/test/server/cards/08_ASH/upgrades/ImprovisedIdentity.spec.ts
@@ -653,9 +653,10 @@ describe('Improvised Identity', function() {
                     context.player1.clickCard(context.cloneDeserter);
                     expect(context.cloneDeserter).toBeInZone('discard');
 
-                    // Two "Draw a card" triggers fire (printed + gained) — resolve both
+                    // Two "Draw a card" triggers fire (printed + gained); they are grouped in the ordering prompt.
+                    // Select the grouped entry, then resolve both via the modal.
                     context.player1.clickPrompt('Draw a card');
-                    context.player1.clickPrompt('Draw a card');
+                    context.player1.clickPrompt('Resolve all remaining (2)');
 
                     // Clone Deserter's Bounty — player1 (the defeater) collects it
                     context.player1.clickPrompt('Trigger');

--- a/test/server/core/abilities/keyword/Support.spec.ts
+++ b/test/server/core/abilities/keyword/Support.spec.ts
@@ -244,8 +244,8 @@ describe('Support keyword', function() {
                 // (same static title and source), they collapse into one grouped entry and the
                 // resolution modal appears directly when it is defeated.
                 expect(context.player1).toHavePrompt('Resolve "Draw a card"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 // Ability is optional, so we click trigger once for each instance of the ability
                 context.player1.clickPrompt('Trigger');

--- a/test/server/core/abilities/keyword/Support.spec.ts
+++ b/test/server/core/abilities/keyword/Support.spec.ts
@@ -241,10 +241,11 @@ describe('Support keyword', function() {
                 expect(context.battlefieldMarine).toBeInZone('discard');
 
                 // Since Battlefield Marine has 2 instances of Krell's When Defeated ability
-                // the player should be prompted to choose which one to trigger when it is defeated
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons(['Draw a card', 'Draw a card']);
-                context.player1.clickPrompt('Draw a card');
+                // (same static title and source), they collapse into one grouped entry and the
+                // resolution modal appears directly when it is defeated.
+                expect(context.player1).toHavePrompt('Resolve "Draw a card"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 // Ability is optional, so we click trigger once for each instance of the ability
                 context.player1.clickPrompt('Trigger');

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -325,9 +325,10 @@ describe('Uniqueness rule', function() {
                 expect(context.yularenInHand).toBeInZone('groundArena');
                 expect(context.yularenInPlay).toBeInZone('discard');
 
-                // triggered ability from both copies of Yularen
-                expect(context.player1).toHaveExactPromptButtons(['Heal 1 damage from your base', 'Heal 1 damage from your base']);
-                context.player1.clickPrompt('Heal 1 damage from your base');
+                // triggered ability from both copies of Yularen, grouped into a single entry that opens a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Heal 1 damage from your base"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
                 expect(context.p1Base.damage).toBe(1);
 
                 expect(context.player2).toBeActivePlayer();
@@ -672,14 +673,11 @@ describe('Uniqueness rule', function() {
                 expect(obi3).toBeInZone('groundArena');
                 expect(context.getChatLogs(1)).toContain('player1 defeats 2 copies of Obi-Wan Kenobi due to the uniqueness rule');
 
-                // Once both are defeated, the player can resolve the When Defeated abilities
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
-                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.'
-                ]);
+                // Once both are defeated, the two identical When Defeated abilities are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card."');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                context.player1.clickPrompt('Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([obi3]);
 
@@ -742,14 +740,11 @@ describe('Uniqueness rule', function() {
                 expect(obi2).toBeInZone('discard');
                 expect(obi3).toBeInZone('discard');
 
-                // Once both are defeated, the player can resolve the When Defeated abilities
-                expect(context.player1).toHavePrompt('You have multiple triggers to resolve. Choose which to resolve first:');
-                expect(context.player1).toHaveExactPromptButtons([
-                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.',
-                    'Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.'
-                ]);
+                // Once both are defeated, the two identical When Defeated abilities are grouped, opening a resolution modal directly
+                expect(context.player1).toHavePrompt('Resolve "Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card."');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                context.player1.clickPrompt('Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card.');
+                context.player1.clickPrompt('Resolve all remaining (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([obi1]);
 

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -327,8 +327,8 @@ describe('Uniqueness rule', function() {
 
                 // triggered ability from both copies of Yularen, grouped into a single entry that opens a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Heal 1 damage from your base"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
                 expect(context.p1Base.damage).toBe(1);
 
                 expect(context.player2).toBeActivePlayer();
@@ -675,9 +675,9 @@ describe('Uniqueness rule', function() {
 
                 // Once both are defeated, the two identical When Defeated abilities are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card."');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([obi3]);
 
@@ -742,9 +742,9 @@ describe('Uniqueness rule', function() {
 
                 // Once both are defeated, the two identical When Defeated abilities are grouped, opening a resolution modal directly
                 expect(context.player1).toHavePrompt('Resolve "Give 2 Experience tokens to another friendly unit. If it\'s a Force unit, draw a card."');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                context.player1.clickPrompt('Resolve all (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([obi1]);
 

--- a/test/server/core/gameSteps/abilityWindow/TriggeredAbilityWindow.spec.ts
+++ b/test/server/core/gameSteps/abilityWindow/TriggeredAbilityWindow.spec.ts
@@ -152,7 +152,7 @@ describe('Simultaneous triggers', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
-            it('should create a named trigger button for each target if the ability does not have a collective trigger', async function () {
+            it('should group the identical triggers into one choice that still resolves once per target if the ability does not have a collective trigger', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -176,22 +176,25 @@ describe('Simultaneous triggers', function() {
                     [context.battlefieldMarine, 1],
                 ]));
 
-                expect(context.player1).toHaveEnabledPromptButtons([
-                    'Defeat a non-unique upgrade on the unit: Battlefield Marine',
-                    'Defeat a non-unique upgrade on the unit: Wampa'
-                ]);
+                // Pryde's ability triggers once per damaged unit; the two identical triggers are grouped into
+                // a single choice that opens the batch-resolution modal
+                expect(context.player1).toHavePrompt('Resolve "Defeat a non-unique upgrade on the unit"');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
 
-                context.player1.clickPrompt('Defeat a non-unique upgrade on the unit: Battlefield Marine');
+                // Resolving the first instance still prompts for the upgrade on its own unit
+                context.player1.clickPrompt('Resolve next');
                 expect(context.player1).toBeAbleToSelectExactly([context.devotion]);
                 context.player1.clickCard(context.devotion);
 
-                expect(context.player1).toHavePrompt('Defeat a non-unique upgrade on the unit: Wampa');
+                // The last instance resolves automatically as the only remaining trigger, targeting the other unit
                 expect(context.player1).toBeAbleToSelectExactly([context.shield]);
                 context.player1.clickCard(context.shield);
 
                 expect(context.player2).toBeActivePlayer();
                 expect(context.devotion).toBeInZone('discard');
+                expect(context.shield).toBeInZone('outsideTheGame');
                 expect(context.battlefieldMarine.isUpgraded()).toBeFalse();
+                expect(context.wampa.isUpgraded()).toBeFalse();
             });
 
             it('should work correctly if sharing the window with another ability and only one of them has collective trigger', async function () {
@@ -219,17 +222,21 @@ describe('Simultaneous triggers', function() {
                     [context.battlefieldMarine, 1],
                 ]));
 
+                // Pryde's two identical triggers are grouped into one choice; Boba's collective-trigger leader
+                // ability remains its own choice alongside it
                 expect(context.player1).toHaveEnabledPromptButtons([
                     'Exhaust this leader to deal 1 indirect damage to a player',
-                    'Defeat a non-unique upgrade on the unit: Battlefield Marine',
-                    'Defeat a non-unique upgrade on the unit: Wampa'
+                    'Defeat a non-unique upgrade on the unit'
                 ]);
 
-                context.player1.clickPrompt('Defeat a non-unique upgrade on the unit: Battlefield Marine');
+                // Resolve Pryde's grouped triggers all at once, choosing the upgrade on each unit in turn
+                context.player1.clickPrompt('Defeat a non-unique upgrade on the unit');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                context.player1.clickPrompt('Resolve all remaining (2)');
+
                 expect(context.player1).toBeAbleToSelectExactly([context.devotion]);
                 context.player1.clickCard(context.devotion);
 
-                context.player1.clickPrompt('Defeat a non-unique upgrade on the unit: Wampa');
                 expect(context.player1).toBeAbleToSelectExactly([context.shield]);
                 context.player1.clickCard(context.shield);
 

--- a/test/server/core/gameSteps/abilityWindow/TriggeredAbilityWindow.spec.ts
+++ b/test/server/core/gameSteps/abilityWindow/TriggeredAbilityWindow.spec.ts
@@ -179,7 +179,7 @@ describe('Simultaneous triggers', function() {
                 // Pryde's ability triggers once per damaged unit; the two identical triggers are grouped into
                 // a single choice that opens the batch-resolution modal
                 expect(context.player1).toHavePrompt('Resolve "Defeat a non-unique upgrade on the unit"');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
 
                 // Resolving the first instance still prompts for the upgrade on its own unit
                 context.player1.clickPrompt('Resolve next');
@@ -231,8 +231,8 @@ describe('Simultaneous triggers', function() {
 
                 // Resolve Pryde's grouped triggers all at once, choosing the upgrade on each unit in turn
                 context.player1.clickPrompt('Defeat a non-unique upgrade on the unit');
-                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all remaining (2)']);
-                context.player1.clickPrompt('Resolve all remaining (2)');
+                expect(context.player1).toHaveExactPromptButtons(['Resolve next', 'Resolve all (2)']);
+                context.player1.clickPrompt('Resolve all (2)');
 
                 expect(context.player1).toBeAbleToSelectExactly([context.devotion]);
                 context.player1.clickCard(context.devotion);


### PR DESCRIPTION
### ⚠️  Requires client PR
https://github.com/SWU-Karabast/forceteki-client/pull/784

## Description

Generalizes simultaneous triggered-ability resolution: "similar" triggers in the same window collapse into a single choice instead of making the player click through N identical prompts.

### What
- When multiple triggered abilities resolve in one window and share the same base title + source card, they group into one entry in the resolution-order prompt.
- Selecting a grouped entry opens a new `BatchTriggerResolution` prompt — resolve the next instance, or all remaining at once.
- Each instance still resolves as its own trigger (per-instance targets/effects and nested triggers unchanged); grouping only affects the ordering UX.

### Technical callouts
- Grouping lives generically in `TriggerWindowBase` (`getGroupKey` / `buildResolutionChoices` / `buildGroupChoice`), keyed on the ability's **static** title + source `internalName` — side-effect-free (safe for sources that have left play) and won't merge distinct unique cards that share a title.
- "Resolve all" auto-repeats through the normal resolution loop so nested triggers interleave per CR 7.6.11 (not batched-then-deferred).
- The per-instance `overrideTitle` (": <card name>") is preserved for display during resolution — it's just no longer used to compare/split triggers.
- Replaces and removes the earlier Advantage-token-specific implementation.
- One behavior change: for mutually-exclusive "pick one of N" triggers (e.g. Jango undeployed), the player no longer chooses which instance resolves; affected specs assert the honest invariant instead.