### PR TITLE
Fix raw function source leaking into auto-single-target prompt

### DIFF
--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -266,12 +266,7 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
     }
 
     private promptForSingleOptionalTarget(player: Player, context: AbilityContext, target: Card) {
-        // This resolver's buildConcreteActivePromptTitle override intentionally returns null for function-valued
-        // titles so the raw function can be resolved later by the select-card prompt (with the selection set).
-        // Here we build a plain handler menu instead, so resolve the title to a concrete string ourselves via the
-        // base implementation, falling back to the ability title when no activePromptTitle was provided.
         const effectName = super.buildConcreteActivePromptTitle(context) ?? context.ability?.getTitle(context);
-
         const activePromptTitle = `Trigger the effect '${effectName}' on target '${target.title}' or pass${this.selector.appendToDefaultTitle ? ' ' + this.selector.appendToDefaultTitle : ''}`;
 
         context.game.promptWithHandlerMenu(player, {

--- a/server/game/core/ability/abilityTargets/CardTargetResolver.ts
+++ b/server/game/core/ability/abilityTargets/CardTargetResolver.ts
@@ -266,7 +266,11 @@ export class CardTargetResolver extends TargetResolver<ICardTargetsResolver<Abil
     }
 
     private promptForSingleOptionalTarget(player: Player, context: AbilityContext, target: Card) {
-        const effectName = this.properties.activePromptTitle ? this.properties.activePromptTitle : context.ability.getTitle(context);
+        // This resolver's buildConcreteActivePromptTitle override intentionally returns null for function-valued
+        // titles so the raw function can be resolved later by the select-card prompt (with the selection set).
+        // Here we build a plain handler menu instead, so resolve the title to a concrete string ourselves via the
+        // base implementation, falling back to the ability title when no activePromptTitle was provided.
+        const effectName = super.buildConcreteActivePromptTitle(context) ?? context.ability?.getTitle(context);
 
         const activePromptTitle = `Trigger the effect '${effectName}' on target '${target.title}' or pass${this.selector.appendToDefaultTitle ? ' ' + this.selector.appendToDefaultTitle : ''}`;
 

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -302,9 +302,6 @@ describe('autoSingleTarget: single-target scenarios', function() {
             });
         });
 
-        // The optional single-target prompt renders the effect's activePromptTitle into a plain handler menu. When
-        // that title is a dynamic function (e.g. The Eye of Aldhani computes it from the player's resources/units),
-        // it must be resolved to a concrete string rather than leaking the raw function source into the prompt.
         describe('when an optional single-target prompt has a function-valued activePromptTitle', function() {
             it('resolves the dynamic title to a concrete string in the play-or-pass prompt when autoSingleTarget is on', async function() {
                 await contextRef.setupTestAsync({

--- a/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
+++ b/test/scenarios/autoSingleTarget/AutoSingleTarget.spec.ts
@@ -302,6 +302,46 @@ describe('autoSingleTarget: single-target scenarios', function() {
             });
         });
 
+        // The optional single-target prompt renders the effect's activePromptTitle into a plain handler menu. When
+        // that title is a dynamic function (e.g. The Eye of Aldhani computes it from the player's resources/units),
+        // it must be resolved to a concrete string rather than leaking the raw function source into the prompt.
+        describe('when an optional single-target prompt has a function-valued activePromptTitle', function() {
+            it('resolves the dynamic title to a concrete string in the play-or-pass prompt when autoSingleTarget is on', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['the-eye-of-aldhani']
+                    },
+                    player2: {
+                        autoSingleTarget: true,
+                        groundArena: ['wampa']
+                    }
+                });
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.theEyeOfAldhani);
+
+                context.moveToRegroupPhase();
+                context.player1.clickDone();
+                context.player2.clickDone();
+
+                // the opponent's single unit produces an optional target prompt; the dynamic title resolves to text,
+                // not the raw source of the activePromptTitle function
+                const effectTitle = 'Select up to 1 units and pay 1 resource for each of them to keep them ready';
+                expect(context.player2).toHavePrompt(`Trigger the effect '${effectTitle}' on target 'Wampa' or pass`);
+                expect(context.player2).toHaveExactPromptButtons([
+                    `${effectTitle} -> Wampa`,
+                    'Pass'
+                ]);
+
+                context.player2.clickPrompt(`${effectTitle} -> Wampa`);
+
+                // paying keeps Wampa ready at the cost of one resource
+                expect(context.player2.exhaustedResourceCount).toBe(1);
+                expect(context.wampa.exhausted).toBeFalse();
+            });
+        });
+
         describe('when deploying a pilot leader as an upgrade with one eligible vehicle', function() {
             const pilotDeployPrompt = 'Deploy Kazuda Xiono as a Pilot';
 


### PR DESCRIPTION
## Problem

With `autoSingleTarget` on, an optional single-target selection whose `activePromptTitle` is a **function** (e.g. The Eye of Aldhani, which computes the title from the player's resources/units) leaked the raw function source into both the prompt title and the choice button:

```
Trigger the effect '(context) => { const upUnits = Math.min(...); return `Select up to ...`; }' on target 'Wampa' or pass
```

## Cause

`CardTargetResolver.promptForSingleOptionalTarget` used `this.properties.activePromptTitle` directly. That resolver overrides `buildConcreteActivePromptTitle` to return `null` for function titles on purpose — the multi-select prompt resolves them later with the selection set — but the single-optional path builds a plain handler menu that needs a concrete string.

## Fix

Resolve the title via the base `buildConcreteActivePromptTitle`, falling back to the ability title (guarded, since delayed-effect contexts have no `ability`).

## Tests

Added a case to the `autoSingleTarget` scenario suite covering a function-valued `activePromptTitle`. Fails with the leaked source before the fix, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)