### PR TITLE
Keep player names anonymous on timeout for spectators 

### DIFF
--- a/server/game/core/Game.ts
+++ b/server/game/core/Game.ts
@@ -774,7 +774,7 @@ export class Game extends EventEmitter {
         }
 
         player.opponent.actionTimer.stop();
-        this.addAlert(AlertType.Notification, `Game ended due to ${player.name} timing out.`);
+        this.addAlert(AlertType.Notification, 'Game ended due to {0} timing out.', player);
 
         if (player.opponent.actionTimer.totalTimeRemainingSeconds < 3) {
             // Both players nearly timed out - treat as draw, don't forfeit Bo3 set

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -280,7 +280,7 @@ export class Player extends GameObject implements IGameStatisticsTrackable {
             : ByoyomiTimer.MainTimeWarningSeconds;
         const alertType = status === PlayerTimeRemainingStatus.Danger ? AlertType.Danger : AlertType.Warning;
 
-        this.game.addAlert(alertType, `${this.name} has ${secondsRemaining} seconds of main time remaining.`);
+        this.game.addAlert(alertType, '{0} has {1} seconds of main time remaining.', this, secondsRemaining);
     }
 
     public getArenaCards(filter: IAllArenasForPlayerCardFilterProperties = {}) {


### PR DESCRIPTION
The timeout messages were building the player's name straight into the
message text. By the time that reaches the client it's just a plain
string, so the client has no way to know part of it is a name — which
means spectators saw real usernames instead of "Player 1"/"Player 2".

The fix is to pass the player as a `{0}` argument instead of writing the
name into the string, the same way `{0} concedes the game` already does.
That sends the player as a proper token, and the client's existing
spectator anonymization picks it up from there.

Two lines, in `Player.ts` (the "X seconds remaining" warning) and
`Game.ts` (the "game ended due to timeout" message).

Tested locally by spectating a real Quick Match and letting a player time
out. All three messages now show "Player x" instead of the username.

After digging in, realized I put the bug report in the wrong repo... so this fixes SWU-Karabast/forceteki-client#796