### PR TITLE
Refine ongoing effect summaries: suppress low-value effects

### DIFF
--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -210,9 +210,9 @@ export interface IConstantAbilityProps<TSource extends Card = Card> {
     gainAbilitySource?: Card;
 
     /**
-     * When true, effects registered by this ability are omitted from the ongoing effect summary sent
-     * to the client. Set for abilities that carry no useful board information (e.g. self cost adjusters
-     * that only change the cost to play the source card itself). See {@link OngoingEffectEngine.summarizeOngoingEffectsForState}.
+     * When true, effects registered by this ability are omitted from the ongoing effect summary sent to
+     * the client. Set on abilities whose effects don't describe the board, such as self cost adjusters
+     * that only change the cost to play the source card itself.
      */
     omitFromOngoingEffectSummary?: boolean;
 }

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -208,6 +208,13 @@ export interface IConstantAbilityProps<TSource extends Card = Card> {
 
     /** If this is a gained ability, gives the source card that is giving the ability */
     gainAbilitySource?: Card;
+
+    /**
+     * When true, effects registered by this ability are omitted from the ongoing effect summary sent
+     * to the client. Set for abilities that carry no useful board information (e.g. self cost adjusters
+     * that only change the cost to play the source card itself). See {@link OngoingEffectEngine.summarizeOngoingEffectsForState}.
+     */
+    omitFromOngoingEffectSummary?: boolean;
 }
 
 export type ITriggeredAbilityPropsWithType<TSource extends Card = Card> = ITriggeredAbilityProps<TSource> & {

--- a/server/game/cards/04_JTL/bases/Colossus.ts
+++ b/server/game/cards/04_JTL/bases/Colossus.ts
@@ -12,7 +12,7 @@ export default class Colossus extends BaseCard {
 
     public override setupCardAbilities(registrar: IBaseAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: 'Draw 1 less card in starting hands',
+            title: 'Draw 1 less card in starting hand',
             ongoingEffect: AbilityHelper.ongoingEffects.modifyStartingHandSize({
                 amount: -1
             })

--- a/server/game/cards/05_LOF/units/GrandInquisitorYoureRightToBeAfraid.ts
+++ b/server/game/cards/05_LOF/units/GrandInquisitorYoureRightToBeAfraid.ts
@@ -14,8 +14,11 @@ export default class GrandInquisitorYoureRightToBeAfraid extends NonLeaderUnitCa
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Other friendly ${TextHelper.Trait.Inquisitor} units gain hidden.`,
-            matchTarget: (card, context) => card !== context.source && card.isUnit() && card.hasSomeTrait(Trait.Inquisitor),
+            title: `Other friendly ${TextHelper.Trait.Inquisitor} units gain ${TextHelper.Hidden}`,
+            matchTarget: (card, context) =>
+                card !== context.source &&
+                card.isUnit() &&
+                card.hasSomeTrait(Trait.Inquisitor),
             ongoingEffect: AbilityHelper.ongoingEffects.gainKeyword({ keyword: KeywordName.Hidden })
         });
     }

--- a/server/game/cards/08_ASH/units/MarrokMysteriousWarrior.ts
+++ b/server/game/cards/08_ASH/units/MarrokMysteriousWarrior.ts
@@ -14,9 +14,12 @@ export default class MarrokMysteriousWarrior extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addConstantAbility({
-            title: `Gain ${TextHelper.Saboteur} while upgraded`,
+            title: `Loses ${TextHelper.Sentinel} and gains ${TextHelper.Saboteur} while upgraded`,
             condition: (context) => context.source.isUpgraded(),
-            ongoingEffect: [AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur), AbilityHelper.ongoingEffects.loseKeyword(KeywordName.Sentinel)]
+            ongoingEffect: [
+                AbilityHelper.ongoingEffects.loseKeyword(KeywordName.Sentinel),
+                AbilityHelper.ongoingEffects.gainKeyword(KeywordName.Saboteur),
+            ]
         });
     }
 }

--- a/server/game/core/ability/ConstantAbility.ts
+++ b/server/game/core/ability/ConstantAbility.ts
@@ -61,6 +61,10 @@ export class ConstantAbility extends GameObjectBase implements IConstantAbility 
         return this.properties.gainAbilitySource;
     }
 
+    public get omitFromOngoingEffectSummary(): boolean {
+        return this.properties.omitFromOngoingEffectSummary ?? false;
+    }
+
     public get ongoingEffect(): IOngoingEffectGenerator | IOngoingEffectGenerator[] {
         return this.properties.ongoingEffect;
     }

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -433,8 +433,7 @@ export class PlayableOrDeployableCard extends Card implements IPlayableOrDeploya
             condition,
             ongoingEffect,
 
-            // These self cost adjusters only change the cost to play this card itself (e.g. Mastery), so they
-            // carry no useful board information in any zone and are omitted from the ongoing effect summary.
+            // this adjuster only changes the cost to play the card itself, so it isn't board state worth summarizing
             omitFromOngoingEffectSummary: true
         };
 

--- a/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
+++ b/server/game/core/card/baseClasses/PlayableOrDeployableCard.ts
@@ -431,7 +431,11 @@ export class PlayableOrDeployableCard extends Card implements IPlayableOrDeploya
             sourceZoneFilter: WildcardZoneName.Any,
             targetController: WildcardRelativePlayer.Any,
             condition,
-            ongoingEffect
+            ongoingEffect,
+
+            // These self cost adjusters only change the cost to play this card itself (e.g. Mastery), so they
+            // carry no useful board information in any zone and are omitted from the ongoing effect summary.
+            omitFromOngoingEffectSummary: true
         };
 
         return costAdjustAbilityProps;

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -94,9 +94,9 @@ function findRegisteringConstantAbility(effect: OngoingEffect) {
 }
 
 /**
- * Effect types that never carry useful board information and are hidden from the summary per player
- * feedback: "enters play ready" only describes how a card already entered play (already resolved), and
- * the starting-hand-size / no-mulligan base modifiers are setup-only and inert for the rest of the game.
+ * Effect types that are never included in the summary: they describe setup or how a card enters play
+ * rather than the ongoing board state ("enters play ready", and the starting-hand-size / no-mulligan
+ * base modifiers, which only apply during setup).
  */
 const summaryExcludedEffectNames: ReadonlySet<EffectName> = new Set([
     EffectName.EntersPlayReady,
@@ -105,27 +105,20 @@ const summaryExcludedEffectNames: ReadonlySet<EffectName> = new Set([
 ]);
 
 /**
- * "Play-time modifier" effects change how or whether a card can be played, so they only carry useful
- * information while the card sits in a zone it can be played from. Once the card moves elsewhere (into
- * play, or a zone it can't be played from) the effect is inert noise and is suppressed. Each entry maps
- * the effect type to the zone(s) in which it stays relevant.
- *
- * e.g. R2-D2's "can be played on a Vehicle with a Pilot" only matters while he's a playable card in hand.
- * (CanPlayFromDiscard is intentionally absent: it's a temporary effect only ever created while the card
- * is in the discard pile, where it is genuinely relevant, so it needs no gating.)
+ * Effect types that only matter while their source card is in a zone it can be played from, mapped to
+ * those zones. Such an effect is included only when its source is in a listed zone, and suppressed once
+ * the card moves elsewhere (e.g. R2-D2's "can be played on a Vehicle with a Pilot" is only relevant in
+ * hand). Effects that are only ever created in the zone they matter in (e.g. CanPlayFromDiscard) don't
+ * need an entry.
  */
 const playModifierEffectRelevantZones: ReadonlyMap<EffectName, ReadonlySet<ZoneName>> = new Map([
     [EffectName.CanBePlayedWithPilotingIgnoringPilotLimit, new Set([ZoneName.Hand])],
 ]);
 
 /**
- * Whether an effect is noise that shouldn't appear in the ongoing effect summary, per player feedback:
- *   - the setup-only / "enters play ready" effect types above.
- *   - self cost adjusters (e.g. Mastery) whose ability only changes the cost to play the source card
- *     itself. Their constant ability opts out via `omitFromOngoingEffectSummary`. Temporary or
- *     other-card cost adjusters (e.g. GNK Power Droid's "next unit costs 1 less", a leader discounting
- *     friendly units) are still surfaced.
- *   - play-time modifiers whose source card has left the zone the effect is relevant in (see above).
+ * Whether an effect should be hidden from the ongoing effect summary: a globally-excluded type, a self
+ * cost adjuster (opted out via its ability's `omitFromOngoingEffectSummary` flag), or a play-time
+ * modifier whose source has left the zone it's relevant in.
  */
 function isExcludedFromSummary(effect: OngoingEffect): boolean {
     if (summaryExcludedEffectNames.has(effect.type)) {

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -94,6 +94,37 @@ function findRegisteringConstantAbility(effect: OngoingEffect) {
 }
 
 /**
+ * Effect types that never carry useful board information and are hidden from the summary per player
+ * feedback: "enters play ready" only describes how a card already entered play (already resolved), and
+ * the starting-hand-size / no-mulligan base modifiers are setup-only and inert for the rest of the game.
+ */
+const summaryExcludedEffectNames: ReadonlySet<EffectName> = new Set([
+    EffectName.EntersPlayReady,
+    EffectName.ModifyStartingHandSize,
+    EffectName.NoMulligan,
+]);
+
+/**
+ * Whether an effect is noise that shouldn't appear in the ongoing effect summary, per player feedback:
+ *   - the setup-only / "enters play ready" effect types above.
+ *   - self cost adjusters (e.g. Mastery) whose ability only changes the cost to play the source card
+ *     itself. Their constant ability opts out via `omitFromOngoingEffectSummary`. Temporary or
+ *     other-card cost adjusters (e.g. GNK Power Droid's "next unit costs 1 less", a leader discounting
+ *     friendly units) are still surfaced.
+ */
+function isExcludedFromSummary(effect: OngoingEffect): boolean {
+    if (summaryExcludedEffectNames.has(effect.type)) {
+        return true;
+    }
+
+    if (effect.type === EffectName.CostAdjuster) {
+        return !!findRegisteringConstantAbility(effect)?.omitFromOngoingEffectSummary;
+    }
+
+    return false;
+}
+
+/**
  * Resolves a description for an ongoing effect, in priority order:
  *   1. An explicit `title` set on the effect itself — for lasting effects via their props, for delayed
  *      effects via their value. Authors set this when the creating ability's title is just a header
@@ -242,6 +273,10 @@ export class OngoingEffectEngine extends GameObjectBase {
 
         for (const effect of this.effects) {
             if (!effect.isEffectActive() || !effect.source?.isCard?.()) {
+                continue;
+            }
+
+            if (isExcludedFromSummary(effect)) {
                 continue;
             }
 

--- a/server/game/core/ongoingEffect/OngoingEffectEngine.ts
+++ b/server/game/core/ongoingEffect/OngoingEffectEngine.ts
@@ -105,12 +105,27 @@ const summaryExcludedEffectNames: ReadonlySet<EffectName> = new Set([
 ]);
 
 /**
+ * "Play-time modifier" effects change how or whether a card can be played, so they only carry useful
+ * information while the card sits in a zone it can be played from. Once the card moves elsewhere (into
+ * play, or a zone it can't be played from) the effect is inert noise and is suppressed. Each entry maps
+ * the effect type to the zone(s) in which it stays relevant.
+ *
+ * e.g. R2-D2's "can be played on a Vehicle with a Pilot" only matters while he's a playable card in hand.
+ * (CanPlayFromDiscard is intentionally absent: it's a temporary effect only ever created while the card
+ * is in the discard pile, where it is genuinely relevant, so it needs no gating.)
+ */
+const playModifierEffectRelevantZones: ReadonlyMap<EffectName, ReadonlySet<ZoneName>> = new Map([
+    [EffectName.CanBePlayedWithPilotingIgnoringPilotLimit, new Set([ZoneName.Hand])],
+]);
+
+/**
  * Whether an effect is noise that shouldn't appear in the ongoing effect summary, per player feedback:
  *   - the setup-only / "enters play ready" effect types above.
  *   - self cost adjusters (e.g. Mastery) whose ability only changes the cost to play the source card
  *     itself. Their constant ability opts out via `omitFromOngoingEffectSummary`. Temporary or
  *     other-card cost adjusters (e.g. GNK Power Droid's "next unit costs 1 less", a leader discounting
  *     friendly units) are still surfaced.
+ *   - play-time modifiers whose source card has left the zone the effect is relevant in (see above).
  */
 function isExcludedFromSummary(effect: OngoingEffect): boolean {
     if (summaryExcludedEffectNames.has(effect.type)) {
@@ -119,6 +134,12 @@ function isExcludedFromSummary(effect: OngoingEffect): boolean {
 
     if (effect.type === EffectName.CostAdjuster) {
         return !!findRegisteringConstantAbility(effect)?.omitFromOngoingEffectSummary;
+    }
+
+    const relevantZones = playModifierEffectRelevantZones.get(effect.type);
+    if (relevantZones) {
+        const sourceZone = (effect.source as Card | undefined)?.zoneName;
+        return !sourceZone || !relevantZones.has(sourceZone);
     }
 
     return false;

--- a/test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts
+++ b/test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts
@@ -21,58 +21,60 @@ describe('Ongoing effect summary', function() {
             it('shows an effect sourced from a visible in-play card, even one active from any zone', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { spaceArena: ['millennium-falcon#piece-of-junk'] }
+                    player1: { groundArena: ['r2d2#artooooooooo'] }
                 });
                 const { context } = contextRef;
 
-                expect(context.millenniumFalcon).toHaveOngoingEffect('This unit enters play ready');
+                // R2-D2's "can be played on a Vehicle with a Pilot" ability is active from any zone; while
+                // he's a visible in-play unit it should be surfaced to everyone
+                expect(context.r2d2).toHaveOngoingEffect('This upgrade can be played on a friendly Vehicle unit with a Pilot on it.');
             });
 
             it('hides an effect sourced from a hidden zone so the card is not leaked', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { hand: ['millennium-falcon#piece-of-junk'] }
+                    player1: { hand: ['r2d2#artooooooooo'] }
                 });
                 const { context } = contextRef;
 
-                // "enters play ready" is active from any zone, but the Falcon is in hand - it must stay hidden
-                // from the default (spectator) perspective the matchers use
-                expect(context.millenniumFalcon).toHaveNoOngoingEffects();
+                // R2-D2's ability is active from any zone, but he's in hand - it must stay hidden from the
+                // default (spectator) perspective the matchers use
+                expect(context.r2d2).toHaveNoOngoingEffects();
             });
 
             it('never surfaces an effect sourced from a facedown resource, even to its controller', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { resources: ['millennium-falcon#piece-of-junk', 'atst', 'atst', 'atst', 'atst'] }
+                    player1: { resources: ['r2d2#artooooooooo', 'atst', 'atst', 'atst', 'atst'] }
                 });
                 const { context } = contextRef;
 
-                // the Falcon's "enters play ready" is active from any zone, but as a blanked resource it must
-                // not appear as a board effect for anyone - not even its controller
-                expect(context.millenniumFalcon).toHaveNoOngoingEffects();
-                expect(context.millenniumFalcon).toHaveNoOngoingEffectsForPlayer(context.player1);
+                // R2-D2's ability is active from any zone, but as a blanked resource it must not appear as a
+                // board effect for anyone - not even its controller
+                expect(context.r2d2).toHaveNoOngoingEffects();
+                expect(context.r2d2).toHaveNoOngoingEffectsForPlayer(context.player1);
             });
 
             it('shows an effect sourced from a hidden zone to the card\'s controller but not the opponent', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
-                    player1: { hand: ['millennium-falcon#piece-of-junk'] }
+                    player1: { hand: ['r2d2#artooooooooo'] }
                 });
                 const { context } = contextRef;
 
-                // the Falcon is active-from-hand for player1, so only player1 may see the effect (and its
-                // own hidden-zone card as the target); player2 must not have it leaked to them
-                expect(context.millenniumFalcon).toHaveExactOngoingEffectsForPlayer(context.player1, [
-                    { description: 'This unit enters play ready', targets: [context.millenniumFalcon] }
+                // R2-D2 is active-from-hand for player1, so only player1 may see the effect (and its own
+                // hidden-zone card as the target); player2 must not have it leaked to them
+                expect(context.r2d2).toHaveExactOngoingEffectsForPlayer(context.player1, [
+                    { description: 'This upgrade can be played on a friendly Vehicle unit with a Pilot on it.', targets: [context.r2d2] }
                 ]);
-                expect(context.millenniumFalcon).toHaveNoOngoingEffectsForPlayer(context.player2);
+                expect(context.r2d2).toHaveNoOngoingEffectsForPlayer(context.player2);
             });
 
             it('flags a hidden-zone effect as controller-only but leaves a visible in-play effect unflagged', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
-                        hand: ['millennium-falcon#piece-of-junk'],
+                        hand: ['r2d2#artooooooooo'],
                         spaceArena: ['millennium-falcon#get-out-and-push']
                     }
                 });
@@ -81,14 +83,14 @@ describe('Ongoing effect summary', function() {
                 const summariesForController = context.game.ongoingEffectEngine
                     .summarizeOngoingEffectsForState(context.player1.player);
 
-                // the hand Falcon's "enters play ready" is only sent to its controller, so it must be flagged
-                const handFalconEffect = summariesForController
-                    .find((summary) => summary.sourceCardUuid === context.millenniumFalconPieceOfJunk.uuid);
-                expect(handFalconEffect.hiddenFromOpponent).toBe(true);
+                // the hand R2-D2's ability is only sent to its controller, so it must be flagged
+                const handR2D2Effect = summariesForController
+                    .find((summary) => summary.sourceCardUuid === context.r2d2.uuid);
+                expect(handR2D2Effect.hiddenFromOpponent).toBe(true);
 
                 // the in-play Falcon's effects are visible to both players, so they must not be flagged
                 const arenaFalconEffects = summariesForController
-                    .filter((summary) => summary.sourceCardUuid === context.millenniumFalconGetOutAndPush.uuid);
+                    .filter((summary) => summary.sourceCardUuid === context.millenniumFalcon.uuid);
                 expect(arenaFalconEffects.length).toBeGreaterThan(0);
                 expect(arenaFalconEffects.every((summary) => !summary.hiddenFromOpponent)).toBe(true);
             });
@@ -151,6 +153,68 @@ describe('Ongoing effect summary', function() {
                     'You may play or deploy 1 additional Pilot on this unit',
                     'This unit gets +1/+0 for each Pilot on it'
                 ]);
+            });
+        });
+
+        describe('excluded effects', function() {
+            it('omits an "enters play ready" effect even from a visible in-play card', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { spaceArena: ['millennium-falcon#piece-of-junk'] }
+                });
+                const { context } = contextRef;
+
+                // the Falcon's only ability is "enters play ready", which describes how it already entered
+                // play - it carries no useful board information and is never surfaced
+                expect(context.millenniumFalcon).toHaveNoOngoingEffects();
+            });
+
+            it('omits a self cost-adjuster constant ability, even from a visible discard pile', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { discard: ['mastery'] }
+                });
+                const { context } = contextRef;
+
+                // Mastery's discount only changes the cost to play Mastery itself, so it is noise in every
+                // zone (here the discard pile, which is visible to everyone)
+                expect(context.mastery).toHaveNoOngoingEffects();
+            });
+
+            it('omits a setup-only starting-hand base ability', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { base: 'colossus' }
+                });
+                const { context } = contextRef;
+
+                // Colossus only modifies the starting hand size during setup and is inert afterwards
+                expect(context.p1Base).toHaveNoOngoingEffects();
+            });
+
+            it('omits setup-only starting-hand and mulligan base abilities', async function() {
+                // Nabat Village's no-mulligan effect changes the setup flow, so this can't use the action-phase
+                // auto-setup; the base and its constant abilities are already in play during the setup phase
+                await contextRef.setupTestAsync({
+                    phase: 'setup',
+                    player1: { base: 'nabat-village' }
+                });
+                const { context } = contextRef;
+
+                // Nabat Village's starting-hand and no-mulligan effects are both setup-only
+                expect(context.p1Base).toHaveNoOngoingEffects();
+            });
+
+            it('still surfaces a board-relevant cost-adjuster constant ability that discounts other cards', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { groundArena: ['jabba-the-hutt#cunning-daimyo'] }
+                });
+                const { context } = contextRef;
+
+                // this discount applies to other cards the player plays (Trick events), so unlike a self
+                // cost adjuster it is genuine board information and must still be shown
+                expect(context.jabbaTheHutt).toHaveOngoingEffect('Each Trick event you play costs 1 resource less');
             });
         });
 

--- a/test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts
+++ b/test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts
@@ -18,16 +18,31 @@ describe('Ongoing effect summary', function() {
                 );
             });
 
-            it('shows an effect sourced from a visible in-play card, even one active from any zone', async function() {
+            it('shows a play-time modifier while its source is in the zone it can be played from', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: { hand: ['r2d2#artooooooooo'] }
+                });
+                const { context } = contextRef;
+
+                // R2-D2's "can be played on a Vehicle with a Pilot" only matters while he's a playable card
+                // in hand, so it is surfaced there (to its controller)
+                expect(context.r2d2).toHaveOngoingEffectForPlayer(
+                    context.player1,
+                    'This upgrade can be played on a friendly Vehicle unit with a Pilot on it.'
+                );
+            });
+
+            it('suppresses a play-time modifier once its source has left the zone it can be played from', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: { groundArena: ['r2d2#artooooooooo'] }
                 });
                 const { context } = contextRef;
 
-                // R2-D2's "can be played on a Vehicle with a Pilot" ability is active from any zone; while
-                // he's a visible in-play unit it should be surfaced to everyone
-                expect(context.r2d2).toHaveOngoingEffect('This upgrade can be played on a friendly Vehicle unit with a Pilot on it.');
+                // in play, R2-D2's "can be played on a Vehicle with a Pilot" is inert - it must not be shown
+                expect(context.r2d2).toHaveNoOngoingEffects();
+                expect(context.r2d2).toHaveNoOngoingEffectsForPlayer(context.player1);
             });
 
             it('hides an effect sourced from a hidden zone so the card is not leaked', async function() {


### PR DESCRIPTION
## Description

Follow-up refinements to the recently released **Ongoing Effect Summaries** feature, based on player feedback that certain effects are noise on the board. The summary now suppresses effects that carry no useful board information, while keeping genuinely informative ones.

### Suppressed everywhere
- **Self cost adjusters** (e.g. Mastery) — abilities that only change the cost to play the source card itself. Implemented via a new `omitFromOngoingEffectSummary` flag on the constant ability, set centrally in `buildCostAdjusterAbilityProps`, so it applies to every self cost-adjuster / aspect-penalty-ignore helper without per-card edits.
- **"Enters play ready"** constant abilities (e.g. Millennium Falcon) — they only describe how a card already entered play.
- **Setup-only base abilities** (`ModifyStartingHandSize`, `NoMulligan` — e.g. Colossus, Nabat Village) — inert for the entire rest of the game.

### Gated to the zone they matter in
- **Play-time modifiers** (e.g. R2-D2's "can be played on a Vehicle with a Pilot") are surfaced only while the source card is in a zone it can be played from (hand), and suppressed once it's in play or elsewhere. Handled by a small effect-type → relevant-zone map that's easy to extend.

### Still shown (intentionally not over-filtered)
- Temporary cost reductions (e.g. GNK Power Droid's "next unit costs 1 less this phase").
- Constant-ability cost adjusters that discount **other** cards (leaders/units like Piett, Jabba, Wedge, Krennic).

Also includes minor ongoing-effect description tweaks (Colossus, Grand Inquisitor, Marrok) for clearer board rendering.

## Testing
- `test/server/core/ongoingEffects/OngoingEffectSummary.spec.ts` extended with coverage for each exclusion category, the play-time-modifier zone gating (shown in hand / suppressed in play), and positive cases that must still surface. Zone-visibility tests were reworked onto a non-excluded from-any-zone effect (R2-D2). All 22 specs pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)