### PR TITLE
Maim

### DIFF
--- a/server/game/cards/09_HMW/events/Maim.ts
+++ b/server/game/cards/09_HMW/events/Maim.ts
@@ -1,0 +1,26 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import { EventCard } from '../../../core/card/EventCard';
+import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { WildcardCardType } from '../../../core/Constants';
+
+export default class Maim extends EventCard {
+    protected override getImplementationId() {
+        return {
+            id: 'maim-id',
+            internalName: 'maim',
+        };
+    }
+
+    public override setupCardAbilities(registrar: IEventAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.setEventAbility({
+            title: 'Deal 1 damage to a unit and exhaust it',
+            targetResolver: {
+                cardTypeFilter: WildcardCardType.Unit,
+                immediateEffect: abilityHelper.immediateEffects.sequential([
+                    abilityHelper.immediateEffects.damage((context) => ({ target: context.target, amount: 1 })),
+                    abilityHelper.immediateEffects.exhaust((context) => ({ target: context.target }))
+                ])
+            }
+        });
+    }
+}

--- a/test/server/cards/09_HMW/events/Maim.spec.ts
+++ b/test/server/cards/09_HMW/events/Maim.spec.ts
@@ -1,0 +1,122 @@
+describe('Maim', function() {
+    integration(function(contextRef) {
+        describe('Maim\'s ability', function() {
+            beforeEach(async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['maim'],
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['green-squadron-awing']
+                    },
+                    player2: {
+                        groundArena: ['wampa', { card: 'atst', exhausted: true }, { card: 'pyke-sentinel', upgrades: ['shield'] }],
+                        spaceArena: ['cartel-spacer'],
+                        leader: { card: 'chewbacca#walking-carpet', deployed: true }
+                    }
+                });
+            });
+
+            it('should deal 1 damage to a unit and exhaust it', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maim);
+
+                expect(context.player1).toHavePrompt('Deal 1 damage to a unit and exhaust it');
+                expect(context.player1).toBeAbleToSelectExactly([
+                    context.battlefieldMarine,
+                    context.greenSquadronAwing,
+                    context.wampa,
+                    context.atst,
+                    context.pykeSentinel,
+                    context.cartelSpacer,
+                    context.chewbacca
+                ]);
+                expect(context.player1).not.toHavePassAbilityButton();
+
+                context.player1.clickCard(context.wampa);
+
+                expect(context.wampa.damage).toBe(1);
+                expect(context.wampa.exhausted).toBeTrue();
+                expect(context.maim).toBeInZone('discard', context.player1);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should be able to target a friendly unit', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maim);
+                context.player1.clickCard(context.battlefieldMarine);
+
+                expect(context.battlefieldMarine.damage).toBe(1);
+                expect(context.battlefieldMarine.exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should be able to target a space unit', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maim);
+                context.player1.clickCard(context.cartelSpacer);
+
+                expect(context.cartelSpacer.damage).toBe(1);
+                expect(context.cartelSpacer.exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should be able to target a deployed leader unit', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maim);
+                context.player1.clickCard(context.chewbacca);
+
+                expect(context.chewbacca.damage).toBe(1);
+                expect(context.chewbacca.exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should still deal 1 damage to a unit that is already exhausted', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maim);
+                context.player1.clickCard(context.atst);
+
+                expect(context.atst.damage).toBe(1);
+                expect(context.atst.exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should defeat a shield instead of dealing damage but still exhaust the unit', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maim);
+                context.player1.clickCard(context.pykeSentinel);
+
+                expect(context.pykeSentinel.damage).toBe(0);
+                expect(context.pykeSentinel).toHaveExactUpgradeNames([]);
+                expect(context.pykeSentinel.exhausted).toBeTrue();
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
+        it('Maim\'s ability should defeat a unit with 1 remaining HP', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['maim']
+                },
+                player2: {
+                    groundArena: [{ card: 'battlefield-marine', damage: 2 }]
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.maim);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.battlefieldMarine).toBeInZone('discard', context.player2);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});


### PR DESCRIPTION
![](https://swudb.com/cdn-cgi/image/width=300/images/cards/HMW/207.png)

Implements the Homeworlds event Maim (HMW 207): deal 1 damage to a unit and exhaust it. Follows the Electromagnetic Pulse pattern of a sequential damage-then-exhaust effect on a single unit target.