### PR TITLE
Tireless Magnaguard

### DIFF
--- a/server/game/cards/09_HMW/units/TirelessMagnaguard.ts
+++ b/server/game/cards/09_HMW/units/TirelessMagnaguard.ts
@@ -1,0 +1,51 @@
+import type { IAbilityHelper } from '../../../AbilityHelper';
+import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
+import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import { Duration, ZoneName } from '../../../core/Constants';
+
+export default class TirelessMagnaguard extends NonLeaderUnitCard {
+    protected override getImplementationId() {
+        return {
+            id: 'tireless-magnaguard-id',
+            internalName: 'tireless-magnaguard',
+        };
+    }
+
+    public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
+        registrar.addWhenDefeatedAbility({
+            title: 'If this unit had 5 or more power, for this phase you may play this unit from your discard pile for free and give 2 Weakness tokens to it',
+            immediateEffect: AbilityHelper.immediateEffects.conditional({
+                // The unit goes to its owner's discard pile, so if it was defeated while an opponent controlled it
+                // (e.g. No Glory, Only Results), it is not in "your" discard pile and the ability has no effect.
+                condition: (context) => context.event.lastKnownInformation.power >= 5 && context.source.owner === context.player,
+                onTrue: AbilityHelper.immediateEffects.simultaneous([
+                    AbilityHelper.immediateEffects.forThisPhaseCardEffect((context) => ({
+                        effect: AbilityHelper.ongoingEffects.canPlayFromDiscard({ player: context.player })
+                    })),
+                    AbilityHelper.immediateEffects.forThisPhasePlayerEffect((context) => ({
+                        target: context.player,
+                        effect: AbilityHelper.ongoingEffects.forFree({
+                            match: (card) => card === context.source && card.zoneName === ZoneName.Discard
+                        })
+                    })),
+                    AbilityHelper.immediateEffects.delayedPlayerEffect((context) => ({
+                        title: 'Give 2 Weakness tokens to Tireless Magnaguard',
+                        target: context.player,
+                        duration: Duration.UntilEndOfPhase,
+                        effectDescription: 'give 2 Weakness tokens to Tireless Magnaguard when it is played from their discard pile this phase',
+                        when: {
+                            onCardPlayed: (event, delayedContext) =>
+                                event.card === delayedContext.source &&
+                                event.player === delayedContext.player &&
+                                event.originalZone === ZoneName.Discard
+                        },
+                        immediateEffect: AbilityHelper.immediateEffects.giveWeakness((delayedContext) => ({
+                            amount: 2,
+                            target: delayedContext.source
+                        }))
+                    }))
+                ])
+            })
+        });
+    }
+}

--- a/test/server/cards/09_HMW/units/TirelessMagnaguard.spec.ts
+++ b/test/server/cards/09_HMW/units/TirelessMagnaguard.spec.ts
@@ -1,0 +1,294 @@
+describe('Tireless Magnaguard', function() {
+    integration(function(contextRef) {
+        describe('Tireless Magnaguard\'s When Defeated ability', function() {
+            it('should allow its owner to play it from their discard pile for free this phase and give it 2 Weakness tokens if it had 5 or more power', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['tireless-magnaguard']
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Player 2 defeats Tireless Magnaguard while it has 5 power
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+                expect(context.player1).toBeActivePlayer();
+
+                // Player 1 plays it from their discard pile for free
+                const readyResourceCount = context.player1.readyResourceCount;
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.player1.readyResourceCount).toBe(readyResourceCount);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames(['weakness', 'weakness']);
+                expect(context.tirelessMagnaguard.getPower()).toBe(3);
+                expect(context.tirelessMagnaguard.getHp()).toBe(1);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should not allow it to be played again if it is defeated again with less than 5 power', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['tireless-magnaguard']
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        groundArena: ['wampa'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.tirelessMagnaguard);
+
+                // Player 1 plays it from their discard pile, it comes back as a 3/1
+                context.player1.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames(['weakness', 'weakness']);
+
+                // Player 2 defeats it again while it has 3 power
+                context.player2.clickCard(context.wampa);
+                context.player2.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+                expect(context.player1).toBeActivePlayer();
+
+                // Player 1 can no longer play it from their discard pile
+                expect(context.tirelessMagnaguard).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            });
+
+            it('should allow it to be replayed repeatedly in the same phase as long as it has 5 or more power each time it is defeated', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        base: 'lair-of-grievous',
+                        hand: ['commence-the-festivities', 'tactical-advantage', 'tactical-advantage'],
+                        groundArena: ['tireless-magnaguard'],
+                        resources: 10
+                    },
+                    player2: {
+                        hand: ['vanquish', 'vanquish'],
+                        groundArena: ['wampa'],
+                        resources: 15
+                    }
+                });
+
+                const { context } = contextRef;
+                const [tacticalAdvantage1, tacticalAdvantage2] = context.player1.findCardsByName('tactical-advantage');
+                const [vanquish1, vanquish2] = context.player2.findCardsByName('vanquish');
+
+                // CYCLE 1: Commence the Festivities attacks with it at 7 power (5 + 2, since Player 1 controls fewer
+                // resources), so it trades with Wampa and is defeated with 5 or more power
+                context.player1.clickCard(context.commenceTheFestivities);
+                context.player1.clickCard(context.tirelessMagnaguard);
+                context.player1.clickCard(context.wampa);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+                expect(context.wampa).toBeInZone('discard', context.player2);
+
+                context.player2.passAction();
+
+                let readyResourceCount = context.player1.readyResourceCount;
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.player1.readyResourceCount).toBe(readyResourceCount);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames(['weakness', 'weakness']);
+                expect(context.tirelessMagnaguard.getPower()).toBe(3);
+
+                // CYCLE 2: still the same action phase. Tactical Advantage puts it back to 5 power before it is
+                // defeated again, so the When Defeated ability grants a fresh permission to play it from the discard pile
+                context.player2.passAction();
+                context.player1.clickCard(tacticalAdvantage1);
+                context.player1.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard.getPower()).toBe(5);
+
+                context.player2.clickCard(vanquish1);
+                context.player2.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+
+                readyResourceCount = context.player1.readyResourceCount;
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.player1.readyResourceCount).toBe(readyResourceCount);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames(['weakness', 'weakness']);
+                expect(context.tirelessMagnaguard.getPower()).toBe(3);
+
+                // CYCLE 3: still the same action phase, third time it is played from the discard pile
+                context.player2.passAction();
+                context.player1.clickCard(tacticalAdvantage2);
+                context.player1.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard.getPower()).toBe(5);
+
+                context.player2.clickCard(vanquish2);
+                context.player2.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+
+                readyResourceCount = context.player1.readyResourceCount;
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.player1.readyResourceCount).toBe(readyResourceCount);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames(['weakness', 'weakness']);
+                expect(context.tirelessMagnaguard.getPower()).toBe(3);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should not allow it to be played from the discard pile if it had less than 5 power when defeated', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'tireless-magnaguard', upgrades: ['weakness'] }]
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                expect(context.tirelessMagnaguard.getPower()).toBe(4);
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+                expect(context.player1).toBeActivePlayer();
+
+                expect(context.tirelessMagnaguard).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            });
+
+            it('should count power modifiers when checking if it had 5 or more power', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: [{ card: 'tireless-magnaguard', upgrades: ['weakness', 'experience'] }]
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                expect(context.tirelessMagnaguard.getPower()).toBe(5);
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames(['weakness', 'weakness']);
+            });
+
+            it('should not allow it to be played from the discard pile in a later phase', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        groundArena: ['tireless-magnaguard']
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+
+                context.moveToNextActionPhase();
+
+                expect(context.tirelessMagnaguard).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            });
+
+            it('should not be free when it is returned from the discard pile to hand and played from hand', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        base: 'lair-of-grievous',
+                        hand: ['renewed-friendship'],
+                        groundArena: ['tireless-magnaguard'],
+                        resources: 15
+                    },
+                    player2: {
+                        hand: ['vanquish'],
+                        hasInitiative: true
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Player 2 defeats it while it has 5 power, so Player 1 may play it from their discard pile for free
+                context.player2.clickCard(context.vanquish);
+                context.player2.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player1);
+
+                // Renewed Friendship returns it from the discard pile to hand instead
+                context.player1.clickCard(context.renewedFriendship);
+                context.player1.clickCard(context.tirelessMagnaguard);
+                expect(context.tirelessMagnaguard).toBeInZone('hand', context.player1);
+
+                context.player2.passAction();
+
+                // Playing it from hand costs full price and does not give it Weakness tokens
+                const readyResourceCount = context.player1.readyResourceCount;
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('groundArena', context.player1);
+                expect(context.player1.readyResourceCount).toBe(readyResourceCount - 4);
+                expect(context.tirelessMagnaguard).toHaveExactUpgradeNames([]);
+                expect(context.tirelessMagnaguard.getPower()).toBe(5);
+                expect(context.tirelessMagnaguard.getHp()).toBe(3);
+            });
+
+            it('should not allow the opponent to play it from its owner\'s discard pile when it is defeated under their control by No Glory, Only Results', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        hand: ['no-glory-only-results']
+                    },
+                    player2: {
+                        groundArena: ['tireless-magnaguard']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Player 1 takes control of Tireless Magnaguard and defeats it
+                context.player1.clickCard(context.noGloryOnlyResults);
+                context.player1.clickCard(context.tirelessMagnaguard);
+
+                expect(context.tirelessMagnaguard).toBeInZone('discard', context.player2);
+                expect(context.player2).toBeActivePlayer();
+
+                // The ability resolved for player 1, so the owner does not get to play it from their discard pile
+                expect(context.tirelessMagnaguard).not.toHaveAvailableActionWhenClickedBy(context.player2);
+                context.player2.passAction();
+
+                // Player 1 cannot play it from player 2's discard pile
+                expect(context.tirelessMagnaguard).not.toHaveAvailableActionWhenClickedBy(context.player1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
[](https://swudb.com/cdn-cgi/image/width=300/images/cards/HMW/109.png)

**Tireless Magnaguard** — When Defeated: If this unit had 5 or more power, for this phase you may play this unit from your discard pile for free and give 2 Weakness tokens to it.

## Implementation
- The 5 power check reads the defeat event's last known information, so buffs and Weakness tokens at the moment of defeat count.
- The permission is only granted when the player resolving the ability owns the unit. A unit defeated under an opponent's control goes to its owner's discard pile, so it is never in "your discard pile" for the player who resolved the ability.
- Play permission and the free cost follow the Stolen AT-Hauler pattern: a phase-long play-from-discard effect on the card, plus a free cost adjuster on the player that only matches while the card is in the discard pile.
- The Weakness tokens are a phase-long delayed effect on the player, fired when that player plays this card out of the discard pile. It cannot live on the card itself because lasting effects are stripped when a card moves from discard into an arena.

## Test cases
- replayed for free and comes back as a 3/1 with 2 Weakness tokens
- once replayed at 3 power, a second defeat grants nothing
- replayed three times in a single action phase, pumped back to 5 power before each defeat (Commence the Festivities, then Tactical Advantage) — there is no per-phase limit
- no permission when it had 4 power at defeat
- power modifiers count: Weakness plus Experience is 5 power and triggers
- the permission expires with the phase
- returned from the discard pile to hand with Renewed Friendship and played from hand: costs full price, no Weakness tokens
- defeated under an opponent's control by No Glory, Only Results: neither player can play it from the owner's discard pile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJnXH2vY5dpcQuEdU6qzDP