### PR TITLE
Fix Clan Wren Loyalist to search for any card sharing a trait

### DIFF
--- a/server/game/cards/08_ASH/units/ClanWrenLoyalist.ts
+++ b/server/game/cards/08_ASH/units/ClanWrenLoyalist.ts
@@ -13,10 +13,10 @@ export default class ClanWrenLoyalist extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'Search the top 5 cards of your deck for a unit that shares a trait with a friendly unit, reveal it, and draw it',
+            title: 'Search the top 5 cards of your deck for a card that shares a trait with a friendly unit, reveal it, and draw it',
             immediateEffect: AbilityHelper.immediateEffects.deckSearch({
                 searchCount: 5,
-                cardCondition: (card, context) => card.isUnit() && context.player.isTraitInPlay([...card.traits]),
+                cardCondition: (card, context) => context.player.isTraitInPlay([...card.traits]),
                 selectedCardsImmediateEffect: AbilityHelper.immediateEffects.revealAndDraw({
                     useDisplayPrompt: true,
                     promptedPlayer: RelativePlayer.Opponent

--- a/test/server/cards/08_ASH/units/ClanWrenLoyalist.spec.ts
+++ b/test/server/cards/08_ASH/units/ClanWrenLoyalist.spec.ts
@@ -34,6 +34,38 @@ describe('Clan Wren Loyalist', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('should let non-unit cards that share a trait with a friendly unit be selected', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['clan-wren-loyalist'],
+                        groundArena: ['ezra-bridger#spectre-six'],
+                        deck: ['spark-of-rebellion', 'fulcrum', 'wampa', 'atst', 'cartel-spacer']
+                    },
+                    player2: {
+                        groundArena: ['snowspeeder']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.clanWrenLoyalist);
+
+                // spark-of-rebellion (spectre event) and fulcrum (rebel upgrade) both share a trait with Ezra
+                expect(context.player1).toHaveExactDisplayPromptCards({
+                    selectable: [context.sparkOfRebellion, context.fulcrum],
+                    invalid: [context.wampa, context.atst, context.cartelSpacer]
+                });
+
+                context.player1.clickCardInDisplayCardPrompt(context.sparkOfRebellion);
+
+                expect(context.player2).toHaveExactViewableDisplayPromptCards([context.sparkOfRebellion]);
+                context.player2.clickDone();
+
+                expect(context.sparkOfRebellion).toBeInZone('hand', context.player1);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('should allow taking nothing after triggering deck search', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
Clan Wren Loyalist searches for "a card that shares a Trait with a unit you control", but the impl restricted the search to units only. Removed the `card.isUnit()` check so any card type (events, upgrades, units) can be found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)