### PR TITLE
Fix return-to-hand effects against Fortify (base) upgrades

### DIFF
--- a/server/game/core/utils/EnumHelpers.ts
+++ b/server/game/core/utils/EnumHelpers.ts
@@ -68,6 +68,32 @@ export namespace EnumHelpers {
         }
     };
 
+    /**
+     * Any zone where cards are considered to be "in play" (CR 4.9.1). Face-down cards in these zones are still considered out
+     * of play, including the backside of leader cards.
+     *
+     * Resource zone excluded because all cards in that zone are facedown and considered out of play.
+     *
+     * @param zone The zone to check.
+     * @returns True if the zone is an in-play zone (GroundArena, SpaceArena, Base, or AnyArena wildcard), false otherwise.
+     */
+    export const isInPlayZone = (zone: ZoneFilter): zone is ZoneName.GroundArena |
+      ZoneName.SpaceArena |
+      ZoneName.Base |
+      WildcardZoneName.AnyArena |
+      WildcardZoneName.AnyAttackable => {
+        switch (zone) {
+            case ZoneName.GroundArena:
+            case ZoneName.SpaceArena:
+            case ZoneName.Base:
+            case WildcardZoneName.AnyArena:
+            case WildcardZoneName.AnyAttackable:
+                return true;
+            default:
+                return false;
+        }
+    };
+
     export const getCardTypesForFilter = (cardTypeFilter: CardTypeFilter): CardType[] => {
         switch (cardTypeFilter) {
             case WildcardCardType.Any:

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -1,6 +1,6 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
-import type { MoveZoneDestination } from '../core/Constants';
+import type { MoveZoneDestination, ZoneFilter } from '../core/Constants';
 import { AbilityRestriction, EffectName, RelativePlayer } from '../core/Constants';
 import {
     CardType,
@@ -56,7 +56,7 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
         }
 
         // Check if the card is leaving play
-        if (EnumHelpers.isArena(card.zoneName) && !EnumHelpers.isArena(event.destination)) {
+        if (this.isLeavingPlay(card, event.destination)) {
             this.leavesPlayEventHandler(card, event.destination, event.context, () => card.moveTo(event.destination));
         } else {
             card.moveTo(event.destination);
@@ -132,9 +132,18 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
         const { attachedUpgradeOverrideHandler } = this.generatePropertiesFromContext(context, additionalProperties);
 
         // Check if the card is leaving play
-        if (EnumHelpers.isArena(card.zoneName) && !EnumHelpers.isArena(event.destination)) {
+        if (this.isLeavingPlay(card, event.destination)) {
             this.addLeavesPlayPropertiesToEvent(event, card, context, additionalProperties, attachedUpgradeOverrideHandler);
         }
+    }
+
+    /**
+     * A card is leaving play when it is currently in play and is being moved to a non-arena zone. `isInPlay()` accounts
+     * for base-attached (Fortify) upgrades, which live in the base zone rather than an arena (`SWU 4.9.1`).
+     */
+    private isLeavingPlay(card: Card, destination: MoveZoneDestination): boolean {
+        // Deck-position destinations (top/bottom) aren't arenas, so casting to ZoneFilter is safe for the arena check.
+        return card.canBeInPlay() && card.isInPlay() && !EnumHelpers.isArena(destination as ZoneFilter);
     }
 
     public override addPropertiesToEvent(event: any, card: Card, context: TContext, additionalProperties?: Partial<IMoveCardProperties>): void {
@@ -165,10 +174,11 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
             }
         }
 
-        // Ensure that if the card is returning to the hand, it must be in the discard pile or in play or be a resource
+        // Ensure that if the card is returning to the hand, it must be in the discard pile or in play or be a resource.
+        // Note that `isInPlay()` covers base-attached (Fortify) upgrades, which live in the base zone rather than an arena.
         if (destination === ZoneName.Hand) {
             if (
-                !([ZoneName.Discard, ZoneName.Resource].includes(card.zoneName)) && !EnumHelpers.isArena(card.zoneName)
+                !([ZoneName.Discard, ZoneName.Resource].includes(card.zoneName)) && !(card.canBeInPlay() && card.isInPlay())
             ) {
                 return false;
             }

--- a/server/game/gameSystems/MoveCardSystem.ts
+++ b/server/game/gameSystems/MoveCardSystem.ts
@@ -142,8 +142,17 @@ export class MoveCardSystem<TContext extends AbilityContext = AbilityContext> ex
      * for base-attached (Fortify) upgrades, which live in the base zone rather than an arena (`SWU 4.9.1`).
      */
     private isLeavingPlay(card: Card, destination: MoveZoneDestination): boolean {
-        // Deck-position destinations (top/bottom) aren't arenas, so casting to ZoneFilter is safe for the arena check.
-        return card.canBeInPlay() && card.isInPlay() && !EnumHelpers.isArena(destination as ZoneFilter);
+        // A leader is leaving play if it is in play and is being moved to a non-arena zone (because they flip when they leave the arenas)
+        if (card.isLeader()) {
+            return card.canBeInPlay() &&
+              card.isInPlay() &&
+              !EnumHelpers.isArena(destination as ZoneFilter);
+        }
+
+        // Other cards are leaving play if they are in play and are moving to an out-of-play zone
+        return card.canBeInPlay() &&
+          card.isInPlay() &&
+          !EnumHelpers.isInPlayZone(destination as ZoneFilter);
     }
 
     public override addPropertiesToEvent(event: any, card: Card, context: TContext, additionalProperties?: Partial<IMoveCardProperties>): void {

--- a/test/server/cards/08_ASH/units/JabbaTheHuttEminenceOfTatooine.spec.ts
+++ b/test/server/cards/08_ASH/units/JabbaTheHuttEminenceOfTatooine.spec.ts
@@ -118,6 +118,32 @@ describe('Jabba The Hutt, Eminence Of Tatooine', function() {
             });
         });
 
+        it('should be able to return a Fortify upgrade attached to a base to its owner\'s hand', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['jabba-the-hutt#eminence-of-tatooine'],
+                    base: { card: 'echo-base', upgrades: ['alliance-shield-generator'] }
+                },
+                player2: {
+                    base: { card: 'kestro-city', upgrades: ['sinister-war-memorial'] }
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.jabbaTheHutt);
+            expect(context.player1).toBeAbleToSelectExactly([context.allianceShieldGenerator, context.sinisterWarMemorial]);
+            context.player1.clickCard(context.allianceShieldGenerator);
+
+            expect(context.player1).toHavePassAbilityPrompt('Play Alliance Shield Generator for free');
+            context.player1.clickPrompt('Trigger');
+            context.player1.clickCard(context.p1Base);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.p1Base).toHaveExactUpgradeNames(['alliance-shield-generator']);
+        });
+
         it('should return a pilot leader upgrade to its owner\'s hand (leader is defeated)', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',


### PR DESCRIPTION
## Bug

Return-to-hand effects (e.g. **Jabba the Hutt, Eminence of Tatooine**) couldn't target Fortify upgrades attached to a base. The upgrade wasn't selectable, and forcing the move hit a contract assertion.

**Cause:** `MoveCardSystem` used `isArena(card.zoneName)` as a stand-in for "in play." Fortify upgrades attach to the base, so they live in the base zone — an in-play zone that isn't an arena — and were excluded from both the target-validity check (`canAffectInternal`) and the leaves-play/unattach path (`eventHandler`/`updateEvent`).

## Fix

Use the existing `canBeInPlay() && isInPlay()` predicate (which already accounts for base-attached upgrades) in place of the arena-only checks, centralized in an `isLeavingPlay` helper. It's a strict superset of the old check, so arena behavior is unchanged — only base upgrades are now additionally handled. Generic fix for any return-to-hand effect, not just Jabba.

## Testing

- New regression test for Jabba returning a Fortify upgrade to hand
- Full suite green: 7983 specs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)