### PR TITLE
Implement 5 HMW cards: Blockade Ship, Dragonboat Freighter, Kelnacca Solitary Master, Noxious Refinery, Surveillance Cruiser

### DIFF
--- a/server/game/cards/09_HMW/units/BlockadeShip.ts
+++ b/server/game/cards/09_HMW/units/BlockadeShip.ts
@@ -1,0 +1,24 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { RelativePlayer, WildcardCardType, ZoneName } from '../../../core/Constants';
+
+export default class BlockadeShip extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'blockade-ship-id',
+            internalName: 'blockade-ship',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        registrar.addConstantAbility({
+            title: 'Enemy ground units get -1/-0 while attacking',
+            targetController: RelativePlayer.Opponent,
+            targetCardTypeFilter: WildcardCardType.Unit,
+            targetZoneFilter: ZoneName.GroundArena,
+            matchTarget: (card) => card.isUnit() && card.isAttacking(),
+            ongoingEffect: AbilityHelper.ongoingEffects.modifyStats({ power: -1, hp: 0 })
+        });
+    }
+}

--- a/server/game/cards/09_HMW/units/DragonboatFreighter.ts
+++ b/server/game/cards/09_HMW/units/DragonboatFreighter.ts
@@ -1,0 +1,30 @@
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import { WildcardCardType } from '../../../core/Constants';
+
+export default class DragonboatFreighter extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'dragonboat-freighter-id',
+            internalName: 'dragonboat-freighter',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        registrar.addWhenPlayedAbility({
+            title: 'Give a Weakness token to a unit. If it\'s a unique unit, exhaust it',
+            optional: true,
+            targetResolver: {
+                cardTypeFilter: WildcardCardType.Unit,
+                immediateEffect: AbilityHelper.immediateEffects.sequential([
+                    AbilityHelper.immediateEffects.giveWeakness(),
+                    AbilityHelper.immediateEffects.conditional({
+                        condition: (context) => context.target.unique,
+                        onTrue: AbilityHelper.immediateEffects.exhaust()
+                    })
+                ])
+            }
+        });
+    }
+}

--- a/server/game/cards/09_HMW/units/KelnaccaSolitaryMaster.ts
+++ b/server/game/cards/09_HMW/units/KelnaccaSolitaryMaster.ts
@@ -1,0 +1,50 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { RelativePlayer, TargetMode, WildcardCardType } from '../../../core/Constants';
+
+export default class KelnaccaSolitaryMaster extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'kelnacca#solitary-master-id',
+            internalName: 'kelnacca#solitary-master',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        registrar.addWhenPlayedAbility({
+            title: 'You may pay any number of resources. For every 3 resources paid this way, deal damage equal to this unit\'s power to an enemy unit',
+            targetResolver: {
+                mode: TargetMode.ChooseNumber,
+                min: 0,
+                max: (context) => context.player.readyResourceCount,
+            },
+            then: (thenContext) => ({
+                title: 'Pay the chosen number of resources',
+                immediateEffect: AbilityHelper.immediateEffects.payResourcesWithoutAdjustment({
+                    amount: parseInt(thenContext.select),
+                    target: thenContext.player
+                }),
+                then: {
+                    title: 'Deal damage equal to this unit\'s power to an enemy unit',
+                    thenCondition: (context) =>
+                        Math.floor(parseInt(thenContext.select) / 3) >= 1 &&
+                        context.player.opponent.hasSomeArenaUnit(),
+                    immediateEffect: AbilityHelper.immediateEffects.sequential(
+                        Array.from({ length: Math.floor(parseInt(thenContext.select) / 3) }, () =>
+                            AbilityHelper.immediateEffects.selectCard({
+                                activePromptTitle: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
+                                cardTypeFilter: WildcardCardType.Unit,
+                                controller: RelativePlayer.Opponent,
+                                immediateEffect: AbilityHelper.immediateEffects.damage({
+                                    amount: thenContext.source.getPower(),
+                                    source: thenContext.source,
+                                })
+                            })
+                        )
+                    )
+                }
+            })
+        });
+    }
+}

--- a/server/game/cards/09_HMW/units/KelnaccaSolitaryMaster.ts
+++ b/server/game/cards/09_HMW/units/KelnaccaSolitaryMaster.ts
@@ -13,37 +13,31 @@ export default class KelnaccaSolitaryMaster extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: 'You may pay any number of resources. For every 3 resources paid this way, deal damage equal to this unit\'s power to an enemy unit',
+            title: 'Pay any number of resources. For every 3 resources paid this way, deal damage equal to this unit\'s power to an enemy unit',
+            contextTitle: (context) => `Pay any number of resources. For every 3 resources paid this way, deal ${context.source.getPower()} damage to an enemy unit`,
             targetResolver: {
                 mode: TargetMode.ChooseNumber,
                 min: 0,
                 max: (context) => context.player.readyResourceCount,
+                immediateEffect: AbilityHelper.immediateEffects.payResourcesWithoutAdjustment((context) => ({
+                    amount: parseInt(context.select),
+                    target: context.player
+                })),
             },
             then: (thenContext) => ({
-                title: 'Pay the chosen number of resources',
-                immediateEffect: AbilityHelper.immediateEffects.payResourcesWithoutAdjustment({
-                    amount: parseInt(thenContext.select),
-                    target: thenContext.player
-                }),
-                then: {
-                    title: 'Deal damage equal to this unit\'s power to an enemy unit',
-                    thenCondition: (context) =>
-                        Math.floor(parseInt(thenContext.select) / 3) >= 1 &&
-                        context.player.opponent.hasSomeArenaUnit(),
-                    immediateEffect: AbilityHelper.immediateEffects.sequential(
-                        Array.from({ length: Math.floor(parseInt(thenContext.select) / 3) }, () =>
-                            AbilityHelper.immediateEffects.selectCard({
-                                activePromptTitle: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
-                                cardTypeFilter: WildcardCardType.Unit,
-                                controller: RelativePlayer.Opponent,
-                                immediateEffect: AbilityHelper.immediateEffects.damage({
-                                    amount: thenContext.source.getPower(),
-                                    source: thenContext.source,
-                                })
+                title: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
+                immediateEffect: AbilityHelper.immediateEffects.simultaneous(
+                    Array.from({ length: Math.floor(parseInt(thenContext.select) / 3) }, () =>
+                        AbilityHelper.immediateEffects.selectCard({
+                            activePromptTitle: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
+                            cardTypeFilter: WildcardCardType.Unit,
+                            controller: RelativePlayer.Opponent,
+                            immediateEffect: AbilityHelper.immediateEffects.damage({
+                                amount: thenContext.source.getPower(),
                             })
-                        )
+                        })
                     )
-                }
+                )
             })
         });
     }

--- a/server/game/cards/09_HMW/units/KelnaccaSolitaryMaster.ts
+++ b/server/game/cards/09_HMW/units/KelnaccaSolitaryMaster.ts
@@ -24,21 +24,24 @@ export default class KelnaccaSolitaryMaster extends NonLeaderUnitCard {
                     target: context.player
                 })),
             },
-            then: (thenContext) => ({
-                title: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
-                immediateEffect: AbilityHelper.immediateEffects.simultaneous(
-                    Array.from({ length: Math.floor(parseInt(thenContext.select) / 3) }, () =>
-                        AbilityHelper.immediateEffects.selectCard({
-                            activePromptTitle: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
-                            cardTypeFilter: WildcardCardType.Unit,
-                            controller: RelativePlayer.Opponent,
-                            immediateEffect: AbilityHelper.immediateEffects.damage({
-                                amount: thenContext.source.getPower(),
+            then: (thenContext) => {
+                const damageInstances = Math.floor(parseInt(thenContext.select) / 3);
+                return {
+                    title: `Deal ${thenContext.source.getPower()} damage to an enemy unit`,
+                    immediateEffect: AbilityHelper.immediateEffects.simultaneous(
+                        Array.from({ length: damageInstances }, (_, i) =>
+                            AbilityHelper.immediateEffects.selectCard({
+                                activePromptTitle: `Deal ${thenContext.source.getPower()} damage to an enemy unit (${i + 1}/${damageInstances})`,
+                                cardTypeFilter: WildcardCardType.Unit,
+                                controller: RelativePlayer.Opponent,
+                                immediateEffect: AbilityHelper.immediateEffects.damage({
+                                    amount: thenContext.source.getPower(),
+                                })
                             })
-                        })
+                        )
                     )
-                )
-            })
+                };
+            }
         });
     }
 }

--- a/server/game/cards/09_HMW/units/SurveillanceCruiser.ts
+++ b/server/game/cards/09_HMW/units/SurveillanceCruiser.ts
@@ -1,0 +1,24 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Trait } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
+
+export default class SurveillanceCruiser extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'surveillance-cruiser-id',
+            internalName: 'surveillance-cruiser',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addWhenPlayedAbility({
+            title: `If an opponent controls an ${TextHelper.Trait.Endor}, ${TextHelper.Trait.Kashyyyk}, ${TextHelper.Trait.Naboo}, or ${TextHelper.Trait.Tatooine} base, draw a card`,
+            immediateEffect: abilityHelper.immediateEffects.conditional({
+                condition: (context) => context.player.opponent.base.hasSomeTrait([Trait.Endor, Trait.Kashyyyk, Trait.Naboo, Trait.Tatooine]),
+                onTrue: abilityHelper.immediateEffects.draw((context) => ({ target: context.player }))
+            })
+        });
+    }
+}

--- a/server/game/cards/09_HMW/units/SurveillanceCruiser.ts
+++ b/server/game/cards/09_HMW/units/SurveillanceCruiser.ts
@@ -2,7 +2,6 @@ import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
 import { Trait } from '../../../core/Constants';
-import { TextHelper } from '../../../core/utils/TextHelper';
 
 export default class SurveillanceCruiser extends NonLeaderUnitCard {
     protected override getImplementationId() {
@@ -14,7 +13,7 @@ export default class SurveillanceCruiser extends NonLeaderUnitCard {
 
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
         registrar.addWhenPlayedAbility({
-            title: `If an opponent controls an ${TextHelper.Trait.Endor}, ${TextHelper.Trait.Kashyyyk}, ${TextHelper.Trait.Naboo}, or ${TextHelper.Trait.Tatooine} base, draw a card`,
+            title: 'Draw a card',
             immediateEffect: abilityHelper.immediateEffects.conditional({
                 condition: (context) => context.player.opponent.base.hasSomeTrait([Trait.Endor, Trait.Kashyyyk, Trait.Naboo, Trait.Tatooine]),
                 onTrue: abilityHelper.immediateEffects.draw((context) => ({ target: context.player }))

--- a/server/game/cards/09_HMW/upgrades/NoxiousRefinery.ts
+++ b/server/game/cards/09_HMW/upgrades/NoxiousRefinery.ts
@@ -1,0 +1,36 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { IUpgradeAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { UpgradeCard } from '../../../core/card/UpgradeCard';
+import { Aspect, PhaseName, RelativePlayer, WildcardCardType } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
+
+export default class NoxiousRefinery extends UpgradeCard {
+    protected override getImplementationId() {
+        return {
+            id: 'noxious-refinery-id',
+            internalName: 'noxious-refinery',
+        };
+    }
+
+    public override setupCardAbilities(registrar: IUpgradeAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addGainTriggeredAbilityTargetingAttached({
+            title: `Reveal the top card of your deck. If it's ${TextHelper.Aggression}, deal 1 damage to an enemy unit`,
+            when: {
+                onPhaseStarted: (context) => context.phase === PhaseName.Regroup
+            },
+            gainCondition: (context) => context.source.parentCard?.isBase(),
+            immediateEffect: abilityHelper.immediateEffects.reveal((context) => ({
+                target: context.player.getTopCardOfDeck(),
+            })),
+            ifYouDo: (ifYouDoContext) => ({
+                title: 'Deal 1 damage to an enemy unit',
+                ifYouDoCondition: () => ifYouDoContext.events[0].cards[0]?.hasSomeAspect(Aspect.Aggression),
+                targetResolver: {
+                    cardTypeFilter: WildcardCardType.Unit,
+                    controller: RelativePlayer.Opponent,
+                    immediateEffect: abilityHelper.immediateEffects.damage({ amount: 1 })
+                }
+            })
+        });
+    }
+}

--- a/test/server/cards/09_HMW/units/BlockadeShip.spec.ts
+++ b/test/server/cards/09_HMW/units/BlockadeShip.spec.ts
@@ -1,0 +1,87 @@
+describe('Blockade Ship', function () {
+    integration(function (contextRef) {
+        it('should reduce an enemy ground unit\'s power by 1 while it is attacking', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['blockade-ship']
+                },
+                player2: {
+                    groundArena: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.passAction();
+            context.player2.clickCard(context.wampa);
+            context.player2.clickCard(context.p1Base);
+
+            expect(context.p1Base.damage).toBe(3);
+            expect(context.player1).toBeActivePlayer();
+        });
+
+        it('should not reduce a friendly ground unit\'s power while attacking', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['blockade-ship'],
+                    groundArena: ['wampa']
+                },
+                player2: {}
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.wampa);
+            context.player1.clickCard(context.p2Base);
+
+            expect(context.p2Base.damage).toBe(4);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should not reduce an enemy space unit\'s power while attacking', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['blockade-ship']
+                },
+                player2: {
+                    spaceArena: ['alliance-xwing']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.passAction();
+            context.player2.clickCard(context.allianceXwing);
+            context.player2.clickCard(context.blockadeShip);
+
+            // Alliance X-Wing is a space unit, so Blockade Ship's ability doesn't reduce its power
+            expect(context.blockadeShip.damage).toBe(2);
+            expect(context.player1).toBeActivePlayer();
+        });
+
+        it('should not reduce an enemy ground unit\'s power while it is only defending', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['blockade-ship'],
+                    groundArena: ['atte-vanguard']
+                },
+                player2: {
+                    groundArena: ['battlefield-marine']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.atteVanguard);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.battlefieldMarine).toBeInZone('discard');
+            expect(context.atteVanguard.damage).toBe(3);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/cards/09_HMW/units/BlockadeShip.spec.ts
+++ b/test/server/cards/09_HMW/units/BlockadeShip.spec.ts
@@ -7,13 +7,13 @@ describe('Blockade Ship', function () {
                     spaceArena: ['blockade-ship']
                 },
                 player2: {
-                    groundArena: ['wampa']
+                    groundArena: ['wampa'],
+                    hasInitiative: true
                 }
             });
 
             const { context } = contextRef;
 
-            context.player1.passAction();
             context.player2.clickCard(context.wampa);
             context.player2.clickCard(context.p1Base);
 
@@ -47,13 +47,13 @@ describe('Blockade Ship', function () {
                     spaceArena: ['blockade-ship']
                 },
                 player2: {
-                    spaceArena: ['alliance-xwing']
+                    spaceArena: ['alliance-xwing'],
+                    hasInitiative: true
                 }
             });
 
             const { context } = contextRef;
 
-            context.player1.passAction();
             context.player2.clickCard(context.allianceXwing);
             context.player2.clickCard(context.blockadeShip);
 
@@ -82,6 +82,33 @@ describe('Blockade Ship', function () {
             expect(context.battlefieldMarine).toBeInZone('discard');
             expect(context.atteVanguard.damage).toBe(3);
             expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should reduce the damage-dependent heal from Hera Syndulla, Renegade General when she attacks into it', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    spaceArena: ['blockade-ship'],
+                    base: { card: 'capital-city', damage: 0 }
+                },
+                player2: {
+                    groundArena: ['hera-syndulla#renegade-general'],
+                    base: { card: 'capital-city', damage: 10 },
+                    hasInitiative: true
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player2.clickCard(context.heraSyndulla);
+            context.player2.clickCard(context.p1Base);
+
+            // Blockade Ship reduces Hera's power from 3 to 2 while attacking
+            expect(context.p1Base.damage).toBe(2);
+
+            // Hera heals her own base equal to the (reduced) damage dealt, so 2 instead of her printed power of 3
+            expect(context.p2Base.damage).toBe(8);
+            expect(context.player1).toBeActivePlayer();
         });
     });
 });

--- a/test/server/cards/09_HMW/units/DragonboatFreighter.spec.ts
+++ b/test/server/cards/09_HMW/units/DragonboatFreighter.spec.ts
@@ -1,0 +1,78 @@
+describe('Dragonboat Freighter', function() {
+    integration(function(contextRef) {
+        it('should give a Weakness token to a non-unique unit without exhausting it', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['dragonboat-freighter'],
+                    groundArena: ['wampa'],
+                },
+                player2: {
+                    groundArena: ['cid-scaleback#cant-be-trusted'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.dragonboatFreighter);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.cidScaleback, context.dragonboatFreighter]);
+            expect(context.player1).toHavePassAbilityButton();
+
+            context.player1.clickCard(context.wampa);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.wampa).toHaveExactUpgradeNames(['weakness']);
+            expect(context.wampa.exhausted).toBeFalse();
+        });
+
+        it('should give a Weakness token to a unique unit and exhaust it', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['dragonboat-freighter'],
+                    groundArena: ['wampa'],
+                },
+                player2: {
+                    groundArena: ['cid-scaleback#cant-be-trusted'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.dragonboatFreighter);
+
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.cidScaleback, context.dragonboatFreighter]);
+
+            context.player1.clickCard(context.cidScaleback);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.cidScaleback).toHaveExactUpgradeNames(['weakness']);
+            expect(context.cidScaleback.exhausted).toBeTrue();
+        });
+
+        it('may be passed', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['dragonboat-freighter'],
+                    groundArena: ['wampa'],
+                },
+                player2: {
+                    groundArena: ['cid-scaleback#cant-be-trusted'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.dragonboatFreighter);
+
+            expect(context.player1).toHavePassAbilityButton();
+            context.player1.clickPrompt('Pass');
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.wampa).toHaveExactUpgradeNames([]);
+            expect(context.cidScaleback).toHaveExactUpgradeNames([]);
+        });
+    });
+});

--- a/test/server/cards/09_HMW/units/KelnaccaSolitaryMaster.spec.ts
+++ b/test/server/cards/09_HMW/units/KelnaccaSolitaryMaster.spec.ts
@@ -77,6 +77,34 @@ describe('Kelnacca, Solitary Master', function () {
             expect(context.player2).toBeActivePlayer();
         });
 
+        it('should deal only one damage instance (rounding down, not up) when paying 4 or 5 resources', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 11
+                },
+                player2: {
+                    groundArena: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 7);
+            context.player1.chooseListOption('5');
+
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            context.player1.clickCard(context.wampa);
+
+            // floor(5 / 3) === 1, so exactly one 4-damage instance is dealt, never 4.5 or 8
+            expect(context.wampa.damage).toBe(4);
+            expect(context.player1.exhaustedResourceCount).toBe(9);
+            expect(context.player2).toBeActivePlayer();
+        });
+
         it('should deal two separate damage instances when paying 6 resources, letting a different unit be chosen each time', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
@@ -114,7 +142,7 @@ describe('Kelnacca, Solitary Master', function () {
             expect(context.player2).toBeActivePlayer();
         });
 
-        it('should allow choosing the same unit for each damage instance, applied as separate hits rather than a multiplied lump sum', async function () {
+        it('should allow choosing the same unit for each damage instance, with a single Shield preventing all instances since they are dealt simultaneously', async function () {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -133,16 +161,48 @@ describe('Kelnacca, Solitary Master', function () {
             expect(context.player1).toHaveNumericPromptRange(0, 7);
             context.player1.chooseListOption('6');
 
-            // first 4-damage instance is fully prevented by the Shield token (a single 8-damage lump would also be fully prevented)
+            // both damage instances are dealt simultaneously, so a single Shield token prevents all of it,
+            // just as a single lump-sum hit would be
             context.player1.clickCardNonChecking(context.atteVanguard);
+            context.player1.clickCardNonChecking(context.atteVanguard);
+
             expect(context.atteVanguard).toHaveExactUpgradeNames([]);
             expect(context.atteVanguard.damage).toBe(0);
-
-            // second instance is a separate hit, so it deals its own 4 damage even though the Shield already absorbed the first
-            context.player1.clickCardNonChecking(context.atteVanguard);
-
-            expect(context.atteVanguard.damage).toBe(4);
             expect(context.player1.exhaustedResourceCount).toBe(10);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should only remove the Shield and deal no damage at all, even across more than two simultaneous instances', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 14
+                },
+                player2: {
+                    // 3 HP is less than a single 4-damage instance, so if even one instance leaked through
+                    // the unit would be defeated
+                    groundArena: [{ card: 'cantina-braggart', upgrades: ['shield'] }]
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 10);
+            context.player1.chooseListOption('9');
+
+            // 3 damage instances (floor(9 / 3)), all targeting the same shielded unit
+            context.player1.clickCardNonChecking(context.cantinaBraggart);
+            context.player1.clickCardNonChecking(context.cantinaBraggart);
+            context.player1.clickCardNonChecking(context.cantinaBraggart);
+
+            // only the Shield is removed; no damage gets through to the unit itself, and it survives
+            expect(context.cantinaBraggart).toBeInZone('groundArena', context.player2);
+            expect(context.cantinaBraggart).toHaveExactUpgradeNames([]);
+            expect(context.cantinaBraggart.damage).toBe(0);
+            expect(context.player1.exhaustedResourceCount).toBe(13);
             expect(context.player2).toBeActivePlayer();
         });
 

--- a/test/server/cards/09_HMW/units/KelnaccaSolitaryMaster.spec.ts
+++ b/test/server/cards/09_HMW/units/KelnaccaSolitaryMaster.spec.ts
@@ -1,0 +1,196 @@
+describe('Kelnacca, Solitary Master', function () {
+    integration(function (contextRef) {
+        it('should deal no damage and pass priority when 0 resources are paid', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 8
+                },
+                player2: {
+                    groundArena: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 4);
+            context.player1.chooseListOption('0');
+
+            expect(context.player1.exhaustedResourceCount).toBe(4);
+            expect(context.wampa.damage).toBe(0);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should still pay resources but deal no damage when fewer than 3 are paid', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 8
+                },
+                player2: {
+                    groundArena: ['wampa']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 4);
+            context.player1.chooseListOption('2');
+
+            expect(context.player1.exhaustedResourceCount).toBe(6);
+            expect(context.wampa.damage).toBe(0);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should deal damage equal to its power to a chosen enemy unit when paying exactly 3 resources', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 8
+                },
+                player2: {
+                    groundArena: ['wampa', 'battlefield-marine']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 4);
+            context.player1.chooseListOption('3');
+
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine]);
+            context.player1.clickCard(context.wampa);
+
+            expect(context.wampa.damage).toBe(4);
+            expect(context.battlefieldMarine.damage).toBe(0);
+            expect(context.player1.exhaustedResourceCount).toBe(7);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should deal two separate damage instances when paying 6 resources, letting a different unit be chosen each time', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 11
+                },
+                player2: {
+                    groundArena: ['wampa', 'battlefield-marine']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 7);
+            context.player1.chooseListOption('6');
+
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine]);
+            // uses the non-checking click variant since this prompt looks identical (same title, same two
+            // selectable units) both before and after — the underlying game state (damage dealt) still changes,
+            // it's just not reflected in the prompt shape the "expect change" heuristic compares
+            context.player1.clickCardNonChecking(context.wampa);
+
+            // second damage instance is a fresh target selection, not part of a single lump-sum hit
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine]);
+            context.player1.clickCardNonChecking(context.battlefieldMarine);
+
+            expect(context.wampa.damage).toBe(4);
+            expect(context.battlefieldMarine).toBeInZone('discard');
+            expect(context.player1.exhaustedResourceCount).toBe(10);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should allow choosing the same unit for each damage instance, applied as separate hits rather than a multiplied lump sum', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 11
+                },
+                player2: {
+                    groundArena: [{ card: 'atte-vanguard', upgrades: ['shield'] }]
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 7);
+            context.player1.chooseListOption('6');
+
+            // first 4-damage instance is fully prevented by the Shield token (a single 8-damage lump would also be fully prevented)
+            context.player1.clickCardNonChecking(context.atteVanguard);
+            expect(context.atteVanguard).toHaveExactUpgradeNames([]);
+            expect(context.atteVanguard.damage).toBe(0);
+
+            // second instance is a separate hit, so it deals its own 4 damage even though the Shield already absorbed the first
+            context.player1.clickCardNonChecking(context.atteVanguard);
+
+            expect(context.atteVanguard.damage).toBe(4);
+            expect(context.player1.exhaustedResourceCount).toBe(10);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should be able to deal damage to a deployed enemy leader unit', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 8
+                },
+                player2: {
+                    groundArena: ['wampa'],
+                    leader: { card: 'cad-bane#still-faster-than-you', deployed: true }
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            context.player1.chooseListOption('3');
+
+            expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.cadBane]);
+            context.player1.clickCard(context.cadBane);
+
+            expect(context.cadBane.damage).toBe(4);
+            expect(context.player2).toBeActivePlayer();
+        });
+
+        it('should still pay resources but skip the damage step when the opponent has no arena units', async function () {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    leader: 'the-armorer#steel-shapes-us',
+                    hand: ['kelnacca#solitary-master'],
+                    resources: 8
+                },
+                player2: {}
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.kelnacca);
+            expect(context.player1).toHaveNumericPromptRange(0, 4);
+            context.player1.chooseListOption('3');
+
+            expect(context.player1.exhaustedResourceCount).toBe(7);
+            expect(context.player2).toBeActivePlayer();
+        });
+    });
+});

--- a/test/server/cards/09_HMW/units/KelnaccaSolitaryMaster.spec.ts
+++ b/test/server/cards/09_HMW/units/KelnaccaSolitaryMaster.spec.ts
@@ -67,7 +67,7 @@ describe('Kelnacca, Solitary Master', function () {
             expect(context.player1).toHaveNumericPromptRange(0, 4);
             context.player1.chooseListOption('3');
 
-            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit (1/1)');
             expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine]);
             context.player1.clickCard(context.wampa);
 
@@ -96,7 +96,7 @@ describe('Kelnacca, Solitary Master', function () {
             expect(context.player1).toHaveNumericPromptRange(0, 7);
             context.player1.chooseListOption('5');
 
-            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit (1/1)');
             context.player1.clickCard(context.wampa);
 
             // floor(5 / 3) === 1, so exactly one 4-damage instance is dealt, never 4.5 or 8
@@ -124,15 +124,12 @@ describe('Kelnacca, Solitary Master', function () {
             expect(context.player1).toHaveNumericPromptRange(0, 7);
             context.player1.chooseListOption('6');
 
-            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit (1/2)');
             expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine]);
-            // uses the non-checking click variant since this prompt looks identical (same title, same two
-            // selectable units) both before and after — the underlying game state (damage dealt) still changes,
-            // it's just not reflected in the prompt shape the "expect change" heuristic compares
             context.player1.clickCardNonChecking(context.wampa);
 
             // second damage instance is a fresh target selection, not part of a single lump-sum hit
-            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit');
+            expect(context.player1).toHavePrompt('Deal 4 damage to an enemy unit (2/2)');
             expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.battlefieldMarine]);
             context.player1.clickCardNonChecking(context.battlefieldMarine);
 

--- a/test/server/cards/09_HMW/units/SurveillanceCruiser.spec.ts
+++ b/test/server/cards/09_HMW/units/SurveillanceCruiser.spec.ts
@@ -1,0 +1,46 @@
+describe('Surveillance Cruiser', function() {
+    integration(function(contextRef) {
+        it('Surveillance Cruiser\'s ability should draw a card if the opponent controls an Endor, Kashyyyk, Naboo, or Tatooine base', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['surveillance-cruiser'],
+                    deck: ['porg', 'rey#skywalker']
+                },
+                player2: {
+                    base: 'jabbas-palace'
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.surveillanceCruiser);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.porg).toBeInZone('hand', context.player1);
+            expect(context.rey).toBeInZone('deck', context.player1);
+            expect(context.player1.handSize).toBe(1);
+        });
+
+        it('Surveillance Cruiser\'s ability should not draw a card if the opponent does not control an Endor, Kashyyyk, Naboo, or Tatooine base', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['surveillance-cruiser'],
+                    deck: ['porg', 'rey#skywalker']
+                },
+                player2: {
+                    base: 'command-center'
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.surveillanceCruiser);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.porg).toBeInZone('deck', context.player1);
+            expect(context.rey).toBeInZone('deck', context.player1);
+        });
+    });
+});

--- a/test/server/cards/09_HMW/units/SurveillanceCruiser.spec.ts
+++ b/test/server/cards/09_HMW/units/SurveillanceCruiser.spec.ts
@@ -1,6 +1,72 @@
 describe('Surveillance Cruiser', function() {
     integration(function(contextRef) {
-        it('Surveillance Cruiser\'s ability should draw a card if the opponent controls an Endor, Kashyyyk, Naboo, or Tatooine base', async function() {
+        it('Surveillance Cruiser\'s ability should draw a card if the opponent controls an Endor base', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['surveillance-cruiser'],
+                    deck: ['porg', 'rey#skywalker']
+                },
+                player2: {
+                    base: 'bright-tree-village'
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.surveillanceCruiser);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.porg).toBeInZone('hand', context.player1);
+            expect(context.rey).toBeInZone('deck', context.player1);
+            expect(context.player1.handSize).toBe(1);
+        });
+
+        it('Surveillance Cruiser\'s ability should draw a card if the opponent controls a Kashyyyk base', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['surveillance-cruiser'],
+                    deck: ['porg', 'rey#skywalker']
+                },
+                player2: {
+                    base: 'kachirho'
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.surveillanceCruiser);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.porg).toBeInZone('hand', context.player1);
+            expect(context.rey).toBeInZone('deck', context.player1);
+            expect(context.player1.handSize).toBe(1);
+        });
+
+        it('Surveillance Cruiser\'s ability should draw a card if the opponent controls a Naboo base', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['surveillance-cruiser'],
+                    deck: ['porg', 'rey#skywalker']
+                },
+                player2: {
+                    base: 'theed-palace'
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.surveillanceCruiser);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.porg).toBeInZone('hand', context.player1);
+            expect(context.rey).toBeInZone('deck', context.player1);
+            expect(context.player1.handSize).toBe(1);
+        });
+
+        it('Surveillance Cruiser\'s ability should draw a card if the opponent controls a Tatooine base', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -27,10 +93,14 @@ describe('Surveillance Cruiser', function() {
                 phase: 'action',
                 player1: {
                     hand: ['surveillance-cruiser'],
-                    deck: ['porg', 'rey#skywalker']
+                    deck: ['porg', 'rey#skywalker'],
+                    // player1's own base has a matching trait, to confirm only the opponent's base is checked
+                    base: 'jabbas-palace'
                 },
                 player2: {
-                    base: 'command-center'
+                    base: 'command-center',
+                    // a Naboo-trait unit doesn't count; only the opponent's base trait matters
+                    groundArena: ['naboo-security-force']
                 }
             });
 

--- a/test/server/cards/09_HMW/upgrades/NoxiousRefinery.spec.ts
+++ b/test/server/cards/09_HMW/upgrades/NoxiousRefinery.spec.ts
@@ -1,0 +1,68 @@
+describe('Noxious Refinery', function() {
+    integration(function(contextRef) {
+        it('should deal 1 damage to an enemy unit when the revealed card has the Aggression aspect', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    deck: ['wampa'],
+                    base: { card: 'kestro-city', upgrades: ['noxious-refinery'] },
+                },
+                player2: {
+                    groundArena: ['battlefield-marine'],
+                    spaceArena: ['cartel-spacer'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.moveToRegroupPhase();
+
+            expect(context.wampa).toBeInZone('deck');
+            expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.cartelSpacer]);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.battlefieldMarine.damage).toBe(1);
+            expect(context.cartelSpacer.damage).toBe(0);
+        });
+
+        it('should not deal damage when the revealed card does not have the Aggression aspect', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    deck: ['porg'],
+                    base: { card: 'kestro-city', upgrades: ['noxious-refinery'] },
+                },
+                player2: {
+                    groundArena: ['battlefield-marine'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.moveToRegroupPhase();
+
+            // Porg is not Aggression, so no damage is dealt; the regroup phase proceeds automatically to the draw step
+            expect(context.porg).toBeInZone('hand', context.player1);
+            expect(context.battlefieldMarine.damage).toBe(0);
+        });
+
+        it('should not trigger anything when the deck is empty', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    deck: [],
+                    base: { card: 'kestro-city', upgrades: ['noxious-refinery'] },
+                },
+                player2: {
+                    groundArena: ['battlefield-marine'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.moveToRegroupPhase();
+
+            expect(context.battlefieldMarine.damage).toBe(0);
+        });
+    });
+});

--- a/test/server/cards/09_HMW/upgrades/NoxiousRefinery.spec.ts
+++ b/test/server/cards/09_HMW/upgrades/NoxiousRefinery.spec.ts
@@ -1,10 +1,11 @@
 describe('Noxious Refinery', function() {
     integration(function(contextRef) {
-        it('should deal 1 damage to an enemy unit when the revealed card has the Aggression aspect', async function() {
+        it('should deal 1 damage to an enemy unit when the revealed card has the Aggression aspect, regardless of deck size, and reveal it before the regroup phase\'s draw step', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
-                    deck: ['wampa'],
+                    // deck has more than one card, to prove the ability isn't limited to (or by) a single-card deck
+                    deck: ['wampa', 'porg', 'rey#skywalker'],
                     base: { card: 'kestro-city', upgrades: ['noxious-refinery'] },
                 },
                 player2: {
@@ -23,6 +24,12 @@ describe('Noxious Refinery', function() {
 
             expect(context.battlefieldMarine.damage).toBe(1);
             expect(context.cartelSpacer.damage).toBe(0);
+
+            // Noxious Refinery's reveal resolves before the regroup phase's automatic "draw 2", so the same
+            // card that was revealed for the Aggression check ends up being one of the 2 cards drawn afterward
+            expect(context.wampa).toBeInZone('hand', context.player1);
+            expect(context.porg).toBeInZone('hand', context.player1);
+            expect(context.rey).toBeInZone('deck', context.player1);
         });
 
         it('should not deal damage when the revealed card does not have the Aggression aspect', async function() {


### PR DESCRIPTION
## Summary

Implements ability logic and integration tests for five upcoming *Homeworlds* (HMW) cards.

---

### Blockade Ship — HMW 251
<img src="https://swudb.com/cdn-cgi/image/quality=95/images/cards/HMW/251.png" width="250">

**Sentinel.** Enemy ground units get -1/-0 while attacking.

---

### Dragonboat Freighter — HMW 231
<img src="https://swudb.com/cdn-cgi/image/quality=95/images/cards/HMW/231.png" width="250">


**When Played:** Give a Weakness token to a unit. If it's a unique unit, exhaust it.

---

### Kelnacca, Solitary Master — HMW 36
<img src="https://swudb.com/cdn-cgi/image/quality=95/images/cards/HMW/036.png" width="250">

**When Played:** You may pay any number of resources. For every 3 resources paid this way, deal damage equal to this unit's power to an enemy unit (each instance of damage is dealt separately and can be re-targeted).

---

### Noxious Refinery — HMW 160
<img src="https://swudb.com/cdn-cgi/image/quality=95/images/cards/HMW/160.png" width="250">


**Fortify.** Attached base gains: "When the regroup phase starts: Reveal the top card of your deck. If it's Aggression, deal 1 damage to an enemy unit."

---

### Surveillance Cruiser — HMW 247
<img src="https://swudb.com/cdn-cgi/image/quality=95/images/cards/HMW/247.png" width="250">


**When Played:** If an opponent controls an Endor, Kashyyyk, Naboo, or Tatooine base, draw a card.