### PR TITLE
fix: ShuffleDeckSystem shuffles the targeted players deck

### DIFF
--- a/server/game/gameSystems/ShuffleDeckSystem.ts
+++ b/server/game/gameSystems/ShuffleDeckSystem.ts
@@ -19,7 +19,9 @@ export class ShuffleDeckSystem<TContext extends AbilityContext = AbilityContext>
     }
 
     public eventHandler(event): void {
-        event.context.player.shuffleDeck();
+        for (const player of Helpers.asArray(event.player)) {
+            player.shuffleDeck();
+        }
     }
 
     public override getEffectMessage(context: TContext, additionalProperties?: Partial<IShuffleDeckProperties>): [string, any[]] {

--- a/test/server/cards/04_JTL/units/AnnihilatorTaggesFlagship.spec.ts
+++ b/test/server/cards/04_JTL/units/AnnihilatorTaggesFlagship.spec.ts
@@ -442,5 +442,80 @@ describe('Annihilator, Tagge\'s Flagship', function() {
             expect(inHandL337Pilot).toBeInZone('discard');
             expect(inDeckL337Pilot).toBeInZone('discard');
         });
+
+        describe('Annihilator\'s deck search', function() {
+            it('shuffles the opponent\'s deck, and not the resolving player\'s', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['annihilator#tagges-flagship'],
+                        spaceArena: ['concord-dawn-interceptors'],
+                        deck: [
+                            'pyke-sentinel',
+                            'wing-leader',
+                            'seasoned-fleet-admiral',
+                            'death-star-stormtrooper',
+                            'superlaser-technician',
+                            'snowtrooper-lieutenant'
+                        ]
+                    },
+                    player2: {
+                        groundArena: ['wampa'],
+                        deck: [
+                            'battlefield-marine',
+                            'cartel-spacer',
+                            'crafty-smuggler',
+                            'elite-p38-starfighter',
+                            'wampa',
+                            'consortium-starviper',
+                            'system-patrol-craft',
+                            'tieln-fighter',
+                            'vanguard-infantry',
+                            'volunteer-soldier'
+                        ]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                const wampaInPlay = context.player2.findCardByName('wampa', 'groundArena');
+                const wampaInDeck = context.player2.findCardByName('wampa', 'deck');
+                const ownDeck = context.player1.deck;
+
+                // Seeded so the shuffle result is identical on every run.
+                context.game.setRandomSeed('annihilator-shuffle');
+
+                context.player1.clickCard(context.annihilator);
+                context.player1.clickCard(wampaInPlay);
+
+                context.player1.clickCardInDisplayCardPrompt(wampaInDeck);
+                context.player1.clickDone();
+
+                expect(wampaInDeck).toBeInZone('discard');
+
+                // Wampa is gone, remaining cards are in a different order
+                expect(context.player2.deck.map((c) => c.internalName)).toEqual([
+                    'tieln-fighter',
+                    'volunteer-soldier',
+                    'system-patrol-craft',
+                    'elite-p38-starfighter',
+                    'battlefield-marine',
+                    'consortium-starviper',
+                    'crafty-smuggler',
+                    'cartel-spacer',
+                    'vanguard-infantry'
+                ]);
+
+                // Only the searched deck is shuffled: the resolving player's own deck is untouched.
+                expect(context.player1.deck.map((c) => c.internalName)).toEqual([
+                    'pyke-sentinel',
+                    'wing-leader',
+                    'seasoned-fleet-admiral',
+                    'death-star-stormtrooper',
+                    'superlaser-technician',
+                    'snowtrooper-lieutenant'
+                ]);
+            });
+        });
     });
 });


### PR DESCRIPTION
Annihilator was shuffling the resolving player's deck, not the targeted player
