### PR TITLE
Fix Ravager and add Luminara tests

### DIFF
--- a/server/game/cards/08_ASH/units/RavagerFinalImperialCommand.ts
+++ b/server/game/cards/08_ASH/units/RavagerFinalImperialCommand.ts
@@ -50,7 +50,7 @@ export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
         if (playedCard.isInPlay()) {
             return playedCard.getPower();
         }
-        return this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.lastKnownInformation.power ?? playedCard.getPrintedPower();
+        return this.cardsLeftPlayThisPhaseWatcher.getLeftPlayEntry(playedCard)?.lastKnownInformation.power ?? playedCard.getPrintedPower();
     }
 
     /** The arena the played unit is in, or was in when it left play.*/
@@ -59,7 +59,7 @@ export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
         if (playedCard.isInPlay()) {
             return playedCard.zoneName;
         }
-        const arena = this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.lastKnownInformation.arena;
+        const arena = this.cardsLeftPlayThisPhaseWatcher.getLeftPlayEntry(playedCard)?.lastKnownInformation.arena;
         return EnumHelpers.isArena(arena) ? arena : playedCard.defaultArena;
     }
 }

--- a/server/game/cards/08_ASH/units/RavagerFinalImperialCommand.ts
+++ b/server/game/cards/08_ASH/units/RavagerFinalImperialCommand.ts
@@ -1,10 +1,15 @@
 import type { IAbilityHelper } from '../../../AbilityHelper';
 import type { INonLeaderUnitAbilityRegistrar } from '../../../core/card/AbilityRegistrationInterfaces';
 import { NonLeaderUnitCard } from '../../../core/card/NonLeaderUnitCard';
+import type { Arena } from '../../../core/Constants';
 import { CardType, WildcardCardType } from '../../../core/Constants';
+import type { StateWatcherRegistrar } from '../../../core/stateWatcher/StateWatcherRegistrar';
 import { EnumHelpers } from '../../../core/utils/EnumHelpers';
+import type { CardsLeftPlayThisPhaseWatcher } from '../../../stateWatchers/CardsLeftPlayThisPhaseWatcher';
 
 export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
+    private cardsLeftPlayThisPhaseWatcher: CardsLeftPlayThisPhaseWatcher;
+
     protected override getImplementationId() {
         return {
             id: '4828998087',
@@ -12,10 +17,14 @@ export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
         };
     }
 
+    protected override setupStateWatchers(registrar: StateWatcherRegistrar, abilityHelper: IAbilityHelper): void {
+        this.cardsLeftPlayThisPhaseWatcher = abilityHelper.stateWatchers.cardsLeftPlayThisPhase();
+    }
+
     public override setupCardAbilities(registrar: INonLeaderUnitAbilityRegistrar, AbilityHelper: IAbilityHelper) {
         registrar.addTriggeredAbility({
             title: 'Deal damage equal to its power to a unit in the same arena',
-            contextTitle: (context) => `Deal ${context.event.card.getPower()} damage to a unit in the ${EnumHelpers.arenaName(context.event.card.zoneName)}`,
+            contextTitle: (context) => `Deal ${this.playedUnitPower(context)} damage to a unit in the ${EnumHelpers.arenaName(this.playedUnitArena(context))}`,
             optional: true,
             when: {
                 onCardPlayed: (event, context) =>
@@ -24,14 +33,33 @@ export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
             },
             targetResolver: {
                 activePromptTitle: (context) =>
-                    `Deal ${context.event.card.getPower()} damage to a unit in the ${EnumHelpers.arenaName(context.event.card.zoneName)}`,
+                    `Deal ${this.playedUnitPower(context)} damage to a unit in the ${EnumHelpers.arenaName(this.playedUnitArena(context))}`,
                 cardTypeFilter: WildcardCardType.Unit,
-                cardCondition: (card, context) => card.zoneName === context.event.card.zoneName,
+                cardCondition: (card, context) => card.zoneName === this.playedUnitArena(context),
                 immediateEffect: AbilityHelper.immediateEffects.damage((context) => ({
-                    amount: context.event.card.getPower(),
+                    amount: this.playedUnitPower(context),
                     source: context.event.card
                 }))
             }
         });
+    }
+
+    /** The unit's power, whether it is currently in play or has just left play. */
+    private playedUnitPower(context): number {
+        const playedCard = context.event.card;
+        if (playedCard.isInPlay()) {
+            return playedCard.getPower();
+        }
+        return this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.power ?? playedCard.getPrintedPower();
+    }
+
+    /** The arena the played unit is in, or was in when it left play.*/
+    private playedUnitArena(context): Arena {
+        const playedCard = context.event.card;
+        if (playedCard.isInPlay()) {
+            return playedCard.zoneName;
+        }
+        const arena = this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.arena;
+        return EnumHelpers.isArena(arena) ? arena : playedCard.defaultArena;
     }
 }

--- a/server/game/cards/08_ASH/units/RavagerFinalImperialCommand.ts
+++ b/server/game/cards/08_ASH/units/RavagerFinalImperialCommand.ts
@@ -50,7 +50,7 @@ export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
         if (playedCard.isInPlay()) {
             return playedCard.getPower();
         }
-        return this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.power ?? playedCard.getPrintedPower();
+        return this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.lastKnownInformation.power ?? playedCard.getPrintedPower();
     }
 
     /** The arena the played unit is in, or was in when it left play.*/
@@ -59,7 +59,7 @@ export default class RavagerFinalImperialCommand extends NonLeaderUnitCard {
         if (playedCard.isInPlay()) {
             return playedCard.zoneName;
         }
-        const arena = this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.arena;
+        const arena = this.cardsLeftPlayThisPhaseWatcher.getMostRecentLeftPlayEntry(playedCard)?.lastKnownInformation.arena;
         return EnumHelpers.isArena(arena) ? arena : playedCard.defaultArena;
     }
 }

--- a/server/game/core/stateWatcher/StateWatcher.ts
+++ b/server/game/core/stateWatcher/StateWatcher.ts
@@ -1,5 +1,5 @@
 import type { IStateListenerResetProperties, IStateListenerProperties } from '../../Interfaces';
-import type { StateWatcherName } from '../Constants';
+import type { CardType, StateWatcherName, Trait, ZoneName } from '../Constants';
 import { GameEvent } from '../event/GameEvent';
 import type { Game } from '../Game';
 import type { IGameObjectBaseState, UnwrapRef } from '../GameObjectBase';
@@ -13,6 +13,17 @@ import { CopyMode, registerStateBase } from '../GameObjectUtils';
 
 export interface IStateWatcherState<TState> extends IGameObjectBaseState {
     entries: TState[];
+}
+
+/**
+ * Simplified last known information for state watcher implementations
+ */
+export interface IStateWatcherLKIEntry {
+    traits: Set<Trait>;
+    type: CardType;
+    power?: number;
+    arena?: ZoneName;
+    // TODO: Add more fields if needed
 }
 
 /**

--- a/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
@@ -1,5 +1,5 @@
 import { StateWatcher } from '../core/stateWatcher/StateWatcher';
-import type { CardType, Trait } from '../core/Constants';
+import type { CardType, Trait, ZoneName } from '../core/Constants';
 import { StateWatcherName } from '../core/Constants';
 import type { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
 import type { Player } from '../core/Player';
@@ -15,9 +15,11 @@ import { registerState, type GameObjectId } from '../core/GameObjectUtils';
 /**
  * Simplified last known information for defeated cards
  */
-export interface IDefeatedCardLKIEntry {
+export interface IStateWatcherLKIEntry {
     traits: Set<Trait>;
     type: CardType;
+    power?: number;
+    arena?: ZoneName;
     // TODO: Add more fields if needed
 }
 
@@ -27,7 +29,7 @@ export interface DefeatedCardEntry {
     controlledBy: GameObjectId<Player>;
     defeatedBy?: GameObjectId<Player>;
     wasDefeatedWhileAttacking: IDefeatSource;
-    lastKnownInformation: IDefeatedCardLKIEntry;
+    lastKnownInformation: IStateWatcherLKIEntry;
 }
 
 interface InPlayUnit {
@@ -59,6 +61,8 @@ export class CardsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedCardEntr
             lastKnownInformation: {
                 traits: x.lastKnownInformation.traits,
                 type: x.lastKnownInformation.type,
+                power: x.lastKnownInformation.power,
+                arena: x.lastKnownInformation.arena,
             }
         }));
     }
@@ -141,6 +145,8 @@ export class CardsDefeatedThisPhaseWatcher extends StateWatcher<DefeatedCardEntr
                     lastKnownInformation: {
                         traits: event.lastKnownInformation.traits,
                         type: event.lastKnownInformation.type,
+                        power: event.lastKnownInformation.power,
+                        arena: event.lastKnownInformation.arena,
                     }
                 })
         });

--- a/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsDefeatedThisPhaseWatcher.ts
@@ -1,5 +1,4 @@
 import { StateWatcher } from '../core/stateWatcher/StateWatcher';
-import type { CardType, Trait, ZoneName } from '../core/Constants';
 import { StateWatcherName } from '../core/Constants';
 import type { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
 import type { Player } from '../core/Player';
@@ -10,18 +9,7 @@ import type { Game } from '../core/Game';
 import type { UnwrapRef, UnwrapRefObject } from '../core/GameObjectBase';
 import type { IDefeatSource } from '../IDamageOrDefeatSource';
 import { registerState, type GameObjectId } from '../core/GameObjectUtils';
-
-
-/**
- * Simplified last known information for defeated cards
- */
-export interface IStateWatcherLKIEntry {
-    traits: Set<Trait>;
-    type: CardType;
-    power?: number;
-    arena?: ZoneName;
-    // TODO: Add more fields if needed
-}
+import type { IStateWatcherLKIEntry } from '../core/stateWatcher/StateWatcher';
 
 export interface DefeatedCardEntry {
     card: GameObjectId<IInPlayCard>;

--- a/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
@@ -1,5 +1,5 @@
 import type { IInPlayCard } from '../core/card/baseClasses/InPlayCard';
-import type { CardType } from '../core/Constants';
+import type { CardType, ZoneName } from '../core/Constants';
 import { StateWatcherName } from '../core/Constants';
 import type { Game } from '../core/Game';
 import type { UnwrapRef } from '../core/GameObjectBase';
@@ -14,6 +14,12 @@ export interface CardLeftPlayEntry {
     card: GameObjectId<IInPlayCard>;
     controlledBy: GameObjectId<Player>;
     cardType: CardType;
+
+    /** The card's power when it left play */
+    power?: number;
+
+    /** Arena card was in when it left play */
+    arena?: ZoneName;
 }
 
 @registerState()
@@ -23,7 +29,7 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
     }
 
     protected override mapCurrentValue(stateValue: CardLeftPlayEntry[]): UnwrapRef<CardLeftPlayEntry[]> {
-        return stateValue.map((x) => ({ controlledBy: this.game.getFromId(x.controlledBy), card: this.game.getFromId(x.card), cardType: x.cardType }));
+        return stateValue.map((x) => ({ controlledBy: this.game.getFromId(x.controlledBy), card: this.game.getFromId(x.card), cardType: x.cardType, power: x.power, arena: x.arena }));
     }
 
     public override getCurrentValue() {
@@ -44,6 +50,11 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
 
         return this.getCurrentValue().filter(playerFilter)
             .map((entry) => entry.card);
+    }
+
+    public getMostRecentLeftPlayEntry(card: IInPlayCard): UnwrapRef<CardLeftPlayEntry> | undefined {
+        const entries = this.getCurrentValue().filter((entry) => entry.card === card);
+        return entries[entries.length - 1];
     }
 
     public someCardLeftPlay({ controller, filter }: {
@@ -93,7 +104,9 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
             update: (currentState, event) => currentState.concat({
                 card: event.card.getObjectId(),
                 controlledBy: event.lastKnownInformation.controller.getObjectId(),
-                cardType: event.lastKnownInformation.type
+                cardType: event.lastKnownInformation.type,
+                power: event.lastKnownInformation.power,
+                arena: event.lastKnownInformation.arena
             })
         });
     }

--- a/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
@@ -5,14 +5,15 @@ import type { UnwrapRef } from '../core/GameObjectBase';
 import { type GameObjectId, registerState } from '../core/GameObjectUtils';
 import type { Player } from '../core/Player';
 import { StateWatcher } from '../core/stateWatcher/StateWatcher';
+import type { IStateWatcherLKIEntry } from '../core/stateWatcher/StateWatcher';
 import type { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
 import { EnumHelpers } from '../core/utils/EnumHelpers';
-import type { IStateWatcherLKIEntry } from './CardsDefeatedThisPhaseWatcher';
 
 export interface CardLeftPlayEntry {
     card: GameObjectId<IInPlayCard>;
     controlledBy: GameObjectId<Player>;
     lastKnownInformation: IStateWatcherLKIEntry;
+    inPlayId?: number;
 }
 
 @registerState()
@@ -25,7 +26,8 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
         return stateValue.map((x) => ({
             card: this.game.getFromId(x.card),
             controlledBy: this.game.getFromId(x.controlledBy),
-            lastKnownInformation: x.lastKnownInformation
+            lastKnownInformation: x.lastKnownInformation,
+            inPlayId: x.inPlayId
         }));
     }
 
@@ -49,9 +51,21 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
             .map((entry) => entry.card);
     }
 
-    public getMostRecentLeftPlayEntry(card: IInPlayCard): UnwrapRef<CardLeftPlayEntry> | undefined {
-        const entries = this.getCurrentValue().filter((entry) => entry.card === card);
-        return entries[entries.length - 1];
+    public getLeftPlayEntry(card: IInPlayCard, inPlayId?: number): UnwrapRef<CardLeftPlayEntry> | undefined {
+        const inPlayIdToCheck = inPlayId ?? this.getCardId(card);
+        if (inPlayIdToCheck == null) {
+            return undefined;
+        }
+
+        return this.getCurrentValue().find((entry) => entry.card === card && entry.inPlayId === inPlayIdToCheck);
+    }
+
+    private getCardId(card: IInPlayCard): number | undefined {
+        if (card.isInPlay()) {
+            return card.inPlayId;
+        }
+
+        return card.zone.hiddenForPlayers == null ? card.mostRecentInPlayId : undefined;
     }
 
     public someCardLeftPlay({ controller, filter }: {
@@ -101,6 +115,7 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
             update: (currentState, event) => currentState.concat({
                 card: event.card.getObjectId(),
                 controlledBy: event.lastKnownInformation.controller.getObjectId(),
+                inPlayId: this.readInPlayId(event.card),
                 lastKnownInformation: {
                     traits: event.lastKnownInformation.traits,
                     type: event.lastKnownInformation.type,

--- a/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
@@ -115,7 +115,7 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
             update: (currentState, event) => currentState.concat({
                 card: event.card.getObjectId(),
                 controlledBy: event.lastKnownInformation.controller.getObjectId(),
-                inPlayId: this.readInPlayId(event.card),
+                inPlayId: this.getCardId(event.card),
                 lastKnownInformation: {
                     traits: event.lastKnownInformation.traits,
                     type: event.lastKnownInformation.type,

--- a/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
+++ b/server/game/stateWatchers/CardsLeftPlayThisPhaseWatcher.ts
@@ -1,25 +1,18 @@
 import type { IInPlayCard } from '../core/card/baseClasses/InPlayCard';
-import type { CardType, ZoneName } from '../core/Constants';
 import { StateWatcherName } from '../core/Constants';
 import type { Game } from '../core/Game';
 import type { UnwrapRef } from '../core/GameObjectBase';
+import { type GameObjectId, registerState } from '../core/GameObjectUtils';
 import type { Player } from '../core/Player';
 import { StateWatcher } from '../core/stateWatcher/StateWatcher';
 import type { StateWatcherRegistrar } from '../core/stateWatcher/StateWatcherRegistrar';
 import { EnumHelpers } from '../core/utils/EnumHelpers';
-
-import { registerState, type GameObjectId } from '../core/GameObjectUtils';
+import type { IStateWatcherLKIEntry } from './CardsDefeatedThisPhaseWatcher';
 
 export interface CardLeftPlayEntry {
     card: GameObjectId<IInPlayCard>;
     controlledBy: GameObjectId<Player>;
-    cardType: CardType;
-
-    /** The card's power when it left play */
-    power?: number;
-
-    /** Arena card was in when it left play */
-    arena?: ZoneName;
+    lastKnownInformation: IStateWatcherLKIEntry;
 }
 
 @registerState()
@@ -29,7 +22,11 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
     }
 
     protected override mapCurrentValue(stateValue: CardLeftPlayEntry[]): UnwrapRef<CardLeftPlayEntry[]> {
-        return stateValue.map((x) => ({ controlledBy: this.game.getFromId(x.controlledBy), card: this.game.getFromId(x.card), cardType: x.cardType, power: x.power, arena: x.arena }));
+        return stateValue.map((x) => ({
+            card: this.game.getFromId(x.card),
+            controlledBy: this.game.getFromId(x.controlledBy),
+            lastKnownInformation: x.lastKnownInformation
+        }));
     }
 
     public override getCurrentValue() {
@@ -70,7 +67,7 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
     }) {
         const playerFilter = (entry: UnwrapRef<CardLeftPlayEntry>) => (controller != null ? entry.controlledBy === controller : true);
 
-        const unitsLeftPlay = this.getCurrentValue().filter((entry) => EnumHelpers.isUnit(entry.cardType));
+        const unitsLeftPlay = this.getCurrentValue().filter((entry) => EnumHelpers.isUnit(entry.lastKnownInformation.type));
 
         if (filter != null) {
             return unitsLeftPlay.filter(filter)
@@ -86,7 +83,7 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
         controller?: Player;
         filter?: (event: UnwrapRef<CardLeftPlayEntry>) => boolean;
     }) {
-        const leaderUnitFilter = (entry: UnwrapRef<CardLeftPlayEntry>) => EnumHelpers.isLeaderUnit(entry.cardType);
+        const leaderUnitFilter = (entry: UnwrapRef<CardLeftPlayEntry>) => EnumHelpers.isLeaderUnit(entry.lastKnownInformation.type);
 
         return this.someUnitLeftPlay({
             controller,
@@ -104,9 +101,12 @@ export class CardsLeftPlayThisPhaseWatcher extends StateWatcher<CardLeftPlayEntr
             update: (currentState, event) => currentState.concat({
                 card: event.card.getObjectId(),
                 controlledBy: event.lastKnownInformation.controller.getObjectId(),
-                cardType: event.lastKnownInformation.type,
-                power: event.lastKnownInformation.power,
-                arena: event.lastKnownInformation.arena
+                lastKnownInformation: {
+                    traits: event.lastKnownInformation.traits,
+                    type: event.lastKnownInformation.type,
+                    power: event.lastKnownInformation.power,
+                    arena: event.lastKnownInformation.arena
+                }
             })
         });
     }

--- a/test/server/cards/08_ASH/units/RavagerFinalImperialCommand.spec.ts
+++ b/test/server/cards/08_ASH/units/RavagerFinalImperialCommand.spec.ts
@@ -272,5 +272,79 @@ describe('Ravager, Final Imperial Command', function () {
                 expect(context.player2).toBeActivePlayer();
             });
         });
+
+        describe('When the played unit leaves play before the ability resolves', function () {
+            it('uses the power the unit had when it left play, and does not block the played unit\'s own triggers', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'maul#old-master',
+                        hand: ['inferno-squad#we-can-grieve-later'],
+                        spaceArena: ['ravager#final-imperial-command'],
+                        groundArena: ['wampa']
+                    },
+                    player2: {
+                        groundArena: ['reinforcement-walker']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                // Maul plays Inferno Squad and immediately defeats it
+                context.player1.clickCard(context.maul);
+                context.player1.clickPrompt('Play a unit from your hand. It costs 1 resource less. Then, defeat it.');
+                context.player1.clickCard(context.infernoSquad);
+                expect(context.infernoSquad).toBeInZone('discard');
+
+                // Ravager deals 3 damage to unit in ground arena
+                context.player1.clickPrompt('Deal 3 damage to a unit in the ground arena');
+                expect(context.player1).toBeAbleToSelectExactly([context.wampa, context.reinforcementWalker]);
+                context.player1.clickCard(context.reinforcementWalker);
+                expect(context.reinforcementWalker.damage).toBe(3);
+
+                // Inferno Squad's own When Played and When Defeated abilities both still resolve
+                context.player1.clickPrompt('Resolve next');
+                context.player1.clickCardNonChecking(context.wampa);
+                expect(context.wampa.damage).toBe(1);
+                expect(context.wampa).toHaveExactUpgradeNames(['weakness']);
+
+                context.player1.clickCard(context.reinforcementWalker);
+                expect(context.reinforcementWalker.damage).toBe(4);
+                expect(context.reinforcementWalker).toHaveExactUpgradeNames(['weakness']);
+
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('uses the unit\'s modified power rather than its printed power', async function () {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'maul#old-master',
+                        hand: ['inferno-squad#we-can-grieve-later'],
+                        spaceArena: ['ravager#final-imperial-command'],
+                        groundArena: ['general-veers#blizzard-force-commander']
+                    },
+                    player2: {
+                        groundArena: ['reinforcement-walker']
+                    }
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maul);
+                context.player1.clickPrompt('Play a unit from your hand. It costs 1 resource less. Then, defeat it.');
+                context.player1.clickCard(context.infernoSquad);
+
+                // General Veers gives Inferno Squad +1 power for 4 total damage
+                context.player1.clickPrompt('Deal 4 damage to a unit in the ground arena');
+                context.player1.clickCard(context.reinforcementWalker);
+
+                expect(context.reinforcementWalker.damage).toBe(4);
+
+                context.player1.clickPrompt('Resolve all (2)');
+                context.player1.clickCardNonChecking(context.reinforcementWalker);
+                context.player1.clickCardNonChecking(context.reinforcementWalker);
+            });
+        });
     });
 });

--- a/test/server/cards/09_HMW/units/LuminaraUnduliBesiegedGeneral.spec.ts
+++ b/test/server/cards/09_HMW/units/LuminaraUnduliBesiegedGeneral.spec.ts
@@ -161,5 +161,72 @@ describe('Luminara Unduli, Besieged General', function() {
                 expect(context.luminaraUnduli.getPower()).toBe(7);
             });
         });
+
+        describe('Luminara\'s ability with Maul, Old Master', function() {
+            it('should still trigger when she is the unit Maul plays and defeats', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'maul#old-master',
+                        hand: ['luminara-unduli#besieged-general'],
+                        groundArena: ['battlefield-marine'],
+                        spaceArena: ['cartel-spacer'],
+                        resources: 20
+                    },
+                    player2: {
+                        groundArena: ['rebel-pathfinder']
+                    },
+                });
+
+                const { context } = contextRef;
+
+                // Maul plays Luminara and immediately defeats her
+                context.player1.clickCard(context.maul);
+                context.player1.clickPrompt('Play a unit from your hand. It costs 1 resource less. Then, defeat it.');
+                context.player1.clickCard(context.luminaraUnduli);
+                expect(context.luminaraUnduli).toBeInZone('discard');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.battlefieldMarine, context.cartelSpacer]);
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickCard(context.battlefieldMarine);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.p2Base.damage).toBe(5);
+                expect(context.battlefieldMarine.getPower()).toBe(3);
+                expect(context.player2).toBeActivePlayer();
+            });
+
+            it('should still trigger when she is already in play and Maul plays and defeats another unit', async function() {
+                await contextRef.setupTestAsync({
+                    phase: 'action',
+                    player1: {
+                        leader: 'maul#old-master',
+                        hand: ['wampa'],
+                        groundArena: ['luminara-unduli#besieged-general', 'battlefield-marine'],
+                        spaceArena: ['cartel-spacer'],
+                        resources: 20
+                    },
+                    player2: {
+                        groundArena: ['rebel-pathfinder']
+                    },
+                });
+
+                const { context } = contextRef;
+
+                context.player1.clickCard(context.maul);
+                context.player1.clickPrompt('Play a unit from your hand. It costs 1 resource less. Then, defeat it.');
+                context.player1.clickCard(context.wampa);
+                expect(context.wampa).toBeInZone('discard');
+
+                expect(context.player1).toBeAbleToSelectExactly([context.luminaraUnduli, context.battlefieldMarine, context.cartelSpacer]);
+                expect(context.player1).toHavePassAbilityButton();
+                context.player1.clickCard(context.luminaraUnduli);
+                context.player1.clickCard(context.p2Base);
+
+                expect(context.p2Base.damage).toBe(9);
+                expect(context.luminaraUnduli.getPower()).toBe(7);
+                expect(context.player2).toBeActivePlayer();
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixed interaction when Maul9 Leader plays a unit while Ravager is on board.  No triggers were resolving due to an exception caused by the Ravager ability prompt trying to read the power from the card that was played (which was at that point in the discard).

Added LKI to the CardLeftPlayThisPhaseWatcher, also added a convenience function to that class to make sure we are getting the most recent instance of that card.

Also added a couple tests for HMW Luminara with Maul9