### PR TITLE
Fix duplicate gained action abilities collapsing independent use limits

### DIFF
--- a/server/game/core/card/Card.ts
+++ b/server/game/core/card/Card.ts
@@ -398,24 +398,13 @@ export class Card extends OngoingEffectSourceBase implements IGameStatisticsTrac
      * abilities have a cost in brackets that must be paid in order to use the ability.
      */
     public getActionAbilities(): ActionAbilityBase[] {
-        const deduplicatedActionAbilities: ActionAbilityBase[] = [];
-
-        // Add any gained action abilities, deduplicating by any identical gained action abilities from
-        // the same source card (e.g., two Heroic Resolve actions)
-        const seenCardNameSources = new Set<string>();
-        for (const action of this.actionAbilities) {
-            if (action.printedAbility) {
-                deduplicatedActionAbilities.push(action);
-            } else if (!seenCardNameSources.has(action.gainAbilitySource.internalName)) {
-                deduplicatedActionAbilities.push(action);
-                seenCardNameSources.add(action.gainAbilitySource.internalName);
-            }
+        // Duplicate gained abilities are deduplicated against legal actions in ActionWindow.getCardLegalActions,
+        // after use limits are checked, so a still-usable copy isn't hidden by one that's at its limit.
+        if (this.isBlank()) {
+            return this.actionAbilities.filter((action) => action.isEpicAction);
         }
 
-        const epicActionAbilities = deduplicatedActionAbilities
-            .filter((action) => action.isEpicAction);
-
-        return this.isBlank() ? epicActionAbilities : deduplicatedActionAbilities;
+        return [...this.actionAbilities];
     }
 
     public getPrintedActionAbilities(): ActionAbilityBase[] {

--- a/server/game/core/gameSteps/ActionWindow.ts
+++ b/server/game/core/gameSteps/ActionWindow.ts
@@ -276,7 +276,21 @@ export class ActionWindow extends UiPrompt {
     private getCardLegalActions(card: Card, player: Player) {
         const actions = card.getActions();
         const legalActions = actions.filter((action) => action.meetsRequirements(action.createContext(player)) === '');
-        return legalActions;
+
+        // Show one button per source for gained abilities from multiple copies of the same card.
+        // Deduplicating after the requirements filter keeps a copy at its use limit from hiding a usable one.
+        const seenGainedSources = new Set<string>();
+        return legalActions.filter((action) => {
+            const gainAbilitySource = action.isCardAbility() && !action.printedAbility ? action.gainAbilitySource : null;
+            if (!gainAbilitySource) {
+                return true;
+            }
+            if (seenGainedSources.has(gainAbilitySource.internalName)) {
+                return false;
+            }
+            seenGainedSources.add(gainAbilitySource.internalName);
+            return true;
+        });
     }
 
     // markBonusActionsTaken() {

--- a/test/server/cards/08_ASH/upgrades/ImprovisedIdentity.spec.ts
+++ b/test/server/cards/08_ASH/upgrades/ImprovisedIdentity.spec.ts
@@ -328,6 +328,40 @@ describe('Improvised Identity', function() {
                     context.player1.clickPrompt('Take nothing');
                     context.player1.clickPrompt('Pass attack');
                 });
+
+                it('should allow the action to be used twice when two copies are attached (each copy has its own limit)', async function() {
+                    await contextRef.setupTestAsync({
+                        phase: 'action',
+                        player1: {
+                            groundArena: [{ card: 'wampa', upgrades: ['improvised-identity', 'improvised-identity'] }],
+                            deck: ['battlefield-marine', 'pyke-sentinel', 'takedown', 'cartel-spacer', 'atst']
+                        }
+                    });
+
+                    const { context } = contextRef;
+
+                    // First copy's use
+                    context.player1.clickCard(context.wampa);
+                    context.player1.clickPrompt(abilityTitle);
+                    context.player1.clickPrompt('Take nothing');
+                    context.player1.clickPrompt('Pass attack');
+
+                    context.player2.passAction();
+
+                    // Second copy still has its own once-per-round use available
+                    context.player1.clickCard(context.wampa);
+                    expect(context.player1).toHaveEnabledPromptButton(abilityTitle);
+                    context.player1.clickPrompt(abilityTitle);
+                    context.player1.clickPrompt('Take nothing');
+                    context.player1.clickPrompt('Pass attack');
+
+                    context.player2.passAction();
+
+                    // Both copies are now exhausted for the round — only the default attack remains
+                    context.player1.clickCard(context.wampa);
+                    expect(context.player1).not.toHaveEnabledPromptButton(abilityTitle);
+                    context.player1.clickPrompt('Cancel');
+                });
             });
 
             it('should still allow the search/discard step when the attached unit is exhausted', async function() {


### PR DESCRIPTION
## Problem

A unit with two copies of **Improvised Identity** attached could only use the granted once-per-round action once, even though each upgrade copy is a distinct ability with its own limit.

## Root cause

`Card.getActionAbilities()` deduplicated gained action abilities by source card `internalName`, keeping only the first copy. This dedup was originally added for **Heroic Resolve**, where it's harmless: each use *defeats a copy of the upgrade* to pay the cost, so a source disappears after each use and the remaining copy's button reappears naturally.

Improvised Identity instead gates reuse with a `perRound(1)` limit and keeps both copies attached. The dedup ran *before* the requirements/limit check, so once the retained first copy hit its limit it was filtered out — and the still-usable second copy had already been discarded, hiding it for the rest of the round.

## Fix

Move deduplication to `ActionWindow.getCardLegalActions`, running it *after* the `meetsRequirements` filter. A copy at its limit is dropped by the filter first, leaving a usable copy to surface. Heroic Resolve still shows one button per source.

## Tests

- Added a regression test for two Improvised Identity copies (two uses allowed, third blocked).
- Full suite green (7962 specs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)