### PR TITLE
The First Legion

### DIFF
--- a/server/game/cards/06_SEC/units/GalenErsoYoullNeverWin.ts
+++ b/server/game/cards/06_SEC/units/GalenErsoYoullNeverWin.ts
@@ -25,7 +25,7 @@ export default class GalenErsoYoullNeverWin extends NonLeaderUnitCard {
                     duration: Duration.WhileSourceInPlay,
                     target: context.player.opponent,
                     cardTargetMode: AllCardsTargetMode.OnlyOwned,
-                    cardTitle: thenContext.select,
+                    matchCondition: (card) => card.title === thenContext.select && !card.isLeader(),
                     effect: abilityHelper.ongoingEffects.blankAllCardsForPlayer(),
                 }))
             })

--- a/server/game/cards/09_HMW/units/TheFirstLegionVadersFist.ts
+++ b/server/game/cards/09_HMW/units/TheFirstLegionVadersFist.ts
@@ -1,0 +1,40 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Duration, TargetMode, Trait } from '../../../core/Constants';
+import { AllCardsTargetMode } from '../../../core/ongoingEffect/OngoingAllCardsForPlayerEffect';
+import { EnumHelpers } from '../../../core/utils/EnumHelpers';
+import { TextHelper } from '../../../core/utils/TextHelper';
+
+export default class TheFirstLegionVadersFist extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'the-first-legion#vaders-fist-id',
+            internalName: 'the-first-legion#vaders-fist',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        registrar.addOnAttackAbility({
+            title: 'Name a trait. Enemy cards, including those not in play, lose that trait for this phase',
+            targetResolver: {
+                mode: TargetMode.DropdownList,
+                options: this.game.traitNames,
+            },
+            then: (thenContext) => {
+                const [trait] = EnumHelpers.checkConvertToEnum(thenContext.select, Trait);
+
+                return {
+                    title: `Enemy cards, including those not in play, lose the ${TextHelper.trait(trait)} trait for this phase`,
+                    immediateEffect: AbilityHelper.immediateEffects.allCardsForPlayerLastingEffect((context) => ({
+                        duration: Duration.UntilEndOfPhase,
+                        target: context.player.opponent,
+                        cardTargetMode: AllCardsTargetMode.OnlyControlled,
+                        ongoingEffectDescription: `remove the ${TextHelper.trait(trait)} trait from all cards controlled by`,
+                        effect: AbilityHelper.ongoingEffects.allCardsForPlayerLoseTrait(trait),
+                    }))
+                };
+            }
+        });
+    }
+}

--- a/server/game/core/Game.ts
+++ b/server/game/core/Game.ts
@@ -37,11 +37,12 @@ import {
     TokenCardName,
     TokenUpgradeName,
     TokenUnitName,
+    Trait,
     WildcardCardType,
     WildcardZoneName,
     ZoneName
 } from './Constants';
-import type { TokenName, Trait } from './Constants';
+import type { TokenName } from './Constants';
 import { StateWatcherRegistrar } from './stateWatcher/StateWatcherRegistrar';
 import { DistributeAmongTargetsPrompt } from './gameSteps/prompts/DistributeAmongTargetsPrompt';
 import HandlerMenuMultipleSelectionPrompt from './gameSteps/prompts/HandlerMenuMultipleSelectionPrompt';
@@ -316,6 +317,11 @@ export class Game extends EventEmitter {
     public cardDataGetter: CardDataGetter;
     public playableCardTitles: string[];
     public allNonLeaderCardTitles: string[];
+
+    /** Title Case display name of every {@link Trait}, sorted alphabetically, for "name a trait" abilities */
+    public readonly traitNames: string[] = Object.values(Trait).map((trait) => Helpers.titleCase(trait))
+        .sort();
+
     public readonly statsTracker: IGameStatisticsTracker;
     public clientUIProperties: IClientUIProperties;
     public spaceArena: SpaceArenaZone;

--- a/server/game/core/ongoingEffect/OngoingAllCardsForPlayerEffect.ts
+++ b/server/game/core/ongoingEffect/OngoingAllCardsForPlayerEffect.ts
@@ -14,6 +14,7 @@ import { registerState } from '../GameObjectUtils';
 
 export enum AllCardsTargetMode {
     OnlyOwned = 'onlyOwned',
+    OnlyControlled = 'onlyControlled',
     OwnedOrControlled = 'ownedOrControlled',
 }
 
@@ -51,14 +52,7 @@ export class OngoingAllCardsForPlayerEffect extends OngoingEffect<Card> {
 
     /** @override */
     public override isValidTarget(target: Card) {
-        if (this.cardTargetMode === AllCardsTargetMode.OnlyOwned && target.owner !== this.player) {
-            return false;
-        }
-
-        if (
-            this.cardTargetMode === AllCardsTargetMode.OwnedOrControlled &&
-            target.owner !== this.player && target.controller !== this.player
-        ) {
+        if (!this.matchesCardTargetMode(target)) {
             return false;
         }
 
@@ -71,11 +65,18 @@ export class OngoingAllCardsForPlayerEffect extends OngoingEffect<Card> {
 
     /** @override */
     public override getTargets() {
+        return this.game.allCards.filter((card) => this.matchesCardTargetMode(card));
+    }
+
+    /** Whether the card's owner / controller relationship to {@link player} matches the configured {@link cardTargetMode} */
+    private matchesCardTargetMode(card: Card): boolean {
         switch (this.cardTargetMode) {
             case AllCardsTargetMode.OnlyOwned:
-                return this.game.allCards.filter((card) => card.owner === this.player);
+                return card.owner === this.player;
+            case AllCardsTargetMode.OnlyControlled:
+                return card.controller === this.player;
             case AllCardsTargetMode.OwnedOrControlled:
-                return this.game.allCards.filter((card) => card.owner === this.player || card.controller === this.player);
+                return card.owner === this.player || card.controller === this.player;
             default:
                 Contract.fail(`Unknown card target mode: ${this.cardTargetMode}`);
         }

--- a/server/game/core/utils/Helpers.ts
+++ b/server/game/core/utils/Helpers.ts
@@ -380,6 +380,12 @@ export namespace Helpers {
         return value.charAt(0).toUpperCase() + value.slice(1);
     }
 
+    /** Capitalize each space-separated word of a value, e.g. 'bounty hunter' -> 'Bounty Hunter' */
+    export function titleCase(value: string): string {
+        return value.split(' ').map(capitalize)
+            .join(' ');
+    }
+
     export function pluralize(count: number, singular: string, plural: string): string {
         if (count === 1) {
             return singular;

--- a/server/game/core/utils/TextHelper.ts
+++ b/server/game/core/utils/TextHelper.ts
@@ -167,8 +167,7 @@ export namespace TextHelper {
      */
     export function trait(trait: TraitEnum | string): string {
         return process.env.NODE_ENV === 'test'
-            ? trait.split(' ').map(Helpers.capitalize)
-                .join(' ')
+            ? Helpers.titleCase(trait)
             : `{trait:${trait.replace(/ /g, '-')}}`;
     }
 

--- a/server/game/gameSystems/AllCardsForPlayerLastingEffectSystem.ts
+++ b/server/game/gameSystems/AllCardsForPlayerLastingEffectSystem.ts
@@ -15,8 +15,9 @@ import * as LastingEffectSystemHelpers from './helpers/LastingEffectSystemHelper
 
 export type IAllCardsForPlayerLastingEffectProperties = DistributiveOmit<ILastingEffectPropertiesBase, 'target' | 'effect'> & Pick<IPlayerTargetSystemProperties, 'target'> & {
     effect: IOngoingAllCardsForPlayerEffectGenerator | IOngoingAllCardsForPlayerEffectGenerator[];
-    cardTitle: string;
-    includeLeaders?: boolean;
+
+    /** If set, only cards matching this condition are affected. Otherwise all of the player's cards are affected. */
+    matchCondition?: (card: Card) => boolean;
     cardTargetMode?: AllCardsTargetMode;
 };
 
@@ -30,8 +31,7 @@ export class AllCardsForPlayerLastingEffectSystem<TContext extends AbilityContex
     protected override readonly defaultProperties: IAllCardsForPlayerLastingEffectProperties = {
         duration: null,
         effect: [],
-        cardTitle: null,
-        includeLeaders: false,
+        matchCondition: null,
         cardTargetMode: AllCardsTargetMode.OnlyOwned
     };
 
@@ -60,15 +60,9 @@ export class AllCardsForPlayerLastingEffectSystem<TContext extends AbilityContex
     private getEffectFactoriesAndProperties(target: Player[], context: TContext, additionalProperties?: Partial<IAllCardsForPlayerLastingEffectProperties>): { effectFactories: IOngoingAllCardsForPlayerEffectGenerator[]; effectProperties: IOngoingAllCardsForPlayerEffectProps[] };
     private getEffectFactoriesAndProperties(target: Player | Player[], context: TContext, additionalProperties?: Partial<IAllCardsForPlayerLastingEffectProperties>): { effectFactories: IOngoingAllCardsForPlayerEffectGenerator[]; effectProperties: IOngoingAllCardsForPlayerEffectProps | IOngoingAllCardsForPlayerEffectProps[] };
     private getEffectFactoriesAndProperties(target: Player | Player[], context: TContext, additionalProperties?: Partial<IAllCardsForPlayerLastingEffectProperties>): { effectFactories: IOngoingAllCardsForPlayerEffectGenerator[]; effectProperties: IOngoingAllCardsForPlayerEffectProps | IOngoingAllCardsForPlayerEffectProps[] } {
-        const { effect, cardTitle, includeLeaders, cardTargetMode, target: _propsTarget, ...otherProperties } = this.generatePropertiesFromContext(context, additionalProperties);
+        const { effect, matchCondition, cardTargetMode, target: _propsTarget, ...otherProperties } = this.generatePropertiesFromContext(context, additionalProperties);
 
-        const matchTarget = (target: Card) => {
-            if (target.title !== cardTitle) {
-                return false;
-            }
-
-            return includeLeaders || !target.isLeader();
-        };
+        const matchTarget = (target: Card) => matchCondition == null || matchCondition(target);
 
         const effectProperties: (target: Player) => IOngoingAllCardsForPlayerEffectProps = (target) => ({
             matchTarget,

--- a/server/game/ongoingEffects/OngoingEffectLibrary.ts
+++ b/server/game/ongoingEffects/OngoingEffectLibrary.ts
@@ -175,6 +175,7 @@ export = {
     // loseAllNonKeywordAbilities: () => OngoingEffectBuilder.card.static(EffectName.LoseAllNonKeywordAbilities),
     gainTrait: (trait: Trait) => OngoingEffectBuilder.card.static(EffectName.GainTrait, trait),
     loseTrait: (trait: Trait) => OngoingEffectBuilder.card.static(EffectName.LoseTrait, trait),
+    allCardsForPlayerLoseTrait: (trait: Trait) => OngoingEffectBuilder.allCardsForPlayer.static(EffectName.LoseTrait, trait),
     // modifyBaseMilitarySkillMultiplier: (value) =>
     //     OngoingEffectBuilder.card.flexible(EffectName.ModifyBaseMilitarySkillMultiplier, value),
     // modifyBasePoliticalSkillMultiplier: (value) =>

--- a/test/helpers/GameFlowWrapper.js
+++ b/test/helpers/GameFlowWrapper.js
@@ -57,6 +57,10 @@ class GameFlowWrapper {
         return playableCardTitles;
     }
 
+    getTraitNames() {
+        return this.game.traitNames;
+    }
+
     allPlayersInInitiativeOrder() {
         return [...this.allPlayers].sort((playerWrapper) => (this.game.initiativePlayer.id === playerWrapper.player.id ? -1 : 1));
     }

--- a/test/helpers/GameStateBuilder.js
+++ b/test/helpers/GameStateBuilder.js
@@ -20,6 +20,7 @@ class GameStateBuilder {
             'allPlayersInInitiativeOrder',
             'getAllNonLeaderCardTitles',
             'getPlayableCardTitles',
+            'getTraitNames',
             'getChatLog',
             'getChatLogs',
             'getPromptedPlayer',

--- a/test/helpers/IntegrationHelper.d.ts
+++ b/test/helpers/IntegrationHelper.d.ts
@@ -77,6 +77,7 @@ interface SwuTestContext {
     allPlayersInInitiativeOrder(): PlayerInteractionWrapper[];
     getAllNonLeaderCardTitles(): string[];
     getPlayableCardTitles();
+    getTraitNames(): string[];
     getChatLog(numbBack = 0);
     getChatLogs(numbBack = 1, inOrder = false);
     getPromptedPlayer(title: string);

--- a/test/server/cards/09_HMW/units/TheFirstLegionVadersFist.spec.ts
+++ b/test/server/cards/09_HMW/units/TheFirstLegionVadersFist.spec.ts
@@ -1,0 +1,303 @@
+import { Trait } from '../../../../../server/game/core/Constants';
+
+describe('The First Legion, Vader\'s Fist', function() {
+    integration(function(contextRef) {
+        describe('The First Legion\'s on attack ability', function() {
+            it('should name a trait and make enemy cards, including those not in play, lose that trait for this phase', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['battlefield-marine'],
+                        groundArena: ['the-first-legion#vaders-fist'],
+                    },
+                    player2: {
+                        leader: 'iden-versio#inferno-squad-commander',
+                        hand: ['first-legion-snowtrooper'],
+                        deck: ['death-trooper'],
+                        discard: ['rebel-pathfinder'],
+                        resources: ['echo-base-defender', 'wampa', 'wampa', 'wampa', 'wampa'],
+                        groundArena: ['snowtrooper-lieutenant', 'scout-bike-pursuer'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                const enemyTrooperCards = [
+                    context.snowtrooperLieutenant,
+                    context.scoutBikePursuer,
+                    context.idenVersio,
+                    context.firstLegionSnowtrooper,
+                    context.deathTrooper,
+                    context.rebelPathfinder,
+                    context.echoBaseDefender
+                ];
+
+                for (const card of enemyTrooperCards) {
+                    expect(card.hasSomeTrait(Trait.Trooper)).toBeTrue();
+                }
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.player1).toHaveExactDropdownListOptions(context.getTraitNames());
+                context.player1.chooseListOption('Trooper');
+
+                expect(context.getChatLogs(5)).toContain('player1 names Trooper using The First Legion');
+                expect(context.getChatLogs(5)).toContain('player1 uses The First Legion to remove the Trooper trait from all cards controlled by player2 for this phase');
+                expect(context.p2Base.damage).toBe(5);
+                expect(context.player2).toBeActivePlayer();
+
+                // all enemy cards lose the Trooper trait, including the leader and cards in hand, deck, discard and resources
+                for (const card of enemyTrooperCards) {
+                    expect(card.hasSomeTrait(Trait.Trooper)).toBeFalse();
+                }
+
+                // other traits are unaffected
+                expect(context.snowtrooperLieutenant.hasSomeTrait(Trait.Imperial)).toBeTrue();
+                expect(context.idenVersio.hasSomeTrait(Trait.Imperial)).toBeTrue();
+                expect(context.rebelPathfinder.hasSomeTrait(Trait.Rebel)).toBeTrue();
+
+                // friendly cards keep the trait
+                expect(context.theFirstLegion.hasSomeTrait(Trait.Trooper)).toBeTrue();
+                expect(context.battlefieldMarine.hasSomeTrait(Trait.Trooper)).toBeTrue();
+
+                // a card the opponent plays later in the phase still lacks the trait
+                context.player2.clickCard(context.firstLegionSnowtrooper);
+                expect(context.firstLegionSnowtrooper).toBeInZone('groundArena');
+                expect(context.firstLegionSnowtrooper.hasSomeTrait(Trait.Trooper)).toBeFalse();
+
+                // the trait comes back at the end of the phase
+                context.moveToNextActionPhase();
+
+                for (const card of enemyTrooperCards) {
+                    expect(card.hasSomeTrait(Trait.Trooper)).toBeTrue();
+                }
+            });
+
+            it('should keep the named trait removed for the rest of the phase even if The First Legion is defeated during the attack', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['the-first-legion#vaders-fist'],
+                    },
+                    player2: {
+                        groundArena: ['general-veers#blizzard-force-commander', 'atst'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // AT-ST gets +1/+1 from General Veers while it has the Imperial trait
+                expect(context.atst.getPower()).toBe(7);
+                expect(context.atst.getHp()).toBe(8);
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.atst);
+                context.player1.chooseListOption('Imperial');
+
+                // the trait is removed before combat damage, so the AT-ST loses the buff and deals 6 damage to The First Legion
+                expect(context.atst.hasSomeTrait(Trait.Imperial)).toBeFalse();
+                expect(context.generalVeers.hasSomeTrait(Trait.Imperial)).toBeFalse();
+                expect(context.atst.getPower()).toBe(6);
+                expect(context.atst.getHp()).toBe(7);
+                expect(context.atst.damage).toBe(5);
+                expect(context.theFirstLegion).toBeInZone('discard');
+                expect(context.player2).toBeActivePlayer();
+
+                // the effect lasts for the phase even though The First Legion has left play
+                context.player2.passAction();
+                expect(context.atst.hasSomeTrait(Trait.Imperial)).toBeFalse();
+                expect(context.atst.getPower()).toBe(6);
+
+                context.moveToNextActionPhase();
+                expect(context.atst.hasSomeTrait(Trait.Imperial)).toBeTrue();
+                expect(context.atst.getPower()).toBe(7);
+            });
+
+            it('should only affect cards controlled by the opponent, regardless of who owns them', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['change-of-heart'],
+                        groundArena: ['the-first-legion#vaders-fist', 'battlefield-marine'],
+                    },
+                    player2: {
+                        hand: ['change-of-heart'],
+                        groundArena: ['scout-bike-pursuer'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // player 1 takes control of Scout Bike Pursuer and player 2 takes control of Battlefield Marine
+                context.player1.clickCard(context.player1.findCardByName('change-of-heart'));
+                context.player1.clickCard(context.scoutBikePursuer);
+                context.player2.clickCard(context.player2.findCardByName('change-of-heart'));
+                context.player2.clickCard(context.battlefieldMarine);
+
+                expect(context.scoutBikePursuer).toBeInZone('groundArena', context.player1);
+                expect(context.battlefieldMarine).toBeInZone('groundArena', context.player2);
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.p2Base);
+                context.player1.chooseListOption('Trooper');
+
+                // Battlefield Marine is owned by player 1 but is an enemy card while player 2 controls it
+                expect(context.battlefieldMarine.hasSomeTrait(Trait.Trooper)).toBeFalse();
+
+                // Scout Bike Pursuer is owned by player 2 but is a friendly card while player 1 controls it
+                expect(context.scoutBikePursuer.hasSomeTrait(Trait.Trooper)).toBeTrue();
+                expect(context.theFirstLegion.hasSomeTrait(Trait.Trooper)).toBeTrue();
+
+                // control returns to the owners in the regroup phase and the effect ends
+                context.moveToNextActionPhase();
+                expect(context.battlefieldMarine).toBeInZone('groundArena', context.player1);
+                expect(context.scoutBikePursuer).toBeInZone('groundArena', context.player2);
+                expect(context.battlefieldMarine.hasSomeTrait(Trait.Trooper)).toBeTrue();
+                expect(context.scoutBikePursuer.hasSomeTrait(Trait.Trooper)).toBeTrue();
+            });
+
+            it('should remove the trait from enemy cards in play, including a deployed leader, as counted by other abilities', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['the-first-legion#vaders-fist'],
+                    },
+                    player2: {
+                        leader: { card: 'iden-versio#inferno-squad-commander', deployed: true },
+                        groundArena: [{ card: 'snowtrooper-lieutenant', upgrades: ['squad-support'] }, 'first-legion-snowtrooper'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Squad Support gives +1/+1 for each Trooper unit its controller has: both Snowtroopers and Iden
+                expect(context.snowtrooperLieutenant.getPower()).toBe(5);
+                expect(context.snowtrooperLieutenant.getHp()).toBe(5);
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.p2Base);
+                context.player1.chooseListOption('Trooper');
+
+                // the deployed leader loses the trait as a unit as well, so Squad Support counts no Trooper units
+                expect(context.idenVersio.hasSomeTrait(Trait.Trooper)).toBeFalse();
+                expect(context.snowtrooperLieutenant.getPower()).toBe(2);
+                expect(context.snowtrooperLieutenant.getHp()).toBe(2);
+
+                context.moveToNextActionPhase();
+                expect(context.idenVersio.hasSomeTrait(Trait.Trooper)).toBeTrue();
+                expect(context.snowtrooperLieutenant.getPower()).toBe(5);
+                expect(context.snowtrooperLieutenant.getHp()).toBe(5);
+            });
+
+            it('should remove the trait from enemy cards in hand, so they cannot be played by an ability that requires it', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['the-first-legion#vaders-fist'],
+                    },
+                    player2: {
+                        leader: { card: 'jabba-the-hutt#crime-boss', deployed: true },
+                        hand: ['nihil-marauder'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.p2Base);
+                context.player1.chooseListOption('Underworld');
+
+                expect(context.nihilMarauder.hasSomeTrait(Trait.Underworld)).toBeFalse();
+
+                // Jabba can no longer play the card in hand, since it is not an Underworld unit any more:
+                // attacking is his only remaining option, so clicking him goes straight to attack targeting
+                context.player2.clickCard(context.jabbaTheHutt);
+                expect(context.player2).toHavePrompt('Choose a target for attack');
+                context.player2.clickPrompt('Cancel');
+
+                context.player2.passAction();
+                context.moveToNextActionPhase();
+
+                // once the phase ends the trait is back and Jabba can play it again
+                expect(context.nihilMarauder.hasSomeTrait(Trait.Underworld)).toBeTrue();
+                context.player1.passAction();
+                context.player2.clickCard(context.jabbaTheHutt);
+                expect(context.player2).toHaveExactPromptButtons([
+                    'Play an Underworld unit unit from your hand',
+                    'Attack',
+                    'Cancel'
+                ]);
+                context.player2.clickPrompt('Cancel');
+                context.player2.passAction();
+            });
+
+            it('should remove the trait from enemy cards in the deck and discard pile, whatever their card type', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['the-first-legion#vaders-fist'],
+                    },
+                    player2: {
+                        hand: ['psychometry'],
+                        discard: ['yoda#old-master'],
+                        deck: ['qimir#everyone-has-a-weakness', 'heightened-awareness', 'force-choke', 'jedi-light-cruiser', 'wampa'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.p2Base);
+                context.player1.chooseListOption('Force');
+
+                // Psychometry searches the deck for a card sharing a trait with a card in the discard pile
+                context.player2.clickCard(context.psychometry);
+                context.player2.clickCard(context.yoda);
+
+                // Yoda lost Force but kept Jedi, and the Force unit, upgrade and event in the deck no longer share a trait with him
+                expect(context.player2).toHaveExactDisplayPromptCards({
+                    selectable: [context.jediLightCruiser],
+                    invalid: [context.qimir, context.heightenedAwareness, context.forceChoke, context.wampa]
+                });
+                context.player2.clickPrompt('Take nothing');
+            });
+
+            it('should be able to name a base trait, which only the enemy base loses', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        base: 'bright-tree-village',
+                        groundArena: ['the-first-legion#vaders-fist', 'village-troublemaker'],
+                    },
+                    player2: {
+                        base: 'bright-tree-village',
+                        groundArena: ['village-troublemaker'],
+                    }
+                });
+
+                const { context } = contextRef;
+                const friendlyTroublemaker = context.player1.findCardByName('village-troublemaker');
+                const enemyTroublemaker = context.player2.findCardByName('village-troublemaker');
+
+                context.player1.clickCard(context.theFirstLegion);
+                context.player1.clickCard(context.p2Base);
+                context.player1.chooseListOption('Endor');
+
+                expect(context.p2Base.hasSomeTrait(Trait.Endor)).toBeFalse();
+                expect(context.p1Base.hasSomeTrait(Trait.Endor)).toBeTrue();
+
+                // Village Troublemaker only has Hidden and Saboteur while its controller has an Endor base
+                expect(enemyTroublemaker.hasSomeKeyword('hidden')).toBeFalse();
+                expect(enemyTroublemaker.hasSomeKeyword('saboteur')).toBeFalse();
+                expect(friendlyTroublemaker.hasSomeKeyword('hidden')).toBeTrue();
+                expect(friendlyTroublemaker.hasSomeKeyword('saboteur')).toBeTrue();
+
+                context.moveToNextActionPhase();
+                expect(context.p2Base.hasSomeTrait(Trait.Endor)).toBeTrue();
+                expect(enemyTroublemaker.hasSomeKeyword('hidden')).toBeTrue();
+                expect(enemyTroublemaker.hasSomeKeyword('saboteur')).toBeTrue();
+            });
+        });
+    });
+});


### PR DESCRIPTION
[The First Legion, Vader's Fist](https://swudb.com/cdn-cgi/image/width=300/images/cards/HMW/108.png)

Replaces #2761, which was opened from a fork. Same change, rebased onto current `main` as a single commit, with @moyerr's review feedback from that PR already folded in:

- the nameable trait list now lives on `Game` as `traitNames`, alongside `playableCardTitles`, and is exposed to tests as `getTraitNames()`
- dropped the display-name lookup map in favour of `EnumHelpers.checkConvertToEnum`, which already matches case-insensitively
- `AllCardsForPlayerLastingEffectSystem` takes a general `matchCondition` predicate instead of `cardTitle` / `includeLeaders`; Galen Erso updated to use it
- `loseTraitAllCardsForPlayer` renamed to `allCardsForPlayerLoseTrait`
- trait removal is now verified through gameplay in each zone: Squad Support and a deployed Iden for cards in play, LAW Jabba for cards in hand, Psychometry across unit/upgrade/event types for the deck and discard pile, and Village Troublemaker for base traits

Also adds `AllCardsTargetMode.OnlyControlled`, since this card affects cards the opponent *controls* rather than the ones they own.

Full suite passes locally: 8068 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwmTMM3ZJ18pxbL16KdChx