### PR TITLE
Fix attachment and reading of LKI (#2588)

### DIFF
--- a/server/game/cards/05_LOF/leaders/QuiGonJinStudentOfTheLivingForce.ts
+++ b/server/game/cards/05_LOF/leaders/QuiGonJinStudentOfTheLivingForce.ts
@@ -1,7 +1,8 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { AbilityContext } from '../../../core/ability/AbilityContext';
 import type { ILeaderUnitAbilityRegistrar, ILeaderUnitLeaderSideAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { LeaderUnitCard } from '../../../core/card/LeaderUnitCard';
-import { Aspect, RelativePlayer, WildcardCardType, WildcardZoneName, ZoneName } from '../../../core/Constants';
+import { Aspect, EventName, RelativePlayer, WildcardCardType, WildcardZoneName, ZoneName } from '../../../core/Constants';
 import { CostAdjustType } from '../../../core/cost/CostAdjuster';
 import { TextHelper } from '../../../core/utils/TextHelper';
 
@@ -26,18 +27,22 @@ export default class QuiGonJinStudentOfTheLivingForce extends LeaderUnitCard {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,
                 immediateEffect: AbilityHelper.immediateEffects.returnToHand()
             },
-            ifYouDo: (ifYouDoContext) => ({
-                title: `Play a non-${TextHelper.Villainy} unit that costs less than ${ifYouDoContext.target.cost}`,
-                targetResolver: {
-                    controller: RelativePlayer.Self,
-                    zoneFilter: ZoneName.Hand,
-                    cardCondition: (card) => card.isUnit() && !card.hasSomeAspect(Aspect.Villainy) && card.cost < ifYouDoContext.target.cost,
-                    immediateEffect: AbilityHelper.immediateEffects.playCardFromHand({
-                        adjustCost: { costAdjustType: CostAdjustType.Free },
-                        playAsType: WildcardCardType.Unit
-                    })
-                }
-            })
+            ifYouDo: (ifYouDoContext) => {
+                const returnedUnitCost = QuiGonJinStudentOfTheLivingForce.returnedUnitCost(ifYouDoContext);
+
+                return {
+                    title: `Play a non-${TextHelper.Villainy} unit that costs less than ${returnedUnitCost}`,
+                    targetResolver: {
+                        controller: RelativePlayer.Self,
+                        zoneFilter: ZoneName.Hand,
+                        cardCondition: (card) => card.isUnit() && !card.hasSomeAspect(Aspect.Villainy) && card.cost < returnedUnitCost,
+                        immediateEffect: AbilityHelper.immediateEffects.playCardFromHand({
+                            adjustCost: { costAdjustType: CostAdjustType.Free },
+                            playAsType: WildcardCardType.Unit
+                        })
+                    }
+                };
+            }
         });
     }
 
@@ -52,18 +57,28 @@ export default class QuiGonJinStudentOfTheLivingForce extends LeaderUnitCard {
                 cardTypeFilter: WildcardCardType.NonLeaderUnit,
                 immediateEffect: AbilityHelper.immediateEffects.returnToHand()
             },
-            ifYouDo: (ifYouDoContext) => ({
-                title: `Play a non-${TextHelper.Villainy} unit that costs less than ${ifYouDoContext.target.cost}`,
-                targetResolver: {
-                    controller: RelativePlayer.Self,
-                    zoneFilter: ZoneName.Hand,
-                    cardCondition: (card) => card.isUnit() && !card.hasSomeAspect(Aspect.Villainy) && card.cost < ifYouDoContext.target.cost,
-                    immediateEffect: AbilityHelper.immediateEffects.playCardFromHand({
-                        adjustCost: { costAdjustType: CostAdjustType.Free },
-                        playAsType: WildcardCardType.Unit
-                    })
-                }
-            })
+            ifYouDo: (ifYouDoContext) => {
+                const returnedUnitCost = QuiGonJinStudentOfTheLivingForce.returnedUnitCost(ifYouDoContext);
+
+                return {
+                    title: `Play a non-${TextHelper.Villainy} unit that costs less than ${returnedUnitCost}`,
+                    targetResolver: {
+                        controller: RelativePlayer.Self,
+                        zoneFilter: ZoneName.Hand,
+                        cardCondition: (card) => card.isUnit() && !card.hasSomeAspect(Aspect.Villainy) && card.cost < returnedUnitCost,
+                        immediateEffect: AbilityHelper.immediateEffects.playCardFromHand({
+                            adjustCost: { costAdjustType: CostAdjustType.Free },
+                            playAsType: WildcardCardType.Unit
+                        })
+                    }
+                };
+            }
         });
+    }
+
+    private static returnedUnitCost(ifYouDoContext: AbilityContext): number {
+        return ifYouDoContext.events.find(
+            (event) => event.name === EventName.OnCardMoved && event.card === ifYouDoContext.target
+        )?.lastKnownInformation?.cost ?? ifYouDoContext.target.cost;
     }
 }

--- a/server/game/cards/05_LOF/units/DrengirSpawn.ts
+++ b/server/game/cards/05_LOF/units/DrengirSpawn.ts
@@ -14,12 +14,12 @@ export default class DrengirSpawn extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
             title: 'Give a number of Experience tokens to this unit equal to the defeated unit\'s cost',
-            contextTitle: (context) => `Give ${context.event.card.cost} Experience tokens to this unit`,
+            contextTitle: (context) => `Give ${context.event.lastKnownInformation?.cost ?? context.event.card.cost} Experience tokens to this unit`,
             when: {
                 onCardDefeated: (event, context) =>
                     event.isDefeatedByAttacker && DefeatCardSystem.defeatSourceCard(event) === context.source
             },
-            immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => ({ amount: context.event.card.cost }))
+            immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => ({ amount: context.event.lastKnownInformation?.cost ?? context.event.card.cost }))
         });
     }
 }

--- a/server/game/cards/05_LOF/units/DrengirSpawn.ts
+++ b/server/game/cards/05_LOF/units/DrengirSpawn.ts
@@ -14,12 +14,12 @@ export default class DrengirSpawn extends NonLeaderUnitCard {
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
             title: 'Give a number of Experience tokens to this unit equal to the defeated unit\'s cost',
-            contextTitle: (context) => `Give ${context.event.lastKnownInformation?.cost ?? context.event.card.cost} Experience tokens to this unit`,
+            contextTitle: (context) => `Give ${context.event.lastKnownInformation.cost} Experience tokens to this unit`,
             when: {
                 onCardDefeated: (event, context) =>
                     event.isDefeatedByAttacker && DefeatCardSystem.defeatSourceCard(event) === context.source
             },
-            immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => ({ amount: context.event.lastKnownInformation?.cost ?? context.event.card.cost }))
+            immediateEffect: AbilityHelper.immediateEffects.giveExperience((context) => ({ amount: context.event.lastKnownInformation.cost }))
         });
     }
 }

--- a/server/game/cards/07_LAW/upgrades/TargetedForRemoval.ts
+++ b/server/game/cards/07_LAW/upgrades/TargetedForRemoval.ts
@@ -13,7 +13,7 @@ export default class TargetedForRemoval extends UpgradeCard {
     public override setupCardAbilities (registrar: IUpgradeAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addGainWhenDefeatedAbilityTargetingAttached({
             title: 'An opponent creates Credit tokens equal to this unit\'s cost',
-            immediateEffect: abilityHelper.immediateEffects.createCreditToken((context) => ({ amount: context.source.printedCost, target: context.player.opponent }))
+            immediateEffect: abilityHelper.immediateEffects.createCreditToken((context) => ({ amount: context.event.lastKnownInformation.cost, target: context.player.opponent }))
         });
     }
 }

--- a/server/game/cards/08_ASH/units/PurrgilUltra.ts
+++ b/server/game/cards/08_ASH/units/PurrgilUltra.ts
@@ -1,7 +1,7 @@
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import type { IAbilityHelper } from '../../../AbilityHelper';
-import { RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { EventName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
 
 export default class PurrgilUltra extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -25,15 +25,19 @@ export default class PurrgilUltra extends NonLeaderUnitCard {
                 cardCondition: (card, context) => card.isUnit() && card !== context?.source,
                 immediateEffect: AbilityHelper.immediateEffects.returnToHand()
             },
-            ifYouDo: (ifYouDoContext) => ({
-                // TODO: Update this ability to read cost from LKI, since cards like Clone can copy
-                // another card's printed attributes while in play
-                title: `Deal ${ifYouDoContext.target.cost} damage to a unit`,
-                targetResolver: {
-                    cardTypeFilter: WildcardCardType.Unit,
-                    immediateEffect: AbilityHelper.immediateEffects.damage({ amount: ifYouDoContext.target.cost }),
-                }
-            })
+            ifYouDo: (ifYouDoContext) => {
+                const returnedUnitCost = ifYouDoContext.events.find(
+                    (event) => event.name === EventName.OnCardMoved && event.card === ifYouDoContext.target
+                )?.lastKnownInformation?.cost ?? ifYouDoContext.target.cost;
+
+                return {
+                    title: `Deal ${returnedUnitCost} damage to a unit`,
+                    targetResolver: {
+                        cardTypeFilter: WildcardCardType.Unit,
+                        immediateEffect: AbilityHelper.immediateEffects.damage({ amount: returnedUnitCost }),
+                    }
+                };
+            }
         });
     }
 }

--- a/server/game/core/gameSystem/CardTargetSystem.ts
+++ b/server/game/core/gameSystem/CardTargetSystem.ts
@@ -196,6 +196,8 @@ export abstract class CardTargetSystem<TContext extends AbilityContext = Ability
             `Attempting to add leaves play contingent events to card ${card.internalName} but is in zone ${card.zone}`
         );
 
+        addLastKnownInformationToEvent(event, card);
+
         event.setContingentEventsGenerator((event) => {
             const onCardLeavesPlayEvent = new GameEvent(EventName.OnCardLeavesPlay, context, {
                 player: context.player,

--- a/server/game/gameSystems/DefeatCardSystem.ts
+++ b/server/game/gameSystems/DefeatCardSystem.ts
@@ -166,8 +166,8 @@ export class DefeatCardSystem<TContext extends AbilityContext = AbilityContext, 
 
         if (card.zoneName !== ZoneName.Resource) {
             this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties);
+        } else {
+            addLastKnownInformationToEvent(event, card);
         }
-
-        addLastKnownInformationToEvent(event, card);
     }
 }

--- a/test/server/cards/05_LOF/leaders/QuiGonJinStudentOfTheLivingForce.spec.ts
+++ b/test/server/cards/05_LOF/leaders/QuiGonJinStudentOfTheLivingForce.spec.ts
@@ -144,6 +144,43 @@ describe('Qui-Gon Jinn, Student of the Living Force', function() {
                 expect(context.quigonJinn.exhausted).toBe(true);
                 expect(context.player1.hasTheForce).toBe(false);
             });
+
+            it('should use the copied unit\'s cost when returning a Clone', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'quigon-jinn#student-of-the-living-force',
+                        base: 'echo-base',
+                        hasForceToken: true,
+                        resources: 7,
+                        hand: ['clone', 'wampa', 'alliance-dispatcher'],
+                        groundArena: ['battlefield-marine']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.clone);
+                context.player1.clickCard(context.battlefieldMarine);
+                expect(context.clone).toBeCloneOf(context.battlefieldMarine);
+
+                context.player2.passAction();
+
+                context.player1.clickCard(context.quigonJinn);
+                context.player1.clickPrompt('Return a friendly non-leader unit to its owner\'s hand. If you do, play a non-Villainy unit that costs less than the returned unit for free');
+                expect(context.player1).toBeAbleToSelectExactly([context.clone, context.battlefieldMarine]);
+                context.player1.clickCard(context.clone);
+                expect(context.clone).toBeInZone('hand');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.allianceDispatcher]);
+                context.player1.clickCard(context.allianceDispatcher);
+                expect(context.allianceDispatcher).toBeInZone('groundArena');
+                expect(context.player1.exhaustedResourceCount).toBe(7); // Clone
+
+                expect(context.player2).toBeActivePlayer();
+                expect(context.quigonJinn.exhausted).toBe(true);
+                expect(context.player1.hasTheForce).toBe(false);
+            });
         });
 
         describe('Qui-Gon Jinn\'s deployed ability', function () {

--- a/test/server/cards/05_LOF/units/DrengirSpawn.spec.ts
+++ b/test/server/cards/05_LOF/units/DrengirSpawn.spec.ts
@@ -79,5 +79,34 @@ describe('Drengir Spawn', function() {
                 expect(context.drengirSpawn).toBeInZone('discard', player1);
             });
         });
+
+        it('should gain Experience tokens equal to the copied unit\'s cost when defeating a Clone', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['drengir-spawn'],
+                },
+                player2: {
+                    hand: ['clone'],
+                    base: 'echo-base',
+                    groundArena: ['alliance-dispatcher'],
+                    resources: 7,
+                    hasInitiative: true
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.clone);
+            context.player2.clickCard(context.allianceDispatcher);
+            expect(context.clone).toBeCloneOf(context.allianceDispatcher);
+
+            context.player1.clickCard(context.drengirSpawn);
+            context.player1.clickCard(context.clone);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.clone).toBeInZone('discard', context.player2);
+            expect(context.drengirSpawn).toHaveExactUpgradeNames(['experience']);
+        });
     });
 });

--- a/test/server/cards/07_LAW/upgrades/TargetedForRemoval.spec.ts
+++ b/test/server/cards/07_LAW/upgrades/TargetedForRemoval.spec.ts
@@ -25,7 +25,7 @@ describe('Targeted For Removal', function () {
                 expect(context.player2.credits).toBe(0);
             });
 
-            xit('works with clone', async function () {
+            it('works with clone', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {

--- a/test/server/cards/08_ASH/units/PurrgilUltra.spec.ts
+++ b/test/server/cards/08_ASH/units/PurrgilUltra.spec.ts
@@ -94,46 +94,83 @@ describe('Purrgil Ultra', function() {
             expect(context.wampa).toBeInZone('groundArena', context.player1);
         });
 
-        // TODO: Uncomment this test once we have LKI working for this ability
-        // it('should work with clone when played', async function() {
-        //     await contextRef.setupTestAsync({
-        //         phase: 'action',
-        //         player1: {
-        //             hand: ['purrgil-ultra', 'clone'],
-        //             groundArena: ['wampa'],
-        //             spaceArena: ['phoenix-squadron-awing'],
-        //             leader: { card: 'grand-inquisitor#hunting-the-jedi', deployed: true },
-        //             resources: 100
-        //         },
-        //         player2: {
-        //             groundArena: ['atst'],
-        //             spaceArena: ['green-squadron-awing']
-        //         }
-        //     });
+        it('should deal damage equal to the copied unit\'s cost when bouncing a Clone when played', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['purrgil-ultra', 'clone'],
+                    groundArena: ['wampa'],
+                    spaceArena: ['phoenix-squadron-awing'],
+                    resources: 100
+                },
+                player2: {
+                    groundArena: ['atst'],
+                    spaceArena: ['green-squadron-awing']
+                }
+            });
 
-        //     const { context } = contextRef;
+            const { context } = contextRef;
 
-        //     context.player1.clickCard(context.clone);
-        //     context.player1.clickCard(context.wampa);
+            context.player1.clickCard(context.clone);
+            context.player1.clickCard(context.wampa);
+            expect(context.clone).toBeCloneOf(context.wampa);
 
-        //     context.player2.passAction();
+            context.player2.passAction();
 
-        //     context.player1.clickCard(context.purrgilUltra);
+            context.player1.clickCard(context.purrgilUltra);
 
-        //     expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.phoenixSquadronAwing, context.clone]);
-        //     expect(context.player1).toHavePassAbilityButton();
-        //     context.player1.clickCard(context.clone);
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.phoenixSquadronAwing, context.clone]);
+            expect(context.player1).toHavePassAbilityButton();
+            context.player1.clickCard(context.clone);
 
-        //     expect(context.player1).toHavePrompt('Deal 4 damage to a unit');
-        //     expect(context.player1).toBeAbleToSelectExactly([context.purrgilUltra, context.phoenixSquadronAwing, context.atst, context.greenSquadronAwing, context.wampa]);
-        //     expect(context.player1).not.toHavePassAbilityButton();
-        //     expect(context.player1).not.toHaveChooseNothingButton();
-        //     context.player1.clickCard(context.atst);
+            expect(context.player1).toHavePrompt('Deal 4 damage to a unit');
+            expect(context.player1).toBeAbleToSelectExactly([context.purrgilUltra, context.phoenixSquadronAwing, context.atst, context.greenSquadronAwing, context.wampa]);
+            expect(context.player1).not.toHavePassAbilityButton();
+            expect(context.player1).not.toHaveChooseNothingButton();
+            context.player1.clickCard(context.atst);
 
-        //     expect(context.player2).toBeActivePlayer();
-        //     expect(context.atst.damage).toBe(4);
-        //     expect(context.clone).toBeInZone('hand', context.player1);
-        // });
+            expect(context.player2).toBeActivePlayer();
+            expect(context.atst.damage).toBe(4);
+            expect(context.clone).toBeInZone('hand', context.player1);
+        });
+
+        it('should deal damage equal to the copied unit\'s cost when bouncing a Clone when defeated', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['clone'],
+                    groundArena: ['wampa'],
+                    spaceArena: ['purrgil-ultra'],
+                    resources: 10
+                },
+                player2: {
+                    hand: ['vanquish'],
+                    groundArena: ['atst'],
+                    resources: 10
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.clone);
+            context.player1.clickCard(context.wampa);
+            expect(context.clone).toBeCloneOf(context.wampa);
+
+            context.player2.clickCard(context.vanquish);
+            context.player2.clickCard(context.purrgilUltra);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.clone]);
+            expect(context.player1).toHavePassAbilityButton();
+            context.player1.clickCard(context.clone);
+
+            expect(context.player1).toHavePrompt('Deal 4 damage to a unit');
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.atst]);
+            context.player1.clickCard(context.atst);
+
+            expect(context.player1).toBeActivePlayer();
+            expect(context.atst.damage).toBe(4);
+            expect(context.clone).toBeInZone('hand', context.player1);
+        });
 
         it('should bounce a friendly unit and deal damage to an enemy unit equal to its cost to enemy unit when defeated', async function() {
             await contextRef.setupTestAsync({


### PR DESCRIPTION
Currently, we do not calculate the LKI cost value for Clone across several cards (https://github.com/SWU-Karabast/forceteki/issues/2588). This is because of two reasons. 

Firstly, Drengir Spawn and Targeted for Removal do not correctly read LKI, and instead read the current state of the card. These cards are fixed by changing their abilities to read from the LKI instead.

Secondly, LKI was not available for Purgill Ultra and Qui-Gon Jinn because in returning units to hand, they trigger `OnCardMoved`, and LKI is only added for `OnCardDefeated`. This is fixed here by moving `addLastKnownInformationToEvent` to `addLeavesPlayPropertiesToEvent` instead of having it only in `DefeatCardSystem`, which provides the LKI information they can then read from.