### PR TITLE
Fix crash when declining a single-legal-target prompt

### DIFF
--- a/server/game/cards/01_SOR/events/PowerFailure.ts
+++ b/server/game/cards/01_SOR/events/PowerFailure.ts
@@ -25,7 +25,7 @@ export default class PowerFailure extends EventCard {
                     canChooseNoCards: true,
                     cardTypeFilter: WildcardCardType.Upgrade,
                     mode: TargetMode.Unlimited,
-                    cardCondition: (card, context) => context.targets.selectedUnit.upgrades.includes(card),
+                    cardCondition: (card, context) => context.targets.selectedUnit.upgrades?.includes(card) ?? false,
                     immediateEffect: AbilityHelper.immediateEffects.defeat(),
                 }
             }

--- a/server/game/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.ts
+++ b/server/game/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.ts
@@ -23,8 +23,8 @@ export default class QuiGonJinnTheNegotiationsWillBeShort extends NonLeaderUnitC
                 deck: {
                     mode: TargetMode.Select,
                     dependsOn: 'unit',
-                    choosingPlayer: (context) => (context.targets.unit == null || context.targets.unit.owner === context.player ? RelativePlayer.Self : RelativePlayer.Opponent),
-                    activePromptTitle: (context) => (context.targets.unit == null ? '' : `Move ${context.targets.unit.title} to [Top] or [Bottom] of your deck`),
+                    choosingPlayer: (context) => (context.targets.unit.owner === context.player ? RelativePlayer.Self : RelativePlayer.Opponent),
+                    activePromptTitle: (context) => `Move ${context.targets.unit.title} to [Top] or [Bottom] of your deck`,
                     choices: (context) => ({
                         [NamedAction.Top]: AbilityHelper.immediateEffects.moveToTopOfDeck({ target: context.targets.unit }),
                         [NamedAction.Bottom]: AbilityHelper.immediateEffects.moveToBottomOfDeck({ target: context.targets.unit }),

--- a/server/game/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.ts
+++ b/server/game/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.ts
@@ -23,8 +23,8 @@ export default class QuiGonJinnTheNegotiationsWillBeShort extends NonLeaderUnitC
                 deck: {
                     mode: TargetMode.Select,
                     dependsOn: 'unit',
-                    choosingPlayer: (context) => (context.targets.unit.owner === context.player ? RelativePlayer.Self : RelativePlayer.Opponent),
-                    activePromptTitle: (context) => `Move ${context.targets.unit.title} to [Top] or [Bottom] of your deck`,
+                    choosingPlayer: (context) => (context.targets.unit == null || context.targets.unit.owner === context.player ? RelativePlayer.Self : RelativePlayer.Opponent),
+                    activePromptTitle: (context) => (context.targets.unit == null ? '' : `Move ${context.targets.unit.title} to [Top] or [Bottom] of your deck`),
                     choices: (context) => ({
                         [NamedAction.Top]: AbilityHelper.immediateEffects.moveToTopOfDeck({ target: context.targets.unit }),
                         [NamedAction.Bottom]: AbilityHelper.immediateEffects.moveToBottomOfDeck({ target: context.targets.unit }),

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -275,8 +275,11 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
             choices: [`${effectName} -> ${target.title}`, 'Pass'],
             handlers: [
                 () => this.setTargetResult(context, target),
-                // finalize the resolution with no target so the resolver doesn't re-prompt (mirrors the "choose nothing" path)
-                () => this.setTargetResult(context, null)
+                // Use the same "nothing selected" representation as the standard multi-card "Choose nothing"
+                // path (an empty array, not null) so that declining this target behaves identically whether
+                // or not autoSingleTarget caused this single-candidate prompt to be shown. Card implementations
+                // that read a dependent target's properties have only ever had to handle the empty-array case.
+                () => this.setTargetResult(context, [])
             ]
         });
     }

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -275,10 +275,7 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
             choices: [`${effectName} -> ${target.title}`, 'Pass'],
             handlers: [
                 () => this.setTargetResult(context, target),
-                // Use the same "nothing selected" representation as the standard multi-card "Choose nothing"
-                // path (an empty array, not null) so that declining this target behaves identically whether
-                // or not autoSingleTarget caused this single-candidate prompt to be shown. Card implementations
-                // that read a dependent target's properties have only ever had to handle the empty-array case.
+                // matches the "Choose nothing" behavior of the standard multi-card prompt
                 () => this.setTargetResult(context, [])
             ]
         });

--- a/test/server/cards/01_SOR/events/PowerFailure.spec.ts
+++ b/test/server/cards/01_SOR/events/PowerFailure.spec.ts
@@ -63,6 +63,19 @@ describe('Power Failure', function() {
                 expect(context.imperialInterceptor).toHaveExactUpgradeNames(['academy-training', 'shield']);
                 expect(context.pykeSentinel).toHaveExactUpgradeNames(['entrenched', 'devotion']);
             });
+
+            it('does not crash and defeats no upgrades if the player declines to choose a unit', function () {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.powerFailure);
+                expect(context.player1).toBeAbleToSelectExactly([context.pykeSentinel, context.imperialInterceptor]);
+                expect(context.player1).toHaveChooseNothingButton();
+                context.player1.clickPrompt('Choose nothing');
+
+                expect(context.imperialInterceptor).toHaveExactUpgradeNames(['academy-training', 'shield']);
+                expect(context.pykeSentinel).toHaveExactUpgradeNames(['entrenched', 'devotion']);
+                expect(context.player2).toBeActivePlayer();
+            });
         });
     });
 });

--- a/test/server/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.spec.ts
+++ b/test/server/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.spec.ts
@@ -78,6 +78,39 @@ describe('Qui-Gon Jinn, The Negotiations Will Be Short', () => {
             });
         });
 
+        // Regression test for a server crash: when there is exactly one legal unit to choose and the
+        // choosing player has the autoSingleTarget setting enabled, the game offers a single "trigger or
+        // pass" prompt instead of the usual multi-card selection prompt. Declining that prompt resolves the
+        // optional 'unit' target to null, which previously crashed the dependent 'deck' target's
+        // choosingPlayer/activePromptTitle callbacks (they assumed a unit was always chosen).
+        it('does not crash and does not move any unit if the player declines the single-legal-target prompt', async () => {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['quigon-jinn#the-negotiations-will-be-short'],
+                    autoSingleTarget: true,
+                },
+                player2: {
+                    hand: ['rivals-fall'],
+                    groundArena: ['wampa'],
+                    hasInitiative: true,
+                }
+            });
+            const { context } = contextRef;
+
+            // Defeat Qui-Gon Jinn with Rival's Fall. Wampa is now the only legal non-leader ground unit,
+            // so player1 (who controls the triggered ability) is offered a single "trigger or pass" prompt.
+            context.player2.clickCard(context.rivalsFall);
+            context.player2.clickCard(context.quigonJinn);
+
+            expect(context.player1).toHaveExactPromptButtons([`Choose a non-leader ground unit. Its owner puts it on the top or bottom of their deck -> ${context.wampa.title}`, 'Pass']);
+            context.player1.clickPrompt('Pass');
+
+            // Ability should resolve as a no-op, with no further prompts for either player
+            expect(context.player1).toBeActivePlayer();
+            expect(context.wampa).toBeInZone('groundArena');
+        });
+
         it('Qui-Gon Jinn\'s when defeated ability with No Glory Only Results allows player1 to choose a non-leader ground unit and player2 puts it on bottom of their deck', async () => {
             await contextRef.setupTestAsync({
                 phase: 'action',

--- a/test/server/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.spec.ts
+++ b/test/server/cards/05_LOF/units/QuiGonJinnTheNegotiationsWillBeShort.spec.ts
@@ -78,11 +78,8 @@ describe('Qui-Gon Jinn, The Negotiations Will Be Short', () => {
             });
         });
 
-        // Regression test for a server crash: when there is exactly one legal unit to choose and the
-        // choosing player has the autoSingleTarget setting enabled, the game offers a single "trigger or
-        // pass" prompt instead of the usual multi-card selection prompt. Declining that prompt resolves the
-        // optional 'unit' target to null, which previously crashed the dependent 'deck' target's
-        // choosingPlayer/activePromptTitle callbacks (they assumed a unit was always chosen).
+        // Regression test: with exactly one legal unit and autoSingleTarget on, declining the single-target
+        // "trigger or pass" prompt previously crashed the dependent 'deck' target.
         it('does not crash and does not move any unit if the player declines the single-legal-target prompt', async () => {
             await contextRef.setupTestAsync({
                 phase: 'action',
@@ -98,8 +95,6 @@ describe('Qui-Gon Jinn, The Negotiations Will Be Short', () => {
             });
             const { context } = contextRef;
 
-            // Defeat Qui-Gon Jinn with Rival's Fall. Wampa is now the only legal non-leader ground unit,
-            // so player1 (who controls the triggered ability) is offered a single "trigger or pass" prompt.
             context.player2.clickCard(context.rivalsFall);
             context.player2.clickCard(context.quigonJinn);
 


### PR DESCRIPTION
## Summary
- `autoSingleTarget`'s "trigger or Pass" prompt resolved a declined optional target to `null`, a value nothing in the codebase had ever been tested against. Declining via the long-standing "Choose nothing" button has always resolved to `[]`, which card code already tolerates. Fixed the single-candidate path to also produce `[]` for consistency.
- Found and fixed one unrelated, pre-existing crash in `PowerFailure.ts` (`selectedUnit.upgrades.includes(...)` with no null-safety), surfaced by an audit of every card using `dependsOn` targets.

## Test plan
- [x] Regression test reproducing the original Qui-Gon Jinn crash (declining a single-legal-target prompt)
- [x] Regression test for the `PowerFailure` bug
- [x] Full suite: `npm test` — 7505 specs, 0 failures