### PR TITLE
Fix two flaky shuffle/RNG tests

### DIFF
--- a/test/server/cards/02_SHD/events/BountyPosting.spec.ts
+++ b/test/server/cards/02_SHD/events/BountyPosting.spec.ts
@@ -16,7 +16,8 @@ describe('Bounty Posting', function() {
 
                 const { context } = contextRef;
 
-                const preShuffleDeck = context.player1.deck;
+                // Seeded so the shuffle result is identical on every run.
+                context.game.setRandomSeed('12345');
 
                 context.player1.clickCard(context.bountyPosting);
                 expect(context.player1).toHaveExactDisplayPromptCards({
@@ -42,7 +43,15 @@ describe('Bounty Posting', function() {
                 context.player1.clickPrompt('Trigger');
                 context.player1.clickCard(context.cloneTrooper);
                 expect(context.cloneTrooper).toHaveExactUpgradeNames(['top-target']);
-                expect(preShuffleDeck).not.toEqual(context.player1.deck);
+
+                // Top Target was drawn; the remaining cards were shuffled into this deterministic order.
+                expect(context.player1.deck.map((c) => c.internalName)).toEqual([
+                    'death-mark',
+                    'pyke-sentinel',
+                    'hylobon-enforcer',
+                    'cell-block-guard',
+                    'tieln-fighter'
+                ]);
                 expect(context.player2).toBeActivePlayer();
             });
 

--- a/test/server/gameSystems/DelayedEffectSystem.spec.ts
+++ b/test/server/gameSystems/DelayedEffectSystem.spec.ts
@@ -142,13 +142,14 @@ describe('Delayed effects', function() {
                 context.djInPlay = djInPlay;
                 context.djInHand = djInHand;
 
+                // Seed before the first steal so both DJs' "random" steals are deterministic
+                // (and guaranteed to pick different resources between the two DJs).
+                context.game.setRandomSeed('12345');
+
                 context.player1.clickCard(djInPlay);
                 context.stolenResource1 = context.player1.resources.filter((resource) => resource.owner === context.player2Object)[0];
                 context.player1.readyResources(7);
                 context.player2.passAction();
-
-                // set an explicit random seed so we can guarantee that different "random" cards are stolen between the two DJs
-                context.game.setRandomSeed('12345');
             });
 
             it('should activate if the in-play card is defeated', function() {


### PR DESCRIPTION
Fixes two intermittent test failures, both caused by the RNG not being pinned before a randomized step.

## Bounty Posting (`BountyPosting.spec.ts`)
The first spec compared the post-shuffle deck against a pre-shuffle reference — but that reference is a *live view* of the same 5 remaining cards (Top Target having been drawn out of both), differing only in order. The shuffle reproduces the original order roughly 1 in 120 runs (5!), causing an intermittent failure.

**Fix:** seed the RNG (`setRandomSeed('12345')`) and assert the exact resulting deck order — deterministic and strictly stronger than "it changed".

## DelayedEffectSystem (`DelayedEffectSystem.spec.ts`)
In the unique-rule describe block, the seed was set *after* the first DJ was already played, so the first steal was unseeded and nondeterministic — and the "seeded" second steal drew from a pool whose composition depended on it. The second DJ re-stole the same resource ~1/10 runs, failing the `not.toBe` check.

**Fix:** move `setRandomSeed('12345')` above the first steal so the entire sequence is deterministic.

Both follow the seeded-shuffle pattern used in `AnnihilatorTaggesFlagship.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)