### PR TITLE
Add Plot declare-then-order step matching paper rules (SWU 7.6.2b)

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -252,6 +252,12 @@ export type IAbilityPropsWithType<TSource extends Card = Card> =
 
 // exported for use in situations where we need to exclude "when" and "aggregateWhen"
 export type ITriggeredAbilityBaseProps<TSource extends Card = Card> = IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>> & {
+    /**
+     * The keyword this triggered ability implements, if any. Used so that generic engine code (e.g. the
+     * Plot declare-step in TriggerWindowBase) can identify the keyword an ability instance represents even
+     * when it's constructed via the generic `TriggeredAbility` class rather than a keyword-specific subclass.
+     */
+    keyword?: KeywordName;
     collectiveTrigger?: boolean;
     targetResolver?: ITriggeredAbilityTargetResolver<TriggeredAbilityContext<TSource>>;
     targetResolvers?: ITriggeredAbilityTargetsResolver<TriggeredAbilityContext<TSource>>;

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -253,12 +253,21 @@ export type IAbilityPropsWithType<TSource extends Card = Card> =
 // exported for use in situations where we need to exclude "when" and "aggregateWhen"
 export type ITriggeredAbilityBaseProps<TSource extends Card = Card> = IAbilityPropsWithSystems<TriggeredAbilityContext<TSource>> & {
     /**
-     * The keyword this triggered ability implements, if any. Used so that generic engine code (e.g. the
-     * Plot declare-step in TriggerWindowBase) can identify the keyword an ability instance represents even
-     * when it's constructed via the generic `TriggeredAbility` class rather than a keyword-specific subclass.
+     * The keyword this triggered ability implements, if any. Used so that generic engine code can
+     * identify the keyword an ability instance represents even when it's constructed via the generic
+     * `TriggeredAbility` class rather than a keyword-specific subclass.
      */
     keyword?: KeywordName;
     collectiveTrigger?: boolean;
+
+    /**
+     * If set, this ability opts into a pre-resolution "declare" step: whenever 2+ pending abilities
+     * share the same label (and originate from the same zone) for the same player, the player first
+     * declares (in one action) the subset they intend to resolve, before choosing resolution order as
+     * normal (see `TriggerWindowBase`'s declare step). The string is shown to the player verbatim (e.g.
+     * "Plot") and is not required to be tied to a `KeywordName` — any ability can opt in with any label.
+     */
+    declareGroupLabel?: string;
     targetResolver?: ITriggeredAbilityTargetResolver<TriggeredAbilityContext<TSource>>;
     targetResolvers?: ITriggeredAbilityTargetsResolver<TriggeredAbilityContext<TSource>>;
     immediateEffect?: GameSystem<TriggeredAbilityContext<TSource>>;

--- a/server/game/abilities/keyword/AmbushAbility.ts
+++ b/server/game/abilities/keyword/AmbushAbility.ts
@@ -14,7 +14,7 @@ import { registerState } from '../../core/GameObjectUtils';
 
 @registerState()
 export class AmbushAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Ambush;
+    public override readonly keyword: KeywordName = KeywordName.Ambush;
 
     public static buildAmbushAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {

--- a/server/game/abilities/keyword/BountyAbility.ts
+++ b/server/game/abilities/keyword/BountyAbility.ts
@@ -22,7 +22,7 @@ export type IResolvedBountyProperties = Omit<ITriggeredAbilityBaseProps, 'canBeT
  */
 @registerState()
 export class BountyAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Bounty;
+    public override readonly keyword: KeywordName = KeywordName.Bounty;
 
     private readonly bountyProperties: IResolvedBountyProperties;
 

--- a/server/game/abilities/keyword/PlotAbility.ts
+++ b/server/game/abilities/keyword/PlotAbility.ts
@@ -18,6 +18,7 @@ export class PlotAbility extends TriggeredAbilityBase {
         return {
             title: `Play ${cardTitle} using ${TextHelper.Plot}`,
             keyword: KeywordName.Plot,
+            declareGroupLabel: TextHelper.Plot,
             optional: true,
             when: {
                 onLeaderDeployed: (event, context) => event.card.owner === context.source.controller && context.source.zoneName === ZoneName.Resource // TODO See if we can remove this zone check once we update Plot registration

--- a/server/game/abilities/keyword/PlotAbility.ts
+++ b/server/game/abilities/keyword/PlotAbility.ts
@@ -12,11 +12,12 @@ import { registerState } from '../../core/GameObjectUtils';
 
 @registerState()
 export class PlotAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Plot;
+    public override readonly keyword: KeywordName = KeywordName.Plot;
 
     public static buildPlotAbilityProperties<TSource extends Card = Card>(cardTitle: string): ITriggeredAbilityProps<TSource> {
         return {
             title: `Play ${cardTitle} using ${TextHelper.Plot}`,
+            keyword: KeywordName.Plot,
             optional: true,
             when: {
                 onLeaderDeployed: (event, context) => event.card.owner === context.source.controller && context.source.zoneName === ZoneName.Resource // TODO See if we can remove this zone check once we update Plot registration

--- a/server/game/abilities/keyword/RestoreAbility.ts
+++ b/server/game/abilities/keyword/RestoreAbility.ts
@@ -10,7 +10,7 @@ import { registerState } from '../../core/GameObjectUtils';
 
 @registerState()
 export class RestoreAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Restore;
+    public override readonly keyword: KeywordName = KeywordName.Restore;
 
     public static buildRestoreAbilityProperties<TSource extends Card = Card>(restoreAmount: number): ITriggeredAbilityProps<TSource> {
         return {

--- a/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
+++ b/server/game/abilities/keyword/SaboteurDefeatShieldsAbility.ts
@@ -13,7 +13,7 @@ import { registerState } from '../../core/GameObjectUtils';
 
 @registerState()
 export class SaboteurDefeatShieldsAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Saboteur;
+    public override readonly keyword: KeywordName = KeywordName.Saboteur;
 
     public static buildSaboteurAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {

--- a/server/game/abilities/keyword/ShieldedAbility.ts
+++ b/server/game/abilities/keyword/ShieldedAbility.ts
@@ -11,7 +11,7 @@ import { registerState } from '../../core/GameObjectUtils';
 
 @registerState()
 export class ShieldedAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Shielded;
+    public override readonly keyword: KeywordName = KeywordName.Shielded;
 
     public static buildShieldedAbilityProperties<TSource extends Card = Card>(): ITriggeredAbilityProps<TSource> {
         return {

--- a/server/game/abilities/keyword/SupportAbility.ts
+++ b/server/game/abilities/keyword/SupportAbility.ts
@@ -9,7 +9,7 @@ import { InitiateAttackSystem } from '../../gameSystems/InitiateAttackSystem';
 
 @registerState()
 export class SupportAbility extends TriggeredAbilityBase {
-    public readonly keyword: KeywordName = KeywordName.Support;
+    public override readonly keyword: KeywordName = KeywordName.Support;
 
     public static buildSupportAbilityProperties<TSource extends Card = Card>(source: TSource): ITriggeredAbilityProps<TSource> {
         return {

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -2,6 +2,7 @@ import { CardAbility } from './CardAbility';
 import { TriggeredAbilityContext } from './TriggeredAbilityContext';
 import { EventName, PlayType, StandardTriggeredAbilityType } from '../Constants';
 import { AbilityType, GameStateChangeRequired, RelativePlayer, Stage } from '../Constants';
+import type { KeywordName } from '../Constants';
 import type { IEventRegistration, ITriggeredAbilityProps, WhenType, WhenTypeOrStandard } from '../../Interfaces';
 import type { GameEvent } from '../event/GameEvent';
 import type { Card } from '../card/Card';
@@ -51,6 +52,7 @@ export interface ITriggeredAbilityState extends IGameObjectBaseState {
 export abstract class TriggeredAbilityBase extends CardAbility {
     public readonly when?: WhenType;
     public readonly aggregateWhen?: (events: GameEvent[], context: TriggeredAbilityContext) => boolean;
+    public readonly keyword?: KeywordName;
     public readonly anyPlayer: boolean;
     public readonly collectiveTrigger: boolean;
     public readonly standardTriggerTypes: StandardTriggeredAbilityType[] = [];
@@ -101,6 +103,10 @@ export abstract class TriggeredAbilityBase extends CardAbility {
         }
 
         this.collectiveTrigger = !!properties.collectiveTrigger;
+
+        if (properties.keyword) {
+            this.keyword = properties.keyword;
+        }
 
         this.mustChangeGameState = !!this.properties.ifYouDo || !!this.properties.ifYouDoNot
             ? GameStateChangeRequired.MustFullyResolve

--- a/server/game/core/ability/TriggeredAbility.ts
+++ b/server/game/core/ability/TriggeredAbility.ts
@@ -55,6 +55,7 @@ export abstract class TriggeredAbilityBase extends CardAbility {
     public readonly keyword?: KeywordName;
     public readonly anyPlayer: boolean;
     public readonly collectiveTrigger: boolean;
+    public readonly declareGroupLabel?: string;
     public readonly standardTriggerTypes: StandardTriggeredAbilityType[] = [];
 
     protected eventRegistrations?: IEventRegistration<(event: GameEvent, window: TriggeredAbilityWindow) => void>[];
@@ -103,6 +104,7 @@ export abstract class TriggeredAbilityBase extends CardAbility {
         }
 
         this.collectiveTrigger = !!properties.collectiveTrigger;
+        this.declareGroupLabel = properties.declareGroupLabel;
 
         if (properties.keyword) {
             this.keyword = properties.keyword;

--- a/server/game/core/ability/TriggeredAbilityContext.ts
+++ b/server/game/core/ability/TriggeredAbilityContext.ts
@@ -7,6 +7,7 @@ export interface ITriggeredAbilityContextProperties extends IAbilityContextPrope
     // TODO: rename this to "triggeringEvent"
     event: any;
     overrideTitle?: string;
+    preConfirmed?: boolean;
 
     /**
      * True if this ability was manually activated by a game system (e.g., UseWhenDefeatedSystem)
@@ -21,21 +22,37 @@ export class TriggeredAbilityContext<TSource extends Card = Card> extends Abilit
     public readonly retriggeredByAbility: boolean;
 
     private _overrideTitle: string = null;
+    private _preConfirmed: boolean = false;
 
     public get overrideTitle(): string | null {
         return this._overrideTitle;
+    }
+
+    /**
+     * True if the controller already committed to resolving this ability (e.g. during a Plot
+     * declare-step) before it reaches the ability resolver, so the resolver should not prompt
+     * for a redundant Trigger / Pass confirmation.
+     */
+    public get preConfirmed(): boolean {
+        return this._preConfirmed;
     }
 
     public constructor(properties: ITriggeredAbilityContextProperties) {
         super(properties);
         this.event = properties.event;
         this._overrideTitle = properties.overrideTitle;
+        this._preConfirmed = properties.preConfirmed || false;
         this.retriggeredByAbility = properties.retriggeredByAbility || false;
     }
 
     public setOverrideTitle(title: string) {
         Contract.assertIsNullLike(this._overrideTitle, () => `Override title has already been set to ${this._overrideTitle}`);
         this._overrideTitle = title;
+    }
+
+    public markPreConfirmed() {
+        Contract.assertFalse(this._preConfirmed, 'Context has already been marked as pre-confirmed');
+        this._preConfirmed = true;
     }
 
     public override isTriggered(): this is TriggeredAbilityContext<TSource> {
@@ -47,7 +64,7 @@ export class TriggeredAbilityContext<TSource extends Card = Card> extends Abilit
     }
 
     public override getProps() {
-        return Object.assign(super.getProps(), { event: this.event, overrideTitle: this.overrideTitle, retriggeredByAbility: this.retriggeredByAbility });
+        return Object.assign(super.getProps(), { event: this.event, overrideTitle: this.overrideTitle, preConfirmed: this.preConfirmed, retriggeredByAbility: this.retriggeredByAbility });
     }
 
     public cancel() {

--- a/server/game/core/ability/TriggeredAbilityContext.ts
+++ b/server/game/core/ability/TriggeredAbilityContext.ts
@@ -22,7 +22,7 @@ export class TriggeredAbilityContext<TSource extends Card = Card> extends Abilit
     public readonly retriggeredByAbility: boolean;
 
     private _overrideTitle: string = null;
-    private _preConfirmed: boolean = false;
+    private _preConfirmed = false;
 
     public get overrideTitle(): string | null {
         return this._overrideTitle;

--- a/server/game/core/gameSteps/AbilityResolver.ts
+++ b/server/game/core/gameSteps/AbilityResolver.ts
@@ -77,7 +77,9 @@ export class AbilityResolver extends BaseStepWithPipeline {
             this.passButtonText = this.context.ability.isAttackAction() ? 'Pass attack' : 'Pass';
         }
 
-        this.passAbilityHandler = (!!this.context.ability.optional || optional) ? {
+        const isPreConfirmed = this.context.isTriggered() && this.context.preConfirmed;
+
+        this.passAbilityHandler = (!isPreConfirmed && (!!this.context.ability.optional || optional)) ? {
             buttonText: this.passButtonText,
             arg: 'passAbility',
             hasBeenShown: false,

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -1,7 +1,7 @@
 import type { Player } from '../../Player';
 import type { GameEvent } from '../../event/GameEvent';
 import type { EventWindow } from '../../event/EventWindow';
-import { AbilityType, KeywordName, SubStepCheck } from '../../Constants';
+import { AbilityType, SubStepCheck } from '../../Constants';
 import { Contract } from '../../utils/Contract';
 import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import type { TriggeredAbilityBase } from '../../ability/TriggeredAbility';
@@ -12,7 +12,7 @@ import type { Game } from '../../Game';
 import { TriggeredAbilityResolutionPrompt } from '../prompts/TriggeredAbilityResolutionPrompt';
 import { BatchTriggerResolutionPrompt } from '../prompts/BatchTriggerResolutionPrompt';
 import type { IResolutionChoice, ITriggerWindowSourceCard } from '../PromptInterfaces';
-import { TextHelper } from '../../utils/TextHelper';
+import { EnumHelpers } from '../../utils/EnumHelpers';
 
 /** Builds the lightweight card summary attached to trigger-style prompt buttons. */
 export function getTriggerSourceCardSummary(card: Card): ITriggerWindowSourceCard {
@@ -50,10 +50,15 @@ export abstract class TriggerWindowBase extends BaseStep {
     private pendingBatchResolve?: { player: Player; groupKey: string } = null;
 
     /**
-     * Players who have already completed the Plot "declare which cards to play" step for this
-     * window (SWU 7.6.2b). Tracked per-window since each leader deploy opens its own window.
+     * Per-player sets of "declare group" keys (see `getDeclareGroupKey`) that have already gone through
+     * the "declare which cards to play" step for this window, for abilities that opt in via
+     * `declareGroupLabel` (see the base class field of the same name). Grouping by zone + label, rather
+     * than gating the whole player once, keeps unrelated declare-eligible mechanics that happen to be
+     * pending at the same time (e.g. two different labels, or the same label from two different zones)
+     * from being merged into a single misleading prompt. Tracked per-window since each triggering event
+     * opens its own window.
      */
-    private plotDeclarationComplete = new Set<Player>();
+    private declaredGroupKeys = new Map<Player, Set<string>>();
 
     protected readonly triggerAbilityType: AbilityType.Triggered | AbilityType.ReplacementEffect | AbilityType.DelayedEffect;
 
@@ -202,15 +207,23 @@ export abstract class TriggerWindowBase extends BaseStep {
             abilitiesToResolve = this.unresolved.get(this.currentlyResolvingPlayer);
         }
 
-        if (!this.plotDeclarationComplete.has(this.currentlyResolvingPlayer)) {
-            this.plotDeclarationComplete.add(this.currentlyResolvingPlayer);
+        const declaredGroups = this.declaredGroupKeys.get(this.currentlyResolvingPlayer) ?? new Set<string>();
+        const nextUndeclaredContext = abilitiesToResolve.find((context) =>
+            context.ability.declareGroupLabel && !declaredGroups.has(this.getDeclareGroupKey(context))
+        );
 
-            const pendingPlotContexts = abilitiesToResolve.filter((context) => context.ability.keyword === KeywordName.Plot);
+        if (nextUndeclaredContext) {
+            const groupKey = this.getDeclareGroupKey(nextUndeclaredContext);
+            const groupContexts = abilitiesToResolve.filter((context) => this.getDeclareGroupKey(context) === groupKey);
 
-            // Only worth a separate declare step when there's an actual subset to choose between (SWU 7.6.2b);
-            // with a single eligible card, the normal Trigger / Pass flow already covers the same choice.
-            if (pendingPlotContexts.length > 1) {
-                this.promptPlotDeclaration(this.currentlyResolvingPlayer, pendingPlotContexts);
+            declaredGroups.add(groupKey);
+            this.declaredGroupKeys.set(this.currentlyResolvingPlayer, declaredGroups);
+
+            // Only worth a separate declare step when there's an actual subset to choose between (e.g. SWU
+            // 7.6.2b for Plot); with a single eligible card, the normal Trigger / Pass flow already covers
+            // the same choice.
+            if (groupContexts.length > 1) {
+                this.promptDeclareStep(this.currentlyResolvingPlayer, groupContexts);
                 return false;
             }
         }
@@ -365,38 +378,49 @@ export abstract class TriggerWindowBase extends BaseStep {
     }
 
     /**
-     * Prompts the player to declare, in one action, which of their pending Plot-eligible cards they
-     * intend to play this turn (SWU 7.6.2b: "show your opponent each card with Plot you plan to
-     * play"). Declared cards are marked pre-confirmed so their later resolution skips the redundant
-     * Trigger / Pass prompt; undeclared cards are dropped from the window entirely so they're never
-     * asked about individually.
+     * Groups pending `declareGroupLabel` contexts so unrelated mechanics that happen to be pending for
+     * the same player at once (different labels, or the same label from different zones) each get their
+     * own declare step rather than being merged into a single prompt.
      */
-    private promptPlotDeclaration(player: Player, plotContexts: TriggeredAbilityContext[]) {
-        const plotSourceCards = plotContexts.map((context) => context.source);
+    private getDeclareGroupKey(context: TriggeredAbilityContext): string {
+        return `${context.source.zoneName}::${context.ability.declareGroupLabel}`;
+    }
+
+    /**
+     * Prompts the player to declare, in one action, which of their pending `declareGroupLabel` abilities
+     * they intend to resolve (e.g. SWU 7.6.2b for Plot: "show your opponent each card with Plot you plan
+     * to play"). Declared instances are marked pre-confirmed so their later resolution skips the
+     * redundant Trigger / Pass prompt; undeclared instances are dropped from the window entirely so
+     * they're never asked about individually.
+     */
+    private promptDeclareStep(player: Player, declareContexts: TriggeredAbilityContext[]) {
+        const declareSourceCards = declareContexts.map((context) => context.source);
+        const groupLabel = declareContexts[0].ability.declareGroupLabel;
+        const zoneText = EnumHelpers.zoneToPlayFromText(declareContexts[0].source.zoneName);
 
         this.game.promptDisplayCardsForSelection(player, {
-            activePromptTitle: `Choose any number of cards to play from resources using ${TextHelper.Plot}`,
-            waitingPromptTitle: `Waiting for opponent to choose cards to play using ${TextHelper.Plot}`,
-            source: `${TextHelper.Plot}`,
-            displayCards: plotSourceCards,
-            maxCards: plotSourceCards.length,
+            activePromptTitle: `Choose any number of cards to play from ${zoneText} using ${groupLabel}`,
+            waitingPromptTitle: `Waiting for opponent to choose cards to play using ${groupLabel}`,
+            source: groupLabel,
+            displayCards: declareSourceCards,
+            maxCards: declareSourceCards.length,
             canChooseFewer: true,
             noSelectedCardsButtonText: 'Choose nothing',
             selectedCardsHandler: (cards) => {
-                this.applyPlotDeclaration(player, plotContexts, cards);
+                this.applyDeclareStep(player, declareContexts, cards);
                 this.promptUnresolvedAbilities();
             }
         });
     }
 
-    private applyPlotDeclaration(player: Player, plotContexts: TriggeredAbilityContext[], chosenCards: Card[]) {
-        for (const context of plotContexts) {
+    private applyDeclareStep(player: Player, declareContexts: TriggeredAbilityContext[], chosenCards: Card[]) {
+        for (const context of declareContexts) {
             if (chosenCards.includes(context.source)) {
                 context.markPreConfirmed();
             }
         }
 
-        const notSelected = new Set(plotContexts.filter((context) => !chosenCards.includes(context.source)));
+        const notSelected = new Set(declareContexts.filter((context) => !chosenCards.includes(context.source)));
         const remaining = this.unresolved.get(player) ?? [];
         this.unresolved.set(player, remaining.filter((context) => !notSelected.has(context)));
     }

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -1,7 +1,7 @@
 import type { Player } from '../../Player';
 import type { GameEvent } from '../../event/GameEvent';
 import type { EventWindow } from '../../event/EventWindow';
-import { AbilityType, SubStepCheck } from '../../Constants';
+import { AbilityType, KeywordName, SubStepCheck } from '../../Constants';
 import { Contract } from '../../utils/Contract';
 import type { TriggeredAbilityContext } from '../../ability/TriggeredAbilityContext';
 import type { TriggeredAbilityBase } from '../../ability/TriggeredAbility';
@@ -47,6 +47,12 @@ export abstract class TriggerWindowBase extends BaseStep {
      * resolve before the next (SWU 7.6.11), and cleared once the group is exhausted.
      */
     private pendingBatchResolve?: { player: Player; groupKey: string } = null;
+
+    /**
+     * Players who have already completed the Plot "declare which cards to play" step for this
+     * window (SWU 7.6.2b). Tracked per-window since each leader deploy opens its own window.
+     */
+    private plotDeclarationComplete = new Set<Player>();
 
     protected readonly triggerAbilityType: AbilityType.Triggered | AbilityType.ReplacementEffect | AbilityType.DelayedEffect;
 
@@ -193,6 +199,19 @@ export abstract class TriggerWindowBase extends BaseStep {
             }
 
             abilitiesToResolve = this.unresolved.get(this.currentlyResolvingPlayer);
+        }
+
+        if (!this.plotDeclarationComplete.has(this.currentlyResolvingPlayer)) {
+            this.plotDeclarationComplete.add(this.currentlyResolvingPlayer);
+
+            const pendingPlotContexts = abilitiesToResolve.filter((context) => context.ability.keyword === KeywordName.Plot);
+
+            // Only worth a separate declare step when there's an actual subset to choose between (SWU 7.6.2b);
+            // with a single eligible card, the normal Trigger / Pass flow already covers the same choice.
+            if (pendingPlotContexts.length > 1) {
+                this.promptPlotDeclaration(this.currentlyResolvingPlayer, pendingPlotContexts);
+                return false;
+            }
         }
 
         // Check to if we're dealing with a multi-selection of the 'same' ability
@@ -342,6 +361,43 @@ export abstract class TriggerWindowBase extends BaseStep {
                 this.promptUnresolvedAbilities();
             },
         }));
+    }
+
+    /**
+     * Prompts the player to declare, in one action, which of their pending Plot-eligible cards they
+     * intend to play this turn (SWU 7.6.2b: "show your opponent each card with Plot you plan to
+     * play"). Declared cards are marked pre-confirmed so their later resolution skips the redundant
+     * Trigger / Pass prompt; undeclared cards are dropped from the window entirely so they're never
+     * asked about individually.
+     */
+    private promptPlotDeclaration(player: Player, plotContexts: TriggeredAbilityContext[]) {
+        const plotSourceCards = plotContexts.map((context) => context.source);
+
+        this.game.promptDisplayCardsForSelection(player, {
+            activePromptTitle: 'Choose any number of cards to play from resources using Plot',
+            waitingPromptTitle: 'Waiting for opponent to choose cards to play using Plot',
+            source: 'Plot',
+            displayCards: plotSourceCards,
+            maxCards: plotSourceCards.length,
+            canChooseFewer: true,
+            noSelectedCardsButtonText: 'Choose nothing',
+            selectedCardsHandler: (cards) => {
+                this.applyPlotDeclaration(player, plotContexts, cards);
+                this.promptUnresolvedAbilities();
+            }
+        });
+    }
+
+    private applyPlotDeclaration(player: Player, plotContexts: TriggeredAbilityContext[], chosenCards: Card[]) {
+        for (const context of plotContexts) {
+            if (chosenCards.includes(context.source)) {
+                context.markPreConfirmed();
+            }
+        }
+
+        const notSelected = new Set(plotContexts.filter((context) => !chosenCards.includes(context.source)));
+        const remaining = this.unresolved.get(player) ?? [];
+        this.unresolved.set(player, remaining.filter((context) => !notSelected.has(context)));
     }
 
     /** Get the set of yet-unresolved abilities for the player whose turn it is to do resolution */

--- a/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
+++ b/server/game/core/gameSteps/abilityWindow/TriggerWindowBase.ts
@@ -12,6 +12,7 @@ import type { Game } from '../../Game';
 import { TriggeredAbilityResolutionPrompt } from '../prompts/TriggeredAbilityResolutionPrompt';
 import { BatchTriggerResolutionPrompt } from '../prompts/BatchTriggerResolutionPrompt';
 import type { IResolutionChoice, ITriggerWindowSourceCard } from '../PromptInterfaces';
+import { TextHelper } from '../../utils/TextHelper';
 
 /** Builds the lightweight card summary attached to trigger-style prompt buttons. */
 export function getTriggerSourceCardSummary(card: Card): ITriggerWindowSourceCard {
@@ -374,9 +375,9 @@ export abstract class TriggerWindowBase extends BaseStep {
         const plotSourceCards = plotContexts.map((context) => context.source);
 
         this.game.promptDisplayCardsForSelection(player, {
-            activePromptTitle: 'Choose any number of cards to play from resources using Plot',
-            waitingPromptTitle: 'Waiting for opponent to choose cards to play using Plot',
-            source: 'Plot',
+            activePromptTitle: `Choose any number of cards to play from resources using ${TextHelper.Plot}`,
+            waitingPromptTitle: `Waiting for opponent to choose cards to play using ${TextHelper.Plot}`,
+            source: `${TextHelper.Plot}`,
             displayCards: plotSourceCards,
             maxCards: plotSourceCards.length,
             canChooseFewer: true,

--- a/server/game/core/utils/EnumHelpers.ts
+++ b/server/game/core/utils/EnumHelpers.ts
@@ -340,6 +340,22 @@ export namespace EnumHelpers {
                 return 'space arena';
         }
     };
+
+    /** Human-readable phrase for "play a card from <zone>" prompts (e.g. the declare step in `TriggerWindowBase`). */
+    export const zoneToPlayFromText = (zone: ZoneName): string => {
+        switch (zone) {
+            case ZoneName.Hand:
+                return 'hand';
+            case ZoneName.Resource:
+                return 'resources';
+            case ZoneName.Deck:
+                return 'deck';
+            case ZoneName.Discard:
+                return 'discard pile';
+            default:
+                return zone;
+        }
+    };
 }
 
 export const isTimedModAction = (actionType: ModActionType): actionType is TimedModActionType => {

--- a/test/server/cards/06_SEC/leaders/BailOrganaDoingEverythingHeCan.spec.ts
+++ b/test/server/cards/06_SEC/leaders/BailOrganaDoingEverythingHeCan.spec.ts
@@ -292,14 +292,20 @@ describe('Bail Organa, Doing Everything He Can', function () {
                 context.player1.clickDone();
 
                 expect(context.bailOrgana.deployed).toBe(true);
+
+                // Declare which Plot cards to play
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.unveiledMight, context.armorOfFortune] });
+                context.player1.clickCardInDisplayCardPrompt(context.unveiledMight);
+                context.player1.clickCardInDisplayCardPrompt(context.armorOfFortune);
+                context.player1.clickDone();
+
                 expect(context.player1).toHaveExactPromptButtons(['Play Unveiled Might using Plot', 'Play Armor of Fortune using Plot']);
                 context.player1.clickPrompt('Play Unveiled Might using Plot');
-                context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.bailOrgana);
                 expect(context.unveiledMight).toBeAttachedTo(context.bailOrgana);
                 expect(context.p1Base.damage).toBe(4);
 
-                context.player1.clickPrompt('Trigger');
+                // Armor of Fortune was also declared, so it auto-resolves as the last remaining Plot card
                 context.player1.clickCard(context.bailOrgana);
                 expect(context.armorOfFortune).toBeAttachedTo(context.bailOrgana);
                 expect(context.p1Base.damage).toBe(3);

--- a/test/server/cards/06_SEC/leaders/ChancellorPalpatineHowLibertyDies.spec.ts
+++ b/test/server/cards/06_SEC/leaders/ChancellorPalpatineHowLibertyDies.spec.ts
@@ -52,6 +52,13 @@ describe('Chancellor Palpatine, How Liberty Dies', function () {
                 context.player1.clickCard(context.chancellorPalpatine);
                 context.player1.clickPrompt('Deploy Chancellor Palpatine');
                 expect(context.chancellorPalpatine).toBeInZone('groundArena');
+
+                // Declare which Plot cards to play
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.unveiledMight] });
+                context.player1.clickCardInDisplayCardPrompt(context.dogmaticShockSquad);
+                context.player1.clickCardInDisplayCardPrompt(context.unveiledMight);
+                context.player1.clickDone();
+
                 expect(context.player1).toHaveExactPromptButtons(['The next card you play using Plot this phase costs 3 resources less.', 'Play Dogmatic Shock Squad using Plot', 'Play Unveiled Might using Plot']);
 
                 // Reduce the next card played using Plot by 3
@@ -59,13 +66,10 @@ describe('Chancellor Palpatine, How Liberty Dies', function () {
 
                 // Play Dogmatic for 3
                 context.player1.clickPrompt('Play Dogmatic Shock Squad using Plot');
-                context.player1.clickPrompt('Trigger');
                 expect(context.player1.exhaustedResourceCount).toBe(3);
                 expect(context.dogmaticShockSquad).toBeInZone('groundArena');
 
-                // Play Unveiled Might for 4
-                expect(context.player1).toHavePassAbilityPrompt('Play Unveiled Might using Plot');
-                context.player1.clickPrompt('Trigger');
+                // Unveiled Might was also declared, so it auto-resolves as the last remaining Plot card, going straight to target selection
                 expect(context.player1).toBeAbleToSelectExactly([context.chancellorPalpatine, context.dogmaticShockSquad]);
                 context.player1.clickCard(context.dogmaticShockSquad);
                 expect(context.player1.exhaustedResourceCount).toBe(7);
@@ -92,11 +96,17 @@ describe('Chancellor Palpatine, How Liberty Dies', function () {
                 context.player1.clickCard(context.chancellorPalpatineHowLibertyDies);
                 context.player1.clickPrompt('Deploy Chancellor Palpatine');
                 expect(context.chancellorPalpatineHowLibertyDies).toBeInZone('groundArena');
+
+                // Declare which Plot cards to play
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.jarJarBinks, context.chancellorPalpatineIAmTheSenate] });
+                context.player1.clickCardInDisplayCardPrompt(context.jarJarBinks);
+                context.player1.clickCardInDisplayCardPrompt(context.chancellorPalpatineIAmTheSenate);
+                context.player1.clickDone();
+
                 expect(context.player1).toHaveExactPromptButtons(['The next card you play using Plot this phase costs 3 resources less.', 'Play Jar Jar Binks using Plot', 'Play Chancellor Palpatine using Plot']);
 
                 // Play Jar Jar Binks for 2
                 context.player1.clickPrompt('Play Jar Jar Binks using Plot');
-                context.player1.clickPrompt('Trigger');
                 expect(context.player1.exhaustedResourceCount).toBe(2);
                 expect(context.jarJarBinks).toBeInZone('groundArena');
                 context.player1.clickCard(context.chancellorPalpatineHowLibertyDies); // Give Palp +2/+2
@@ -104,9 +114,7 @@ describe('Chancellor Palpatine, How Liberty Dies', function () {
                 // Reduce the next card played using Plot by 3
                 context.player1.clickPrompt('The next card you play using Plot this phase costs 3 resources less.');
 
-                // Play Chancellor Palpatine unit for 0
-                expect(context.player1).toHavePassAbilityPrompt('Play Chancellor Palpatine using Plot');
-                context.player1.clickPrompt('Trigger');
+                // Chancellor Palpatine was also declared, so it auto-resolves as the last remaining Plot card
 
                 // Verify 2 Spy tokens were created for player1
                 const spies = context.player1.findCardsByName('spy');

--- a/test/server/core/abilities/keyword/Plot.spec.ts
+++ b/test/server/core/abilities/keyword/Plot.spec.ts
@@ -248,11 +248,17 @@ describe('Plot keyword', function() {
 
                 context.player1.clickCard(context.idenVersio);
                 context.player1.clickPrompt('Deploy Iden Versio');
+
+                // Declare which Plot cards to play
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.cadBane] });
+                context.player1.clickCardInDisplayCardPrompt(context.dogmaticShockSquad);
+                context.player1.clickCardInDisplayCardPrompt(context.cadBane);
+                context.player1.clickDone();
+
                 expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Play Cad Bane using Plot', 'Shielded']);
 
                 // Resolve Cad Banea
                 context.player1.clickPrompt('Play Cad Bane using Plot');
-                context.player1.clickPrompt('Trigger');
                 expect(context.cadBane).toBeInZone('groundArena');
                 expect(context.pykeSentinel).toBeInZone('resource');
                 expect(context.player1).toHavePrompt('Defeat a unit with 2 or less remaining HP');
@@ -261,7 +267,6 @@ describe('Plot keyword', function() {
 
                 expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Shielded']);
                 context.player1.clickPrompt('Shielded');
-                context.player1.clickPrompt('Trigger');
                 expect(context.dogmaticShockSquad).toBeInZone('groundArena');
                 expect(context.moistureFarmer).toBeInZone('resource');
 
@@ -287,11 +292,17 @@ describe('Plot keyword', function() {
 
                 context.player1.clickCard(context.idenVersio);
                 context.player1.clickPrompt('Deploy Iden Versio');
+
+                // Declare which Plot cards to play
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.cadBane] });
+                context.player1.clickCardInDisplayCardPrompt(context.dogmaticShockSquad);
+                context.player1.clickCardInDisplayCardPrompt(context.cadBane);
+                context.player1.clickDone();
+
                 expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Play Cad Bane using Plot', 'Shielded']);
 
                 // Resolve Cad Banea
                 context.player1.clickPrompt('Play Cad Bane using Plot');
-                context.player1.clickPrompt('Trigger');
                 expect(context.cadBane).toBeInZone('groundArena');
                 expect(context.pykeSentinel).toBeInZone('resource');
 
@@ -308,7 +319,6 @@ describe('Plot keyword', function() {
 
                 expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Shielded']);
                 context.player1.clickPrompt('Shielded');
-                context.player1.clickPrompt('Trigger');
                 expect(context.dogmaticShockSquad).toBeInZone('groundArena');
                 expect(context.moistureFarmer).toBeInZone('resource');
 
@@ -339,20 +349,51 @@ describe('Plot keyword', function() {
 
                 context.player1.clickCard(context.idenVersio);
                 context.player1.clickPrompt('Deploy Iden Versio');
-                expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Play Cad Bane using Plot', 'Shielded']);
 
-                // Resolve Cad Banea
-                context.player1.clickPrompt('Play Cad Bane using Plot');
-                context.player1.clickPrompt('Pass');
-                expect(context.cadBane).toBeInZone('resource');
+                // Declare which Plot cards to play - decline Cad Bane by not selecting it
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.cadBane] });
+                context.player1.clickCardInDisplayCardPrompt(context.dogmaticShockSquad);
+                context.player1.clickDone();
 
+                // Cad Bane was never declared, so it is not offered as a trigger at all
                 expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Shielded']);
                 context.player1.clickPrompt('Shielded');
-                context.player1.clickPrompt('Trigger');
                 expect(context.dogmaticShockSquad).toBeInZone('groundArena');
                 expect(context.pykeSentinel).toBeInZone('resource');
+                expect(context.cadBane).toBeInZone('resource');
 
                 expect(context.player1.exhaustedResourceCount).toBe(6);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should be able to immediately decline all Plot cards at once', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'iden-versio#inferno-squad-commander',
+                        resources: ['dogmatic-shock-squad', 'cad-bane#impressed-now', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa', 'wampa'],
+                        deck: ['pyke-sentinel', 'moisture-farmer']
+                    },
+                    player2: {
+                        groundArena: [{ card: 'battlefield-marine', damage: 1 }]
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.idenVersio);
+                context.player1.clickPrompt('Deploy Iden Versio');
+
+                // Decline Plot entirely in a single action, even though two cards are eligible
+                expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.cadBane] });
+                expect(context.player1).toHaveEnabledPromptButton('Choose nothing');
+                context.player1.clickPrompt('Choose nothing');
+
+                // Neither Plot card is offered afterward; Shielded is the only remaining trigger and resolves on its own
+                expect(context.dogmaticShockSquad).toBeInZone('resource');
+                expect(context.cadBane).toBeInZone('resource');
+                expect(context.player1.exhaustedResourceCount).toBe(0);
 
                 expect(context.player2).toBeActivePlayer();
             });
@@ -478,23 +519,23 @@ describe('Plot keyword', function() {
             context.player1.clickCard(context.admiralTrench);
             context.player1.clickPrompt('Deploy Admiral Trench');
             expect(context.player1.exhaustedResourceCount).toBe(3);
-            expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Play Cad Bane using Plot', 'Play Topple the Summit using Plot',
+
+            // Declare which Plot cards to play - only Topple the Summit this time
+            expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.cadBane, context.toppleTheSummit] });
+            context.player1.clickCardInDisplayCardPrompt(context.toppleTheSummit);
+            context.player1.clickDone();
+
+            expect(context.player1).toHaveExactPromptButtons(['Play Topple the Summit using Plot',
                 '(No effect) Reveal the top 4 cards of your deck. An opponent discards 2 of them. Draw 1 of the remaining cards and discard the other']);
 
             // Resolve Topple the Summit
             context.player1.clickPrompt('Play Topple the Summit using Plot');
-            context.player1.clickPrompt('Trigger');
             expect(context.player1.exhaustedResourceCount).toBe(7); // This is one less than normal because the Topple the Summit was not replaced due to the empty deck
             expect(context.battlefieldMarine).toBeInZone('discard');
 
-            // Resolve Cad Bane
-            context.player1.clickPrompt('Play Cad Bane using Plot');
-            context.player1.clickPrompt('Pass');
+            // Cad Bane and Dogmatic Shock Squad were never declared, so they remain resources untouched
             expect(context.cadBane).toBeInZone('resource');
-
-            // Resolve Dogmatic Shock Squad
-            context.player1.clickPrompt('Play Dogmatic Shock Squad using Plot');
-            context.player1.clickPrompt('Pass');
+            expect(context.dogmaticShockSquad).toBeInZone('resource');
 
             expect(context.player2).toBeActivePlayer();
             context.player2.clickCard(context.rivalsFall);
@@ -506,19 +547,20 @@ describe('Plot keyword', function() {
             context.player1.clickCard(context.admiralTrench);
             context.player1.clickPrompt('Deploy Admiral Trench');
             expect(context.player1.exhaustedResourceCount).toBe(3);
-            expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot', 'Play Cad Bane using Plot',
-                '(No effect) Reveal the top 4 cards of your deck. An opponent discards 2 of them. Draw 1 of the remaining cards and discard the other']);
 
-            // Resolve Cad Bane
-            context.player1.clickPrompt('Play Cad Bane using Plot');
-            context.player1.clickPrompt('Pass');
-            expect(context.cadBane).toBeInZone('resource');
+            // Declare which Plot cards to play - only Dogmatic Shock Squad this time
+            expect(context.player1).toHaveExactDisplayPromptCards({ selectable: [context.dogmaticShockSquad, context.cadBane] });
+            context.player1.clickCardInDisplayCardPrompt(context.dogmaticShockSquad);
+            context.player1.clickDone();
+
+            expect(context.player1).toHaveExactPromptButtons(['Play Dogmatic Shock Squad using Plot',
+                '(No effect) Reveal the top 4 cards of your deck. An opponent discards 2 of them. Draw 1 of the remaining cards and discard the other']);
 
             // Resolve Dogmatic Shock Squad
             context.player1.clickPrompt('Play Dogmatic Shock Squad using Plot');
-            context.player1.clickPrompt('Trigger');
             expect(context.dogmaticShockSquad).toBeInZone('groundArena');
             expect(context.player1.exhaustedResourceCount).toBe(10); // This is one less than normal because the Dogmatic Shock Squad was not replaced due to the empty deck
+            expect(context.cadBane).toBeInZone('resource');
 
             expect(context.player2).toBeActivePlayer();
         });


### PR DESCRIPTION
## Summary

Star Wars Unlimited's comprehensive rule 7.6.2b for Plot states:

> After deploying a leader, show your opponent each card with Plot you plan to play, then play them one at a time in any order. Any abilities triggered by playing a card with Plot must be resolved before playing the next card with Plot.

The previous implementation didn't match this: when a leader deployed with multiple Plot-eligible resources, each Plot trigger was just added to the normal simultaneous-trigger resolution list, and the player decided whether to play each one (via a per-card Trigger/Pass prompt) only as they got to it in the ordering step. There was no upfront "declare which cards you intend to play" step, and no way to decline Plot entirely in one action when multiple cards were eligible — you had to Pass on each one individually.

This PR adds a one-time **declare step**: after deploying a leader, if 2 or more resource-zone cards with Plot are eligible, the player first selects the whole subset of cards they intend to play via Plot (including "none of them," in a single action). Only afterward do they choose the order to actually play the declared cards, one at a time — with any other simultaneous triggers (Shielded, leader deploy abilities, etc.) still freely interleavable in that ordering step, exactly as before.

For the common case of exactly **one** eligible Plot card, the existing 1-click accept / 1-click decline (Trigger/Pass) flow is unchanged — the new declare step only kicks in when there's an actual subset to choose from.

## How it works

- **`TriggeredAbilityBase`** (`server/game/core/ability/TriggeredAbility.ts`) now exposes a `keyword` field, read from the ability's `properties.keyword`. This lets generic engine code identify "this pending trigger is a Plot ability" without importing the keyword-specific `PlotAbility` class. (Note: keyword-ability classes like `PlotAbility`, `ShieldedAbility`, etc. are constructed via a shared generic `TriggeredAbility` class in production — their own subclass constructors are effectively dead code — so the `keyword` has to be threaded through the shared props object rather than set in a subclass field. `PlotAbility.buildPlotAbilityProperties()` was updated accordingly; the other keyword classes only needed an `override` modifier to compile against the new base field.)
- **`TriggeredAbilityContext`** gained a `preConfirmed` flag (`markPreConfirmed()` / `preConfirmed` getter), mirroring the existing `overrideTitle` pattern.
- **`AbilityResolver`** skips the per-ability Trigger/Pass sub-prompt when the context is pre-confirmed, since that decision was already made during the declare step.
- **`TriggerWindowBase`** runs the new declare step once per resolving player per window (tracked via a `plotDeclarationComplete` set), using the same "select any number of cards" display-prompt style used elsewhere (e.g. Chancellor Palpatine's search-and-reveal ability) so only the actual Plot-eligible cards are shown — not the player's whole resource zone. Declared cards are marked pre-confirmed; undeclared cards are removed from the trigger window entirely so they're never asked about individually. Everything downstream (the multi-trigger ordering prompt, interleaving with Shielded/leader abilities, etc.) is untouched.

## Test plan

- [x] Updated `test/server/core/abilities/keyword/Plot.spec.ts` for the new declare-step flow, plus a new test asserting Plot can be declined entirely in one click even with 2+ eligible cards
- [x] Updated `ChancellorPalpatineHowLibertyDies.spec.ts` and `BailOrganaDoingEverythingHeCan.spec.ts` (both exercise 2+ simultaneous Plot cards)
- [x] Full test suite: 7513 specs, 0 failures (9 pre-existing/unrelated pending specs)
- [x] Manually verified via a local dev game (leader with 2 off-aspect Plot-eligible resources + a leader deploy ability like Support) that the declare step shows only the eligible cards, supports "choose nothing," and that declared cards interleave correctly with other simultaneous triggers in any order

## Screenshots
<img width="1126" height="628" alt="image" src="https://github.com/user-attachments/assets/db216c6e-4f42-4273-95a8-4355d58b26ac" />
<img width="508" height="272" alt="image" src="https://github.com/user-attachments/assets/37dfc7ac-e6ee-4e91-aff0-daaf355af4f0" />
