### PR TITLE
Fix flaky top-of-deck assertion in Anakin Skywalker spec

### DIFF
--- a/test/server/cards/09_IC27/units/AnakinSkywalkerDestinedForDarkness.spec.ts
+++ b/test/server/cards/09_IC27/units/AnakinSkywalkerDestinedForDarkness.spec.ts
@@ -39,7 +39,6 @@ describe('Anakin Skywalker, Destined for Darkness', function () {
 
             expect(context.player1).toBeActivePlayer();
             expect(context.darthVader).toBeInZone('hand', context.player1);
-            expect(context.player1.deck[0]).not.toBe(context.brainInvaders);
         });
 
         it('Anakin Skywalker\'s when defeated ability should search whole deck for a Darth Vader (No Glory Only Results)', async function () {
@@ -81,7 +80,6 @@ describe('Anakin Skywalker, Destined for Darkness', function () {
 
             expect(context.player1).toBeActivePlayer();
             expect(context.darthVader).toBeInZone('hand', context.player2);
-            expect(context.player2.deck[0]).not.toBe(context.brainInvaders);
         });
 
         it('Anakin Skywalker\'s when defeated ability should fail if deck is empty', async function () {


### PR DESCRIPTION
## What was flaky and why

`AnakinSkywalkerDestinedForDarkness.spec.ts` asserted:

```ts
expect(context.player1.deck[0]).not.toBe(context.brainInvaders);
```

Anakin's when-defeated ability searches the **entire deck**, which shuffles it (CR 8.27). This line tried to prove the shuffle happened by checking the top card changed — but after shuffling the ~15 remaining cards, `brainInvaders` lands back on top **~1/15 of the time**. The RNG is entropy-seeded (not fixed), so it failed sporadically in CI.

Worse, `.toBe` compares **raw card objects**. On failure Jasmine stores the card as `actual`/`expected`, which references `Game → SnapshotManager → game` (a cycle). In `--parallel` mode that result is serialized over IPC and throws `Converting circular structure to JSON`, masking the real assertion and mis-reporting it as an unrelated **"Suite error"**.

## Fix

Removed both lines (player1 + player2 variants). The whole-deck search is already fully covered by the display-prompt assertions (all 15 non-Vader cards shown) and Darth Vader ending in hand, so the unreliable top-card check adds no real coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)