### PR TITLE
Phee Genoa, Liberator of Ancient Wonders

### DIFF
--- a/server/game/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.ts
+++ b/server/game/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.ts
@@ -1,0 +1,47 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { NamedAction, RelativePlayer, TargetMode } from '../../../core/Constants';
+import { TextHelper } from '../../../core/utils/TextHelper';
+
+export default class PheeGenoaLiberatorOfAncientWonders extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'phee-genoa#liberator-of-ancient-wonders-id',
+            internalName: 'phee-genoa#liberator-of-ancient-wonders',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, abilityHelper: IAbilityHelper) {
+        registrar.addTriggeredAbility({
+            title: `Exhaust the deployed leader unless its controller pays ${TextHelper.resource(2)}`,
+            contextTitle: (context) => `Exhaust ${context.event.card.title} unless its controller pays ${TextHelper.resource(2)}`,
+            when: {
+                onLeaderDeployed: (event, context) => event.card.controller === context.player.opponent
+            },
+            targetResolver: {
+                mode: TargetMode.SelectUnless,
+                choosingPlayer: RelativePlayer.Opponent,
+                activePromptTitle: (context) => `[Exhaust] ${context.event.card.title} or [Pay] ${TextHelper.resource(2)}`,
+
+                // A leader deployed as a pilot is an upgrade and cannot be exhausted, but the choice is still offered
+                // to its controller. Choosing to exhaust it simply has no effect.
+                showUnresolvable: true,
+                unlessEffect: {
+                    effect: (context) => abilityHelper.immediateEffects.payResources({
+                        target: context.event.card.controller,
+                        amount: 2
+                    }),
+                    promptButtonText: NamedAction.Pay
+                },
+                defaultEffect: {
+                    effect: (context) => abilityHelper.immediateEffects.exhaust({
+                        target: context.event.card
+                    }),
+                    promptButtonText: NamedAction.Exhaust
+                },
+                highlightCards: (context) => context.event.card,
+            }
+        });
+    }
+}

--- a/test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts
+++ b/test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts
@@ -1,0 +1,126 @@
+describe('Phee Genoa, Liberator of Ancient Wonders', function() {
+    integration(function(contextRef) {
+        describe('Phee Genoa\'s triggered ability', function() {
+            beforeEach(async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['phee-genoa#liberator-of-ancient-wonders'],
+                        leader: 'sabine-wren#galvanized-revolutionary',
+                    },
+                    player2: {
+                        leader: 'boba-fett#collecting-the-bounty',
+                    }
+                });
+            });
+
+            it('should exhaust the enemy leader when its controller does not pay 2 resources', function() {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.bobaFett);
+                context.player2.clickPrompt('Deploy Boba Fett');
+
+                expect(context.player2).toHavePrompt('[Exhaust] Boba Fett or [Pay] 2 resources');
+                expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
+                context.player2.clickPrompt('Exhaust');
+
+                expect(context.bobaFett.deployed).toBeTrue();
+                expect(context.bobaFett.exhausted).toBeTrue();
+                expect(context.player2.exhaustedResourceCount).toBe(0);
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should not exhaust the enemy leader when its controller pays 2 resources', function() {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.bobaFett);
+                context.player2.clickPrompt('Deploy Boba Fett');
+
+                expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
+                context.player2.clickPrompt('Pay');
+
+                expect(context.bobaFett.deployed).toBeTrue();
+                expect(context.bobaFett.exhausted).toBeFalse();
+                expect(context.player2.exhaustedResourceCount).toBe(2);
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should exhaust the enemy leader without prompting when its controller cannot pay 2 resources', function() {
+                const { context } = contextRef;
+
+                context.player1.passAction();
+                context.player2.exhaustResources(19);
+
+                context.player2.clickCard(context.bobaFett);
+                context.player2.clickPrompt('Deploy Boba Fett');
+
+                expect(context.bobaFett.deployed).toBeTrue();
+                expect(context.bobaFett.exhausted).toBeTrue();
+                expect(context.player2.exhaustedResourceCount).toBe(19);
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should not trigger when a friendly leader deploys', function() {
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.sabineWren);
+                context.player1.clickPrompt('Deploy Sabine Wren');
+
+                expect(context.sabineWren.deployed).toBeTrue();
+                expect(context.sabineWren.exhausted).toBeFalse();
+                expect(context.player1.exhaustedResourceCount).toBe(0);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
+
+        describe('Phee Genoa\'s triggered ability when an enemy leader deploys as a pilot', function() {
+            beforeEach(async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['phee-genoa#liberator-of-ancient-wonders'],
+                    },
+                    player2: {
+                        leader: 'wedge-antilles#leader-of-red-squadron',
+                        spaceArena: ['cartel-spacer'],
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.wedgeAntilles);
+                context.player2.clickPrompt('Deploy Wedge Antilles as a Pilot');
+                context.player2.clickCard(context.cartelSpacer);
+            });
+
+            it('should still prompt, and choosing to exhaust has no effect since the leader is an upgrade', function() {
+                const { context } = contextRef;
+
+                expect(context.player2).toHavePrompt('[Exhaust] Wedge Antilles or [Pay] 2 resources');
+                expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
+                context.player2.clickPrompt('Exhaust');
+
+                expect(context.wedgeAntilles).toBeAttachedTo(context.cartelSpacer);
+                expect(context.player2.exhaustedResourceCount).toBe(0);
+                expect(context.player1).toBeActivePlayer();
+            });
+
+            it('should still allow its controller to pay 2 resources instead', function() {
+                const { context } = contextRef;
+
+                expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
+                context.player2.clickPrompt('Pay');
+
+                expect(context.wedgeAntilles).toBeAttachedTo(context.cartelSpacer);
+                expect(context.player2.exhaustedResourceCount).toBe(2);
+                expect(context.player1).toBeActivePlayer();
+            });
+        });
+    });
+});

--- a/test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts
+++ b/test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts
@@ -126,5 +126,55 @@ describe('Phee Genoa, Liberator of Ancient Wonders', function() {
                 expect(context.player1).toBeActivePlayer();
             });
         });
+
+        it('Phee Genoa\'s triggered ability should have no phase limit, triggering on each enemy leader deploy in the same phase', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    groundArena: ['phee-genoa#liberator-of-ancient-wonders'],
+                },
+                player2: {
+                    leader: 'grogu#charming-companion',
+                    groundArena: ['darth-traya#lord-of-betrayal'],
+                    hand: ['sabine-wren#you-can-count-on-me', 'obiwan-kenobi#finding-what-doesnt-exist'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.passAction();
+
+            // First deploy: Grogu deploys off a 4-cost unique unit and Phee's ability triggers
+            context.player2.clickCard(context.sabineWren);
+            expect(context.player2).toHavePassAbilityPrompt('Deploy Grogu');
+            context.player2.clickPrompt('Trigger');
+
+            expect(context.player2).toHavePrompt('[Exhaust] Grogu or [Pay] 2 resources');
+            context.player2.clickPrompt('Exhaust');
+            expect(context.grogu.exhausted).toBeTrue();
+
+            // Defeat Grogu so he returns to the leader zone, undeployed
+            context.player1.clickCard(context.pheeGenoa);
+            context.player1.clickCard(context.grogu);
+            expect(context.grogu.deployed).toBeFalse();
+
+            // Darth Traya readies Grogu on the leader side so he can deploy again
+            context.player2.clickCard(context.darthTraya);
+            context.player2.clickCard(context.p1Base);
+            context.player2.clickCard(context.grogu);
+            expect(context.grogu.exhausted).toBeFalse();
+
+            context.player1.passAction();
+
+            // Second deploy in the same phase: Phee's ability triggers again
+            context.player2.clickCard(context.obiwanKenobi);
+            expect(context.player2).toHavePassAbilityPrompt('Deploy Grogu');
+            context.player2.clickPrompt('Trigger');
+
+            expect(context.player2).toHavePrompt('[Exhaust] Grogu or [Pay] 2 resources');
+            expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
+            context.player2.clickPrompt('Exhaust');
+            expect(context.grogu.exhausted).toBeTrue();
+        });
     });
 });

--- a/test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts
+++ b/test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts
@@ -89,7 +89,9 @@ describe('Phee Genoa, Liberator of Ancient Wonders', function() {
                         spaceArena: ['cartel-spacer'],
                     }
                 });
+            });
 
+            it('should still prompt, and choosing to exhaust has no effect since the leader is an upgrade', function() {
                 const { context } = contextRef;
 
                 context.player1.passAction();
@@ -97,10 +99,6 @@ describe('Phee Genoa, Liberator of Ancient Wonders', function() {
                 context.player2.clickCard(context.wedgeAntilles);
                 context.player2.clickPrompt('Deploy Wedge Antilles as a Pilot');
                 context.player2.clickCard(context.cartelSpacer);
-            });
-
-            it('should still prompt, and choosing to exhaust has no effect since the leader is an upgrade', function() {
-                const { context } = contextRef;
 
                 expect(context.player2).toHavePrompt('[Exhaust] Wedge Antilles or [Pay] 2 resources');
                 expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
@@ -113,6 +111,12 @@ describe('Phee Genoa, Liberator of Ancient Wonders', function() {
 
             it('should still allow its controller to pay 2 resources instead', function() {
                 const { context } = contextRef;
+
+                context.player1.passAction();
+
+                context.player2.clickCard(context.wedgeAntilles);
+                context.player2.clickPrompt('Deploy Wedge Antilles as a Pilot');
+                context.player2.clickCard(context.cartelSpacer);
 
                 expect(context.player2).toHaveEnabledPromptButtons(['Pay', 'Exhaust']);
                 context.player2.clickPrompt('Pay');


### PR DESCRIPTION
[Card image — Phee Genoa, Liberator of Ancient Wonders (HMW 214)](https://swudb.com/cdn-cgi/image/width=300/images/cards/HMW/214.png)

Implements Phee Genoa, Liberator of Ancient Wonders (HMW 214).

### Implementation

A triggered ability on `onLeaderDeployed` for an opponent's leader, using a `SelectUnless` target resolver so the leader's controller chooses between paying 2 resources and having the leader exhausted.

Pilot deploys are handled as a "no effect" case rather than as a non-trigger: a leader deployed as a pilot is an upgrade, so it can't be exhausted, but its controller is still offered the choice. `showUnresolvable: true` keeps the Exhaust button on the prompt in that situation — picking it simply does nothing. If the controller can't afford 2 resources, the prompt is skipped entirely and the exhaust resolves directly.

### Tests

`test/server/cards/09_HMW/units/PheeGenoaLiberatorOfAncientWonders.spec.ts` — 6 specs covering: exhaust chosen, pay chosen, controller unable to pay (no prompt), friendly leader deploy (no trigger), and both branches of the prompt after a pilot deploy.

All 6 pass in both normal and whole-suite undo mode; `tsc` (server + test) and `eslint --quiet` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PpWW7rka2C8WstDh6LFqB