### PR TITLE
Persist development test-user preferences

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   dynamodb-local:
     image: amazon/dynamodb-local:latest
     container_name: karabast-dynamodb-local
+    # Docker creates named volumes as root, so DynamoDB Local needs root access
+    # to initialize its SQLite database in the mounted data directory.
+    user: root
     ports:
       - "8000:8000"
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /home/dynamodblocal/data"
@@ -12,7 +15,9 @@ services:
     networks:
       - karabast-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000 || exit 1"]
+      # DynamoDB returns HTTP 400 for an unsigned request, which still proves
+      # that the local service is up and accepting connections.
+      test: ["CMD-SHELL", "curl -sS -o /dev/null http://localhost:8000"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     container_name: karabast-dynamodb-local
     ports:
       - "8000:8000"
-    command: "-jar DynamoDBLocal.jar -sharedDb -inMemory"
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /home/dynamodblocal/data"
+    volumes:
+      - dynamodb-data:/home/dynamodblocal/data
     environment:
       - DYNAMODB_LOCAL=true
     networks:
@@ -17,3 +19,5 @@ services:
 networks:
   karabast-network:
     driver: bridge
+volumes:
+  dynamodb-data:

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -150,13 +150,21 @@ export class GameServer {
         // increase stack trace limit for better error logging
         Error.stackTraceLimit = 50;
 
+        const userFactory = new UserFactory();
+        if (process.env.ENVIRONMENT === 'development') {
+            console.log('SETUP: Initializing development test users.');
+            await userFactory.ensureDevelopmentTestUsersAsync();
+            console.log('SETUP: Development test users initialized.');
+        }
+
         return new GameServer(
             cardDataGetter,
             deckValidator,
             serverRoleUsersCache,
             cosmeticsService,
             modActionCache,
-            testGameBuilder
+            testGameBuilder,
+            userFactory
         );
     }
 
@@ -205,7 +213,7 @@ export class GameServer {
         intervalStartTime: 0
     };
 
-    private readonly userFactory: UserFactory = new UserFactory();
+    private readonly userFactory: UserFactory;
     public readonly deckService: DeckService = new DeckService();
     public readonly cosmeticsService?: CosmeticsService;
     public readonly swuStatsHandler: SwuStatsHandler;
@@ -223,7 +231,8 @@ export class GameServer {
         serverRoleUsersCache?: ServerRoleUsersCache,
         cosmeticsService?: CosmeticsService,
         modActionCache?: ModActionService,
-        testGameBuilder?: any
+        testGameBuilder?: any,
+        userFactory?: UserFactory
     ) {
         const app = express();
         app.use(express.json());
@@ -237,6 +246,7 @@ export class GameServer {
         this.serverRoleUsersCache = serverRoleUsersCache;
         this.cosmeticsService = cosmeticsService;
         this.modActionService = modActionCache;
+        this.userFactory = userFactory ?? new UserFactory();
 
         const corsOptions = {
             origin: env.corsOrigins,

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -150,10 +150,9 @@ export class GameServer {
         // increase stack trace limit for better error logging
         Error.stackTraceLimit = 50;
 
-        const userFactory = new UserFactory();
         if (process.env.ENVIRONMENT === 'development') {
             console.log('SETUP: Initializing development test users.');
-            await userFactory.ensureDevelopmentTestUsersAsync();
+            await new UserFactory().ensureDevelopmentTestUsersAsync();
             console.log('SETUP: Development test users initialized.');
         }
 
@@ -163,8 +162,7 @@ export class GameServer {
             serverRoleUsersCache,
             cosmeticsService,
             modActionCache,
-            testGameBuilder,
-            userFactory
+            testGameBuilder
         );
     }
 
@@ -213,7 +211,7 @@ export class GameServer {
         intervalStartTime: 0
     };
 
-    private readonly userFactory: UserFactory;
+    private readonly userFactory: UserFactory = new UserFactory();
     public readonly deckService: DeckService = new DeckService();
     public readonly cosmeticsService?: CosmeticsService;
     public readonly swuStatsHandler: SwuStatsHandler;
@@ -231,8 +229,7 @@ export class GameServer {
         serverRoleUsersCache?: ServerRoleUsersCache,
         cosmeticsService?: CosmeticsService,
         modActionCache?: ModActionService,
-        testGameBuilder?: any,
-        userFactory?: UserFactory
+        testGameBuilder?: any
     ) {
         const app = express();
         app.use(express.json());
@@ -246,7 +243,6 @@ export class GameServer {
         this.serverRoleUsersCache = serverRoleUsersCache;
         this.cosmeticsService = cosmeticsService;
         this.modActionService = modActionCache;
-        this.userFactory = userFactory ?? new UserFactory();
 
         const corsOptions = {
             origin: env.corsOrigins,
@@ -482,7 +478,7 @@ export class GameServer {
                 let moderation = user.getModeration();
                 let needsUsernameChange = user.needsUsernameChange();
 
-                // Ephemeral authenticated test users can exist in development without the database-backed moderation service.
+                // The moderation service is unavailable when the server is running without DynamoDB.
                 if (user.isAuthenticatedUser() && this.modActionService) {
                     const userId = user.getId();
                     const activeActions = this.modActionService.getActiveActionsForPlayer(userId);

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -472,7 +472,8 @@ export class GameServer {
                 let moderation = user.getModeration();
                 let needsUsernameChange = user.needsUsernameChange();
 
-                if (user.isAuthenticatedUser()) {
+                // Ephemeral authenticated test users can exist in development without the database-backed moderation service.
+                if (user.isAuthenticatedUser() && this.modActionService) {
                     const userId = user.getId();
                     const activeActions = this.modActionService.getActiveActionsForPlayer(userId);
 

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -928,10 +928,9 @@ export class GameServer {
             }
         });
 
-        app.put('/api/user/:userId/preferences', this.buildAuthMiddleware('PUT-preferences'), async (req, res, next) => {
+        app.put('/api/user/preferences', this.buildAuthMiddleware('PUT-preferences'), async (req, res, next) => {
             try {
                 const { preferences } = req.body;
-                const { userId } = req.params;
                 const user = req.user as User;
                 if (user.isAnonymousUser()) {
                     logger.error(`GameServer (PUT-preferences): Anonymous user ${user.getId()} attempted to save preferences to dynamodb`);
@@ -940,7 +939,7 @@ export class GameServer {
                         message: 'Error attempting to save preferences'
                     });
                 }
-                await this.userFactory.updateUserPreferencesAsync(userId, preferences);
+                await this.userFactory.updateUserPreferencesAsync(user.getId(), preferences);
                 return res.status(200).json({
                     success: true,
                     message: 'Preferences saved successfully',

--- a/server/gamenode/GameServer.ts
+++ b/server/gamenode/GameServer.ts
@@ -1504,10 +1504,10 @@ export class GameServer {
             }
         });
 
-        app.post('/api/start-test-game', async (req, res, next) => {
+        app.post('/api/start-test-game', this.buildAuthMiddleware('start-test-game'), async (req, res, next) => {
             const { filename } = req.body;
             try {
-                await this.startTestGame(filename);
+                await this.startTestGame(filename, req.user as User);
                 return res.status(200).json({ success: true });
             } catch (err) {
                 logger.error('GameServer: Error in start-test=game:', err);
@@ -2122,7 +2122,7 @@ export class GameServer {
         this.userLobbyMap.set(user.getId(), { lobbyId: lobby.id, role: UserRole.Player });
     }
 
-    private async startTestGame(filename: string) {
+    private async startTestGame(filename: string, requestingUser: User) {
         const lobby = new Lobby(
             'Test Game',
             MatchmakingType.PublicLobby,
@@ -2136,13 +2136,45 @@ export class GameServer {
             this.testGameBuilder
         );
         this.lobbies.set(lobby.id, lobby);
-        const order66 = this.userFactory.createAnonymousUser('exe66', 'Order66');
-        const theWay = this.userFactory.createAnonymousUser('th3w4y', 'ThisIsTheWay');
+        const requestingUsername = requestingUser.getUsername();
+        Contract.assertTrue(
+            requestingUsername === 'Order66' || requestingUsername === 'ThisIsTheWay',
+            `User ${requestingUser.getId()} is not a development test user`
+        );
+
+        let order66: User;
+        let theWay: User;
+        if (requestingUser.isAuthenticatedUser()) {
+            // Database-backed test games use both accounts' real IDs so either browser can connect.
+            const order66Account = await this.userFactory.createDevelopmentTestUserAsync('order66');
+            const theWayAccount = await this.userFactory.createDevelopmentTestUserAsync('this-is-the-way');
+            Contract.assertNotNullLike(order66Account, 'Database-backed test user Order66 has not logged in yet');
+            Contract.assertNotNullLike(theWayAccount, 'Database-backed test user ThisIsTheWay has not logged in yet');
+
+            const expectedRequestingAccount = requestingUsername === 'Order66' ? order66Account : theWayAccount;
+            Contract.assertEqual(
+                requestingUser.getId(),
+                expectedRequestingAccount.getId(),
+                `Authenticated user ${requestingUser.getId()} is not the ${requestingUsername} development test account`
+            );
+
+            order66 = order66Account;
+            theWay = theWayAccount;
+        } else {
+            Contract.assertTrue(requestingUser.isDevTestUser(), `Anonymous user ${requestingUser.getId()} is not a development test user`);
+            // Browser-only development users retain the legacy IDs stored in localStorage.
+            order66 = this.userFactory.createAnonymousUser('exe66', 'Order66');
+            theWay = this.userFactory.createAnonymousUser('th3w4y', 'ThisIsTheWay');
+        }
         lobby.createLobbyUser(order66);
         lobby.createLobbyUser(theWay);
-        this.userLobbyMap.set(order66.id, { lobbyId: lobby.id, role: UserRole.Player });
-        this.userLobbyMap.set(theWay.id, { lobbyId: lobby.id, role: UserRole.Player });
-        await lobby.startTestGameAsync(filename);
+        this.userLobbyMap.set(order66.getId(), { lobbyId: lobby.id, role: UserRole.Player });
+        this.userLobbyMap.set(theWay.getId(), { lobbyId: lobby.id, role: UserRole.Player });
+        await lobby.startTestGameAsync(
+            filename,
+            { id: order66.getId(), username: order66.getUsername() },
+            { id: theWay.getId(), username: theWay.getUsername() }
+        );
     }
 
     private getTestSetupGames() {

--- a/server/gamenode/Lobby.ts
+++ b/server/gamenode/Lobby.ts
@@ -1208,7 +1208,11 @@ export class Lobby {
         logger.info('Lobby: cleaning lobby', { lobbyId: this.id });
     }
 
-    public async startTestGameAsync(filename: string) {
+    public async startTestGameAsync(
+        filename: string,
+        player1Info: Pick<IUser, 'id' | 'username'>,
+        player2Info: Pick<IUser, 'id' | 'username'>
+    ) {
         const testJSONPath = path.resolve(__dirname, `../../../test/gameSetups/${filename}`);
         Contract.assertTrue(fs.existsSync(testJSONPath), `Test game setup file ${testJSONPath} doesn't exist`);
 
@@ -1227,8 +1231,8 @@ export class Lobby {
             setupData,
             this.cardDataGetter,
             router,
-            { id: 'exe66', username: 'Order66' },
-            { id: 'th3w4y', username: 'ThisIsTheWay' },
+            player1Info,
+            player2Info,
             UndoMode.Free
         );
 

--- a/server/utils/authUtils.ts
+++ b/server/utils/authUtils.ts
@@ -11,12 +11,19 @@ export const checkServerRoleUserPrivileges = (
     apiPath: string,
     userId: string,
     role: ServerRole,
-    cache: ServerRoleUsersCache
+    cache?: ServerRoleUsersCache
 ): IAuthResponse => {
     if (!userId) {
         return {
             success: false,
             message: 'Authentication required'
+        };
+    }
+
+    if (!cache) {
+        return {
+            success: false,
+            message: 'Server role service unavailable'
         };
     }
 

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -47,6 +47,13 @@ const refreshTokenFieldMap: Record<RefreshTokenSource, {
     [RefreshTokenSource.SWUBase]: 'swubaseRefreshToken',
 };
 
+type DevelopmentTestProviderId = 'order66' | 'this-is-the-way';
+
+const developmentTestUsers: Record<DevelopmentTestProviderId, { id: string; username: string }> = {
+    order66: { id: 'exe66', username: 'Order66' },
+    'this-is-the-way': { id: 'th3w4y', username: 'ThisIsTheWay' },
+};
+
 
 /**
  * Factory class responsible for creating the appropriate User instance
@@ -64,6 +71,10 @@ export class UserFactory {
     public async createUserFromTokenAsync(token: string): Promise<User> {
         try {
             const dbService = await this.dbServicePromise;
+            if (!dbService) {
+                return this.createEphemeralDevelopmentTestUserFromToken(token);
+            }
+
             const basicUser = await this.authenticateWithTokenAsync(token);
             Contract.assertNotNullLike(basicUser, 'Token authentication failed, User not found from token');
 
@@ -79,11 +90,15 @@ export class UserFactory {
         }
     }
 
-    /** Loads one of the two database-backed test accounts for local development test games. */
-    public async createDevelopmentTestUserAsync(providerId: 'order66' | 'this-is-the-way'): Promise<AuthenticatedUser | null> {
+    /** Loads one of the two test accounts for local development test games. */
+    public async createDevelopmentTestUserAsync(providerId: DevelopmentTestProviderId): Promise<AuthenticatedUser | null> {
         Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Development test users can only be loaded in development');
 
         const dbService = await this.dbServicePromise;
+        if (!dbService) {
+            return this.createEphemeralDevelopmentTestUser(providerId);
+        }
+
         const userId = await dbService.getUserIdByOAuthAsync('dev-user', providerId);
         if (!userId) {
             return null;
@@ -96,6 +111,35 @@ export class UserFactory {
 
         userData = await this.processModerationAsync(userData);
         return new AuthenticatedUser(userData);
+    }
+
+    private createEphemeralDevelopmentTestUserFromToken(token: string): AuthenticatedUser {
+        Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Ephemeral test users can only authenticate in development');
+
+        const secret = process.env.NEXTAUTH_SECRET;
+        Contract.assertTrue(!!secret, 'NEXTAUTH_SECRET environment variable must be set and not empty for authentication to work');
+        const decoded = jwt.verify(token, secret) as any;
+        Contract.assertEqual(decoded.provider, 'dev-user', 'Ephemeral authentication is restricted to the development user provider');
+        Contract.assertTrue(
+            decoded.providerId === 'order66' || decoded.providerId === 'this-is-the-way',
+            'Unknown development test user'
+        );
+
+        const providerId = decoded.providerId as DevelopmentTestProviderId;
+        const expectedUser = developmentTestUsers[providerId];
+        Contract.assertEqual(decoded.name, expectedUser.username, 'Development test user name does not match its provider identity');
+        return this.createEphemeralDevelopmentTestUser(providerId);
+    }
+
+    private createEphemeralDevelopmentTestUser(providerId: DevelopmentTestProviderId): AuthenticatedUser {
+        const testUser = developmentTestUsers[providerId];
+        return new AuthenticatedUser({
+            id: testUser.id,
+            username: testUser.username,
+            showWelcomeMessage: false,
+            preferences: getDefaultPreferences(),
+            needsUsernameChange: false,
+        });
     }
 
     /**

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -79,6 +79,25 @@ export class UserFactory {
         }
     }
 
+    /** Loads one of the two database-backed test accounts for local development test games. */
+    public async createDevelopmentTestUserAsync(providerId: 'order66' | 'this-is-the-way'): Promise<AuthenticatedUser | null> {
+        Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Development test users can only be loaded in development');
+
+        const dbService = await this.dbServicePromise;
+        const userId = await dbService.getUserIdByOAuthAsync('dev-user', providerId);
+        if (!userId) {
+            return null;
+        }
+
+        let userData = await dbService.getUserProfileAsync(userId);
+        if (!userData) {
+            return null;
+        }
+
+        userData = await this.processModerationAsync(userData);
+        return new AuthenticatedUser(userData);
+    }
+
     /**
      * Creates an anonymous user with a generated ID or provided ID
      * @param id Optional ID for the anonymous user

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -72,7 +72,7 @@ export class UserFactory {
         try {
             const dbService = await this.dbServicePromise;
             if (!dbService) {
-                return this.createEphemeralDevelopmentTestUserFromToken(token);
+                return this.createLocalDevelopmentTestUserFromToken(token);
             }
 
             const basicUser = await this.authenticateWithTokenAsync(token);
@@ -161,8 +161,8 @@ export class UserFactory {
         }
     }
 
-    private createEphemeralDevelopmentTestUserFromToken(token: string): AuthenticatedUser {
-        Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Ephemeral test users can only authenticate in development');
+    private createLocalDevelopmentTestUserFromToken(token: string): AnonymousUser {
+        Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Local test users can only authenticate in development');
 
         const secret = process.env.NEXTAUTH_SECRET;
         Contract.assertTrue(!!secret, 'NEXTAUTH_SECRET environment variable must be set and not empty for authentication to work');
@@ -176,7 +176,7 @@ export class UserFactory {
         const providerId = decoded.providerId as DevelopmentTestProviderId;
         const expectedUser = developmentTestUsers[providerId];
         Contract.assertEqual(decoded.name, expectedUser.username, 'Development test user name does not match its provider identity');
-        return this.createEphemeralDevelopmentTestUser(providerId);
+        return this.createAnonymousUser(expectedUser.id, expectedUser.username);
     }
 
     private createEphemeralDevelopmentTestUser(providerId: DevelopmentTestProviderId): AuthenticatedUser {

--- a/server/utils/user/UserFactory.ts
+++ b/server/utils/user/UserFactory.ts
@@ -113,6 +113,54 @@ export class UserFactory {
         return new AuthenticatedUser(userData);
     }
 
+    /** Ensures the two persistent local-development test accounts exist without requiring an initial browser login. */
+    public async ensureDevelopmentTestUsersAsync(): Promise<void> {
+        Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Development test users can only be initialized in development');
+
+        const dbService = await this.dbServicePromise;
+        if (!dbService) {
+            return;
+        }
+
+        for (const providerId of Object.keys(developmentTestUsers) as DevelopmentTestProviderId[]) {
+            const testUser = developmentTestUsers[providerId];
+            let userId = await dbService.getUserIdByOAuthAsync('dev-user', providerId);
+
+            if (!userId) {
+                userId = testUser.id;
+                try {
+                    await dbService.saveOAuthLinkAsync('dev-user', providerId, userId);
+                } catch (error) {
+                    if (error.name !== 'ConditionalCheckFailedException') {
+                        throw error;
+                    }
+
+                    // Another initializer won the race. Use the ID it registered.
+                    userId = await dbService.getUserIdByOAuthAsync('dev-user', providerId);
+                    Contract.assertNotNullLike(userId, `Development test user ${testUser.username} OAuth link could not be initialized`);
+                }
+            }
+
+            const existingProfile = await dbService.getUserProfileAsync(userId);
+            if (!existingProfile) {
+                const now = new Date().toISOString();
+                await dbService.saveUserProfileAsync({
+                    id: userId,
+                    username: testUser.username,
+                    lastLogin: now,
+                    createdAt: now,
+                    usernameLastUpdatedAt: now,
+                    showWelcomeMessage: false,
+                    preferences: getDefaultPreferences(),
+                    needsUsernameChange: false,
+                });
+            }
+
+            // This write is idempotent and also repairs databases created before username links were required.
+            await dbService.saveUsernameLinkAsync(testUser.username, userId);
+        }
+    }
+
     private createEphemeralDevelopmentTestUserFromToken(token: string): AuthenticatedUser {
         Contract.assertEqual(process.env.ENVIRONMENT, 'development', 'Ephemeral test users can only authenticate in development');
 

--- a/test/server/utils/authUtils.spec.ts
+++ b/test/server/utils/authUtils.spec.ts
@@ -1,0 +1,13 @@
+import { ServerRole } from '../../../server/services/DynamoDBInterfaces';
+import { checkServerRoleUserPrivileges } from '../../../server/utils/authUtils';
+
+describe('checkServerRoleUserPrivileges', () => {
+    it('safely denies access when the server role cache is unavailable', () => {
+        const result = checkServerRoleUserPrivileges('/api/user-is-moderator', 'exe66', ServerRole.Moderator, undefined);
+
+        expect(result).toEqual({
+            success: false,
+            message: 'Server role service unavailable'
+        });
+    });
+});

--- a/test/server/utils/user/UserFactory.spec.ts
+++ b/test/server/utils/user/UserFactory.spec.ts
@@ -1,0 +1,48 @@
+import jwt from 'jsonwebtoken';
+import { UserFactory } from '../../../../server/utils/user/UserFactory';
+
+describe('UserFactory development test users', () => {
+    const originalEnvironment = process.env.ENVIRONMENT;
+    const originalUseLocalDynamoDb = process.env.USE_LOCAL_DYNAMODB;
+    const originalNextAuthSecret = process.env.NEXTAUTH_SECRET;
+
+    beforeEach(() => {
+        process.env.ENVIRONMENT = 'development';
+        process.env.USE_LOCAL_DYNAMODB = 'false';
+        process.env.NEXTAUTH_SECRET = 'test-secret';
+    });
+
+    afterEach(() => {
+        if (originalEnvironment === undefined) {
+            delete process.env.ENVIRONMENT;
+        } else {
+            process.env.ENVIRONMENT = originalEnvironment;
+        }
+        if (originalUseLocalDynamoDb === undefined) {
+            delete process.env.USE_LOCAL_DYNAMODB;
+        } else {
+            process.env.USE_LOCAL_DYNAMODB = originalUseLocalDynamoDb;
+        }
+        if (originalNextAuthSecret === undefined) {
+            delete process.env.NEXTAUTH_SECRET;
+        } else {
+            process.env.NEXTAUTH_SECRET = originalNextAuthSecret;
+        }
+    });
+
+    it('uses the legacy local user identity when DynamoDB is disabled', async () => {
+        const token = jwt.sign({
+            provider: 'dev-user',
+            providerId: 'order66',
+            name: 'Order66',
+        }, process.env.NEXTAUTH_SECRET);
+
+        const user = await new UserFactory().createUserFromTokenAsync(token);
+
+        expect(user.isAnonymousUser()).toBeTrue();
+        expect(user.isAuthenticatedUser()).toBeFalse();
+        expect(user.isDevTestUser()).toBeTrue();
+        expect(user.getId()).toBe('exe66');
+        expect(user.getUsername()).toBe('Order66');
+    });
+});


### PR DESCRIPTION
## Summary

- persist the local DynamoDB data directory across container restarts
- seed both development test accounts so a developer only needs to sign in as the side they want to use
- use database-backed authenticated users when local DynamoDB is enabled
- preserve the legacy fixed-ID local user flow when DynamoDB is disabled
- safely deny server-role checks when the role cache is unavailable

## Why

The first implementation represented no-Dynamo development users as authenticated accounts. That caused the client and server to invoke database-backed features such as deck loading and role checks, leading to null service errors and encouraging service-by-service in-memory fallbacks.

This version makes the persistence boundary explicit: development JWTs are still verified, but without DynamoDB they resolve to the existing local test identities (`exe66` and `th3w4y`). That restores browser/local-storage behavior without emulating DynamoDB.

## Developer impact

With local DynamoDB enabled, both test accounts are provisioned automatically and their preferences persist. With DynamoDB disabled, developers retain the lightweight legacy flow and can start test games without database-backed account services.

## Validation

- `npm run build-dev`
- focused Jasmine specs for no-Dynamo dev identity and unavailable role cache
- ESLint on changed files (no errors; existing warnings remain)
- `git diff --check`
