### PR TITLE
Attribute token upgrade creation to the correct player

### DIFF
--- a/server/game/cards/08_ASH/leaders/SabineWrenBargainingOnBelief.ts
+++ b/server/game/cards/08_ASH/leaders/SabineWrenBargainingOnBelief.ts
@@ -21,12 +21,15 @@ export default class SabineWrenBargainingOnBelief extends LeaderUnitCard {
             title: `An opponent gives 2 Advantage tokens to a unit they control. If they do, the next unit you play this phase gains ${TextHelper.Shielded} for this phase`,
             cost: abilityHelper.costs.exhaustSelf(),
             targetResolver: {
-                activePromptTitle: `Choose a unit to give 2 Advantage tokens. The next unit your opponent plays this phase gains ${TextHelper.Shielded} for this phase`,
+                activePromptTitle: `Give 2 Advantage tokens to a unit. The next unit your opponent plays this phase gains ${TextHelper.Shielded} for this phase`,
                 waitingPromptTitle: 'Waiting for opponent to select a unit for Sabine Wren\'s ability',
                 cardTypeFilter: WildcardCardType.Unit,
                 choosingPlayer: RelativePlayer.Opponent,
                 controller: RelativePlayer.Opponent,
-                immediateEffect: abilityHelper.immediateEffects.giveAdvantage({ amount: 2 })
+                immediateEffect: abilityHelper.immediateEffects.giveAdvantage({
+                    createdBy: RelativePlayer.Opponent,
+                    amount: 2
+                })
             },
             effect: 'have {1} give 2 Advantage tokens to {0} to create a delayed effect',
             effectArgs: (context) => [context.player.opponent.name],

--- a/server/game/gameSystems/GiveTokenUpgradeSystem.ts
+++ b/server/game/gameSystems/GiveTokenUpgradeSystem.ts
@@ -1,7 +1,7 @@
 import type { AbilityContext } from '../core/ability/AbilityContext';
 import type { Card } from '../core/card/Card';
 import type { CardTypeFilter } from '../core/Constants';
-import { TokenUpgradeName } from '../core/Constants';
+import { RelativePlayer, TokenUpgradeName } from '../core/Constants';
 import { EventName, GameStateChangeRequired, WildcardCardType } from '../core/Constants';
 import type { ICardTargetSystemProperties } from '../core/gameSystem/CardTargetSystem';
 import { CardTargetSystem } from '../core/gameSystem/CardTargetSystem';
@@ -17,6 +17,9 @@ export interface IGiveTokenUpgradeProperties extends ICardTargetSystemProperties
     tokenType: TokenUpgradeName;
     amount?: number;
 
+    /** The player considered to have created (given) the token(s). Defaults to `RelativePlayer.Self`. */
+    createdBy?: RelativePlayer;
+
     /** Shield-only: whether the created Shield token should be removed before other shields when preventing damage. Ignored for other token types. */
     highPriorityRemoval?: boolean;
 }
@@ -27,7 +30,8 @@ export class GiveTokenUpgradeSystem<TContext extends AbilityContext = AbilityCon
     public override readonly eventName = EventName.OnTokensCreated;
     protected override readonly targetTypeFilter: CardTypeFilter[] = [WildcardCardType.Unit];
     protected override readonly defaultProperties: Omit<IGiveTokenUpgradeProperties, 'tokenType'> = {
-        amount: 1
+        amount: 1,
+        createdBy: RelativePlayer.Self
     };
 
     // event handler doesn't do anything since the tokens were generated in updateEvent
@@ -155,6 +159,10 @@ export class GiveTokenUpgradeSystem<TContext extends AbilityContext = AbilityCon
         event.card = cardsArray.length === 1 ? cardsArray[0] : null;
 
         const properties = this.generatePropertiesFromContext(context, additionalProperties);
+
+        if (properties.createdBy === RelativePlayer.Opponent && context.player.opponent) {
+            event.player = context.player.opponent;
+        }
 
         event.amount = properties.amount;
         event.tokenType = properties.tokenType;

--- a/test/server/cards/07_LAW/leaders/TheClientPleaseLowerYourBlaster.spec.ts
+++ b/test/server/cards/07_LAW/leaders/TheClientPleaseLowerYourBlaster.spec.ts
@@ -54,7 +54,7 @@ describe('The Client, Please Lower Your Blaster', function() {
                 expect(context.wampa.exhausted).toBeTrue();
             });
 
-            xit('exhausts an enemy unit if opponent ability make you create token upgrade ', async function() {
+            it('exhausts an enemy unit if opponent ability make you create token upgrade ', async function() {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {

--- a/test/server/cards/08_ASH/leaders/SabineWrenBargainingOnBelief.spec.ts
+++ b/test/server/cards/08_ASH/leaders/SabineWrenBargainingOnBelief.spec.ts
@@ -21,7 +21,7 @@ describe('Sabine Wren, Bargaining On Belief', function() {
                 context.player1.clickPrompt('An opponent gives 2 Advantage tokens to a unit they control. If they do, the next unit you play this phase gains Shielded for this phase');
 
                 expect(context.player1).toHavePrompt('Waiting for opponent to select a unit for Sabine Wren\'s ability');
-                expect(context.player2).toHavePrompt('Choose a unit to give 2 Advantage tokens. The next unit your opponent plays this phase gains Shielded for this phase');
+                expect(context.player2).toHavePrompt('Give 2 Advantage tokens to a unit. The next unit your opponent plays this phase gains Shielded for this phase');
 
                 expect(context.player2).toBeAbleToSelectExactly([context.atst, context.awing]);
                 expect(context.player2).not.toHavePassAbilityButton();

--- a/test/server/cards/09_HMW/leaders/JarJarBinksBombadGeneral.spec.ts
+++ b/test/server/cards/09_HMW/leaders/JarJarBinksBombadGeneral.spec.ts
@@ -224,7 +224,7 @@ describe('Jar Jar Binks, Bombad General', function () {
                 expect(context.player1.exhaustedResourceCount).toBe(1);
             });
 
-            xit('deals 1 damage to a unit and heals 1 damage from a base if a token upgrade was created this phase (our opponent make us create token upgrades)', async function () {
+            it('deals 1 damage to a unit and heals 1 damage from a base if a token upgrade was created this phase (our opponent make us create token upgrades)', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -251,7 +251,7 @@ describe('Jar Jar Binks, Bombad General', function () {
                 context.player1.clickCard(context.p1Base);
 
                 expect(context.player2).toBeActivePlayer();
-                expect(context.wampa.damage).toBe(2);
+                expect(context.wampa.damage).toBe(1);
                 expect(context.p1Base.damage).toBe(1);
                 expect(context.jarJarBinks.exhausted).toBeTrue();
                 expect(context.player1.exhaustedResourceCount).toBe(1);
@@ -443,7 +443,7 @@ describe('Jar Jar Binks, Bombad General', function () {
                 expect(context.p1Base.damage).toBe(1);
             });
 
-            xit('deals 1 damage to a unit and heals 1 damage from a base if a token upgrade was created this phase (our opponent make us create token upgrades)', async function () {
+            it('deals 1 damage to a unit and heals 1 damage from a base if a token upgrade was created this phase (our opponent make us create token upgrades)', async function () {
                 await contextRef.setupTestAsync({
                     phase: 'action',
                     player1: {
@@ -474,7 +474,7 @@ describe('Jar Jar Binks, Bombad General', function () {
                 context.player1.clickCard(context.p1Base);
 
                 expect(context.player2).toBeActivePlayer();
-                expect(context.wampa.damage).toBe(2);
+                expect(context.wampa.damage).toBe(1);
                 expect(context.p1Base.damage).toBe(1);
             });
         });


### PR DESCRIPTION
Fixes #2751

## Motivation
`GiveTokenUpgradeSystem` always credited token creation to the ability's controller (`context.player`). But for abilities where an *opponent* gives the tokens — e.g. **Sabine Wren: Bargaining on Belief** (*"An opponent gives 2 Advantage tokens…"*) — the opponent is the creator. This wrote the wrong `event.player`, which `TokensCreatedThisPhaseWatcher` and Moff Jerjerrod both rely on for creator-attribution (so The Client / Jar Jar Binks saw the wrong creator).

## Change
- Add an optional `createdBy?: RelativePlayer` (default `Self`) to `GiveTokenUpgradeSystem` that re-attributes `event.player`. Inert unless a card opts in.
- Sabine passes `createdBy: RelativePlayer.Opponent`.
- Un-skip the tests staged in #2750 (The Client + Jar Jar Binks Sabine cases).