### PR TITLE
(fix) pit droid team and wedge leader should stack

### DIFF
--- a/server/game/core/cost/CostAdjuster.ts
+++ b/server/game/core/cost/CostAdjuster.ts
@@ -376,7 +376,11 @@ export abstract class CostAdjuster extends GameObjectBase {
         }
 
         const upgrade = context.source;
-        Contract.assertTrue(upgrade.isUpgrade(), `attachTargetCondition can only be used with upgrade cards, attempting to use with '${upgrade.title}'`);
+        // Pilots are still units in hand while their upgrade play costs are being evaluated.
+        Contract.assertTrue(
+            upgrade.isUpgrade() || (upgrade.isUnit() && context.playType === PlayType.Piloting),
+            `attachTargetCondition can only be used with upgrade cards or units played using Piloting, attempting to use with '${upgrade.title}'`
+        );
 
         if (context.stage === Stage.Cost && context.target != null) {
             return this.attachTargetCondition(context.target, context, this.sourceCard);
@@ -395,5 +399,4 @@ export abstract class CostAdjuster extends GameObjectBase {
         return false;
     }
 }
-
 

--- a/test/server/cards/08_ASH/units/PitDroidTeam.spec.ts
+++ b/test/server/cards/08_ASH/units/PitDroidTeam.spec.ts
@@ -1,5 +1,37 @@
 describe('Pit Droid Team', function() {
     integration(function(contextRef) {
+        it('stacks with Wedge Antilles when playing a pilot from hand', async function() {
+            await contextRef.setupTestAsync({
+                phase: 'action',
+                player1: {
+                    resources: 3,
+                    base: 'dagobah-swamp',
+                    leader: 'wedge-antilles#leader-of-red-squadron',
+                    hand: ['hopeful-volunteer', 'electrostaff'],
+                    groundArena: ['pit-droid-team', 'battlefield-marine'],
+                    spaceArena: ['concord-dawn-interceptors'],
+                },
+            });
+
+            const { context } = contextRef;
+            context.player1.clickCard(context.wedgeAntilles);
+            expect(context.player1).toBeAbleToSelectExactly([context.hopefulVolunteer]);
+            context.player1.clickCard(context.hopefulVolunteer);
+            context.player1.clickCard(context.concordDawnInterceptors);
+
+            expect(context.concordDawnInterceptors).toHaveExactUpgradeNames(['hopeful-volunteer']);
+            expect(context.player1.exhaustedResourceCount).toBe(0);
+            expect(context.wedgeAntilles.exhausted).toBeTrue();
+            expect(context.player2).toBeActivePlayer();
+
+            context.player2.passAction();
+            context.player1.clickCard(context.electrostaff);
+            context.player1.clickCard(context.battlefieldMarine);
+
+            expect(context.battlefieldMarine).toHaveExactUpgradeNames(['electrostaff']);
+            expect(context.player1.exhaustedResourceCount).toBe(2);
+        });
+
         it('discounts the first upgrade played on another friendly unit each phase and resets next phase', async function() {
             await contextRef.setupTestAsync({
                 phase: 'action',


### PR DESCRIPTION
Bug from [here](https://discord.com/channels/1220057752961814568/1345468050568380568/1547440019860357311)

I reproduced with the following game test json file:

```json
{
    "phase": "action",
    "player1": {
        "hasInitiative": true,
        "resources": 3,
        "base": "dagobah-swamp",
        "leader": "wedge-antilles#leader-of-red-squadron",
        "hand": [
            "hopeful-volunteer"
        ],
        "groundArena": [
            "pit-droid-team"
        ],
        "spaceArena": [
            "concord-dawn-interceptors"
        ]
    },
    "player2": {
        "resources": 3,
        "base": "chopper-base",
        "leader": "sabine-wren#galvanized-revolutionary"
    }
}
```


