### PR TITLE
Fix crash from LAW Han Solo On Attack ability with autoSingleTarget

### DIFF
--- a/server/game/cards/07_LAW/leaders/HanSoloIGotAReallyGoodFeeling.ts
+++ b/server/game/cards/07_LAW/leaders/HanSoloIGotAReallyGoodFeeling.ts
@@ -33,7 +33,11 @@ export default class HanSoloIGotAReallyGoodFeeling extends LeaderUnitCard {
         registrar.addOnAttackAbility({
             title: 'Defeat any number of friendly tokens',
             targetResolver: {
-                activePromptTitle: (_context, selectedCards) => `Defeat any number of friendly tokens (${selectedCards.length} selected)`,
+                // `selectedCards` is only provided by the multi-select card grid; when the prompt is reduced to a
+                // yes/no (e.g. autoSingleTarget with a single token), it is absent and the selection suffix is omitted.
+                activePromptTitle: (_context, selectedCards) => selectedCards == null
+                    ? 'Defeat any number of friendly tokens'
+                    : `Defeat any number of friendly tokens (${selectedCards.length} selected)`,
                 mode: TargetMode.Unlimited,
                 canChooseNoCards: true,
                 cardTypeFilter: WildcardCardType.Token,

--- a/server/game/cards/07_LAW/leaders/HanSoloIGotAReallyGoodFeeling.ts
+++ b/server/game/cards/07_LAW/leaders/HanSoloIGotAReallyGoodFeeling.ts
@@ -33,11 +33,11 @@ export default class HanSoloIGotAReallyGoodFeeling extends LeaderUnitCard {
         registrar.addOnAttackAbility({
             title: 'Defeat any number of friendly tokens',
             targetResolver: {
-                // `selectedCards` is only provided by the multi-select card grid; when the prompt is reduced to a
-                // yes/no (e.g. autoSingleTarget with a single token), it is absent and the selection suffix is omitted.
-                activePromptTitle: (_context, selectedCards) => selectedCards == null
-                    ? 'Defeat any number of friendly tokens'
-                    : `Defeat any number of friendly tokens (${selectedCards.length} selected)`,
+                activePromptTitle: (_context, selectedCards) => (
+                    selectedCards == null
+                        ? 'Defeat any number of friendly tokens'
+                        : `Defeat any number of friendly tokens (${selectedCards.length} selected)`
+                ),
                 mode: TargetMode.Unlimited,
                 canChooseNoCards: true,
                 cardTypeFilter: WildcardCardType.Token,

--- a/test/server/cards/07_LAW/leaders/HanSoloIGotAReallyGoodFeeling.spec.ts
+++ b/test/server/cards/07_LAW/leaders/HanSoloIGotAReallyGoodFeeling.spec.ts
@@ -268,6 +268,38 @@ describe('Han Solo, I Got a Really Good Feeling', function() {
                 expect(context.player2).toBeActivePlayer();
             });
 
+            it('does not error out when auto single target is enabled', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        autoSingleTarget: true,
+                        leader: { card: 'han-solo#i-got-a-really-good-feeling', deployed: true },
+                        groundArena: ['spy']
+                    },
+                    player2: {
+                        groundArena: ['consular-security-force']
+                    }
+                });
+
+                const { context } = contextRef;
+                const p1Spy = context.player1.findCardByName('spy');
+
+                context.player1.clickCard(context.hanSolo);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toHavePrompt('Trigger the effect \'Defeat any number of friendly tokens\' on target \'Spy\' or pass');
+                expect(context.player1).toHaveExactPromptButtons(['Defeat any number of friendly tokens -> Spy', 'Pass']);
+                context.player1.clickPrompt('Defeat any number of friendly tokens -> Spy');
+
+                expect(p1Spy).toBeInZone('outsideTheGame');
+
+                expect(context.player1).toHavePrompt('Deal 1 damage to a unit');
+                context.player1.clickCard(context.consularSecurityForce);
+
+                expect(context.consularSecurityForce.damage).toBe(1);
+                expect(context.player2).toBeActivePlayer();
+            });
+
             it('is automatically skipped if there are no friendly tokens in play', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',


### PR DESCRIPTION
When autoSingleTarget is enabled and Han Solo's deployed On Attack
ability ("Defeat any number of friendly tokens") has exactly one
eligible token, the resolver reduces to a yes/no "trigger or pass"
prompt. That path builds the prompt title by calling the resolver's
activePromptTitle with only the context, leaving selectedCards
undefined. Han's title function dereferenced selectedCards.length,
throwing a TypeError and leaving the game with an unresolved prompt.

Make the card's activePromptTitle defensive: the multi-select grid
always passes a selectedCards array (so the "(0 selected)" grid prompt
is unchanged), while the yes/no path passes none, in which case we omit
the selection suffix and show the plain ability title.

Han Solo is the only card in the codebase that reads the selectedCards
param of activePromptTitle; the other consumer (ExploitCostAdjuster) is
only reached via the grid prompt, so it is not affected.