### PR TITLE
Fix uniqueness rule for Fortify upgrades

### DIFF
--- a/server/game/core/Game.ts
+++ b/server/game/core/Game.ts
@@ -55,7 +55,6 @@ import { GroundArenaZone } from './zone/GroundArenaZone';
 import { SpaceArenaZone } from './zone/SpaceArenaZone';
 import { AllArenasZone } from './zone/AllArenasZone';
 import type { IAllArenasZoneCardFilterProperties, IAllArenasSpecificTypeCardFilterProperties } from './zone/AllArenasZone';
-import { EnumHelpers } from './utils/EnumHelpers';
 import { SelectCardPrompt } from './gameSteps/prompts/SelectCardPrompt';
 import { DisplayCardsWithButtonsPrompt } from './gameSteps/prompts/DisplayCardsWithButtonsPrompt';
 import { DisplayCardsForSelectionPrompt } from './gameSteps/prompts/DisplayCardsForSelectionPrompt';
@@ -1539,14 +1538,14 @@ export class Game extends EventEmitter {
         const checkedCards: Card[] = [];
 
         for (const movedCard of this.state.movedCards.map((id) => this.getFromId(id))) {
-            if (EnumHelpers.isArena(movedCard.zoneName) && movedCard.unique) {
+            if (movedCard.unique && movedCard.canBeInPlay() && movedCard.isInPlay()) {
                 const existingCard = checkedCards.find((otherCard) =>
                     otherCard.title === movedCard.title &&
                     otherCard.subtitle === movedCard.subtitle &&
                     otherCard.controller === movedCard.controller
                 );
 
-                if (!existingCard && movedCard.canBeInPlay()) {
+                if (!existingCard) {
                     checkedCards.push(movedCard);
                     movedCard.checkUnique();
                 }

--- a/server/game/core/Player.ts
+++ b/server/game/core/Player.ts
@@ -628,7 +628,8 @@ export class Player extends GameObject implements IGameStatisticsTrackable {
      * @returns {import('./card/baseClasses/InPlayCard').IInPlayCard[]} Duplicates of passed card (does not check unique status)
      */
     public getDuplicatesInPlay(card: IInPlayCard): IInPlayCard[] {
-        return this.getArenaCards().filter((otherCard) =>
+        return this.getInPlayCards().filter((otherCard): otherCard is IInPlayCard =>
+            otherCard.canBeInPlay() &&
             otherCard.title === card.title &&
             otherCard.subtitle === card.subtitle &&
             otherCard !== card

--- a/test/server/core/card/UniqueRule.spec.ts
+++ b/test/server/core/card/UniqueRule.spec.ts
@@ -148,6 +148,41 @@ describe('Uniqueness rule', function() {
             });
         });
 
+        describe('When another copy of a unique Fortify upgrade attached to the base enters play for the same controller,', function() {
+            beforeEach(async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: [
+                            'the-tarkin-doctrine#protect-and-punish',
+                            'the-tarkin-doctrine#protect-and-punish'
+                        ],
+                    }
+                });
+
+                const { context } = contextRef;
+                [context.tarkinDoctrine1, context.tarkinDoctrine2] = context.player1.findCardsByName('the-tarkin-doctrine#protect-and-punish');
+            });
+
+            it('the oldest copy is defeated automatically', function () {
+                const { context } = contextRef;
+
+                // Play the first copy onto the base
+                context.player1.clickCard(context.tarkinDoctrine1);
+                context.player1.clickCard(context.p1Base);
+                context.player2.passAction();
+
+                // Play the second copy onto the base, triggering the uniqueness rule
+                context.player1.clickCard(context.tarkinDoctrine2);
+                context.player1.clickCard(context.p1Base);
+
+                // The oldest copy is defeated by default; the newest remains attached to the base
+                expect(context.tarkinDoctrine1).toBeInZone('discard');
+                expect(context.tarkinDoctrine2).toBeAttachedTo(context.p1Base);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
         describe('When another copy of a unique piloting card enters play for the same controller,', function() {
             beforeEach(async function () {
                 await contextRef.setupTestAsync({


### PR DESCRIPTION
The uniqueness rule was only checking cards _in an arena_, but Fortify upgrades live in the base zone, so we need to make sure we check there too.
