### PR TITLE
Fix Overgrowth and Command crashing when no friendly unit can deal damage

### DIFF
--- a/server/game/cards/09_HMW/events/Overgrowth.ts
+++ b/server/game/cards/09_HMW/events/Overgrowth.ts
@@ -2,7 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { TextHelper } from '../../../core/utils/TextHelper';
-import { GameStateChangeRequired, RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class Overgrowth extends EventCard {
     protected override getImplementationId() {
@@ -24,20 +24,20 @@ export default class Overgrowth extends EventCard {
                         cardTypeFilter: WildcardCardType.Unit,
                         zoneFilter: WildcardZoneName.AnyArena,
                         name: 'friendlyUnit',
-
-                        // only units that can actually deal damage are selectable, so the damage step can't be fizzled
-                        // by choosing a unit with no power (and can never resolve without a chosen friendly unit)
-                        mustChangeGameState: GameStateChangeRequired.MustFullyOrPartiallyResolve,
-                        immediateEffect: abilityHelper.immediateEffects.selectCard({
-                            activePromptTitle: (context) => `Deal ${context.targets.friendlyUnit?.getPower()} damage to an enemy unit`,
-                            controller: RelativePlayer.Opponent,
-                            cardTypeFilter: WildcardCardType.Unit,
-                            zoneFilter: WildcardZoneName.AnyArena,
-                            name: 'enemyUnit',
-                            immediateEffect: abilityHelper.immediateEffects.damage((context) => ({
-                                amount: context.targets.friendlyUnit?.getPower(),
-                                target: context.targets.enemyUnit
-                            }))
+                        immediateEffect: abilityHelper.immediateEffects.conditional({
+                            // if no friendly unit can deal damage, the selection resolves without a unit, so there is nothing to damage with
+                            condition: (context) => context.targets.friendlyUnit != null,
+                            onTrue: abilityHelper.immediateEffects.selectCard({
+                                activePromptTitle: (context) => `Deal ${context.targets.friendlyUnit.getPower()} damage to an enemy unit`,
+                                controller: RelativePlayer.Opponent,
+                                cardTypeFilter: WildcardCardType.Unit,
+                                zoneFilter: WildcardZoneName.AnyArena,
+                                name: 'enemyUnit',
+                                immediateEffect: abilityHelper.immediateEffects.damage((context) => ({
+                                    amount: context.targets.friendlyUnit.getPower(),
+                                    target: context.targets.enemyUnit
+                                }))
+                            })
                         })
                     }),
                 }),

--- a/server/game/cards/09_HMW/events/Overgrowth.ts
+++ b/server/game/cards/09_HMW/events/Overgrowth.ts
@@ -2,7 +2,7 @@ import { EventCard } from '../../../core/card/EventCard';
 import type { IEventAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import { TextHelper } from '../../../core/utils/TextHelper';
-import { RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
+import { GameStateChangeRequired, RelativePlayer, Trait, WildcardCardType, WildcardZoneName } from '../../../core/Constants';
 
 export default class Overgrowth extends EventCard {
     protected override getImplementationId() {
@@ -24,6 +24,10 @@ export default class Overgrowth extends EventCard {
                         cardTypeFilter: WildcardCardType.Unit,
                         zoneFilter: WildcardZoneName.AnyArena,
                         name: 'friendlyUnit',
+
+                        // only units that can actually deal damage are selectable, so the damage step can't be fizzled
+                        // by choosing a unit with no power (and can never resolve without a chosen friendly unit)
+                        mustChangeGameState: GameStateChangeRequired.MustFullyOrPartiallyResolve,
                         immediateEffect: abilityHelper.immediateEffects.selectCard({
                             activePromptTitle: (context) => `Deal ${context.targets.friendlyUnit?.getPower()} damage to an enemy unit`,
                             controller: RelativePlayer.Opponent,

--- a/server/game/cards/09_HMW/events/Overgrowth.ts
+++ b/server/game/cards/09_HMW/events/Overgrowth.ts
@@ -24,20 +24,16 @@ export default class Overgrowth extends EventCard {
                         cardTypeFilter: WildcardCardType.Unit,
                         zoneFilter: WildcardZoneName.AnyArena,
                         name: 'friendlyUnit',
-                        immediateEffect: abilityHelper.immediateEffects.conditional({
-                            // if no friendly unit can deal damage, the selection resolves without a unit, so there is nothing to damage with
-                            condition: (context) => context.targets.friendlyUnit != null,
-                            onTrue: abilityHelper.immediateEffects.selectCard({
-                                activePromptTitle: (context) => `Deal ${context.targets.friendlyUnit.getPower()} damage to an enemy unit`,
-                                controller: RelativePlayer.Opponent,
-                                cardTypeFilter: WildcardCardType.Unit,
-                                zoneFilter: WildcardZoneName.AnyArena,
-                                name: 'enemyUnit',
-                                immediateEffect: abilityHelper.immediateEffects.damage((context) => ({
-                                    amount: context.targets.friendlyUnit.getPower(),
-                                    target: context.targets.enemyUnit
-                                }))
-                            })
+                        immediateEffect: abilityHelper.immediateEffects.selectCard({
+                            activePromptTitle: (context) => `Deal ${context.targets.friendlyUnit.getPower()} damage to an enemy unit`,
+                            controller: RelativePlayer.Opponent,
+                            cardTypeFilter: WildcardCardType.Unit,
+                            zoneFilter: WildcardZoneName.AnyArena,
+                            name: 'enemyUnit',
+                            immediateEffect: abilityHelper.immediateEffects.damage((context) => ({
+                                amount: context.targets.friendlyUnit.getPower(),
+                                target: context.targets.enemyUnit
+                            }))
                         })
                     }),
                 }),

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -104,11 +104,8 @@ export class SelectCardSystem<TContext extends AbilityContext = AbilityContext> 
                 return;
             }
 
-            // a mandatory selection can still resolve without a card, e.g. when the resolver finds no target that the
-            // wrapped effect could do anything to and skips the prompt entirely. there is no selection to apply the
-            // effect to in that case. a selection that lets the player choose no cards (e.g. TargetMode.UpTo) is
-            // different: choosing nothing is a real choice there, and the effect still resolves against the empty
-            // selection
+            // a mandatory selection resolves without a card when the resolver finds no effective target and skips the
+            // prompt, leaving nothing to apply the effect to. choosing nothing in an "up to" selection is a real choice
             if (selectedCards.length === 0 && !this.selectionAllowsChoosingNoCards(context, additionalProperties)) {
                 return;
             }

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -99,22 +99,25 @@ export class SelectCardSystem<TContext extends AbilityContext = AbilityContext> 
         context.game.queueSimpleStep(() => {
             const selectedCards = Helpers.asArray(context.targets[properties.name]);
 
-            // a mandatory selection can still resolve without a card, e.g. when the resolver finds no target that the
-            // wrapped effect could do anything to and skips the prompt. there is nothing to apply the effect to in that
-            // case, unlike a selection that lets the player choose no cards (e.g. TargetMode.UpTo), where the effect
-            // still resolves against the empty selection
-            const resolvedWithoutSelection = selectedCards.length === 0 &&
-              !this.selectionAllowsChoosingNoCards(context, additionalProperties);
-
             if (targetResults.cancelled || (properties.cancelIfNoTargets && selectedCards.length === 0)) {
                 properties.cancelHandler?.();
-            } else if (!resolvedWithoutSelection) {
-                if (!properties.isCost && Helpers.asArray(context.target).length > 0) {
-                    this.addOnSelectEffectMessage(context, properties);
-                }
-                properties.onSelectHandler?.(context.targets[properties.name] ?? context.target);
-                properties.immediateEffect.queueGenerateEventGameSteps(events, context, additionalProperties);
+                return;
             }
+
+            // a mandatory selection can still resolve without a card, e.g. when the resolver finds no target that the
+            // wrapped effect could do anything to and skips the prompt entirely. there is no selection to apply the
+            // effect to in that case. a selection that lets the player choose no cards (e.g. TargetMode.UpTo) is
+            // different: choosing nothing is a real choice there, and the effect still resolves against the empty
+            // selection
+            if (selectedCards.length === 0 && !this.selectionAllowsChoosingNoCards(context, additionalProperties)) {
+                return;
+            }
+
+            if (!properties.isCost && Helpers.asArray(context.target).length > 0) {
+                this.addOnSelectEffectMessage(context, properties);
+            }
+            properties.onSelectHandler?.(context.targets[properties.name] ?? context.target);
+            properties.immediateEffect.queueGenerateEventGameSteps(events, context, additionalProperties);
         }, `Execute immediate effect for select card system "${properties.name}"`);
     }
 

--- a/server/game/gameSystems/SelectCardSystem.ts
+++ b/server/game/gameSystems/SelectCardSystem.ts
@@ -97,9 +97,18 @@ export class SelectCardSystem<TContext extends AbilityContext = AbilityContext> 
         targetResolver.resolve(context, targetResults);
 
         context.game.queueSimpleStep(() => {
-            if (targetResults.cancelled || (properties.cancelIfNoTargets && Helpers.asArray(context.target).length === 0)) {
+            const selectedCards = Helpers.asArray(context.targets[properties.name]);
+
+            // a mandatory selection can still resolve without a card, e.g. when the resolver finds no target that the
+            // wrapped effect could do anything to and skips the prompt. there is nothing to apply the effect to in that
+            // case, unlike a selection that lets the player choose no cards (e.g. TargetMode.UpTo), where the effect
+            // still resolves against the empty selection
+            const resolvedWithoutSelection = selectedCards.length === 0 &&
+              !this.selectionAllowsChoosingNoCards(context, additionalProperties);
+
+            if (targetResults.cancelled || (properties.cancelIfNoTargets && selectedCards.length === 0)) {
                 properties.cancelHandler?.();
-            } else {
+            } else if (!resolvedWithoutSelection) {
                 if (!properties.isCost && Helpers.asArray(context.target).length > 0) {
                     this.addOnSelectEffectMessage(context, properties);
                 }

--- a/test/server/cards/01_SOR/events/Command.spec.ts
+++ b/test/server/cards/01_SOR/events/Command.spec.ts
@@ -119,6 +119,35 @@ describe('Command', function() {
             context.ignoreUnresolvedActionPhasePrompts = true;
         });
 
+        it('Command\'s damage ability should fizzle if no friendly unit has any power', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['command'],
+                    groundArena: ['moisture-farmer', 'coruscanti-spy']
+                },
+                player2: {
+                    groundArena: ['atst']
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.command);
+            context.player1.clickPrompt('A friendly unit deals damage equal to its power to a non-unique enemy unit.');
+
+            // no friendly unit can deal damage, so nothing is selected and no damage is dealt
+            expect(context.atst.damage).toBe(0);
+            expect(context.player1).toHaveEnabledPromptButtons([
+                'Give 2 Experience tokens to a unit.',
+                'Put this event into play as a resource.',
+                '(No effect) Return a unit from your discard pile to your hand.'
+            ]);
+
+            // since we only clicked one option
+            context.ignoreUnresolvedActionPhasePrompts = true;
+        });
+
         it('Command\'s damage ability should fizzle if there is no legal friendly unit', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',

--- a/test/server/cards/09_HMW/events/Overgrowth.spec.ts
+++ b/test/server/cards/09_HMW/events/Overgrowth.spec.ts
@@ -20,10 +20,16 @@ describe('Overgrowth', function() {
 
             expect(context.player1).toHavePrompt('Choose a friendly unit. It deals damage equal to its power to an enemy unit');
             expect(context.player1).toBeAbleToSelectExactly([context.gungi, context.porg]);
+
+            // the damage is not optional, the player cannot skip either step
+            expect(context.player1).not.toHavePassAbilityButton();
+            expect(context.player1).not.toHaveChooseNothingButton();
             context.player1.clickCard(context.gungi);
 
             expect(context.player1).toHavePrompt('Deal 2 damage to an enemy unit');
             expect(context.player1).toBeAbleToSelectExactly([context.atst, context.awing]);
+            expect(context.player1).not.toHavePassAbilityButton();
+            expect(context.player1).not.toHaveChooseNothingButton();
             context.player1.clickCard(context.atst);
 
             expect(context.player2).toBeActivePlayer();
@@ -85,6 +91,102 @@ describe('Overgrowth', function() {
 
             // 97th legion's power should still be 5, damage should dealt before resourcing event
             expect(context.atst.damage).toBe(5);
+            expect(context.overgrowth).toBeInZone('resource', context.player1);
+            expect(context.overgrowth.exhausted).toBeTrue();
+        });
+        it('Overgrowth\'s ability should not offer units that cannot deal damage as a way to skip the damage', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['overgrowth'],
+                    groundArena: ['moisture-farmer', 'battlefield-marine'],
+                    base: 'origin-tree'
+                },
+                player2: {
+                    groundArena: ['atst'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.overgrowth);
+
+            // Moisture Farmer has 0 power, so selecting it would deal no damage
+            expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.player1).toHavePrompt('Deal 3 damage to an enemy unit');
+            context.player1.clickCard(context.atst);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.atst.damage).toBe(3);
+            expect(context.overgrowth).toBeInZone('resource', context.player1);
+            expect(context.overgrowth.exhausted).toBeTrue();
+        });
+
+        it('Overgrowth\'s ability should resource this event when no friendly unit can deal damage', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['overgrowth'],
+                    groundArena: ['moisture-farmer', 'coruscanti-spy'],
+                    base: 'origin-tree'
+                },
+                player2: {
+                    groundArena: ['atst'],
+                    spaceArena: ['awing'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.overgrowth);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.atst.damage).toBe(0);
+            expect(context.awing.damage).toBe(0);
+            expect(context.overgrowth).toBeInZone('resource', context.player1);
+            expect(context.overgrowth.exhausted).toBeTrue();
+        });
+
+        it('Overgrowth\'s ability should resource this event when the opponent controls no unit', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['overgrowth'],
+                    groundArena: ['battlefield-marine'],
+                    base: 'origin-tree'
+                },
+                player2: {}
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.overgrowth);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.overgrowth).toBeInZone('resource', context.player1);
+            expect(context.overgrowth.exhausted).toBeTrue();
+        });
+
+        it('Overgrowth\'s ability should resource this event when we control no unit', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    hand: ['overgrowth'],
+                    base: 'origin-tree'
+                },
+                player2: {
+                    groundArena: ['atst'],
+                }
+            });
+
+            const { context } = contextRef;
+
+            context.player1.clickCard(context.overgrowth);
+
+            expect(context.player2).toBeActivePlayer();
+            expect(context.atst.damage).toBe(0);
             expect(context.overgrowth).toBeInZone('resource', context.player1);
             expect(context.overgrowth.exhausted).toBeTrue();
         });

--- a/test/server/cards/09_HMW/events/Overgrowth.spec.ts
+++ b/test/server/cards/09_HMW/events/Overgrowth.spec.ts
@@ -94,7 +94,7 @@ describe('Overgrowth', function() {
             expect(context.overgrowth).toBeInZone('resource', context.player1);
             expect(context.overgrowth.exhausted).toBeTrue();
         });
-        it('Overgrowth\'s ability should not offer units that cannot deal damage as a way to skip the damage', async function() {
+        it('Overgrowth\'s ability should allow selecting a unit with 0 power, dealing no damage', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',
                 player1: {
@@ -111,15 +111,13 @@ describe('Overgrowth', function() {
 
             context.player1.clickCard(context.overgrowth);
 
-            // Moisture Farmer has 0 power, so selecting it would deal no damage
-            expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine]);
-            context.player1.clickCard(context.battlefieldMarine);
+            expect(context.player1).toBeAbleToSelectExactly([context.moistureFarmer, context.battlefieldMarine]);
 
-            expect(context.player1).toHavePrompt('Deal 3 damage to an enemy unit');
-            context.player1.clickCard(context.atst);
+            // Moisture Farmer has 0 power, so no damage is dealt
+            context.player1.clickCard(context.moistureFarmer);
 
             expect(context.player2).toBeActivePlayer();
-            expect(context.atst.damage).toBe(3);
+            expect(context.atst.damage).toBe(0);
             expect(context.overgrowth).toBeInZone('resource', context.player1);
             expect(context.overgrowth.exhausted).toBeTrue();
         });


### PR DESCRIPTION
## The bug

Play **Overgrowth** with a Kashyyyk base while every friendly unit has 0 power (Moisture Farmer, Coruscanti Spy, …) and the opponent controls at least one unit. The friendly unit prompt never appears; instead the game asks to `Deal undefined damage to an enemy unit`, and clicking a target throws:

```
Contract assertion failure: Null-like object value: undefined
    at DamageSystem.addAbilityDamagePropertiesToEvent
```

The ability aborts there, so Overgrowth is never resourced — it sits in the discard pile.

**Command** hits the identical crash: choose `A friendly unit deals damage equal to its power to a non-unique enemy unit` with only 0-power units on board.

## Why it happens

`CardTargetResolver` applies two different bars to a selection:

1. **Legality** (`checkCardCondition`) at `GameStateChangeRequired.None` — a 0-power unit passes, because 0 damage is still a legal damage effect.
2. **Effectiveness** (`CardTargetResolver.ts:151-168`) at `MustFullyOrPartiallyResolve` — when *no* legal target would change game state, the resolver deliberately skips the prompt and sets the target to `null`.

So with every friendly unit at 0 power, the selection resolves to no unit at all. `SelectCardSystem` then ran its wrapped effect anyway — it only checked `targetResults.cancelled`, never whether a card was actually chosen.

For most cards that is invisible: the wrapped effect is a card target system, and no target means no events. But when the wrapped effect is *another selection that reads the outer target* — the shape both Overgrowth and Command use — the enemy unit prompt opens with `friendlyUnit` still `null`, the damage amount evaluates to `undefined`, and `DamageSystem` asserts on it.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Overgrowth, at least one friendly unit with power | works | unchanged |
| Overgrowth, 0-power unit picked alongside a real attacker | selectable, deals no damage | unchanged |
| Overgrowth, **every** friendly unit at 0 power | `Deal undefined damage` prompt → crash → event **not** resourced | no damage prompt, no damage, event resourced |
| Command damage mode, every friendly unit at 0 power | same crash | mode fizzles, remaining modes resolve normally |
| "Up to" selections where the player chooses nothing | effect resolves against the empty selection | unchanged |

## The fix

`SelectCardSystem` skips the wrapped effect when a **mandatory** selection resolved without a card:

```ts
if (selectedCards.length === 0 && !this.selectionAllowsChoosingNoCards(context, additionalProperties)) {
    return;
}
```

The `selectionAllowsChoosingNoCards` half is load-bearing, not defensive. Selections like `TargetMode.UpTo` treat choosing nothing as a real choice and still need their effect: The Eye Of Aldhani exhausts every *un*selected unit, so an unconditional skip breaks it. The full suite caught that.

Two smaller changes ride along:

- The emptiness check reads `context.targets[properties.name]` rather than `context.target`. `context.target` is only written when a selection is unnamed (`TargetResolver.setTargetResult`), so the existing `cancelIfNoTargets` check silently never fired for a named selection. Behavioural no-op for its only caller (`DiscloseAspectsSystem`, unnamed), and the flag now works if anyone reaches for it.
- Overgrowth drops `?.` to `.` on its two `friendlyUnit` reads, since a selection is now guaranteed before that effect runs. A regression should fail loudly rather than quietly become `undefined`.

## Tests

- `Overgrowth.spec.ts` — 0-power unit is offered alongside a real attacker and deals nothing when picked; neither prompt offers a pass or choose-nothing button; the event is resourced in all four dead ends (no friendly units, no enemy units, no unit that can deal damage, non-Kashyyyk base).
- `Command.spec.ts` — new fizzle case for "no friendly unit has any power", matching the two fizzle tests already there.

Both new crash tests were confirmed to fail with the guard reverted and pass with it, so they genuinely cover the bug.

Full suite green: 8099 specs, 0 failures (8 pre-existing `xit`s). Lint clean. This touches core targeting that all 106 `selectCard` cards route through, so the suite is the main evidence of safety — the `selectionAllowsChoosingNoCards` condition is the line worth a close read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBpcPepAx7Xh2J8HTBpBxj