### PR TITLE
Suppress pre-enter-play abilities on cards blanked out of play

### DIFF
--- a/server/game/core/card/propertyMixins/PreEnterPlayAbilityRegistration.ts
+++ b/server/game/core/card/propertyMixins/PreEnterPlayAbilityRegistration.ts
@@ -20,7 +20,9 @@ export function WithPreEnterPlayAbilities<TBaseClass extends PlayableOrDeployabl
     @registerStateBase()
     class WithPreEnterPlayAbilities extends BaseClass {
         public getPreEnterPlayAbilities(): PreEnterPlayAbility[] {
-            return this.preEnterPlayAbilities;
+            // Pre-enter-play abilities are card abilities, so a card blanked out of play (all abilities
+            // lost) resolves none of them as it enters play.
+            return this.isBlankOutOfPlay() ? [] : this.preEnterPlayAbilities;
         }
 
         public getPrintedPreEnterPlayAbilities(): PreEnterPlayAbility[] {

--- a/server/game/core/card/propertyMixins/PreEnterPlayAbilityRegistration.ts
+++ b/server/game/core/card/propertyMixins/PreEnterPlayAbilityRegistration.ts
@@ -20,8 +20,6 @@ export function WithPreEnterPlayAbilities<TBaseClass extends PlayableOrDeployabl
     @registerStateBase()
     class WithPreEnterPlayAbilities extends BaseClass {
         public getPreEnterPlayAbilities(): PreEnterPlayAbility[] {
-            // Pre-enter-play abilities are card abilities, so a card blanked out of play (all abilities
-            // lost) resolves none of them as it enters play.
             return this.isBlankOutOfPlay() ? [] : this.preEnterPlayAbilities;
         }
 

--- a/test/server/cards/03_TWI/units/Clone.spec.ts
+++ b/test/server/cards/03_TWI/units/Clone.spec.ts
@@ -584,6 +584,34 @@ describe('Clone', function() {
                 expect(handClone.isClonedUnit).toBeTrue();
             });
 
+            it('cannot copy a unit when blanked in hand (Galen Erso) and enters play as a defeated 0/0', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['galen-erso#youll-never-win'],
+                    },
+                    player2: {
+                        hand: ['clone'],
+                        groundArena: ['wampa'],
+                        resources: 20
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Galen names Clone, blanking it in player2's hand (including out of play)
+                context.player1.clickCard(context.galenErso);
+                context.player1.chooseListOption('Clone');
+
+                // Playing the blanked Clone offers no copy prompt: its pre-enter-play ability is gone
+                context.player2.clickCard(context.clone);
+
+                // With no copy, Clone enters as its printed 0/0 and is immediately defeated
+                expect(context.clone).toBeInZone('discard');
+                expect(context.wampa).toBeInZone('groundArena');
+                expect(context.player1).toBeActivePlayer();
+            });
+
             it('is not defeated if blanked', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',

--- a/test/server/cards/07_TS26/units/FivesIHaveProof.spec.ts
+++ b/test/server/cards/07_TS26/units/FivesIHaveProof.spec.ts
@@ -285,6 +285,37 @@ describe('Fives, I Have Proof!', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('cannot copy any When Played abilities when blanked in hand (Galen Erso)', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['fives#i-have-proof'],
+                        resources: 20
+                    },
+                    player2: {
+                        hand: ['galen-erso#youll-never-win'],
+                        spaceArena: ['patrolling-vwing'],
+                        resources: 20
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                // Galen (player2's) names Fives, blanking him in player1's hand (including out of play)
+                context.player2.clickCard(context.galenErso);
+                context.player2.chooseListOption('Fives');
+
+                // Playing the blanked Fives offers no copy prompt: his pre-enter-play ability is gone
+                context.player1.clickCard(context.fives);
+
+                // Fives enters play as a vanilla unit; Patrolling V-Wing's "When Played: Draw a card" was not copied
+                expect(context.fives).toBeInZone('groundArena');
+                expect(context.player1.handSize).toBe(0);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('should retain a copied "for this phase" lasting effect even after Fives is defeated', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
## Problem

`getPreEnterPlayAbilities()` ignored blank state and returned a card's pre-enter-play abilities unconditionally — unlike action/constant/triggered ability getters, which all respect blanking. As a result, a card blanked out of play could still resolve its pre-enter-play ability when played.

Example: if Galen Erso names "Clone", the opponent's Clone in hand loses all abilities, but playing it still offered the "choose a unit to clone" prompt.

## Fix

Gate `getPreEnterPlayAbilities()` on `isBlankOutOfPlay()`, matching the existing alternate-play-cost gate. A blanked Clone now enters as its printed 0/0 and is immediately defeated (0-HP state check); a blanked Fives copies nothing and enters as a vanilla unit.

## Tests

- `Clone.spec.ts`: blanked-in-hand Clone enters as a defeated 0/0.
- `FivesIHaveProof.spec.ts`: blanked-in-hand Fives copies no When Played abilities.

Both verified to fail without the fix.