### PR TITLE
Flag ongoing effects hidden from the opponent in the state summary

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -656,4 +656,10 @@ export interface IOngoingEffectSummary {
     sourceCardUuid: string;
     source: IOngoingEffectSourceSummary;
     targets: string[];
+
+    /**
+     * True when this effect's source is in a zone the controller's opponent can't see (e.g. hand), so the
+     * summary is only sent to the controller. Lets the FE reassure the player no hidden info has been leaked.
+     */
+    hiddenFromOpponent?: boolean;
 }

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -276,6 +276,9 @@ export class OngoingEffectEngine extends GameObjectBase {
                     sourceSubtitle: source.subtitle,
                     effectDescription: describeEffect(effect),
                 },
+                // Sources in a hidden zone survive the skip check above only when the viewer is the controller
+                // (never the opponent), so flag those effects as controller-only for the FE.
+                hiddenFromOpponent: EnumHelpers.isHiddenFromOpponent(source.zoneName, RelativePlayer.Self),
                 targets: effect.targets
                     .filter((effectTarget) =>
                         effectTarget?.isCard?.() &&

--- a/test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts
+++ b/test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts
@@ -68,6 +68,31 @@ describe('Ongoing effect summary', function() {
                 expect(context.millenniumFalcon).toHaveNoOngoingEffectsForPlayer(context.player2);
             });
 
+            it('flags a hidden-zone effect as controller-only but leaves a visible in-play effect unflagged', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['millennium-falcon#piece-of-junk'],
+                        spaceArena: ['millennium-falcon#get-out-and-push']
+                    }
+                });
+                const { context } = contextRef;
+
+                const summariesForController = context.game.ongoingEffectEngine
+                    .summarizeOngoingEffectsForState(context.player1.player);
+
+                // the hand Falcon's "enters play ready" is only sent to its controller, so it must be flagged
+                const handFalconEffect = summariesForController
+                    .find((summary) => summary.sourceCardUuid === context.millenniumFalconPieceOfJunk.uuid);
+                expect(handFalconEffect.hiddenFromOpponent).toBe(true);
+
+                // the in-play Falcon's effects are visible to both players, so they must not be flagged
+                const arenaFalconEffects = summariesForController
+                    .filter((summary) => summary.sourceCardUuid === context.millenniumFalconGetOutAndPush.uuid);
+                expect(arenaFalconEffects.length).toBeGreaterThan(0);
+                expect(arenaFalconEffects.every((summary) => !summary.hiddenFromOpponent)).toBe(true);
+            });
+
             it('uses the lasting effect\'s explicit title for a modal-choice effect (ability title is just a header)', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
## Summary

Adds an optional `hiddenFromOpponent` flag to `IOngoingEffectSummary` so the frontend can tell the player when an ongoing-effect tile is only visible to them.

Effects sourced from a zone the opponent can't see (e.g. the player's hand) already only appear in the controller's own state summary — but the client has no way to know that, so it can't reassure the player that no hidden information has been leaked. This flag closes that gap.

## Changes

- **`Interfaces.ts`**: add optional `hiddenFromOpponent?: boolean` to `IOngoingEffectSummary`.
- **`OngoingEffectEngine.summarizeOngoingEffectsForState`**: set the flag using `isHiddenFromOpponent(source.zoneName, RelativePlayer.Self)` — the same predicate the opponent's view uses in the skip-check above. A hidden-zone source only survives to be pushed when the viewer is its controller (never the opponent), so the flag is `true` exactly for controller-only effects and falsy for in-play (arena) sources everyone can see. (Resource-sourced effects are already dropped entirely, so they never carry the flag.)
- **`OngoingEffectSummary.spec.ts`**: new test with one Falcon in hand and another in the space arena, asserting the hand source is flagged `hiddenFromOpponent: true` while the arena source's summaries are not.

The consuming client change (rendering an "Only visible to you" note) is being iterated on separately.

## Testing

`npm run test-fast test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts` — 16 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)