### PR TITLE
Update deck validation logic Next Set mode

### DIFF
--- a/server/utils/deck/DeckValidator.ts
+++ b/server/utils/deck/DeckValidator.ts
@@ -7,8 +7,8 @@ import { DecklistLocation, DeckValidationFailureReason, IllegalInFormatReason, t
 import type { ICardDataJson, ISetCode } from '../cardData/CardDataInterfaces';
 import { Contract } from '../../game/core/utils/Contract';
 import { EnumHelpers } from '../../game/core/utils/EnumHelpers';
-import type { ISetCatalog } from './SwuSetData';
-import { defaultSetCatalog, formatRules, SwuSetId } from './SwuSetData';
+import type { ISetCatalog, ISwuSet } from './SwuSetData';
+import { defaultSetCatalog, formatRules, isReleased, ReleaseStage, SwuSetId } from './SwuSetData';
 
 const maxCopiesOfCards = new Map([
     ['2177194044', 15], // Swarming Vulture Droid
@@ -111,7 +111,7 @@ export class DeckValidator {
 
         // Determine candidate rotation blocks
         let candidateBlocks = cardPool === CardPool.Current
-            ? rotationBlocks.filter((block) => block.sets.some((s) => s.released))
+            ? rotationBlocks.filter((block) => block.sets.some((s) => isReleased(s)))
             : [...rotationBlocks];
 
         // Apply rotation window (take the last N blocks)
@@ -122,21 +122,37 @@ export class DeckValidator {
         const legalSets = new Set<SwuSetId>();
         for (const block of candidateBlocks) {
             for (const set of block.sets) {
-                if (cardPool === CardPool.Current && !set.released) {
-                    continue;
+                if (DeckValidator.isSetInCardPool(set, cardPool)) {
+                    legalSets.add(set.id);
                 }
-                legalSets.add(set.id);
             }
         }
 
         // Add non-rotating sets that are legal in this format
         for (const nrs of nonRotatingSets) {
-            if (nrs.legalFormats.has(format) && (cardPool === CardPool.NextSet || nrs.released)) {
+            if (nrs.legalFormats.has(format) && DeckValidator.isSetInCardPool(nrs, cardPool)) {
                 legalSets.add(nrs.id);
             }
         }
 
         return legalSets;
+    }
+
+    /**
+     * Whether a set belongs to the given constructed card pool (Current or NextSet):
+     * - `Released` sets are always in the pool.
+     * - The `Next` set is in the pool only under {@link CardPool.NextSet}.
+     * - `Future` sets are never in a constructed pool — they preview further out than the next release, so
+     *   including them would make a NextSet meta reflect more than the immediately-upcoming set.
+     *
+     * Not used for Open (all sets) or Limited (single-set) pools, which compute legality separately.
+     */
+    private static isSetInCardPool(set: ISwuSet, cardPool: CardPool): boolean {
+        if (isReleased(set)) {
+            return true;
+        }
+
+        return set.releaseStage === ReleaseStage.Next && cardPool === CardPool.NextSet;
     }
 
     /**
@@ -153,8 +169,8 @@ export class DeckValidator {
         }
 
         const targetSet = cardPool === CardPool.Current
-            ? [...allSets].reverse().find((s) => s.released && s.mainline)
-            : allSets.find((s) => !s.released && s.mainline);
+            ? [...allSets].reverse().find((s) => isReleased(s) && s.mainline)
+            : allSets.find((s) => s.releaseStage === ReleaseStage.Next && s.mainline);
 
         Contract.assertNotNullLike(targetSet, `No ${cardPool === CardPool.Current ? 'released' : 'unreleased'} mainline sets found for Limited format`);
 
@@ -435,8 +451,13 @@ export class DeckValidator {
             return;
         }
 
-        const rules = formatRules.get(format);
-        if (rules?.bannedCards.has(this.setCodeToId.get(setCode))) {
+        const rules = this.getSetCatalog().formatRules.get(format);
+        const banned = rules?.bannedCards.get(this.setCodeToId.get(setCode));
+
+        // A suspension with an `expiresWith` set lifts once that set is in the pool
+        const banExpired = banned?.expiresWith != null && legalSets.has(banned.expiresWith);
+
+        if (banned && !banExpired) {
             failures[DeckValidationFailureReason.IllegalInFormat].push({
                 id: setCode,
                 name: cardData.titleAndSubtitle,

--- a/server/utils/deck/SwuSetData.ts
+++ b/server/utils/deck/SwuSetData.ts
@@ -79,8 +79,6 @@ export const rotationBlocks: IRotationBlock[] = [
         sets: [
             { id: SwuSetId.LAW, releaseStage: ReleaseStage.Released, mainline: true },
             { id: SwuSetId.ASH, releaseStage: ReleaseStage.Released, mainline: true },
-            // HMW is the next set to release; IC27 previews overlap HMW's preview season but release later, so
-            // it stays Future and is excluded from HMW's NextSet meta.
             { id: SwuSetId.HMW, releaseStage: ReleaseStage.Next, mainline: true },
             { id: SwuSetId.IC27, releaseStage: ReleaseStage.Future, mainline: false }
         ]

--- a/server/utils/deck/SwuSetData.ts
+++ b/server/utils/deck/SwuSetData.ts
@@ -21,10 +21,30 @@ export enum BlockId {
     B = 'B'
 }
 
+/**
+ * Where a set sits in the release timeline. Drives which card pools include it:
+ * - `Released`: in play now — legal under the Current pool (and every later pool).
+ * - `Next`: the single upcoming set that releases next — added under the NextSet pool so players can
+ *   test the post-release meta, but not yet legal under Current.
+ * - `Future`: a set previewing further out than `Next` (e.g. a second, overlapping preview season). Not
+ *   part of any constructed pool yet — excluded from Current and NextSet alike so a NextSet meta reflects
+ *   only the immediately-upcoming set.
+ */
+export enum ReleaseStage {
+    Released = 'released',
+    Next = 'next',
+    Future = 'future',
+}
+
 export interface ISwuSet {
     id: SwuSetId;
-    released: boolean;
+    releaseStage: ReleaseStage;
     mainline: boolean;
+}
+
+/** True if the set is released and therefore legal under the Current card pool. */
+export function isReleased(set: ISwuSet): boolean {
+    return set.releaseStage === ReleaseStage.Released;
 }
 
 export interface INonRotatingSet extends ISwuSet {
@@ -40,27 +60,29 @@ export const rotationBlocks: IRotationBlock[] = [
     {
         id: BlockId.Zero,
         sets: [
-            { id: SwuSetId.SOR, released: true, mainline: true },
-            { id: SwuSetId.SHD, released: true, mainline: true },
-            { id: SwuSetId.TWI, released: true, mainline: true }
+            { id: SwuSetId.SOR, releaseStage: ReleaseStage.Released, mainline: true },
+            { id: SwuSetId.SHD, releaseStage: ReleaseStage.Released, mainline: true },
+            { id: SwuSetId.TWI, releaseStage: ReleaseStage.Released, mainline: true }
         ]
     },
     {
         id: BlockId.A,
         sets: [
-            { id: SwuSetId.JTL, released: true, mainline: true },
-            { id: SwuSetId.LOF, released: true, mainline: true },
-            { id: SwuSetId.IBH, released: true, mainline: false },
-            { id: SwuSetId.SEC, released: true, mainline: true }
+            { id: SwuSetId.JTL, releaseStage: ReleaseStage.Released, mainline: true },
+            { id: SwuSetId.LOF, releaseStage: ReleaseStage.Released, mainline: true },
+            { id: SwuSetId.IBH, releaseStage: ReleaseStage.Released, mainline: false },
+            { id: SwuSetId.SEC, releaseStage: ReleaseStage.Released, mainline: true }
         ]
     },
     {
         id: BlockId.B,
         sets: [
-            { id: SwuSetId.LAW, released: true, mainline: true },
-            { id: SwuSetId.ASH, released: true, mainline: true },
-            { id: SwuSetId.HMW, released: false, mainline: true },
-            { id: SwuSetId.IC27, released: false, mainline: false }
+            { id: SwuSetId.LAW, releaseStage: ReleaseStage.Released, mainline: true },
+            { id: SwuSetId.ASH, releaseStage: ReleaseStage.Released, mainline: true },
+            // HMW is the next set to release; IC27 previews overlap HMW's preview season but release later, so
+            // it stays Future and is excluded from HMW's NextSet meta.
+            { id: SwuSetId.HMW, releaseStage: ReleaseStage.Next, mainline: true },
+            { id: SwuSetId.IC27, releaseStage: ReleaseStage.Future, mainline: false }
         ]
     },
 ];
@@ -69,23 +91,36 @@ export const nonRotatingSets: INonRotatingSet[] = [
     {
         id: SwuSetId.TS26,
         legalFormats: new Set([SwuGameFormat.Eternal]),
-        released: true,
+        releaseStage: ReleaseStage.Released,
         mainline: false
     },
 ];
 
+/**
+ * A card suspended in a format. `name` is the card's internal name (also used as a human-readable label).
+ * `expiresWith`, if set, lifts the suspension once that set is in the validated card pool — so a ban that
+ * the publisher has said ends with a set's release passes under NextSet immediately, and under Current
+ * automatically once that set actually releases (its stage flips to Released), with no further code change.
+ */
+export interface IBannedCard {
+    name: string;
+    expiresWith?: SwuSetId;
+}
+
 export interface IFormatRules {
     minDeckSize: number;
     maxCardCopies?: number;
-    bannedCards: Map<string, string>;
+    bannedCards: Map<string, IBannedCard>;
     rotationBlockCount?: number;
 }
 
-const bannedPremierCards = new Map<string, string>();
+const bannedPremierCards = new Map<string, IBannedCard>([
+    ['5648009238', { name: 'cad-bane#still-faster-than-you' }]
+]);
 
-const bannedEternalCards = new Map([
-    ['4203363893', 'war-juggernaut'],
-    ['3722493191', 'ig2000#assassins-aggressor'],
+const bannedEternalCards = new Map<string, IBannedCard>([
+    ['4203363893', { name: 'war-juggernaut', expiresWith: SwuSetId.HMW }],
+    ['3722493191', { name: 'ig2000#assassins-aggressor', expiresWith: SwuSetId.HMW }],
 ]);
 
 export const formatRules = new Map<SwuGameFormat, IFormatRules>([

--- a/test/server/utils/CommonDeckRuleTests.ts
+++ b/test/server/utils/CommonDeckRuleTests.ts
@@ -3,18 +3,21 @@ import { DeckValidationFailureReason, IllegalInFormatReason } from '../../../ser
 import type { IDecklistInternal } from '../../../server/utils/deck/DeckInterfaces';
 import { DeckValidator } from '../../../server/utils/deck/DeckValidator';
 import type { UnitTestCardDataGetter } from '../../../server/utils/cardData/UnitTestCardDataGetter';
-import { formatRules, nonRotatingSets, rotationBlocks } from '../../../server/utils/deck/SwuSetData';
-import { buildCardEntry, buildValidationTestDeck, getDeckFiller, getFirstBase, getFirstCardInSet, getFirstLeader, getLegalSetCodes, TEST_PREVIEW_SET_CODE } from './DeckValidatorTestUtils';
+import { formatRules, isReleased, nonRotatingSets, rotationBlocks } from '../../../server/utils/deck/SwuSetData';
+import { buildCardEntry, buildValidationTestDeck, getDeckFiller, getFirstBase, getFirstCardInSet, getFirstLeader, getLegalSetCodes, TEST_FUTURE_SET_CODE, TEST_PREVIEW_SET_CODE } from './DeckValidatorTestUtils';
 
 // Representative sets for the format-legality probes, derived from the set data so they don't need manual
 // upkeep as sets release and rotate. Uppercased to match `card.setId.set`. Any probe may be undefined (e.g.
 // there is currently no unreleased mainline set); undefined probes are skipped.
 const rotationSets = rotationBlocks.flatMap((block) => block.sets);
-const OLD_RELEASED_SET = rotationSets.find((s) => s.released)?.id.toUpperCase();           // earliest released set (rotated out of the rotating formats)
+const OLD_RELEASED_SET = rotationSets.find(isReleased)?.id.toUpperCase();                  // earliest released set (rotated out of the rotating formats)
 const NON_ROTATING_SET = nonRotatingSets[0]?.id.toUpperCase();                             // a non-rotating set (legal only in Eternal/Open)
-// Synthetic upcoming unreleased mainline ("preview") set, injected by the test utils so this probe is always
-// available regardless of the real release calendar (see DeckValidatorTestUtils).
+// Synthetic upcoming unreleased mainline ("preview"/next) set, injected by the test utils so this probe is
+// always available regardless of the real release calendar (see DeckValidatorTestUtils).
 const PREVIEW_SET = TEST_PREVIEW_SET_CODE;
+// Synthetic "future" set — previews further out than the next set, so it is excluded from every constructed
+// pool (Current and NextSet alike).
+const FUTURE_SET = TEST_FUTURE_SET_CODE;
 
 /** Per-format configuration that drives the shared deck-building rule tests. */
 export interface ICommonDeckRuleConfig {
@@ -233,14 +236,36 @@ export function registerCommonDeckRuleTests(getContext: () => ICommonTestContext
                 expect(failures[DeckValidationFailureReason.IllegalInFormat]).toBeUndefined();
             });
         }
+
+        // A "future" set (previewing further out than the next set) must stay illegal even under NextSet — the
+        // NextSet meta only reflects the immediately-upcoming set. Skipped where the future set is legal anyway
+        // (Open includes everything).
+        if (!nextSetLegalSets.has(FUTURE_SET)) {
+            it(`should reject a ${FUTURE_SET} card even under NextSet (previews beyond the next set)`, function () {
+                const ctx = getContext();
+                const filler = getDeckFiller(ctx.cardDataGetter, minDeckSize - 1, nextSetLegalSets);
+                const futureCard = getFirstCardInSet(ctx.cardDataGetter, FUTURE_SET);
+                const leader = getFirstLeader(ctx.cardDataGetter, nextSetLegalSets).internalName;
+                const base = getFirstBase(ctx.cardDataGetter, nextSetLegalSets).internalName;
+                const deck = buildValidationTestDeck(ctx.cardDataGetter, leader, base, [...filler, futureCard]);
+                const failures = ctx.validator.validateInternalDeck(deck, { format: config.format, cardPool: CardPool.NextSet });
+                expect(failures[DeckValidationFailureReason.IllegalInFormat]).toBeDefined();
+                expect(failures[DeckValidationFailureReason.IllegalInFormat][0].reason).toBe(IllegalInFormatReason.NotLegalInFormat);
+            });
+        }
     });
 
     // Ban list — derived from the format's own suspended cards, so any format with a ban list (Eternal now,
     // Premier again in the future) is covered automatically.
-    const bannedCards = [...rules.bannedCards.values()];
-    if (bannedCards.length > 0) {
+    // `name` is the card's internal name (see IBannedCard), which is what buildCardEntry looks up. Only bans
+    // that are still active in this pool are asserted here — a ban whose `expiresWith` set is already legal in
+    // this pool has lifted (see the NextSet coverage in the per-format specs).
+    const activeBannedCardNames = [...rules.bannedCards.values()]
+        .filter((b) => !(b.expiresWith != null && currentLegalSets.has(b.expiresWith.toUpperCase())))
+        .map((b) => b.name);
+    if (activeBannedCardNames.length > 0) {
         describe('ban list', function () {
-            for (const bannedCard of bannedCards) {
+            for (const bannedCard of activeBannedCardNames) {
                 it(`should reject the suspended card ${bannedCard}`, function () {
                     const ctx = getContext();
                     const filler = getDeckFiller(ctx.cardDataGetter, minDeckSize - 1, config.legalSets);

--- a/test/server/utils/DeckValidatorTestUtils.ts
+++ b/test/server/utils/DeckValidatorTestUtils.ts
@@ -1,18 +1,19 @@
 import type { IDecklistInternal, IInternalCardEntry } from '../../../server/utils/deck/DeckInterfaces';
 import { UnitTestCardDataGetter } from '../../../server/utils/cardData/UnitTestCardDataGetter';
-import type { ISetCatalog } from '../../../server/utils/deck/SwuSetData';
-import { formatRules, nonRotatingSets, rotationBlocks, SwuSetId } from '../../../server/utils/deck/SwuSetData';
+import type { IFormatRules, ISetCatalog } from '../../../server/utils/deck/SwuSetData';
+import { formatRules, isReleased, nonRotatingSets, ReleaseStage, rotationBlocks, SwuSetId } from '../../../server/utils/deck/SwuSetData';
 import { setCodeToString } from '../../../server/Util';
 import { DeckValidator } from '../../../server/utils/deck/DeckValidator';
 import type { CardDataGetter } from '../../../server/utils/cardData/CardDataGetter';
 import type { ICardDataJson } from '../../../server/utils/cardData/CardDataInterfaces';
-import type { CardPool, SwuGameFormat } from '../../../server/game/core/Constants';
+import { SwuGameFormat } from '../../../server/game/core/Constants';
+import type { CardPool } from '../../../server/game/core/Constants';
 
 // Released set IDs (uppercase to match card.setId.set from JSON)
 export const RELEASED_SETS = new Set<string>([
-    ...rotationBlocks.flatMap((b) => b.sets).filter((s) => s.released)
+    ...rotationBlocks.flatMap((b) => b.sets).filter(isReleased)
         .map((s) => s.id.toUpperCase()),
-    ...nonRotatingSets.filter((s) => s.released).map((s) => s.id.toUpperCase()),
+    ...nonRotatingSets.filter(isReleased).map((s) => s.id.toUpperCase()),
 ]);
 
 /** Uppercased legal set codes for a format + card pool, for matching against `card.setId.set`. */
@@ -45,6 +46,11 @@ export function getDeckFiller(cardDataGetter: UnitTestCardDataGetter, count: num
         }
         const card = cardDataGetter.getCardSync(cardId);
         if (!isPlayableType(card)) {
+            continue;
+        }
+        // Skip synthetic fixture cards (preview/future/banned stand-ins, all prefixed with `__`) so they never
+        // leak into generic filler — some live in real legal sets and must only appear when a test adds them.
+        if (card.internalName.startsWith('__')) {
             continue;
         }
         if (!legalSets.has(card.setId.set)) {
@@ -164,26 +170,37 @@ export async function makeValidatorWithUnknownSetCard(cardDataGetter: UnitTestCa
 }
 
 // ---------------------------------------------------------------------------
-// Synthetic "preview" set support
-// Whether a real set is an unreleased ("preview") mainline set changes over time, and there are periods with
-// no preview set at all. To keep the preview/NextSet tests running unconditionally, we inject a synthetic
-// preview set ('TPRV') that is always present: an unreleased mainline set with its own leader, base, and units.
-// The validator reads this via an alternate ISetCatalog, and a subclass teaches the enum-based set parsing to
-// recognize the synthetic set code. Production code and data are untouched.
+// Synthetic set + ban fixtures
+// The real release calendar and ban list change over time, so tests that must keep exercising the preview,
+// future-set, and ban-expiry logic use synthetic stand-ins injected via an alternate ISetCatalog instead of
+// pinning to real sets/cards. There are three:
+//   - TPRV: a `Next` mainline set (the upcoming set) — legal under NextSet, excluded from Current.
+//   - TFUT: a `Future` set (previews further out than the next set) — excluded from every constructed pool.
+//   - a synthetic suspended card in a released set whose ban `expiresWith` TPRV — active under Current, lifted
+//     under NextSet (mirrors the real "ban expires with the next set's release" behavior, durably).
+// A subclass teaches the enum-based set parsing to recognize the synthetic set codes. Production code/data are
+// untouched. All synthetic cards use a `__` internal-name prefix so getDeckFiller skips them.
 // ---------------------------------------------------------------------------
 
-/** Uppercase set code (matches `card.setId.set`) for the synthetic preview set. */
+/** Uppercase set code (matches `card.setId.set`) for the synthetic preview ("next") set. */
 export const TEST_PREVIEW_SET_CODE = 'TPRV';
 
 /** Lowercase set id (matches the `SwuSetId` enum-value convention) for the synthetic preview set. */
 const TEST_PREVIEW_SET_ID = 'tprv';
 
-/** Builds a synthetic preview-set card of the given printed type. */
-function makePreviewCard(kind: 'leader' | 'base' | 'unit', num: number): ICardDataJson {
-    const internalName = `__tprv-${kind}-${num}__`;
+/** Uppercase set code for the synthetic future set (previews beyond the next set). */
+export const TEST_FUTURE_SET_CODE = 'TFUT';
+
+/** Lowercase set id for the synthetic future set. */
+const TEST_FUTURE_SET_ID = 'tfut';
+
+/** Builds a synthetic card of the given set/type. Internal name is `__`-prefixed so filler skips it. */
+function makeSyntheticCard(setCode: string, kind: 'leader' | 'base' | 'unit', num: number): ICardDataJson {
+    const slug = setCode.toLowerCase();
+    const internalName = `__${slug}-${kind}-${num}__`;
     return {
-        id: `__tprv-${kind}-${num}-id__`,
-        title: `TPRV ${kind} ${num}`,
+        id: `${internalName}-id__`,
+        title: `${setCode} ${kind} ${num}`,
         subtitle: '',
         cost: 1,
         hp: 1,
@@ -194,8 +211,8 @@ function makePreviewCard(kind: 'leader' | 'base' | 'unit', num: number): ICardDa
         traits: [],
         keywords: [],
         types: [kind],
-        setId: { set: TEST_PREVIEW_SET_CODE, number: num },
-        setCodes: [{ set: TEST_PREVIEW_SET_CODE, number: num }],
+        setId: { set: setCode, number: num },
+        setCodes: [{ set: setCode, number: num }],
         internalName,
         arena: 'ground',
     };
@@ -203,24 +220,52 @@ function makePreviewCard(kind: 'leader' | 'base' | 'unit', num: number): ICardDa
 
 // One leader, one base, and enough units to fill a minimum Limited deck (whose NextSet pool is this single set).
 const PREVIEW_CARDS: ICardDataJson[] = [
-    makePreviewCard('leader', 100),
-    makePreviewCard('base', 101),
-    ...Array.from({ length: 35 }, (_, i) => makePreviewCard('unit', i + 1)),
+    makeSyntheticCard(TEST_PREVIEW_SET_CODE, 'leader', 100),
+    makeSyntheticCard(TEST_PREVIEW_SET_CODE, 'base', 101),
+    ...Array.from({ length: 35 }, (_, i) => makeSyntheticCard(TEST_PREVIEW_SET_CODE, 'unit', i + 1)),
 ];
 
+// A few playable cards suffice: future-set tests only ever add a single TFUT card to an otherwise-legal deck.
+const FUTURE_CARDS: ICardDataJson[] = Array.from({ length: 3 }, (_, i) => makeSyntheticCard(TEST_FUTURE_SET_CODE, 'unit', i + 1));
+
+// The synthetic suspended card lives in the latest released mainline set (derived, so it stays a real, always-
+// legal set regardless of the calendar) — and, critically, one getFirstCardInSet never probes, so it can't leak
+// into another test. Number 999 avoids colliding with a real card in that set.
+const bannedCardSetCode = ([...rotationBlocks.flatMap((b) => b.sets)].reverse().find((s) => isReleased(s) && s.mainline)?.id ?? SwuSetId.SOR).toUpperCase();
+const TEST_BANNED_CARD: ICardDataJson = makeSyntheticCard(bannedCardSetCode, 'unit', 999);
+
+/** Internal name of the synthetic suspended card whose ban expires with the synthetic next (TPRV) set. */
+export const TEST_BANNED_CARD_NAME = TEST_BANNED_CARD.internalName;
+
+/** All synthetic cards served by the preview card-data getter. */
+const SYNTHETIC_CARDS: ICardDataJson[] = [...PREVIEW_CARDS, ...FUTURE_CARDS, TEST_BANNED_CARD];
+
+/** formatRules with a synthetic Eternal suspension added (expiring with TPRV) so ban-expiry is testable. */
+function buildTestFormatRules(): Map<SwuGameFormat, IFormatRules> {
+    const testRules = new Map(formatRules);
+    const eternalRules = testRules.get(SwuGameFormat.Eternal);
+    const eternalBans = new Map(eternalRules.bannedCards);
+    eternalBans.set(TEST_BANNED_CARD.id, { name: TEST_BANNED_CARD_NAME, expiresWith: TEST_PREVIEW_SET_ID as SwuSetId });
+    testRules.set(SwuGameFormat.Eternal, { ...eternalRules, bannedCards: eternalBans });
+    return testRules;
+}
+
 /**
- * The default set catalog with a synthetic unreleased mainline "preview" set appended to the latest block.
- * Under {@link CardPool.Current} it is excluded (unreleased), so current-pool legality is unchanged; under
- * {@link CardPool.NextSet} it becomes legal, which is what the preview tests exercise.
+ * The default set catalog with the synthetic sets appended to the latest block (TPRV as `Next`, TFUT as
+ * `Future`) and a synthetic Eternal suspension. Under {@link CardPool.Current} TPRV/TFUT are excluded, so
+ * current-pool legality is unchanged; under {@link CardPool.NextSet} TPRV becomes legal (TFUT never does).
  */
 export const TEST_SET_CATALOG: ISetCatalog = {
     rotationBlocks: rotationBlocks.map((block, i) => {
         return i === rotationBlocks.length - 1
-            ? { ...block, sets: [...block.sets, { id: TEST_PREVIEW_SET_ID as SwuSetId, released: false, mainline: true }] }
+            ? { ...block, sets: [...block.sets,
+                { id: TEST_PREVIEW_SET_ID as SwuSetId, releaseStage: ReleaseStage.Next, mainline: true },
+                { id: TEST_FUTURE_SET_ID as SwuSetId, releaseStage: ReleaseStage.Future, mainline: false },
+            ] }
             : { ...block, sets: [...block.sets] };
     }),
     nonRotatingSets,
-    formatRules,
+    formatRules: buildTestFormatRules(),
 };
 
 /** A {@link UnitTestCardDataGetter} that also serves the synthetic preview-set cards. */
@@ -230,7 +275,7 @@ class PreviewTestCardDataGetter extends UnitTestCardDataGetter {
 
     public constructor(folderRoot: string) {
         super(folderRoot);
-        for (const card of PREVIEW_CARDS) {
+        for (const card of SYNTHETIC_CARDS) {
             this.previewById.set(card.id, card);
             this.previewByName.set(card.internalName, card);
             this.cardMap.set(card.id, { id: card.id, title: card.title, subtitle: card.subtitle, internalName: card.internalName, cost: card.cost });
@@ -269,12 +314,14 @@ class PreviewDeckValidator extends DeckValidator {
         return TEST_SET_CATALOG;
     }
 
-    // The base implementation only recognizes real `SwuSetId` members; re-add the synthetic preview set so its
-    // cards resolve to a real (illegal-under-Current, legal-under-NextSet) set rather than an unknown one.
+    // The base implementation only recognizes real `SwuSetId` members; re-add the synthetic set codes so their
+    // cards resolve to a recognized set (with the intended pool legality) rather than an unknown one. The
+    // synthetic banned card uses a real released set code, so the base implementation already handles it.
     protected override parseSets(cardData: ICardDataJson): SwuSetId[] {
         const base = super.parseSets(cardData);
         const codes = (cardData.setCodes ?? [cardData.setId]).map((c) => c.set.toLowerCase());
-        return codes.includes(TEST_PREVIEW_SET_ID) ? [...base, TEST_PREVIEW_SET_ID as SwuSetId] : base;
+        const extra = [TEST_PREVIEW_SET_ID, TEST_FUTURE_SET_ID].filter((id) => codes.includes(id)) as SwuSetId[];
+        return [...base, ...extra];
     }
 }
 

--- a/test/server/utils/EternalValidator.spec.ts
+++ b/test/server/utils/EternalValidator.spec.ts
@@ -1,5 +1,5 @@
 import { CardPool, SwuGameFormat } from '../../../server/game/core/Constants';
-import { DeckValidationFailureReason } from '../../../server/utils/deck/DeckInterfaces';
+import { DeckValidationFailureReason, IllegalInFormatReason } from '../../../server/utils/deck/DeckInterfaces';
 import type { IInternalCardEntry, ISwuDbFormatDecklist } from '../../../server/utils/deck/DeckInterfaces';
 import { DeckValidator } from '../../../server/utils/deck/DeckValidator';
 import { UnitTestCardDataGetter } from '../../../server/utils/cardData/UnitTestCardDataGetter';
@@ -8,7 +8,8 @@ import {
     buildValidationTestDeck,
     createPreviewValidatorSetup,
     getDeckFiller,
-    RELEASED_SETS
+    RELEASED_SETS,
+    TEST_BANNED_CARD_NAME
 } from './DeckValidatorTestUtils';
 import { registerCommonDeckRuleTests } from './CommonDeckRuleTests';
 
@@ -61,6 +62,25 @@ describe('Eternal deck validation', function () {
             const deck = buildDeck(all.slice(0, 50), { sideboard: all.slice(50, 61) });
             const failures = validator.validateInternalDeck(deck, nextSetProps());
             expect(failures[DeckValidationFailureReason.MaxSideboardSizeExceeded]).toBeUndefined();
+        });
+
+        // A suspension whose `expiresWith` set is the upcoming set is active under Current but lifts under
+        // NextSet (which includes that set) — the behavior the real "expires with the next release" bans rely
+        // on. Exercised here with the synthetic ban (expiring with the synthetic TPRV set) so it stays valid
+        // regardless of the real ban list.
+        it('should keep the card suspended under Current while its ban is active', function () {
+            const filler = getDeckFiller(cardDataGetter, 49, RELEASED_SETS);
+            const deck = buildDeck([...filler, buildCardEntry(cardDataGetter, TEST_BANNED_CARD_NAME)]);
+            const failures = validator.validateInternalDeck(deck, eternalProps());
+            expect(failures[DeckValidationFailureReason.IllegalInFormat]).toBeDefined();
+            expect(failures[DeckValidationFailureReason.IllegalInFormat][0].reason).toBe(IllegalInFormatReason.Suspended);
+        });
+
+        it('should accept the card under NextSet once its ban has expired', function () {
+            const filler = getDeckFiller(cardDataGetter, 49, RELEASED_SETS);
+            const deck = buildDeck([...filler, buildCardEntry(cardDataGetter, TEST_BANNED_CARD_NAME)]);
+            const failures = validator.validateInternalDeck(deck, nextSetProps());
+            expect(failures[DeckValidationFailureReason.IllegalInFormat]).toBeUndefined();
         });
     });
 });

--- a/test/server/utils/OpenValidator.spec.ts
+++ b/test/server/utils/OpenValidator.spec.ts
@@ -17,7 +17,7 @@ const LEADER = 'luke-skywalker#faithful-friend'; // SOR — legal in Open
 const BASE = 'kestro-city';                      // SOR — legal in Open
 
 // Cards on the Eternal ban list, used to confirm Open enforces no ban list of its own.
-const ETERNAL_BANNED_CARDS = [...formatRules.get(SwuGameFormat.Eternal).bannedCards.values()];
+const ETERNAL_BANNED_CARDS = [...formatRules.get(SwuGameFormat.Eternal).bannedCards.values()].map((b) => b.name);
 
 describe('Open deck validation', function () {
     let validator: DeckValidator;


### PR DESCRIPTION
- Next Set mode should include the next set to be released (HMW), but still exclude any known future sets (IC27)
- Ban lists now have an optional expiration set. For example, the current Eternal suspensions expire with the release of Homeworlds
- Add Cad Bane leader to the premier ban list